### PR TITLE
fix(cd): soft-fail Google OAuth seed when master key rotated

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -59,19 +59,19 @@ def _bootstrap_env_from_db() -> None:
                     seeded, "y" if seeded == 1 else "ies")
 
     from services import google_oauth
-    # Mirror reconcile_service_env's soft-fail above: a stale client_id/secret
-    # encrypted under a rotated master key would raise RuntimeError from
-    # config_service.get and crash the entire backend boot for a feature the
-    # user may not even use. Skip + warn instead; the user re-sets via
-    # Settings → Services when they next try Google OAuth.
-    try:
-        if google_oauth.seed_client_from_env():
-            logger.info("[BOOTSTRAP] Migrated Google OAuth client from env to DB (client_type=desktop)")
-    except RuntimeError as exc:
-        logger.warning(
+    # safe_seed_client_from_env mirrors reconcile_service_env's soft-fail:
+    # a stale client_id/secret encrypted under a rotated master key
+    # surfaces as a warning instead of crashing the whole backend boot for
+    # one optional feature. The user re-sets via Settings → Services when
+    # they next try Google OAuth.
+    seeded = google_oauth.safe_seed_client_from_env(
+        on_warn=lambda exc: logger.warning(
             "[BOOTSTRAP] Skipped Google OAuth client seed: %s. "
             "Re-set via Settings → Services to restore.", exc,
-        )
+        ),
+    )
+    if seeded:
+        logger.info("[BOOTSTRAP] Migrated Google OAuth client from env to DB (client_type=desktop)")
 
 
 _bootstrap_env_from_db()

--- a/backend/server.py
+++ b/backend/server.py
@@ -59,8 +59,19 @@ def _bootstrap_env_from_db() -> None:
                     seeded, "y" if seeded == 1 else "ies")
 
     from services import google_oauth
-    if google_oauth.seed_client_from_env():
-        logger.info("[BOOTSTRAP] Migrated Google OAuth client from env to DB (client_type=desktop)")
+    # Mirror reconcile_service_env's soft-fail above: a stale client_id/secret
+    # encrypted under a rotated master key would raise RuntimeError from
+    # config_service.get and crash the entire backend boot for a feature the
+    # user may not even use. Skip + warn instead; the user re-sets via
+    # Settings → Services when they next try Google OAuth.
+    try:
+        if google_oauth.seed_client_from_env():
+            logger.info("[BOOTSTRAP] Migrated Google OAuth client from env to DB (client_type=desktop)")
+    except RuntimeError as exc:
+        logger.warning(
+            "[BOOTSTRAP] Skipped Google OAuth client seed: %s. "
+            "Re-set via Settings → Services to restore.", exc,
+        )
 
 
 _bootstrap_env_from_db()

--- a/backend/services/google_oauth.py
+++ b/backend/services/google_oauth.py
@@ -29,7 +29,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Iterable, Literal, Optional
+from typing import Callable, Iterable, Literal, Optional
 from urllib.parse import urlencode
 
 import requests
@@ -225,6 +225,29 @@ def seed_client_from_env() -> bool:
         return False
     save_client(env_id.strip(), env_secret.strip(), "desktop")
     return True
+
+
+def safe_seed_client_from_env(
+    *, on_warn: Optional[Callable[[Exception], None]] = None,
+) -> bool:
+    """Bootstrap-safe wrapper around :func:`seed_client_from_env`.
+
+    Mirrors :func:`services.runtime_config.reconcile_service_env`'s soft-fail
+    policy: if the stored ``client_id``/``client_secret`` is encrypted under
+    a rotated master key, ``config_service.get`` raises ``RuntimeError`` —
+    swallow it here so backend boot proceeds (the user re-sets via Settings
+    when they next need Google OAuth) instead of crash-looping the whole
+    container for one optional feature.
+
+    Non-``RuntimeError`` exceptions propagate — those signal programming
+    bugs and should not be hidden.
+    """
+    try:
+        return seed_client_from_env()
+    except RuntimeError as exc:
+        if on_warn is not None:
+            on_warn(exc)
+        return False
 
 
 def load_tokens() -> Optional[GoogleOAuthTokens]:

--- a/backend/tests/test_services/test_google_oauth.py
+++ b/backend/tests/test_services/test_google_oauth.py
@@ -147,6 +147,100 @@ class TestSeedClientFromEnv:
         assert oauth_env.seed_client_from_env() is False
 
 
+class TestSafeSeedClientFromEnv:
+    """Bootstrap-safe wrapper. Prevents a stale OAuth secret encrypted under
+    a rotated master key from crash-looping the entire backend container —
+    historically caused a CD outage (PR #7) when reconcile_service_env's
+    soft-fail policy was missing from this second bootstrap call site.
+    """
+
+    def test_swallows_runtime_error_from_decrypt_fail(
+        self, oauth_env, monkeypatch,
+    ):
+        """Unit: when seed_client_from_env raises RuntimeError (the exact
+        exception type config_service.get raises on InvalidToken), the safe
+        wrapper must return False and forward the exception to on_warn —
+        not let it propagate.
+        """
+        def boom() -> bool:
+            raise RuntimeError(
+                "oauth.google/client_id: stored secret could not be decrypted "
+                "(master key rotated without re-encrypting?)"
+            )
+        monkeypatch.setattr(oauth_env, "seed_client_from_env", boom)
+
+        captured: list[Exception] = []
+        result = oauth_env.safe_seed_client_from_env(on_warn=captured.append)
+
+        assert result is False
+        assert len(captured) == 1
+        assert "could not be decrypted" in str(captured[0])
+
+    def test_pass_through_true_on_success(self, oauth_env, monkeypatch):
+        monkeypatch.setattr(oauth_env, "seed_client_from_env", lambda: True)
+        assert oauth_env.safe_seed_client_from_env() is True
+
+    def test_pass_through_false_on_no_op(self, oauth_env, monkeypatch):
+        monkeypatch.setattr(oauth_env, "seed_client_from_env", lambda: False)
+        assert oauth_env.safe_seed_client_from_env() is False
+
+    def test_does_not_swallow_non_runtime_errors(
+        self, oauth_env, monkeypatch,
+    ):
+        """Programming bugs (AttributeError, ValueError, …) must propagate.
+        Soft-fail is scoped to the InvalidToken-shaped RuntimeError only —
+        broadening it would hide real defects at boot.
+        """
+        def buggy() -> bool:
+            raise ValueError("programmer error")
+        monkeypatch.setattr(oauth_env, "seed_client_from_env", buggy)
+        with pytest.raises(ValueError, match="programmer error"):
+            oauth_env.safe_seed_client_from_env()
+
+    def test_cross_layer_real_decrypt_fail_with_rotated_key(
+        self, oauth_env, monkeypatch,
+    ):
+        """Cross-layer integration (no mock at the seed layer): write a real
+        client_id/secret encrypted with master key A, rotate to master key B,
+        then call safe_seed_client_from_env. If a future refactor narrows
+        the except clause, drops the wrapper, or changes the RuntimeError
+        type config_service.get raises, this test fails — the regression
+        gets caught BEFORE production CD crash-loops.
+
+        This is the regression that PR #7 fixed; the unit tests above mock
+        the inner layer, so a contract change between config_service and
+        google_oauth would silently bypass them.
+        """
+        # Step 1: store a real Fernet-encrypted client under master key A.
+        oauth_env.save_client("real-cid", "real-sec", "desktop")
+        assert oauth_env.load_client() is not None  # sanity
+
+        # Step 2: rotate master key. The DB row's ciphertext is now
+        # un-decryptable — config_service.get will raise RuntimeError on
+        # any read of the affected secret keys.
+        from core import auth as core_auth
+        from core import secrets_crypto
+
+        rotated_key = "rotated-master-key-yyyyy"
+        monkeypatch.setenv("JARVIS_API_KEY", rotated_key)
+        monkeypatch.setattr(core_auth, "JARVIS_API_KEY", rotated_key)
+        secrets_crypto.reload_master_key()
+
+        # Sanity: reading the secret directly really does raise. If this
+        # assertion ever stops holding, the rest of the test loses its
+        # teeth, so we assert the trigger is live.
+        with pytest.raises(RuntimeError, match="could not be decrypted"):
+            oauth_env.config_service.get("oauth.google", "client_id")
+
+        # Step 3: the wrapper must NOT raise — boot must proceed.
+        captured: list[Exception] = []
+        result = oauth_env.safe_seed_client_from_env(on_warn=captured.append)
+
+        assert result is False
+        assert len(captured) == 1
+        assert "could not be decrypted" in str(captured[0])
+
+
 class TestTokenStorage:
     def test_save_load_round_trip(self, oauth_env):
         tokens = oauth_env.GoogleOAuthTokens(


### PR DESCRIPTION
## Summary

Hot-fix for backend CD crash-looping on:

```
RuntimeError: oauth.google/client_id: stored secret could not be decrypted
(master key rotated without re-encrypting?); re-set the value via Settings
or the Setup Wizard.
```

Stack: `server.py:62` → `google_oauth.seed_client_from_env()` → `load_client()` → `_get("client_id")` → `config_service.get` raising on InvalidToken.

PR #6 already fixed this exact pattern for `reconcile_service_env` (soft-fail per-secret + warn) but missed this second call site in the same `_bootstrap_env_from_db()` function.

## Fix

Wrap the seed call in `try/except RuntimeError` and log a warning — mirrors the `reconcile_service_env` policy that PR #6 introduced. Boot proceeds; the user re-sets the OAuth client via Settings → Services when they next need Google OAuth.

Surgical: only the OAuth seed path. `JARVIS_API_KEY` restore on the line above could hit the same RuntimeError in theory, but that secret is the master key itself — failing loud there is correct (an unbooted admin path is safer than a silently-disabled API).

## Test plan

- [x] No new test — regression coverage for "decrypt-fail in bootstrap doesn't crash boot" already lives in `test_runtime_config.py::test_undecryptable_secret_does_not_crash_bootstrap`. New try/except is a 6-line block matching that exact pattern.
- [ ] Manual: redeploy CD on `felixnguyen95/jarvis-backend:latest` after merge — confirm `[BOOTSTRAP] Skipped Google OAuth client seed: …` appears in logs and `/api/health` returns 200.
- [ ] User re-sets OAuth client in Settings → Services and Google OAuth flow works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)