### PR TITLE
docs: restore LICENSE, README, CONTRIBUTING, SECURITY for the public release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Jarvis
+
+Thanks for your interest! This project is in active development and contributions are welcome.
+
+## Before you start
+
+- Check existing issues and pull requests to avoid duplicate work.
+- For substantial changes (new agents, new MCP tools, architecture shifts), open a discussion or issue first so we can align on direction.
+- Read [`AGENTS.md`](AGENTS.md) and [`backend/ADDING_AGENT_GUIDE.md`](backend/ADDING_AGENT_GUIDE.md) — they explain how the spawn system, agent cards, and MCP tool servers fit together.
+
+## Dev setup
+
+```bash
+# Clone with submodules (fast-agent, figma-ui-mcp, mcp-atlassian)
+git clone --recurse-submodules https://github.com/<your-user-or-org>/jarvis.git
+cd jarvis
+
+# Configure secrets (do not commit)
+cp backend/.env.example backend/.env
+cp backend/fastagent.secrets.yaml.example backend/fastagent.secrets.yaml
+# Edit both files with your API keys
+
+# Bring the stack up
+docker compose up -d --build
+
+# Run backend tests
+cd backend && uv run pytest
+
+# Run dashboard tests
+cd ../dashboard && npm run test:unit && npm run test:e2e
+```
+
+## Branch & commit conventions
+
+- Work on a feature branch off `main`. Keep branches focused.
+- Commit messages: short imperative subject ("fix race in spawn registry"), longer body for "why" if needed.
+- Squash trivial fixup commits before opening a PR.
+
+## Code style
+
+- **Python**: follow surrounding style. The repo uses `ruff` and type hints where present — match what you see in the file.
+- **TypeScript / Vue**: keep dashboard components small; prefer composition API.
+
+## Pull request checklist
+
+Before requesting review:
+
+- [ ] Tests pass locally (`uv run pytest` for backend, `npm run test:unit && npm run test:e2e` for dashboard)
+- [ ] No secrets, hardcoded paths, or personal info introduced
+- [ ] Updated docs / SKILL.md / `.env.example` if behavior or config changed
+- [ ] PR description explains *why*, not just *what*
+
+## Submodules
+
+`backend/fast-agent`, `backend/figma-ui-mcp`, and `backend/mcp-atlassian` are pinned submodules. If you need to change code inside a submodule:
+
+1. Open a PR in the submodule's own repo.
+2. After it merges, bump the submodule pointer in `jarvis` with a follow-up PR.
+
+Do **not** commit modifications inside submodule directories from the parent repo.
+
+## Reporting bugs
+
+Open a GitHub issue with:
+
+- A minimal reproduction
+- Expected vs. actual behavior
+- Logs (`docker compose logs jarvis-backend`) or stack traces
+- Environment (host OS, Docker version, branch / commit)
+
+## Reporting security issues
+
+See [`SECURITY.md`](SECURITY.md). Don't file public issues for vulnerabilities.
+
+## License
+
+By contributing, you agree your contributions will be licensed under the project's [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Phuc Nguyen Van
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# Jarvis
+
+Self-hostable AI assistant built on [fast-agent](https://github.com/evalstate/fast-agent) with the Model Context Protocol (MCP). Spawns a multi-agent team that can plan, research, design, code, test, and deploy together.
+
+> **Status:** active development. Public release lineage starts at `v1.0.0`.
+> Core architecture is documented in [`AGENTS.md`](AGENTS.md) and
+> [`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md).
+
+## What it does
+
+- **Multi-agent spawn**: a 7-role agile team (PM, BA, SA, Dev, Designer, QE, DSO) coordinates over inter-agent email and meeting protocols.
+- **MCP-first tools**: filesystem, GitHub, Atlassian, Figma, web scraping (Scrapling), Roborock vacuum, Google Calendar / Gmail, story crawler, TTS — all exposed as MCP servers.
+- **Web dashboard**: Vue + Vite UI for chatting with Jarvis, configuring providers, viewing agent timelines, managing secrets.
+- **Self-host friendly**: single `docker compose up -d` brings up the whole stack on a Linux box.
+
+## Quick start
+
+```bash
+git clone --recurse-submodules https://github.com/<your-user-or-org>/jarvis.git
+cd jarvis
+
+# Copy and edit secrets
+cp backend/.env.example backend/.env
+cp backend/fastagent.secrets.yaml.example backend/fastagent.secrets.yaml
+# Edit both files with your API keys
+
+docker compose up -d --build
+```
+
+- Web UI: <http://localhost>
+- Backend API: <http://localhost:8000>
+
+For a full self-host walkthrough (firewall, SSL, GitHub Actions self-hosted runner, Cloudflare Tunnel) see [`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md).
+
+## Project layout
+
+```
+jarvis/
+├── backend/                    FastAPI server, fast-agent runtime, MCP tool servers
+│   ├── agent.py                Static agent definitions (Jarvis + sub-agents)
+│   ├── server.py               FastAPI entry point + lifespan
+│   ├── routes/                 HTTP/SSE endpoints
+│   ├── services/               Business logic (sessions, spawn bridge, TTS, ...)
+│   ├── tools/                  Custom MCP tool servers (IoT, story crawler, ...)
+│   ├── team_templates/         Agent team definitions (agile_team.yaml)
+│   ├── fast-agent/             Submodule — fast-agent framework + spawn system
+│   ├── figma-ui-mcp/           Submodule — Figma MCP server
+│   └── mcp-atlassian/          Submodule — Atlassian MCP server
+├── dashboard/                  Vue 3 + Vite web UI (the active frontend)
+├── xiaozhi_integration/        Bridges a Xiaozhi ESP32 device to the backend over MCP
+├── docs/                       Self-hosting and architecture docs
+└── docker-compose.yaml         Top-level stack (backend + web)
+```
+
+## Architecture in one paragraph
+
+Jarvis is a `fast-agent` application. A root agent (Jarvis) delegates tool calls to a curated set of sub-agents, each backed by its own MCP servers. The spawn system lets Jarvis (or a PM agent) dynamically launch isolated agent subprocesses for parallel work. Agents communicate via an inter-agent email bus and a meeting-room protocol. Sessions, agent registry, and secrets live in SQLite under `backend/data/` (gitignored). Skills (Markdown files with YAML frontmatter) inject reusable prompts and references at runtime. See [`AGENTS.md`](AGENTS.md) for a deeper tour.
+
+## Contributing
+
+Pull requests welcome. Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening one.
+
+## Security
+
+Found a vulnerability? See [`SECURITY.md`](SECURITY.md). Please don't file public issues for security bugs.
+
+## License
+
+[MIT](LICENSE) © 2026 Phuc Nguyen Van.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+The latest release on `main` is the only actively supported version. Older tags do not receive security backports.
+
+## Reporting a Vulnerability
+
+**Do not file a public GitHub issue for security bugs.**
+
+Instead, please use [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) — open the **Security** tab of this repository and click **"Report a vulnerability"**.
+
+When reporting, include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce (or a proof-of-concept)
+- The affected version / commit SHA
+- Any suggested mitigation
+
+You should expect an initial acknowledgement within **5 business days**. If you don't hear back within that window, please follow up via the same advisory thread.
+
+## Disclosure
+
+We aim to release a fix and public advisory within **30 days** of triage. Coordinated disclosure with the reporter is preferred — credit will be given in the advisory unless you prefer to remain anonymous.
+
+## Out of scope
+
+- Issues in upstream submodules (`fast-agent`, `figma-ui-mcp`, `mcp-atlassian`) should be reported to those projects directly.
+- Self-hosting misconfiguration (e.g. exposing the backend on a public IP without authentication) — these are user responsibilities documented in [`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md).
+- API keys you commit to your own fork. Rotate them at the provider; the repo cannot help recover them.


### PR DESCRIPTION
## Summary

The `Initial commit: Omnigentx Jarvis` tree that seeded `omnigentx/jarvis` `main` is missing four root-level docs that existed in the pre-public-cleanup snapshot. The public repo needs them:

- **`README.md`** — landing page on github.com/omnigentx/jarvis. Without it, a visitor sees the file tree with no orientation.
- **`CONTRIBUTING.md`** — gates PR onboarding (dev setup, branch conventions, PR checklist, submodule policy).
- **`SECURITY.md`** — GitHub's expected vulnerability-report channel; surfaced under the repo's **Security** tab.
- **`LICENSE`** — makes the MIT terms explicit. Required for OSS reuse.

Restored verbatim from the pre-sync local snapshot, with two corrections caught during review (so the docs match reality on `main`, not the pre-cleanup state):

- **README.md / CONTRIBUTING.md**: dropped references to `frontend/` (the Flutter client). That directory was intentionally excluded from the public release, so a "deprecated frontend" mention would point at a non-existent path and confuse new contributors.
- **CONTRIBUTING.md**: `cd dashboard && npm test` doesn't resolve — there's no `test` script in `dashboard/package.json`. Replaced with the two real commands `npm run test:unit && npm run test:e2e`, matching what `.github/workflows/ci.yml` actually runs.

## Internal-link audit

- `AGENTS.md` ✓ exists on main
- `backend/ADDING_AGENT_GUIDE.md` ✓ exists on main
- `docs/SELF_HOSTING.md` ✓ exists on main

No broken links.

## Verification

Docs-only diff, but ran the full CI matrix anyway per the project rule:

- backend pytest: **690 passed, 1 skipped, 0 failed**
- vite build: **pass**
- Playwright e2e: **27 passed, 0 failed**

## Test plan

- [ ] CI all three jobs go green
- [ ] Manual: open the repo on github.com — README renders as the landing page; Security tab shows the SECURITY.md guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
