### PR TITLE
fix(setup): wizard mints session cookie so exit doesn't pop AuthGate

### DIFF
--- a/dashboard/src/stores/setup.js
+++ b/dashboard/src/stores/setup.js
@@ -91,6 +91,24 @@ export const useSetupStore = defineStore('setup', {
         })
         setApiKey(apiKey)
         this._applyStatus(res)
+
+        // Mint a session cookie now so the dashboard's auth.probe() at
+        // the next non-bare route resolves authenticated:true. Without
+        // this, the user finishes the wizard, navigates to /agents,
+        // and immediately hits the AuthGate modal with "session
+        // expired" — confusing UX since they just typed the key.
+        //
+        // Best-effort: if /api/auth/login is unreachable here (older
+        // backend, network blip), don't block the wizard. The
+        // dashboard will fall back to the modal which now serves as a
+        // proper recovery path. We import the auth store lazily to
+        // avoid pulling Pinia into module-init order assumptions of
+        // the setup store itself.
+        try {
+          const { useAuthStore } = await import('./auth.js')
+          await useAuthStore().login(apiKey)
+        } catch (_) { /* non-fatal */ }
+
         return res
       } catch (err) {
         this.lastSubmitError = _formatApiError(err)

--- a/dashboard/src/stores/setup.js
+++ b/dashboard/src/stores/setup.js
@@ -98,16 +98,35 @@ export const useSetupStore = defineStore('setup', {
         // and immediately hits the AuthGate modal with "session
         // expired" — confusing UX since they just typed the key.
         //
-        // Best-effort: if /api/auth/login is unreachable here (older
-        // backend, network blip), don't block the wizard. The
-        // dashboard will fall back to the modal which now serves as a
-        // proper recovery path. We import the auth store lazily to
-        // avoid pulling Pinia into module-init order assumptions of
-        // the setup store itself.
+        // Both wizard paths (typed key, "Generate" button) carry an
+        // apiKey value here: ``generateApiKey()`` runs client-side
+        // (crypto.getRandomValues), so the FE always knows the value
+        // it's sending and ``login(apiKey)`` will match against the
+        // ``apply_api_key`` the backend just performed for /setup/auth.
+        //
+        // SetupGate middleware exempts ``/api/auth/*`` (see
+        // ``backend/middleware/setup_gate.py::_ALLOWED_PREFIXES``), so
+        // calling /api/auth/login mid-wizard works even though
+        // ``overall_complete`` is still false. If a future change
+        // narrows that exemption, this call will start 503-ing and
+        // wizard users will hit the AuthGate after navigating out.
+        //
+        // Best-effort: programming-error try/catch (import failure)
+        // PLUS an explicit ok:false branch (login itself returns a
+        // structured failure for HTTP/network errors). Wizard
+        // completion is not blocked — AuthGate is the recovery path.
         try {
           const { useAuthStore } = await import('./auth.js')
-          await useAuthStore().login(apiKey)
-        } catch (_) { /* non-fatal */ }
+          const result = await useAuthStore().login(apiKey)
+          if (!result || !result.ok) {
+            console.warn(
+              '[setup] post-auth login() did not establish session:',
+              result?.status, result?.reason,
+            )
+          }
+        } catch (err) {
+          console.warn('[setup] post-auth login() threw:', err)
+        }
 
         return res
       } catch (err) {

--- a/dashboard/tests/e2e/fixtures/setup_wizard_fresh.yaml
+++ b/dashboard/tests/e2e/fixtures/setup_wizard_fresh.yaml
@@ -49,3 +49,18 @@ responses:
         - { name: "verify",      completed: false, skipped: false }
       overall_complete: false
       current_step: "llm"
+
+  # After Step 1 succeeds, submitAuth (stores/setup.js) calls
+  # POST /api/auth/login to mint a session cookie so the dashboard
+  # doesn't pop the AuthGate the moment the user navigates out of
+  # the wizard. Best-effort — wizard ignores any login() failure —
+  # but tests assert no unexpected requests, so the fixture must
+  # answer.
+  "POST /api/auth/login":
+    status: 200
+    headers:
+      set-cookie: "jarvis_csrf=fixture-csrf-xyz; Path=/; SameSite=Lax"
+    json:
+      status: "ok"
+      csrf_token: "fixture-csrf-xyz"
+      expires_in: 3600

--- a/dashboard/tests/e2e/flows/setup-wizard.spec.ts
+++ b/dashboard/tests/e2e/flows/setup-wizard.spec.ts
@@ -79,7 +79,65 @@ test('submitting a valid master key advances from Step 1 to Step 2', async ({
   // Assertion 2: URL moved to Step 2.
   await expect(page).toHaveURL(/\/setup\/llm/)
 
+  // Assertion 3: post-auth login fired so the user has a cookie before
+  // ever leaving the wizard. Without this, the dashboard's first
+  // /api/auth/whoami after wizard exit returns authenticated:false
+  // and pops the AuthGate — exactly the regression PR #11 fixes.
+  recorder.assertContains('POST', '/api/auth/login')
+
   expect(backend.unexpected.length).toBe(0)
+})
+
+test('Step 1 mints a session: navigating away no longer pops AuthGate', async ({
+  page,
+}) => {
+  // Pin the contract called out in PR #11 — wizard exit must not
+  // immediately trigger the AuthGate. Symptom on staging before the
+  // fix: user finishes Step 1, navigates to /agents, modal opens
+  // saying "session expired" even though they just typed the key.
+  //
+  // The YAML noise fixture answers /api/auth/whoami with
+  // authenticated:true unconditionally — that would let the test
+  // pass *even without* the fix. So we override that specific path
+  // with a cookie-aware handler: returns authenticated only when
+  // the jarvis_csrf cookie is present (the same cookie the login
+  // response sets). That way:
+  //   - WITH fix: Step 1 → login() fires → cookie set → whoami=true → modal hidden ✓
+  //   - WITHOUT fix: no login → no cookie → whoami=false → modal opens ✗
+  await seedApiKey(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'setup_wizard_fresh.yaml')])
+
+  // Override whoami AFTER mockBackend so this route handler wins.
+  // page.route LIFO means the most-recently-added handler runs first.
+  await page.route('**/api/auth/whoami', async (route) => {
+    const reqCookies = route.request().headers()['cookie'] || ''
+    const hasCsrf = /jarvis_csrf=/.test(reqCookies)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        authenticated: hasCsrf,
+        ...(hasCsrf ? { expires_in: 3600, abs_expires_in: 36000 } : {}),
+      }),
+    })
+  })
+
+  await page.goto('/setup/auth')
+  const KEY = 'e2e-master-key-0123456789abcdef'
+  await page.locator('#new-key').fill(KEY)
+  await page.locator('#confirm-key').fill(KEY)
+  await page.getByRole('button', { name: /continue/i }).click()
+  await expect(page).toHaveURL(/\/setup\/llm/)
+
+  // Now jump to a non-bare route. Without the fix this triggers
+  // auth.probe() against a cookie-less whoami → authenticated:false →
+  // AuthGate. With the fix the cookie is in place and the modal
+  // stays hidden.
+  await page.goto('/')
+
+  await expect(
+    page.getByRole('dialog', { name: /authentication required/i }),
+  ).toBeHidden({ timeout: 5000 })
 })
 
 test('negative control: setup already complete stays on Verify step', async ({


### PR DESCRIPTION
## Symptom

User on staging finishes the Setup Wizard, navigates to `/agents`, and immediately sees the AuthGate modal:

> Authentication required — Your session has expired. Please log in again.

…even though they typed their key seconds ago. Reported here: comment in this thread + screenshot.

## Root cause

`POST /api/setup/auth` is the wizard's bootstrap endpoint — it **sets** the API key on the backend but never mints a session cookie. The dashboard's `auth.probe()` at the next non-bare route hits `/api/auth/whoami`, sees no cookie, transitions the auth store to `UNAUTHENTICATED`, and the AuthGate opens.

The "session expired" copy is misleading on top of it (the user never had a session in the first place), but the actual UX fix is to mint a cookie at the right moment — right after the user proves they own the key.

This gap was introduced when PR #10 added the auth store but did not patch the setup-store path that completes the auth bootstrap.

## Fix

`stores/setup.js::submitAuth` — after `POST /api/setup/auth` succeeds, lazy-import the auth store and call `.login(apiKey)`. Best-effort: a failure here is non-fatal (older backend, network blip), and the AuthGate now serves as the recovery path.

Lazy import on the auth store keeps the setup store independent of Pinia init order.

`setup_wizard_fresh.yaml` E2E fixture gains a `POST /api/auth/login` mock with the same shape the real backend returns, so the existing "no unexpected requests" invariant still passes.

## Test plan

- [x] Dashboard E2E: 55 / 55 passing
- [x] Dashboard unit: 36 / 36 passing
- [x] `vite build` green
- [ ] Smoke staging: complete Setup Wizard end-to-end, navigate to `/agents`, AuthGate must NOT open

🤖 Generated with [Claude Code](https://claude.com/claude-code)