### PR TITLE
Drop env-var fallback chain in ConfigService.get — DB is THE source

### DIFF
--- a/backend/services/config_service.py
+++ b/backend/services/config_service.py
@@ -3,8 +3,10 @@
 Responsibilities
 ----------------
 
-* Apply the precedence chain **DB → env var → caller-supplied default** when
-  reading a value (YAML files are handled separately by the YAML editor).
+* Read a value from the DB only — no env-var fallback chain. The DB is the
+  single source of truth (YAML files are handled separately by the YAML
+  editor). Callers may pass an explicit ``default``; if they need to also
+  consult an env var, they must do it visibly at the call site.
 * Encrypt/decrypt secret values transparently using :mod:`core.secrets_crypto`.
 * Append an audit row to ``config_history`` on every mutation. Secret values
   are masked (``***``) in history so we never persist ciphertext that might
@@ -20,7 +22,6 @@ bugs.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from dataclasses import dataclass
 from datetime import datetime
@@ -125,47 +126,42 @@ class ConfigService:
         key: str,
         *,
         default: Optional[str] = None,
-        env_var: Optional[str] = None,
-        env_fallback: bool = True,
     ) -> Optional[str]:
-        """Return the resolved value (DB → env → default).
+        """Return the DB value, or ``default`` if no row exists.
+
+        DB is the single source of truth. There is no env-var fallback
+        chain inside this method on purpose — a silent ``os.getenv``
+        lookup would mask a missing/empty DB row with an unrelated env
+        value of the same name. Callers that genuinely need to consult an
+        env var (typically only first-boot bootstrap helpers) must do so
+        explicitly with ``os.getenv(...)`` at the call site so the read
+        is visible in the diff.
 
         Args:
             category: Logical grouping (``'auth'``, ``'llm'``, ``'service.github'``, ...).
-            key: Setting name. Conventionally an env-var-style identifier.
-            default: Returned when no value is found anywhere.
-            env_var: Env var to consult when DB is empty. Defaults to ``key``.
-            env_fallback: When ``False``, skip the env step entirely. New
-                callers that treat the DB as the single source of truth
-                should set this to ``False`` so an unintentionally-set env
-                var can never mask a missing/empty DB row.
+            key: Setting name.
+            default: Returned when no DB row is present.
 
         Raises:
             RuntimeError: A secret row is present in the DB but cannot be
                 decrypted (e.g. master key rotated without re-encrypting
                 stored secrets). Surfaces loudly so the user fixes the
-                state instead of silently consuming a stale env value.
+                state instead of silently consuming a stale value.
         """
         row = self._fetch(category, key)
-        if row is not None and row.value is not None:
-            decoded = self._decode(row.value, row.is_secret, category, key)
-            if decoded is not None:
-                return decoded
-            # Secret stored but undecryptable — refuse to fall through. A
-            # silent fallback to env or default would hide a real corruption
-            # / key-rotation issue and could substitute a wrong value.
-            raise RuntimeError(
-                f"{category}/{key}: stored secret could not be decrypted "
-                "(master key rotated without re-encrypting?); re-set the "
-                "value via Settings or the Setup Wizard."
-            )
-
-        if env_fallback:
-            env_name = env_var if env_var is not None else key
-            env_value = os.getenv(env_name)
-            if env_value is not None:
-                return env_value
-        return default
+        if row is None or row.value is None:
+            return default
+        decoded = self._decode(row.value, row.is_secret, category, key)
+        if decoded is not None:
+            return decoded
+        # Secret stored but undecryptable — refuse to fall through. A
+        # silent fallback to default would hide a real corruption /
+        # key-rotation issue and could substitute a wrong value.
+        raise RuntimeError(
+            f"{category}/{key}: stored secret could not be decrypted "
+            "(master key rotated without re-encrypting?); re-set the "
+            "value via Settings or the Setup Wizard."
+        )
 
     def get_entry(self, category: str, key: str) -> Optional[ConfigEntry]:
         """Metadata-rich read for a single key (no env fallback)."""

--- a/backend/services/repo_config.py
+++ b/backend/services/repo_config.py
@@ -20,7 +20,7 @@ KEY = "JARVIS_REPO_URL"
 
 
 def get_repo_url() -> str:
-    value = config_service.get(CATEGORY, KEY, env_fallback=False)
+    value = config_service.get(CATEGORY, KEY)
     if value is None or not value.strip():
         raise RuntimeError(
             f"{CATEGORY}/{KEY} is not configured. "

--- a/backend/tests/e2e/test_jarvis_repo_flow.py
+++ b/backend/tests/e2e/test_jarvis_repo_flow.py
@@ -149,8 +149,10 @@ async def test_resolution_survives_simulated_restart(client, monkeypatch):
     assert repo_config.get_repo_url() == "https://github.com/owner/jarvis.git"
 
     # Sanity: the singleton actually read from DB and not memoization.
+    # ``ConfigService.get`` is DB-only by contract — the env value set
+    # above must not leak in here either.
     row = config_module.config_service.get(
-        "service.jarvis_repo", "JARVIS_REPO_URL", env_fallback=False
+        "service.jarvis_repo", "JARVIS_REPO_URL"
     )
     assert row == "https://github.com/owner/jarvis.git"
 

--- a/backend/tests/test_services/test_config_service.py
+++ b/backend/tests/test_services/test_config_service.py
@@ -56,25 +56,11 @@ class TestPlainRoundTrip:
         svc.set("llm", "model", "gpt-4o-mini")
         assert svc.get("llm", "model") == "gpt-4o-mini"
 
-    def test_get_missing_returns_default(self, svc):
+    def test_get_missing_returns_none(self, svc):
+        assert svc.get("llm", "nope") is None
+
+    def test_get_missing_returns_explicit_default(self, svc):
         assert svc.get("llm", "nope", default="fallback") == "fallback"
-
-    def test_get_falls_back_to_env(self, svc, monkeypatch):
-        monkeypatch.setenv("LLM_TEMP", "0.7")
-        assert svc.get("llm", "LLM_TEMP") == "0.7"
-
-    def test_get_env_var_override_name(self, svc, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_BASE", "https://api.openai.com")
-        # Key is "base_url" but env var is different.
-        assert (
-            svc.get("llm", "base_url", env_var="OPENAI_API_BASE")
-            == "https://api.openai.com"
-        )
-
-    def test_db_takes_precedence_over_env(self, svc, monkeypatch):
-        monkeypatch.setenv("LLM_MODEL", "gpt-env")
-        svc.set("llm", "LLM_MODEL", "gpt-db")
-        assert svc.get("llm", "LLM_MODEL") == "gpt-db"
 
     def test_set_overwrites_existing(self, svc):
         svc.set("llm", "model", "gpt-3.5")
@@ -82,33 +68,40 @@ class TestPlainRoundTrip:
         assert svc.get("llm", "model") == "gpt-4o"
 
 
-class TestEnvFallbackOptOut:
-    """``env_fallback=False`` makes the DB the single source of truth.
+class TestNoEnvFallback:
+    """DB is the single source of truth — env vars are never consulted.
 
-    Used by callers like ``services.repo_config`` that must never silently
-    consume an env var standing in for a missing DB row.
+    The pre-refactor ``get()`` had an opaque ``DB → env → default`` chain
+    that could silently substitute an unrelated env value of the same
+    name for a missing DB row. These tests pin the no-fallback contract
+    so a future "convenience" tweak can't quietly reintroduce it.
     """
 
-    def test_db_hit_unaffected(self, svc, monkeypatch):
+    def test_db_miss_does_not_fall_back_to_env(self, svc, monkeypatch):
+        monkeypatch.setenv("MODEL", "gpt-env")
+        assert svc.get("llm", "MODEL") is None
+
+    def test_db_miss_with_env_set_still_uses_explicit_default(
+        self, svc, monkeypatch
+    ):
+        monkeypatch.setenv("MODEL", "gpt-env")
+        assert svc.get("llm", "MODEL", default="gpt-default") == "gpt-default"
+
+    def test_db_hit_with_conflicting_env_returns_db(self, svc, monkeypatch):
         svc.set("llm", "MODEL", "gpt-db")
         monkeypatch.setenv("MODEL", "gpt-env")
-        assert svc.get("llm", "MODEL", env_fallback=False) == "gpt-db"
+        assert svc.get("llm", "MODEL") == "gpt-db"
 
-    def test_db_miss_skips_env(self, svc, monkeypatch):
-        monkeypatch.setenv("MODEL", "gpt-env")
-        assert svc.get("llm", "MODEL", env_fallback=False) is None
+    def test_get_rejects_legacy_env_var_kwarg(self, svc):
+        # The old ``env_var=`` kwarg was the explicit hook for env-fallback.
+        # It's gone — calling code that still passes it must fail loudly so
+        # the migration is mechanical, not silent.
+        with pytest.raises(TypeError):
+            svc.get("llm", "base_url", env_var="OPENAI_API_BASE")  # type: ignore[call-arg]
 
-    def test_db_miss_returns_explicit_default(self, svc, monkeypatch):
-        monkeypatch.setenv("MODEL", "gpt-env")
-        assert (
-            svc.get("llm", "MODEL", default="gpt-default", env_fallback=False)
-            == "gpt-default"
-        )
-
-    def test_default_keeps_legacy_env_fallback(self, svc, monkeypatch):
-        # No regression for the 22 existing call sites that expect env to win.
-        monkeypatch.setenv("MODEL", "gpt-env")
-        assert svc.get("llm", "MODEL") == "gpt-env"
+    def test_get_rejects_legacy_env_fallback_kwarg(self, svc):
+        with pytest.raises(TypeError):
+            svc.get("llm", "MODEL", env_fallback=False)  # type: ignore[call-arg]
 
 
 # ---- Secret values -----------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #1. The previous PR introduced `env_fallback: bool = True` as an opt-out parameter so existing callers wouldn't break — but a default of `True` directly contradicts the "fail loud / single source of truth" principle that motivated the PR in the first place. A silent `os.getenv` fallback in `ConfigService.get()` is exactly the foot-gun this work set out to fix for `JARVIS_REPO_URL`; keeping it elsewhere "for compat" was incoherent.

This PR removes the env path entirely.

## Changes

- **`backend/services/config_service.py`** — `get(category, key, *, default=None)` is now a pure DB read with explicit-default. Removed `env_var` and `env_fallback` params. Passing either now raises `TypeError` so any missed migration is mechanical, not silent. Module docstring updated to drop the precedence-chain claim. Dead `import os` cleaned up.
- **`backend/services/repo_config.py`** — drop the now-redundant `env_fallback=False` argument (the contract _is_ the default).
- **`backend/tests/test_services/test_config_service.py`** — replaced `TestEnvFallbackOptOut` (which pinned the opt-out kwarg) with `TestNoEnvFallback`:
  - DB miss with env set returns `None` (or explicit `default=`).
  - Conflicting env never shadows DB hit.
  - Legacy `env_var=` and `env_fallback=` kwargs raise `TypeError`.
  - Removed `test_get_falls_back_to_env`, `test_get_env_var_override_name`, `test_db_takes_precedence_over_env` (subsumed by the new contract).
- **`backend/tests/e2e/test_jarvis_repo_flow.py`** — drop the paranoia `env_fallback=False` from the simulated-restart test; comment-document that DB-only is the contract itself.

## Risk audit

Verified all 22 production callers of `config_service.get()` (server.py, routes/setup.py, routes/settings.py, services/llm_provider_sync.py, services/google_oauth.py, services/git_credential_sync.py) — none rely on the silent env fallback:

- Bootstrap helpers that genuinely need an env read (e.g. `server.py:51` master-key restore from `.env`) already do `os.environ.get(...)` explicitly at the call site.
- Wizard / settings code only reads DB-stored values.
- `services/llm_provider_sync.py` reads keys that are populated either by the wizard (DB) or by the boot-time `reconcile_service_env` seed (DB → env, not the other direction).

`grep -r 'env_var=' backend/ --include='*.py' | grep -v test_` confirms no production code passes the legacy kwarg either.

## Verification

All three CI jobs green locally on commit `126979a` (this branch tip):

- `backend pytest`: **690 passed, 1 skipped, 0 failed**
- `dashboard vite build`: **pass**
- `dashboard Playwright e2e`: **27 passed, 0 failed**

## Test plan

- [ ] CI pytest goes green
- [ ] CI dashboard build goes green
- [ ] CI Playwright e2e goes green
- [ ] Manual: deploy with no `JARVIS_API_KEY` env and a populated DB → master key restore still works (covered by `server.py:51` explicit `os.environ.get` + DB read pattern, which is unchanged).
- [ ] Manual: deploy with a stale env var (e.g. old `OPENAI_API_KEY` left in `.env`) and an empty DB row for `llm.openai_api_key` → app surfaces "not configured" instead of silently using the env value. This is the regression scenario this PR exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
