### PR TITLE
fix(deploy): proxy /ws/ to backend so hands-free voice connects

### DIFF
--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -40,6 +40,25 @@ server {
         proxy_read_timeout 300s;
     }
 
+    # Hands-free voice WebSocket. Without this block requests for
+    # /ws/voice fall through to the SPA fallback (index.html) and the
+    # browser reports "WebSocket failed to open". The Upgrade/Connection
+    # headers + HTTP/1.1 are required for nginx to perform the WS
+    # handshake; long read_timeout keeps idle hands-free sessions alive.
+    location /ws/ {
+        proxy_pass http://jarvis-backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
     # Gzip
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml;


### PR DESCRIPTION
## Summary

- Hands-free Mic on `jarvis.omnigentx.com/chat` showed `WebSocket failed to open` because the dashboard nginx had no `/ws/` location — request fell into the SPA `try_files` fallback and got `200 + index.html` instead of `101 Switching Protocols`.
- Add a `location /ws/` block with `proxy_http_version 1.1` + `Upgrade`/`Connection: upgrade` headers and 1h read/send timeouts so an idle hands-free session isn't killed by nginx's 60s default.

## Root cause (verified on prod)

```
browser → Cloudflare edge → cloudflared tunnel → 127.0.0.1:80 (jarvis_web nginx) → 127.0.0.1:8000 (jarvis_backend)
```

| Layer | curl result for `/ws/voice` |
|---|---|
| Inner nginx (port 80) — **before fix** | `HTTP/1.1 200 OK` · `Content-Type: text/html` · body = SPA `index.html` |
| Backend direct (port 8000) | `HTTP/1.1 101 Switching Protocols` · `Upgrade: websocket` · valid `Sec-WebSocket-Accept` |

→ Outer layers (Cloudflare edge, cloudflared tunnel) and backend are all fine; the only broken layer is the inner nginx.

## Test plan

- [x] `nginx -t` passes (validated against `nginx:alpine` container with stub DNS for `jarvis-backend`)
- [ ] After CD redeploy, on the server: `curl -i -H "Upgrade: websocket" -H "Connection: Upgrade" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" -H "Sec-WebSocket-Version: 13" http://127.0.0.1/ws/voice` returns `101 Switching Protocols` (not `200` + HTML)
- [ ] Open `https://jarvis.omnigentx.com/chat` → click Mic → DevTools Network shows WS request status `101` and "WebSocket failed to open" banner is gone
- [ ] Speak a sentence → partial transcripts appear → response audio plays

## Notes

- Config-only change; no unit / integration / e2e tests — the only verifier is `nginx -t` (passing) plus the post-deploy curl above.
- No outer-proxy change needed. Cloudflare orange-cloud + cloudflared tunnel pass WebSocket frames without configuration on this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)