### PR TITLE
feat: orchestrator + team + meeting stabilization (+ token tracking, inject wake, monitor v2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,9 +227,11 @@ Font:             Inter (all weights: Regular, Medium, Semi Bold, Bold)
 ### SSE Endpoints
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/agents/activity-stream` | GET | Global agent status stream (`ActivityStreamManager`) |
+| `/api/agents/activity-stream` | GET | Global agent status + `message_turn` stream (`ActivityStreamManager`) |
+| `/api/agents/{name}/messages` | GET | Initial / paginated `agent.message_history` for the v2 monitor (`?since=N`, `?limit=L`) |
+| `/api/agents/{name}/turns/{idx}/full` | GET | Untruncated PromptMessageExtended for one turn (used by "Show full") |
 | `/api/chat-stream` | POST | Chat with streaming progress (`ProgressManager` + `ToolRunnerHooks`) |
-| `/api/agents/{name}/timeline` | GET | Per-agent timeline events SSE |
+| `/api/agents/{name}/timeline` | GET | Per-agent timeline events SSE (legacy AgentDetail "Activity" tab) |
 | `/api/scheduler/stream` | GET | Cron job execution events SSE |
 
 ### SSE Event Flow (Chat)
@@ -253,10 +255,47 @@ MCP Subprocess (agent)
     → Team completion check → Notification (when all members finish)
 ```
 
+### Team Monitor v2 — message_history-driven (canonical)
+The monitor UI reads turns directly from `agent.message_history` rather
+than from synthesized `tool_call`/`tool_result`/`response` events. One
+event channel, one shape, no duplicates.
+
+```
+agent.message_history  ←  source of truth (fast-agent llm_decorator._persist_history)
+        │
+        ├─ in-process: ToolRunnerHooks.after_llm_call / after_tool_call
+        │     → services.agent_message_stream.emit_message_history_delta
+        │     → activity_stream broadcast: {event_type: "message_turn", data: {turn_idx, message}}
+        │
+        └─ subprocess: isolated_runner._install_tool_hooks
+              → emit_event("message_turn", run_id, role, turn_idx, message)
+              → SpawnProgressBridge._forward_message_turn (applies trim_message_for_stream)
+              → activity_stream broadcast (same shape)
+
+Frontend: useAgentTurns composable dedups by (agent, turn_idx) and bridges
+recentEvents → per-agent buffer. AgentTerminal.vue renders the buffer.
+```
+
+`trim_message_for_stream` caps any text block above 16 KiB, marking
+`_truncated=true` + `_full_size`. The UI fetches uncapped content from
+`/api/agents/{name}/turns/{idx}/full` when the user clicks "Show full".
+
+`tool_call`, `tool_result`, and `response` event_types are **no longer
+broadcast** on the activity-stream — they're contained within
+`message_turn`. Lifecycle events (`started`/`idle`/`error`/`thinking`/
+`agent_paused`/`agent_resumed`/`token_usage`/`agent_added`/
+`agent_removed`) stay as a separate channel.
+
+The terminal-style grid is the ONLY monitor UI — the legacy v1 card
+view was removed (see commit "feat(dashboard): TeamMonitor terminal UI
++ meeting transcript + voice"). No feature flag, no fallback.
+
 ### Rules
 - **No polling.** If you need data updates, use SSE or WebSocket.
 - SSE connections must implement exponential backoff (1s → 30s max) on disconnect.
 - Dashboard SSE reconnects on tab visibility change (`visibilitychange` event).
+- New monitor work should plug into `useAgentTurns` / `<AgentTerminal>`,
+  not synthesize parallel event types.
 
 ## Voice Architecture
 
@@ -389,7 +428,7 @@ Reference: [fast-agent Tool Runner docs](https://fast-agent.ai/agents/tool_runne
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **jarvis** (32588 symbols, 91071 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **jarvis** (35435 symbols, 99356 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **jarvis** (32588 symbols, 91071 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **jarvis** (35435 symbols, 99356 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/backend/.fast-agent/skills/project-management/SKILL.md
+++ b/backend/.fast-agent/skills/project-management/SKILL.md
@@ -51,8 +51,8 @@ Read `references/JIRA_TRACKING.md` BEFORE creating any deliverable. When delegat
 **Step 3** — Spawn agents → `spawn_team_members(roles="...", first_task="...")`
   - Include meeting_id + Jira link in `first_task` — members get everything they need
   - ⚠️ Do NOT send a separate email after spawning — `first_task` already delivers the assignment!
-**Step 4** — Join meeting, present kickoff (deliverables, structure, dependencies, DoD)
-**Step 5** — Wait for acknowledgments, then `[DECISION] VERDICT: PASS`
+**Step 4 (Speak #1, present)** — Join meeting, present kickoff (deliverables, structure, dependencies, DoD). Do NOT include `[DECISION] VERDICT:` in this speak — see *Verdict gating* below.
+**Step 5 (Speak #2, verdict)** — `wait_for_my_turn` again, read the new transcript entries, then issue `[DECISION] VERDICT: PASS — <summary>. Next actions: <list>` once any gate is met (also see below).
 
 > The meeting IS the task assignment. Use `send_email` ONLY for follow-up clarifications after the meeting, not for initial task delivery.
 
@@ -63,6 +63,25 @@ Every meeting has 2 exit conditions:
 2. ✅ Next actions defined
 
 When BOTH met → `[DECISION] VERDICT: PASS — [summary]. Next actions: [list]`
+
+### Verdict gating (load-bearing — applies to every meeting you host)
+
+The `meeting_room` server ends the meeting on the FIRST
+`[DECISION] VERDICT: PASS|RESOLVED|ESCALATE` it sees, regardless of who
+has spoken. So the contract is **two speaks**:
+
+1. **Speak #1 — present.** Agenda / deliverables / DoD. No `[DECISION]
+   VERDICT:` token anywhere in this message, not even as a self-pep.
+2. `wait_for_my_turn` again; read transcript.
+3. **Speak #2 — verdict.** Allowed once any gate below holds:
+   - Every non-PM participant has spoken or skipped, OR
+   - `current_round >= max_rounds` (force-close), OR
+   - You name the silent member(s) in the verdict body
+     (`Note: <name> did not ack — closing anyway because <reason>`).
+
+Inlining the verdict into Speak #1 closes the meeting before anyone
+else can take a turn — the transcript ends up as your monologue and
+members never confirm receipt of the brief.
 
 **Rules:**
 - Meetings = decisions, NOT doing work

--- a/backend/.fast-agent/skills/self-audit-tools/SKILL.md
+++ b/backend/.fast-agent/skills/self-audit-tools/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: self-audit-tools
+description: >
+  Protocol for an agent to audit its OWN visible toolset. Read when a task
+  asks you to "audit your tools" / "list and verify your capabilities" /
+  "self-audit". Defines what to call vs. what to only describe, the
+  markdown exchange format, and what an aggregator (PM) actually can —
+  and cannot — verify about reports from team members.
+---
+
+# Self-Audit Tools Skill
+
+When a task asks you to audit your own toolset, follow this protocol exactly.
+This skill is the **single source of truth** for self-audit; the task brief
+will not duplicate these rules, so read this in full before acting.
+
+## Capability honesty — read this first
+
+This skill is written around what each role can actually observe:
+
+| Role | Can observe | Cannot observe |
+|---|---|---|
+| Member (audit subject) | Own tool catalog, own tool-call results, own message history | Other members' tools, other members' message history |
+| Aggregator (orchestrator / PM) | Emails received, meeting transcripts, `agent_spawner__get_team_status` (high-level state per member) **AND its own toolset** | Members' tool catalogs, members' tool-call counts, anything not explicitly emailed or said in a meeting |
+| Requester (Jarvis / user) | Whatever the aggregator delivers | Same blind spots as the aggregator |
+
+That table is load-bearing. Rules below honour it — the aggregator never
+"verifies counts" of another member because it cannot. The aggregator only
+checks what is plainly present in the text it receives.
+
+## Which role are you?
+
+Answer this **first**, in your own head, before reading further:
+
+- **No team around you** (solo spawn, no PM, no peers in roster). You are
+  a *standalone member*. Run Part A and email the report to the
+  requester named in your context (Jarvis / parent agent). Part B does
+  not apply.
+- **You are a team member** (BA / SA / Dev / Designer / QE / DSO / etc.,
+  with a PM in your roster). Run Part A and email your report to the
+  PM. Do not run Part B — only the orchestrator aggregates.
+- **You are the orchestrator** (PM, role tagged `orchestrator` in the
+  template, or first spawned by `spawn_team_tool`). Run **both**
+  parts: Part A for your own toolset (no email — you are the
+  recipient), then Part B to collect member emails and produce the
+  combined roll-up that interleaves your own audit with theirs.
+
+Re-read the table above and the bullet list whenever you forget which
+half of the skill applies to you.
+
+## TL;DR (read first, act second)
+
+**As a member doing the audit:**
+
+1. Enumerate **every** tool you can see — not just the ones you happened to use.
+2. Classify each: **READ** (safe to call) vs **WRITE/DESTRUCTIVE** (do NOT call).
+3. For READ tools: call once with the safest minimal valid args. Record the
+   outcome verbatim.
+4. For WRITE/DESTRUCTIVE tools: do NOT call. Record purpose + the call shape
+   you would use, based on the tool's schema.
+5. Email the markdown report to the requester (usually PM). Use a meeting
+   only to point at the email — never paste the table into a transcript.
+6. Even if early steps fail (turn errors, ACK errors, etc.) — keep going.
+   The audit deliverable is the inventory, not the meeting choreography.
+
+**As an orchestrator (PM) running an audit round:**
+
+7. Do Part A on **your own** toolset first. Keep your inventory table
+   in memory (or save it as a workspace draft) — you do NOT email
+   yourself, you do NOT speak it in a meeting. Your audit becomes the
+   first entry in the roll-up at Step 10.
+8. Wait until `agent_spawner__get_team_status` shows all members done,
+   or a sane deadline. Collect the inbox.
+9. For each report received, do only the checks plainly observable in
+   the text: structure present, summary internally reconciles, table
+   non-empty.
+10. Concatenate **your own** audit and every member's report verbatim
+    under a single header. Name who replied and who did not. Do NOT
+    invent counts or thresholds across members.
+
+## When to apply
+
+- Brief contains "audit your tools" / "self-audit" / "list and verify tools".
+- You are asked to characterise your own capabilities.
+- This skill is **only** about *your own* tools. Do not audit other agents.
+
+---
+
+# Part A — Member protocol
+
+## Step 1 — Enumerate your tools
+
+You see every tool you can call (the tool catalog is given in your
+system context). Do not guess from role title; enumerate. List every
+tool with full canonical name (e.g. `filesystem__list_directory`,
+`github__search_repositories`, `meeting_room__speak`).
+
+**Anti-pattern:** reporting only the 2-3 tools you happened to use for
+housekeeping (ACK, leave_meeting, get_meeting_status) and calling that an
+audit. That is the meeting trace, not a tool audit.
+
+## Step 2 — Classify each tool: READ vs WRITE/DESTRUCTIVE
+
+Rule of thumb: **does calling the tool change observable state anywhere**
+(filesystem, database, external API, queue, agent memory, other agent's
+inbox)?
+
+| Class | Definition | Examples |
+|---|---|---|
+| **READ** | Returns data, no side effect | `*__list_*`, `*__get_*`, `*__search_*`, `*__read_*`, `*__status`, `*_info`, `git_log`, `git_diff`, `jira_get_issue`, `confluence_search`, `github__list_commits` |
+| **WRITE** | Creates/modifies state | `*__create_*`, `*__update_*`, `*__edit_*`, `*__write_*`, `*__send_*`, `jira_transition_issue`, `github__create_pull_request` |
+| **DESTRUCTIVE** | Deletes or otherwise non-reversible | `*__delete_*`, `git_reset --hard`, `execute(rm ...)`, `jira_delete_issue` |
+
+If the schema description is ambiguous, default to **WRITE** (safer).
+Tools named `get_*` / `list_*` / `status` are strong READ signals even
+if the description is vague.
+
+**The communication-tools paradox.** `email__send_email` and
+`meeting_room__speak` are WRITE-class — they emit observable messages.
+This does NOT mean "you cannot use them". It means: **do not call them
+as dummy audit tests** (no "audit test email", no "audit test speak").
+You may — and must — use them for their primary purpose: delivering
+the report and acknowledging meeting turns. Record them as
+`status=skipped, note="skipped: write — used for audit delivery, not test-called"`.
+
+## Step 3 — Test READ tools
+
+Call each READ tool exactly once with the safest minimal valid arguments.
+
+### Argument hygiene
+
+- Use a known-existing benign resource (e.g. `github.com/octocat/Hello-World`,
+  `https://example.com`).
+- Use `limit=1` / `per_page=1` / `start_at=0` to keep results tiny.
+- For filesystem tools, restrict to a directory you are explicitly allowed.
+  If unsure and the tool exists, call `filesystem__list_allowed_directories`
+  first to learn the safe roots.
+- Never use real production identifiers (a customer's email, an unrelated
+  Jira key).
+
+### Timeouts and hangs
+
+If a tool call does not return within ~30 seconds, stop waiting. Mark
+`status=error, note="timeout (>30s)"` and move on. One hung tool must
+not block the rest of the audit.
+
+### Restrictions like "do not read source"
+
+If your brief says "do not read source code of this repo to do the audit",
+that means: do not USE file reads as the AUDIT METHOD (inferring tool
+behaviour from source). It does **NOT** mean "skip every filesystem
+tool from the inventory". Still test the filesystem READ tools with a
+benign path (allowed workspace, `/tmp`). Only skip if the brief
+literally names a tool.
+
+### Recording the outcome
+
+For each READ call:
+- `status` = `ok` | `error`
+- `note` = the verbatim error message, or empty
+- If the error is your own bad args (validation, not-found), the *tool
+  itself* worked — mark `status=ok, note="schema works; got expected
+  validation error for synthetic args"`. Reserve `status=error` for the
+  tool genuinely failing (rate limit, server down, auth missing, timeout).
+
+## Step 4 — Document WRITE/DESTRUCTIVE tools without calling
+
+For each WRITE/DESTRUCTIVE tool:
+- `status` = `skipped`
+- `note` = one-line description of what the tool would do + the call shape.
+
+Example: `skipped: opens a PR against a remote repo; usage: github__create_pull_request({owner, repo, title, head, base, body})`.
+
+## Step 5 — Exchange format: markdown, never JSON
+
+### Per-member report (your email body)
+
+```markdown
+# Self-audit — <Your Name>
+
+Summary: **N** tools — **X** ok / **Y** skipped (write/destructive) / **Z** error.
+
+Top errors (omit this section if Z == 0):
+- `<tool name>` — <one-line reason>
+
+## Tool inventory
+
+| # | Tool | Class | Status | Note / Usage |
+|---:|---|---|---|---|
+| 1 | filesystem__list_directory | READ | ok |  |
+| 2 | filesystem__write_file | WRITE | skipped | usage: `filesystem__write_file({path, content})` |
+| 3 | github__search_repositories | READ | ok |  |
+| 4 | github__create_pull_request | WRITE | skipped | usage: `github__create_pull_request({owner, repo, title, head, base, body})` |
+| 5 | email__send_email | WRITE | skipped | used for audit delivery, not test-called |
+```
+
+(The numbers above are an illustrative shape, not a target — your real
+counts come from your real tools.)
+
+### Table rules
+
+- One row per tool, one tool per row. Do not collapse families.
+- `Tool` = full canonical name `<server>__<tool>`.
+- `Class` ∈ {READ, WRITE, DESTRUCTIVE}.
+- `Status` ∈ {ok, skipped, error}.
+- `Note / Usage` is plain text or inline code; no line breaks in a cell
+  (use ` — ` or `; `).
+- **Self-reconcile before sending:** `X + Y + Z` MUST equal `N`. This is the
+  only arithmetic check downstream (PM) can perform on your report, so
+  do it yourself first.
+
+### Sending — depends on your role
+
+| Your role | Action |
+|---|---|
+| **Team member** (BA / SA / Dev / QE / Designer / DSO …) | Email the markdown block to the orchestrator (PM). See template below. |
+| **Standalone audit subject** (no PM in roster) | Email the markdown block to the spawner / parent agent named in your context (Jarvis / user-facing agent). Your email IS the deliverable; there is no roll-up step. |
+| **Orchestrator** (PM or first-spawned) | Do NOT send an email. Keep this markdown block ready — it goes inline at the top of the Step 10 roll-up, before the member reports you collect. |
+
+For the two email-sending cases:
+
+```
+email__send_email(
+  to       = "<requester name>",   # PM if you are a member; Jarvis / parent if standalone
+  subject  = "[AUDIT] <your name> self-audit complete",
+  body     = "<the markdown block above, verbatim>",
+  priority = "normal",
+)
+```
+
+The orchestrator MUST NOT email itself, post the table into a meeting,
+or write it to a workspace file as a final deliverable — those are
+indirection paths that confuse the roll-up. The orchestrator's audit
+lives in memory (or as a workspace draft) until Step 10 concatenates
+it with the member reports.
+
+### In a concurrent meeting
+
+If a meeting is in flight (e.g. sprint review), say exactly ONE sentence
+when it is your turn:
+
+> "Self-audit complete; full report emailed to <recipient>. Summary: N tools, X ok / Y skipped / Z error."
+
+Do not paste the table. Do not narrate findings. The meeting is for
+discussion, not bulk data.
+
+## Step 6 — When the meeting flow misbehaves, keep auditing
+
+Common failures during a self-audit kickoff:
+
+| Symptom | Reason | Do this |
+|---|---|---|
+| `speak` → "Not your turn. Current speaker: X" | Race — multiple members tried to ACK at once | Wait for `MEETING_TURN` signal in your inbox; on your turn, ACK then continue. Do NOT abandon the audit. |
+| `leave_meeting` → "Cannot leave_meeting while it's your turn" | You are the current speaker | Call `speak` (or `skip_turn`) first; that advances the turn. THEN leave. |
+| Kickoff times out before your ACK | `max_rounds` reached | Skip the ACK — it's housekeeping. Continue Steps 1–5 anyway and email the report. |
+
+The audit deliverable (the inventory table) is what matters. Do not
+conflate "I had trouble with meeting_room" with "I couldn't do the audit".
+
+## Step 7 — Re-runs
+
+If the audit is re-triggered (user asks again, PM re-spawns), your new
+email REPLACES the previous one. Do not concatenate to or amend the old
+report — the aggregator will use the latest email per sender.
+
+---
+
+# Part B — Orchestrator / aggregator protocol
+
+This part is for the orchestrator (typically the PM in an agile team,
+or any agent marked `orchestrator` in the template). If you are a
+member and not the orchestrator, **skip this part entirely** — your
+deliverable is the email from Part A.
+
+**Before reading Step 8 onwards, run Part A on your own toolset.** You
+are both an audit subject and the aggregator. Keep your own inventory
+in scratch memory (or as a workspace draft markdown file); it goes
+inline at the head of the roll-up in Step 10. Do NOT send the
+`[AUDIT]` email to yourself — that would be a delivery indirection
+with no recipient.
+
+## What you can and cannot do (recap)
+
+You CAN see, plainly, in your own inbox / meeting transcripts:
+- Whether an email arrived from each member.
+- The body text of each email — including the markdown table.
+- The high-level state of each member via `agent_spawner__get_team_status`
+  (running / idle / completed / error — not tool details).
+
+You CANNOT see:
+- Any member's tool catalog.
+- Any member's tool-call history.
+- The "right" number of tools any member should have audited.
+
+Therefore your verdict is about **what arrived and whether the text
+itself is well-formed**, not about whether the numbers are objectively
+correct. There is no ground truth available to you. Do not invent one.
+
+## Step 8 — Wait for reports
+
+1. Note the spawned member list (from your own spawn call or
+   `agent_spawner__get_team_status`).
+2. Wait until `agent_spawner__get_team_status` reports every member as
+   `idle` / `completed` / `error`, OR a reasonable deadline you choose
+   for the task (e.g. 5 minutes after spawn if the audit is short).
+3. Read your inbox. Collect all `[AUDIT]`-tagged emails.
+
+If a member never replies and never goes terminal, name them in the
+roll-up as "no report received" rather than waiting forever.
+
+## Step 9 — Per-report sanity checks (text-level only)
+
+For each email received, check ONLY what is visible in the text:
+
+| Check | Pass condition | How to apply |
+|---|---|---|
+| **Structure present** | Email body has a `## Tool inventory` heading and a markdown table under it. | Plain string scan. |
+| **Table non-trivial** | The table has more than a handful of rows AND lists at least one tool whose canonical name does NOT start with `meeting_room__` or `email__`. | Plain scan. A 3-row table consisting only of meeting/email tools means the member did housekeeping and called it an audit. |
+| **Internal reconcile** | The member's own summary `X + Y + Z` equals their own `N`. | Arithmetic on numbers they themselves wrote. |
+
+These three checks are the only verdict criteria. You are not checking
+whether the agent's count is "right" — you cannot. You are checking
+that the report is shaped like an audit report and adds up to itself.
+
+## Step 10 — Produce the roll-up
+
+Emit ONE markdown document to the requester (Jarvis / user). The
+roll-up has FOUR pieces — your own audit is the first; member emails
+follow verbatim:
+
+```markdown
+# Self-audit — Team Roll-up
+
+Submissions: K of M (including yourself).
+- Replied: <list of agent names, with you marked "(orchestrator, inline)">
+- Did not reply: <list of agent names, or "none">
+
+Verdict: **PASS** / **PARTIAL** / **FAIL** — <one-sentence rationale>
+
+## Self-audit — <Your name> (orchestrator)
+
+<paste your own Part A markdown block verbatim — same shape as a
+member email body. No "[AUDIT]" subject line; you didn't email it.>
+
+## Per-member reports
+
+<for each replied member, paste their email body verbatim, prefixed by a `---` separator>
+
+## Notes (optional)
+
+<free-text observations you can plainly support from the text — e.g.
+"Member X listed 3 tools and all were meeting_room — likely did not
+enumerate properly". Skip this section if nothing notable.>
+```
+
+Count yourself in the `K of M` denominator and numerator. The Step 9
+checks (structure / non-trivial / internal reconcile) apply to your
+own audit too — apply them honestly to your own block before
+declaring the verdict.
+
+### Verdict definition (text-level only)
+
+- **PASS** if every spawned member replied AND every reply passed all
+  three Step 9 checks.
+- **PARTIAL** if some replied with passing reports and some did not
+  reply or replied with malformed/trivial reports. Name the gaps in
+  the rationale.
+- **FAIL** if the majority of members did not reply or replied with
+  malformed reports.
+
+You do NOT compute numeric thresholds across members. You do NOT
+compare any member's count to an expected toolset size. You only
+report what is plainly there.
+
+## Step 11 — Deliver and stop
+
+Send the roll-up to the requester. Do not start a new round of audit
+unless explicitly asked.
+
+---
+
+# Anti-patterns (applies to both roles)
+
+- **Member: Reporting 3 tools and calling it done.** Listing only the
+  tools you happened to use for ACK + leave is not an audit. Enumerate
+  everything.
+- **Member: Sending JSON instead of markdown.** Use the markdown table.
+- **Member: Pasting the table into a meeting.** Use email; in the meeting,
+  one sentence pointer.
+- **Member: Skipping a whole tool family because of a vague rule.**
+  "Không đọc file" does not mean skipping `list_directory` /
+  `get_file_info` / `search_files`. Re-read Step 3.
+- **Member: Test-calling WRITE tools "just to check".** Do not.
+  Describe them. The audit-delivery email is the only WRITE call you
+  are required to make.
+- **Member: Marking `error` for your own bad args.** That is `ok`
+  (schema works) — see Step 3.
+- **Member: Abandoning audit because meeting turns misbehaved.** The
+  audit is the deliverable; meeting choreography is noise.
+- **PM / Orchestrator: Inventing counts or thresholds across members.**
+  You have no ground truth for any member's full toolset. Step 9 is
+  your entire verdict toolbox.
+- **PM / Orchestrator: Rubber-stamping PASS just because emails arrived.**
+  Apply the three Step 9 checks. A 3-row meeting-only table is FAIL.
+- **PM / Orchestrator: Re-computing or "correcting" a member's numbers.**
+  Their table, their numbers. You report them verbatim.
+- **PM / Orchestrator: Waiting indefinitely for a non-responder.**
+  Mark them as "no report received" and ship the partial roll-up.
+- **PM / Orchestrator: Skipping your own audit.** You are also an audit
+  subject. Run Part A on yourself, inline the result in Step 10. Do
+  NOT email yourself, do NOT list yourself as "did not reply" because
+  you didn't email.
+- **PM / Orchestrator: Emailing yourself the audit.** Self-addressed
+  emails clutter the inbox and confuse the Step 9 reconcile. Your
+  audit lives inline in the roll-up; the inbox is for member emails
+  only.
+
+# Definition of done
+
+**Member is done when:**
+1. Enumerated every tool visible.
+2. Tested every READ tool exactly once (or marked timeout).
+3. Recorded every WRITE/DESTRUCTIVE tool with `skipped` + usage shape.
+4. Summary `X + Y + Z` equals `N` (self-reconcile).
+5. Emailed the markdown report to the requester.
+6. (If in a meeting) posted a one-sentence pointer to the email.
+
+**Orchestrator (PM) is done when:**
+1. Ran Part A on own toolset — own inventory block ready (not emailed).
+2. Every spawned member is terminal or the deadline passed.
+3. Each received email passed (or failed) Step 9 checks.
+4. The roll-up document was delivered to the requester with Submissions
+   (counting self), Verdict, the orchestrator's own inventory inline,
+   and verbatim per-member reports.
+5. No counts were invented across members; no member's numbers were
+   altered.
+
+If any step is missing, say so honestly. Do not declare PASS to close
+the loop.

--- a/backend/core/agent_registry_db.py
+++ b/backend/core/agent_registry_db.py
@@ -407,7 +407,16 @@ class AgentRegistryDB:
             return json.loads(row["data_json"]) if row else None
 
     def list_team_sessions(self) -> list[dict]:
-        """List all team sessions ordered by session_id descending."""
+        """List all team sessions ordered by session_id descending.
+
+        Note: read-side helper. Single source of truth for the
+        ``team_sessions`` table is ``fast_agent.spawn.registry_backends.
+        TeamSessionStore`` — write/delete operations should go through
+        ``fast_agent.spawn.team_spawner.delete_team_session`` /
+        ``delete_team_sessions_by_team_name`` so callers see one canonical
+        deletion path. ``team_spawner`` itself reads SQLite on every
+        access (no in-memory cache).
+        """
         with _connect() as conn:
             rows = conn.execute(
                 "SELECT data_json FROM team_sessions ORDER BY session_id DESC"

--- a/backend/routes/agent_timeline.py
+++ b/backend/routes/agent_timeline.py
@@ -77,11 +77,16 @@ def _load_meetings() -> list[dict]:
             state = json.loads(r["state_json"]) if r["state_json"] else {}
             mid = r["meeting_id"]
 
+            # config_json: write-once setup (agenda, description, created_by,
+            # created_at). state_json: ALL mutable fields, including
+            # participants, max_rounds, turn pointers (post-B1). Fall back
+            # to config_json for legacy rows written before the refactor.
             meetings.append({
                 "meeting_id": mid,
                 "agenda": config.get("agenda", ""),
-                "participants": config.get("participants", []),
-                "max_rounds": config.get("max_rounds"),
+                "description": config.get("description", ""),
+                "participants": state.get("participants") or config.get("participants", []),
+                "max_rounds": state.get("max_rounds") or config.get("max_rounds"),
                 "created_by": config.get("created_by", ""),
                 "created_at": r["created_at"],
                 "outcome": state.get("outcome"),
@@ -90,6 +95,7 @@ def _load_meetings() -> list[dict]:
                 "joined": state.get("joined", []),
                 "current_round": state.get("current_round"),
                 "current_turn": state.get("current_turn", 0),
+                "turn_started_at": state.get("turn_started_at"),
                 "transcript": transcripts.get(mid, []),
             })
     except Exception as e:

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -21,8 +21,62 @@ from agent import fast
 import time as _time
 
 
+def _fetch_latest_snapshots_batch(
+    agent_names: list[str], snapshots_db_path: str | None,
+) -> dict[str, tuple[str | None, float | None]]:
+    """Batch-fetch the latest snapshot ``(trigger, created_at)`` for every
+    agent name in one SQLite query.
+
+    Replaces per-agent ``SELECT ... WHERE agent_name = ?`` with a single
+    ``WHERE agent_name IN (...)`` + ``GROUP BY``. For a 30-agent roster
+    this drops 30 round-trips to 1. Returns a dict keyed by agent_name;
+    missing entries means the agent has no snapshot yet.
+
+    Empty list short-circuits to ``{}`` — caller doesn't have to check.
+    """
+    out: dict[str, tuple[str | None, float | None]] = {}
+    if not agent_names or not snapshots_db_path:
+        return out
+    # Deduplicate while preserving names — the SQL parameter list grows
+    # quadratically if the caller passes the same name twice.
+    unique_names = list(dict.fromkeys(agent_names))
+    placeholders = ",".join("?" for _ in unique_names)
+    try:
+        with sqlite3.connect(snapshots_db_path, timeout=0.5) as conn:
+            # ``ROWID`` (an alias for the auto-increment id) breaks ties
+            # in ``created_at`` and is always strictly increasing per
+            # insert, so taking MAX(id) per agent gives us the freshest
+            # snapshot deterministically without needing a window
+            # function (which isn't available in older SQLite builds).
+            rows = conn.execute(
+                f"SELECT s.agent_name, s.trigger, s.created_at "
+                f"FROM agent_context_snapshots s "
+                f"JOIN (SELECT agent_name, MAX(id) AS max_id "
+                f"      FROM agent_context_snapshots "
+                f"      WHERE agent_name IN ({placeholders}) "
+                f"      GROUP BY agent_name) latest "
+                f"ON s.agent_name = latest.agent_name "
+                f"AND s.id = latest.max_id",
+                unique_names,
+            ).fetchall()
+            for agent_name, trigger, created_at in rows:
+                try:
+                    ts = float(created_at) if created_at is not None else None
+                except (TypeError, ValueError):
+                    ts = None
+                out[agent_name] = (trigger, ts)
+    except sqlite3.Error:
+        # Probe failure is non-fatal — caller falls back to raw status.
+        # Single batch failure is preferable to N per-agent failures
+        # logged separately.
+        pass
+    return out
+
+
 def _compute_effective_status(
-    record: dict, *, snapshots_db_path: str | None = None,
+    record: dict, *,
+    snapshots_db_path: str | None = None,
+    snapshot_cache: dict[str, tuple[str | None, float | None]] | None = None,
 ) -> str:
     """Derive effective status from multi-signal evidence.
 
@@ -108,9 +162,18 @@ def _compute_effective_status(
 
     # Latest snapshot — trigger + created_at, written directly by the
     # subprocess to SQLite (independent of bridge health).
+    #
+    # Prefer the pre-fetched batch dict (one query for the whole roster
+    # via ``_fetch_latest_snapshots_batch``) over a per-agent SELECT.
+    # Per-agent fallback is kept for direct callers that don't go
+    # through ``list_agents`` (tests, debug endpoints).
     latest_trigger: str | None = None
     snapshot_ts: float | None = None
-    if snapshots_db_path:
+    if snapshot_cache is not None:
+        cached = snapshot_cache.get(agent_name)
+        if cached is not None:
+            latest_trigger, snapshot_ts = cached
+    elif snapshots_db_path:
         try:
             with sqlite3.connect(snapshots_db_path, timeout=0.5) as conn:
                 row = conn.execute(
@@ -551,12 +614,27 @@ async def list_agents(include_completed: bool = False):
         # re-running Path.resolve() per agent.
         _snap_db = _snapshots_db_path()
 
+        # Batch-fetch the latest snapshot for every agent in ONE query
+        # instead of one query per agent. For an N-agent roster this
+        # cuts SQLite round-trips from N to 1 — important once teams
+        # grow past ~10 agents (incident scale: 7-agent retro audit
+        # used to fan out 7 selects per ``/agents`` poll).
+        _all_names = [
+            r.get("agent_name") or r.get("role") or ""
+            for _, r in seen_names.values()
+        ]
+        _snapshot_cache = _fetch_latest_snapshots_batch(_all_names, _snap_db)
+
         for run_id, record in seen_names.values():
             agent_name = record.get("agent_name", record.get("role", "agent"))
             # Multi-signal status (channel sock + snapshot trigger) instead
             # of trusting the bridge-fed DB field alone. See
             # ``_compute_effective_status`` for the decision tree.
-            status = _compute_effective_status(record, snapshots_db_path=_snap_db)
+            status = _compute_effective_status(
+                record,
+                snapshots_db_path=_snap_db,
+                snapshot_cache=_snapshot_cache,
+            )
 
             role = record.get("role", "")
             icon = "smart_toy"
@@ -1240,6 +1318,17 @@ async def delete_team(team_name: str):
         from core.database import NotificationModel, get_db_session
         db = get_db_session()
         try:
+            # ⚠️ JSON SPACING IS LOAD-BEARING (matches writer in
+            # ``spawn_progress_bridge._create_team_notification``).
+            # ``json.dumps()`` default emits ``"key": "value"`` with a
+            # space after the colon. These ``LIKE %...%`` substring
+            # filters depend on that exact spacing. If the writer ever
+            # switches to ``separators=(',', ':')`` this filter silently
+            # matches nothing → cascade cleanup breaks → next re-spawn
+            # of same team_name hits stale notification → dedupe blocks
+            # the new completion notification.
+            # Proper migration path: SQLite's ``json_extract()`` on the
+            # metadata_json column — see GH issue for that work.
             q = db.query(NotificationModel).filter(
                 NotificationModel.metadata_json.contains('"source": "team_completion"'),
             )

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -7,6 +7,7 @@ Activities are persisted in SQLite and streamed via SSE.
 import os
 import re
 import logging
+import sqlite3
 from pathlib import Path
 
 import json as _json
@@ -18,6 +19,158 @@ from pydantic import BaseModel
 from core.auth import verify_api_key
 from agent import fast
 import time as _time
+
+
+def _compute_effective_status(
+    record: dict, *, snapshots_db_path: str | None = None,
+) -> str:
+    """Derive effective status from multi-signal evidence.
+
+    Background (the 2026-05-11 ``running``-stuck-forever UI bug):
+    ``spawn_registry.status`` is updated only via the spawn-event bridge
+    socket. If that socket dies (R1/R2 race, subprocess SIGKILL'd before
+    emitting final event), the DB value can be frozen at ``running``
+    indefinitely while the agent has actually exited or gone idle.
+
+    Instead of trusting the single bridge-fed field, cross-check with:
+
+    * **Channel sock probe** — file present + connect-test succeeds ⇒
+      subprocess is alive (sitting in keep-alive ``listen()``).
+    * **Latest agent snapshot** — the subprocess writes its
+      ``trigger`` (``task_complete`` / ``idle`` / ``error``) and
+      ``created_at`` DIRECTLY to SQLite, bypassing the bridge entirely.
+      That is our most trustworthy "what is the agent actually doing"
+      signal.
+    * **``record.last_active_at``** — the bridge updates this on every
+      thinking/tool_call/tool_result/response event. Compared against
+      the snapshot's ``created_at`` it tells us whether the latest idle
+      snapshot is fresh or stale-from-a-prior-turn.
+
+    All values returned are members of the canonical ``SpawnStatus``
+    set used by the bridge and startup cleanup
+    (``mark_stale_running``) so consumers do not see novel values.
+    Decision tree (only overrides the mutable states ``running`` /
+    ``starting`` / ``resumed`` / ``idle`` / ``pending`` / ``unknown`` —
+    terminal states like ``completed`` / ``error`` / ``paused`` are
+    trusted as-is):
+
+    Channel alive (subprocess in keep-alive):
+      * snapshot trigger ∈ {task_complete, idle} AND
+        snapshot.created_at >= record.last_active_at  → ``idle``
+        (subprocess wrote the idle snapshot AFTER its last bridge-
+        relayed activity event ⇒ genuinely idle now, not mid-turn).
+      * Otherwise → keep raw (likely mid-LLM call: prior idle snapshot
+        is stale relative to current activity).
+
+    Channel dead (subprocess exited):
+      * trigger = ``error`` → ``error``.
+      * trigger ∈ {task_complete, idle}:
+          - lifecycle ``oneshot`` → ``completed`` (one-and-done done).
+          - lifecycle ``resumable`` / missing → ``idle``. The agent is
+            hibernating: ``auto_wake_if_idle`` respawns it from snapshot
+            on the next inbound message. This matches the canonical
+            rule already enforced by ``spawn_progress_bridge`` (live
+            ``result`` event) and ``mark_stale_running`` (startup
+            cleanup) — see those for the same ``"idle" if lifecycle ==
+            "resumable" else "completed"`` pattern.
+      * No snapshot trigger → keep raw. Could be the spawn race window
+        (channel not yet bound, no snapshot yet) or a true crash with
+        no terminal event. Without snapshot evidence we cannot
+        distinguish; ``mark_stale_running`` will flip to idle/completed
+        on the next backend restart.
+
+    Probe exception → keep raw (don't invent a state from a failed
+    probe).
+    """
+    raw = (record.get("status") or "unknown")
+    # Terminal / overlay states are authoritative — never second-guess.
+    if raw in {"completed", "error", "killed", "failed", "cancelled",
+               "paused", "timeout"}:
+        return raw
+    # Anything outside the mutable set is unknown to the helper — defer
+    # to whatever the writer chose.
+    if raw not in {"running", "starting", "resumed", "idle", "pending",
+                   "unknown"}:
+        return raw
+
+    agent_name = record.get("agent_name") or record.get("role") or ""
+    if not agent_name:
+        return raw
+
+    # Probe channel liveness via connect (not just file-stat — orphan
+    # sock files from SIGKILL'd processes would otherwise lie).
+    channel_alive: bool | None
+    try:
+        from fast_agent.spawn.agent_channel import AgentChannel
+        channel_alive = AgentChannel.is_alive(agent_name)
+    except Exception:
+        channel_alive = None
+
+    # Latest snapshot — trigger + created_at, written directly by the
+    # subprocess to SQLite (independent of bridge health).
+    latest_trigger: str | None = None
+    snapshot_ts: float | None = None
+    if snapshots_db_path:
+        try:
+            with sqlite3.connect(snapshots_db_path, timeout=0.5) as conn:
+                row = conn.execute(
+                    "SELECT trigger, created_at FROM agent_context_snapshots "
+                    "WHERE agent_name = ? ORDER BY created_at DESC "
+                    "LIMIT 1",
+                    (agent_name,),
+                ).fetchone()
+                if row:
+                    latest_trigger = row[0]
+                    try:
+                        snapshot_ts = float(row[1]) if row[1] is not None else None
+                    except (TypeError, ValueError):
+                        snapshot_ts = None
+        except sqlite3.Error:
+            pass
+
+    lifecycle = (record.get("lifecycle") or "").lower()
+
+    if channel_alive is True:
+        if latest_trigger in {"task_complete", "idle"}:
+            # Disambiguate "fresh idle" from "stale snapshot during
+            # active turn". The bridge bumps ``last_active_at`` on every
+            # LLM-side event; the subprocess writes the idle snapshot
+            # AT THE END of a turn. If the snapshot is newer than the
+            # last activity event we know the subprocess has settled.
+            last_active = record.get("last_active_at") or 0.0
+            try:
+                last_active = float(last_active)
+            except (TypeError, ValueError):
+                last_active = 0.0
+            if snapshot_ts is None or snapshot_ts >= last_active:
+                return "idle"
+        # No fresh-idle evidence → trust raw (likely mid-LLM-call).
+        return raw
+
+    if channel_alive is False:
+        if latest_trigger == "error":
+            return "error"
+        if latest_trigger in {"task_complete", "idle"}:
+            # Canonical rule (matches spawn_progress_bridge + mark_stale_running):
+            # resumable agents go idle (respawnable); oneshot complete for good.
+            return "completed" if lifecycle == "oneshot" else "idle"
+        # Channel dead AND no snapshot evidence. Two indistinguishable
+        # scenarios — fresh-spawn race (channel about to bind) vs.
+        # silent crash. Trust raw; backend-restart cleanup will reconcile.
+        return raw
+
+    # Probe inconclusive (exception).
+    return raw
+
+
+def _snapshots_db_path() -> str | None:
+    """Resolve the path to the SQLite DB that holds ``agent_context_snapshots``.
+
+    Uses the same env var the spawn registry uses so both sides agree.
+    """
+    p = os.environ.get("SPAWN_REGISTRY_DB", "data/jarvis.db")
+    full = Path(p).resolve()
+    return str(full) if full.exists() else None
 
 
 _default_model_cache: str | None = None
@@ -394,10 +547,17 @@ async def list_agents(include_completed: bool = False):
             
             seen_names[agent_name] = (best_run_id, best_record)
         
+        # Resolve snapshot DB path once for the whole loop — avoids
+        # re-running Path.resolve() per agent.
+        _snap_db = _snapshots_db_path()
+
         for run_id, record in seen_names.values():
             agent_name = record.get("agent_name", record.get("role", "agent"))
-            status = record.get("status", "unknown")
-            
+            # Multi-signal status (channel sock + snapshot trigger) instead
+            # of trusting the bridge-fed DB field alone. See
+            # ``_compute_effective_status`` for the decision tree.
+            status = _compute_effective_status(record, snapshots_db_path=_snap_db)
+
             role = record.get("role", "")
             icon = "smart_toy"
             if "PM" in role:
@@ -987,20 +1147,22 @@ async def delete_team(team_name: str):
         raise HTTPException(status_code=404, detail=f"Team '{team_name}' not found")
     
     workspaces_root = project_root / ".runtime" / "data" / "workspaces"
-    
-    # ── 3. Scan session JSON files to find matching session_ids by team_name ──
-    # Session files store team_name inside JSON. Workspace dirs use template name
-    # (e.g. "agile-team_{sid}") not team_name, so we must scan session content.
-    sessions_dir = workspaces_root / "team_sessions"
-    if sessions_dir.is_dir():
-        for session_file in sessions_dir.glob("*.json"):
-            try:
-                session_data = _json.loads(session_file.read_text())
-                if session_data.get("team_name") == team_name:
-                    session_ids.add(session_file.stem)
-            except Exception:
-                continue
-    
+
+    # ── 3. Find session_ids that belong to this team (SoT = TeamSessionStore) ──
+    # Workspace dirs use template name (e.g. "agile-team_{sid}") not team_name,
+    # so we must look up sessions by team_name from the canonical store. The
+    # ``team_sessions`` data lives in SQLite (fast-agent's TeamSessionStore);
+    # there is no filesystem JSON copy any more — earlier versions of this
+    # route scanned a non-existent ``workspaces/team_sessions/*.json`` dir,
+    # which always matched zero files and silently leaked rows.
+    try:
+        from fast_agent.spawn.team_spawner import list_team_sessions as _list_team_sessions
+        for sess in _list_team_sessions():
+            if sess.get("team_name") == team_name and sess.get("session_id"):
+                session_ids.add(sess["session_id"])
+    except Exception as e:
+        logger.warning("[AGENTS API] team_sessions lookup error: %s", e)
+
     # ── 4. Remove workspace dirs (match by session_id suffix, not team_name) ──
     # Dirs are named "{template}_{session_id}", e.g. "agile-team_6d85b825"
     if workspaces_root.is_dir():
@@ -1028,16 +1190,26 @@ async def delete_team(team_name: str):
                 except Exception as e:
                     logger.warning("Failed to remove messages %s: %s", msg_dir, e)
     
-    # ── 6. Remove team session files ──
-    if sessions_dir.is_dir():
-        for sid in session_ids:
-            session_file = sessions_dir / f"{sid}.json"
-            if session_file.exists():
-                try:
-                    session_file.unlink()
-                    cleanup_log.append(f"session {sid}.json")
-                except Exception as e:
-                    logger.warning("Failed to remove session file %s: %s", session_file, e)
+    # ── 6. Drop team sessions from the canonical SoT ──
+    # Single owner of ``team_sessions`` (SQLite + in-memory cache) is
+    # ``fast_agent.spawn.team_spawner``. Going through its public delete
+    # function keeps the cache consistent with the row write — direct
+    # SQL from this route would leave the cached TeamSession objects
+    # stale, which used to surface as "Jarvis spawned a team that
+    # immediately self-resumed an orphan session" (incident 2026-05-10).
+    try:
+        from fast_agent.spawn.team_spawner import (
+            delete_team_session as _ts_delete,
+            delete_team_sessions_by_team_name as _ts_delete_by_name,
+        )
+        ts_deleted = sum(1 for sid in session_ids if _ts_delete(sid))
+        # Belt-and-braces: catch sessions that weren't in the resolved
+        # ``session_ids`` set but carry our team_name in their stored data.
+        ts_deleted += _ts_delete_by_name(team_name)
+        if ts_deleted:
+            cleanup_log.append(f"{ts_deleted} team_session(s)")
+    except Exception as e:
+        logger.warning("[AGENTS API] team_sessions cleanup error: %s", e)
     
     # ── 7. Clean up DB activities ──
     try:
@@ -1055,7 +1227,40 @@ async def delete_team(team_name: str):
             db.close()
     except Exception:
         pass
-    
+
+    # ── 7b. Clean up team_completion notifications ──
+    # Without this, a stale notification keyed on the team_name lingers
+    # in /notifications even after the user deletes the team — and
+    # blocks the dedupe of the next team that reuses the same name.
+    # (See 2026-05-14 toolset-self-audit incident.) We match both
+    # ``team_name`` (covers pre-2026-05-14 rows that lack session_id)
+    # and the resolved ``session_ids`` (covers post-fix rows that key
+    # dedupe by session).
+    try:
+        from core.database import NotificationModel, get_db_session
+        db = get_db_session()
+        try:
+            q = db.query(NotificationModel).filter(
+                NotificationModel.metadata_json.contains('"source": "team_completion"'),
+            )
+            patterns = [f'"team_name": "{team_name}"']
+            patterns.extend(f'"session_id": "{sid}"' for sid in session_ids)
+            from sqlalchemy import or_
+            q = q.filter(
+                or_(*(NotificationModel.metadata_json.contains(p) for p in patterns))
+            )
+            n_dropped = q.delete(synchronize_session=False)
+            db.commit()
+            if n_dropped:
+                cleanup_log.append(f"{n_dropped} notification(s)")
+        except Exception as e:
+            db.rollback()
+            logger.warning("[AGENTS API] notification cleanup error: %s", e)
+        finally:
+            db.close()
+    except Exception:
+        pass
+
     # (Context snapshots cleaned by lifecycle hook in spawn_progress_bridge._handle_removal)
     
     # ── 8. Remove agent card files ──
@@ -1111,6 +1316,45 @@ async def list_all_skills():
 
 
 # ─── Agent Activity Endpoints ─────────────────────────────────────────────────────
+
+
+@router.get("/{name}/messages", dependencies=[Depends(verify_api_key)])
+async def get_agent_messages(name: str, since: int = 0, limit: int = 200):
+    """Return PromptMessageExtended turns from agent.message_history.
+
+    Source of truth for the Team Monitor v2 UI. Each turn is one item:
+    ``{turn_idx, role, message: <PromptMessageExtended dump>}``.
+    Large text blocks are truncated — use ``/turns/{turn_idx}/full`` for
+    untruncated content when the user expands a turn.
+
+    Query params:
+      ``since`` — first turn_idx to include (used for delta fetch on
+                  reconnect; clients pass the highest turn_idx they have).
+      ``limit`` — cap on returned turns (latest ``limit`` if history is
+                  longer). Default 200; clamped to a sane range.
+    """
+    from services.agent_message_stream import list_agent_messages
+
+    if limit <= 0 or limit > 500:
+        limit = 200
+    return list_agent_messages(name, since=max(0, since), limit=limit)
+
+
+@router.get("/{name}/turns/{turn_idx}/full", dependencies=[Depends(verify_api_key)])
+async def get_agent_turn_full(name: str, turn_idx: int):
+    """Return the untruncated PromptMessageExtended for one turn.
+
+    Called when a user clicks "Show full" on a truncated content block.
+    """
+    from services.agent_message_stream import get_agent_turn_full as _get_full
+
+    result = _get_full(name, turn_idx)
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Turn {turn_idx} not found for agent '{name}'",
+        )
+    return result
 
 
 @router.get("/activities/recent", dependencies=[Depends(verify_api_key)])

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -209,9 +209,16 @@ def _prepare_audio_url(book_id, tts_text, base_url=""):
 @router.post("/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest, raw_request: Request = None, _=Depends(verify_api_key)):
     from services.shared_state import agent_app
+    from services.sse_progress import current_run_id
     _t0 = _time.time()
     _msg_preview = request.message[:80] + "..." if len(request.message) > 80 else request.message
     logger.info(f'[REQUEST] POST /chat cid={request.conversation_id} msg="{_msg_preview}"')
+    # Tag this call's token rows with a fresh run_id so the dashboard can
+    # correlate them back to this request. Without setting the ContextVar
+    # the always-on token-persistence hook would still write rows, just
+    # without correlation. See ``services/sse_progress.py``.
+    _run_id = f"chat-{uuid.uuid4().hex[:8]}"
+    _run_token = current_run_id.set(_run_id)
     try:
         raw_response, cid = await session_service.resume_and_send(
             agent_app, request.message, request.conversation_id
@@ -247,6 +254,8 @@ async def chat(request: ChatRequest, raw_request: Request = None, _=Depends(veri
         _duration = _time.time() - _t0
         logger.error(f"[RESPONSE] POST /chat duration={_duration:.1f}s status=error: {e}", exc_info=True)
         return ChatResponse(response=f"Error: {str(e)}")
+    finally:
+        current_run_id.reset(_run_token)
 
 
 @router.post("/chat-stream")
@@ -346,26 +355,31 @@ async def chat_stream(raw_request: Request, _=Depends(verify_api_key)):
         _state.spawn_bridge.set_request_id(request_id)
 
     async def run_chat():
+        # Tag every LLM call this request makes with ``request_id`` so the
+        # always-on token-persistence hook (attached at app startup) can
+        # write rows the dashboard can correlate back to this request.
+        from services.sse_progress import current_run_id
+        _run_token = current_run_id.set(request_id)
         try:
             original_hooks = {}
             progress_hooks = create_progress_hooks(request_id, session_id=conversation_id)
-            
+
             # Merge pause hooks for in-process agents
             from services.pause_manager import pause_manager
-            
+
             for name, agent in agent_app._agents.items():
                 original_hooks[name] = getattr(agent, 'tool_runner_hooks', None)
                 existing = original_hooks[name]
-                
+
                 # Create pause hooks for this agent
                 pause_hooks = pause_manager.create_pause_hooks(name)
                 combined = merge_hooks(progress_hooks, pause_hooks)
-                
+
                 if existing:
                     agent.tool_runner_hooks = merge_hooks(existing, combined)
                 else:
                     agent.tool_runner_hooks = combined
-            
+
             try:
                 # Expose conversation_id so spawn tools can auto-capture it
                 _state.current_conversation_id = conversation_id
@@ -475,7 +489,7 @@ async def chat_stream(raw_request: Request, _=Depends(verify_api_key)):
             _duration = _time.time() - _t0
             logger.error(f"[RESPONSE] POST /chat-stream duration={_duration:.1f}s status=error: {e}", exc_info=True)
             progress_manager.push(request_id, "error", {"message": str(e)})
-            
+
             # Broadcast idle even on error so dashboard cards don't stay "Running"
             try:
                 from services.activity_stream import activity_stream_manager
@@ -489,7 +503,9 @@ async def chat_stream(raw_request: Request, _=Depends(verify_api_key)):
                     })
             except Exception:
                 pass
-    
+        finally:
+            current_run_id.reset(_run_token)
+
     asyncio.create_task(run_chat())
     
     async def event_generator():

--- a/backend/routes/inject.py
+++ b/backend/routes/inject.py
@@ -203,6 +203,41 @@ async def _inject_via_message_bus(
 
         logger.info("[INJECT] MessageBus: Dashboard → %s (queued)", agent_name)
 
+        # ── Wake agent NOW so it picks up the inbox message immediately ──
+        # Without this, the agent only sees the message on the next
+        # ``before_llm_call`` hook tick — which never fires if the agent
+        # is idle with no active tool loop. Result: the inject sits in
+        # the inbox forever and the dashboard sees no activity. Path B
+        # and Path C both kick off a fresh LLM call as part of their
+        # flow; Path A relies on the alive agent's inbox watcher, so we
+        # MUST send an explicit ``wake`` signal here for parity.
+        try:
+            from fast_agent.spawn.servers._team_helpers import auto_wake_if_idle
+            auto_wake_if_idle(agent_name)
+        except Exception as _wake_exc:
+            # Wake is best-effort — failure here doesn't fail the inject
+            # itself (the message is already in the inbox). Log loudly so
+            # we notice when the wake path regresses.
+            logger.warning(
+                "[INJECT] MessageBus: auto_wake_if_idle(%s) failed: %s. "
+                "Message is queued in inbox but agent will not start "
+                "processing until next external trigger.",
+                agent_name, _wake_exc,
+            )
+
+        # ── Broadcast ``started`` so the dashboard reflects active state ──
+        # Mirrors Path B (resume) and Path C (generate) which already do
+        # this. Without it, ``agent.status`` stays as ``idle`` until the
+        # spawned agent emits its first ``thinking`` / ``tool_call`` /
+        # ``message_turn`` event — a multi-second gap where the user
+        # sees no feedback after clicking submit.
+        activity_stream_manager.broadcast({
+            "event_type": "started",
+            "agent_name": agent_name,
+            "message": f"Processing inject: {message[:60]}{'…' if len(message) > 60 else ''}",
+            "timestamp": time.time(),
+        })
+
         return InjectResponse(
             status="queued",
             agent_name=agent_name,
@@ -319,6 +354,10 @@ async def _inject_via_generate(
         progress_hooks = create_progress_hooks(request_id)
 
         from services.pause_manager import pause_manager
+        # Tag every LLM call inside this inject with ``request_id`` so the
+        # always-on token-persistence hook can correlate token_usage rows.
+        from services.sse_progress import current_run_id
+        _run_token = current_run_id.set(request_id)
 
         for name, ag in agent_app._agents.items():
             original_hooks[name] = getattr(ag, 'tool_runner_hooks', None)
@@ -339,6 +378,7 @@ async def _inject_via_generate(
             for name, ag in agent_app._agents.items():
                 original = original_hooks.get(name)
                 ag.tool_runner_hooks = original if original else None
+            current_run_id.reset(_run_token)
 
         file_count = len(files_data) if files_data else 0
         logger.info(

--- a/backend/routes/inject.py
+++ b/backend/routes/inject.py
@@ -203,6 +203,22 @@ async def _inject_via_message_bus(
 
         logger.info("[INJECT] MessageBus: Dashboard → %s (queued)", agent_name)
 
+        # ── KNOWN GAP: token rows for this inject's LLM calls will carry
+        # an empty ``run_id`` (no correlation back to this request). See
+        # https://github.com/omnigentx/jarvis/issues/17.
+        #
+        # Why: setting ``current_run_id`` ContextVar here is useless. The
+        # LLM call that processes this inject fires in a DIFFERENT
+        # asyncio task — the alive agent's inbox-watcher loop running
+        # inside the spawned subprocess. ContextVar values don't
+        # propagate across that task boundary.
+        #
+        # The token hook still writes its row (with empty run_id) rather
+        # than silently dropping the LLM call. Dashboard per-conversation
+        # cost will be inaccurate for Path A injects until issue #17
+        # ships a proper fix (MessageBus context_meta → InboxWatcherHook
+        # → ContextVar bridging).
+
         # ── Wake agent NOW so it picks up the inbox message immediately ──
         # Without this, the agent only sees the message on the next
         # ``before_llm_call`` hook tick — which never fires if the agent

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -433,6 +433,13 @@ async def voice_ws(ws: WebSocket) -> None:
             progress_manager.create(req_id)
             progress_hooks = create_progress_hooks(req_id, session_id=session_id)
 
+            # Tag every LLM call this turn makes with req_id so the
+            # always-on token-persistence hook can correlate token_usage
+            # rows back to this voice turn. ContextVar is asyncio-aware:
+            # parallel turns on different sockets see their own values.
+            from services.sse_progress import current_run_id
+            _run_token = current_run_id.set(req_id)
+
             # Snapshot original hooks so we can restore even if the task is
             # cancelled mid-turn. We also remember the *exact* hook object
             # we attached so the restore step can detect when a newer
@@ -479,6 +486,7 @@ async def voice_ws(ws: WebSocket) -> None:
                 except (asyncio.CancelledError, Exception):
                     pass
                 progress_manager.remove(req_id)
+                current_run_id.reset(_run_token)
 
             # Cancellation absorbed by fast-agent: the OpenAI provider
             # (and likely others) catches ``asyncio.CancelledError`` from

--- a/backend/server.py
+++ b/backend/server.py
@@ -112,7 +112,10 @@ async def lifespan(app: FastAPI):
     event_socket_server = None
     try:
         from services.spawn_progress_bridge import SpawnProgressBridge
-        from services.spawn_event_socket import SpawnEventSocketServer
+        from services.spawn_event_socket import (
+            SpawnEventSocketServer,
+            _BackendAlreadyRunning,
+        )
         from services.sse_progress import progress_manager
         from core.agent_registry_db import AgentRegistryDB
 
@@ -126,9 +129,26 @@ async def lifespan(app: FastAPI):
         # Start Unix domain socket server for receiving events from MCP subprocesses
         socket_path = str(Path(".runtime/state/spawn_events.sock").resolve())
         event_socket_server = SpawnEventSocketServer(socket_path, state.spawn_bridge)
-        await event_socket_server.start()
+        try:
+            await event_socket_server.start()
+        except _BackendAlreadyRunning as exc:
+            # Single-instance enforcement: another backend already owns
+            # the spawn event socket. Refuse to continue — without the
+            # bridge, every spawned subprocess will emit events into the
+            # void (status updates lost, UI shows "running" forever).
+            # Fail loud so the operator notices instead of silently
+            # degrading to the broken state that motivated this fix.
+            logger.error(
+                "ABORT: %s\n"
+                "Hint: lsof -nP -iTCP:8000 -sTCP:LISTEN  (find live backend)\n"
+                "      pgrep -fa 'uvicorn server:app'    (find all uvicorn)\n",
+                exc,
+            )
+            raise SystemExit(2) from exc
         os.environ["SPAWN_EVENT_SOCKET"] = socket_path
         logger.info("Spawn event socket ready: %s", socket_path)
+    except SystemExit:
+        raise
     except Exception as e:
         logger.warning("Failed to start spawn event socket: %s", e)
 
@@ -393,16 +413,42 @@ async def lifespan(app: FastAPI):
     async with fast.run() as agent:
         state.agent_app = agent
         logger.info("FastAgent initialized.")
-        
+
+        # ── Always-on token-persistence hook ──────────────────
+        # Attached BEFORE the cron scheduler is wired so any
+        # scheduled agent_turn fired in the milliseconds between
+        # ``set_agent_refs`` and the loop's first tick still gets
+        # its tokens persisted. Callers (chat / voice / inject /
+        # cron) only need to set the ``current_run_id`` ContextVar
+        # around their send call — the hook reads it at LLM-call
+        # time. This is the single source of truth for token
+        # tracking on in-process agents; team-spawn subprocesses
+        # have their own emit_event path (see isolated_runner +
+        # spawn_progress_bridge._handle_token_usage).
+        try:
+            from services.sse_progress import attach_token_persistence_hooks_to_all
+            _n_hooked = attach_token_persistence_hooks_to_all(agent)
+            logger.info("[TOKEN] Default token-persistence hook attached to %d agent(s)", _n_hooked)
+        except Exception as _e:
+            logger.warning("[TOKEN] Failed to attach default token hook: %s", _e, exc_info=True)
+
         # Wire CronScheduler agent references (for agent_turn execution)
         if state.cron_scheduler:
             state.cron_scheduler.set_agent_refs(agent, state.session_service)
-        
+
         # Pre-load dynamic agent cards and attach to Jarvis
         from services.dynamic_agents import preload_agent_cards, signal_reload_loop
         loaded = await preload_agent_cards(agent)
         if loaded:
             logger.info("Dynamic agents ready: %s", loaded)
+            # Newly preloaded dynamic agents also need the token hook.
+            # ``attach_token_persistence_hooks_to_all`` is idempotent
+            # (per-agent sentinel) so re-running is safe.
+            try:
+                from services.sse_progress import attach_token_persistence_hooks_to_all
+                attach_token_persistence_hooks_to_all(agent)
+            except Exception as _e:
+                logger.warning("[TOKEN] Failed to re-attach hook after preload: %s", _e)
         
         # Start reload loop for hot-loading agent card changes
         reload_task = asyncio.create_task(signal_reload_loop(agent))

--- a/backend/services/agent_message_stream.py
+++ b/backend/services/agent_message_stream.py
@@ -1,0 +1,328 @@
+"""Stream agent.message_history deltas as `message_turn` SSE events.
+
+Source of truth for the Team Monitor v2 UI. Each turn an LLM/tool call
+appends to ``agent.message_history`` (maintained by fast-agent at
+``llm_decorator._persist_history``), this module forwards the new
+``PromptMessageExtended`` (one event per turn) to the activity stream.
+
+Each agent object carries a small integer cursor so we know what's new.
+Large text blocks (assistant content, tool_results) are truncated for
+the live event; the UI fetches the full payload on demand from
+``GET /api/agents/{name}/turns/{turn_idx}/full`` (see ``routes/agents``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Per-agent cursor lives on the agent object so it survives across
+# request-scoped hook factory recreations.
+HISTORY_CURSOR_ATTR = "_message_stream_cursor"
+
+# Cap a single text block at 16 KiB so a 140 KiB serpapi blob doesn't
+# blow up SSE chunk size or the browser DOM. UI fetches full content
+# via the per-turn endpoint when the user clicks "Show full".
+MAX_BLOCK_TEXT_BYTES = 16 * 1024
+
+# Per-agent ring buffer of broadcast turns. We must keep our own copy
+# because some agents (e.g. ``FinanceAgent`` invoked via Jarvis's
+# ``agent__FinanceAgent`` tool) run on a CLONE that is discarded after
+# the call — see ``agents_as_tools_agent._invoke_child_agent``. The
+# persistent ``agent_app._agents[name]`` template never observes those
+# turns, so a page-load fetch of ``/messages`` would otherwise return
+# empty even though events were broadcast live moments earlier.
+#
+# Keys are normalized agent names (e.g. ``FinanceAgent``, not
+# ``FinanceAgent[1]``). Values are full untruncated PromptMessageExtended
+# dumps in turn_idx order (no gaps within one run; later runs reset
+# turn_idx to 0 and overwrite earlier entries). Capped so memory stays
+# bounded across many runs.
+_RECENT_TURNS_PER_AGENT_CAP = 200
+_recent_turns: dict[str, list[dict]] = {}
+
+
+def _truncate_block(block: Any) -> Any:
+    """Truncate a content block in place if its text exceeds the cap.
+
+    Pydantic-dumped blocks are plain dicts. Non-text blocks (image, etc.)
+    are returned unchanged.
+    """
+    if not isinstance(block, dict):
+        return block
+    text = block.get("text")
+    if not isinstance(text, str):
+        return block
+    encoded = text.encode("utf-8", errors="ignore")
+    if len(encoded) <= MAX_BLOCK_TEXT_BYTES:
+        return block
+    block["text"] = encoded[:MAX_BLOCK_TEXT_BYTES].decode("utf-8", errors="ignore")
+    block["_truncated"] = True
+    block["_full_size"] = len(encoded)
+    return block
+
+
+def trim_message_for_stream(payload: dict) -> dict:
+    """Mutate ``payload`` in place to cap large text blocks. Returns it.
+
+    Applies to: top-level ``content`` blocks, plus each
+    ``tool_results[*].content`` block. ``tool_calls`` arguments are left
+    alone (they're parameters, normally small; redaction is the caller's
+    job).
+    """
+    for block in payload.get("content") or []:
+        _truncate_block(block)
+
+    for _tid, result in (payload.get("tool_results") or {}).items():
+        if not isinstance(result, dict):
+            continue
+        for block in result.get("content") or []:
+            _truncate_block(block)
+
+    return payload
+
+
+def _record_recent_turn(agent_name: str, turn_idx: int, full_payload: dict) -> None:
+    """Cache the FULL (untruncated) turn dump in the per-agent ring buffer.
+
+    Keeps the latest ``_RECENT_TURNS_PER_AGENT_CAP`` entries. Replaces by
+    turn_idx so re-runs (turn_idx resets to 0) overwrite earlier slots.
+    """
+    bucket = _recent_turns.get(agent_name)
+    if bucket is None:
+        bucket = []
+        _recent_turns[agent_name] = bucket
+    # Replace existing slot if present, else insert in sorted order.
+    for i, existing in enumerate(bucket):
+        if existing.get("turn_idx") == turn_idx:
+            bucket[i] = {"turn_idx": turn_idx, "message": full_payload}
+            return
+    bucket.append({"turn_idx": turn_idx, "message": full_payload})
+    # Bound size — drop oldest when above cap.
+    if len(bucket) > _RECENT_TURNS_PER_AGENT_CAP:
+        del bucket[: len(bucket) - _RECENT_TURNS_PER_AGENT_CAP]
+
+
+def get_recent_turns(agent_name: str) -> list[dict]:
+    """Return cached turns for an agent (read-only snapshot)."""
+    return list(_recent_turns.get(agent_name) or [])
+
+
+def reset_recent_turns(agent_name: str | None = None) -> None:
+    """Test helper: clear the cache (one agent or all)."""
+    if agent_name is None:
+        _recent_turns.clear()
+    else:
+        _recent_turns.pop(agent_name, None)
+
+
+def emit_message_history_delta(agent, agent_name: str, run_id: str | None) -> int:
+    """Broadcast each new ``PromptMessageExtended`` in ``agent.message_history``.
+
+    Returns the number of turns emitted (useful for tests/observability).
+    Resets cursor to 0 if history was cleared (e.g. /clear command) —
+    new turns are emitted starting at 0 again.
+    """
+    try:
+        history = list(agent.message_history)
+    except Exception as exc:
+        logger.debug("[message_stream] history not accessible on %s: %s", agent_name, exc)
+        return 0
+
+    cursor = getattr(agent, HISTORY_CURSOR_ATTR, 0)
+    if cursor > len(history):
+        cursor = 0  # history was cleared
+
+    if cursor >= len(history):
+        return 0
+
+    # Lazy import to avoid circular dependency at module load.
+    from services.activity_stream import activity_stream_manager
+
+    emitted = 0
+    for idx in range(cursor, len(history)):
+        msg = history[idx]
+        try:
+            full = msg.model_dump(mode="json", exclude_none=True)
+        except Exception as exc:
+            logger.warning(
+                "[message_stream] model_dump failed for %s turn %d: %s",
+                agent_name, idx, exc,
+            )
+            continue
+
+        # Cache the FULL (untruncated) payload so the read endpoints
+        # ``/messages`` and ``/turns/{idx}/full`` can still serve it
+        # after the live agent (often a discarded clone) goes away.
+        _record_recent_turn(agent_name, idx, full)
+
+        # The broadcast version is trimmed for SSE size.
+        # ``trim_message_for_stream`` mutates a copy so the cache stays full.
+        trimmed = trim_message_for_stream(json.loads(json.dumps(full)))
+
+        activity_stream_manager.broadcast({
+            "agent_name": agent_name,
+            "event_type": "message_turn",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "data": {
+                "turn_idx": idx,
+                "role": trimmed.get("role"),
+                "message": trimmed,
+            },
+        })
+        emitted += 1
+
+    setattr(agent, HISTORY_CURSOR_ATTR, len(history))
+    return emitted
+
+
+# ── Read-side helpers used by the messages REST endpoints ──
+
+
+def _resolve_agent_history(agent_name: str) -> list:
+    """Return the agent's PromptMessageExtended list, live or from snapshot.
+
+    Resolution order:
+      1. Live AgentApp runtime (``state.agent_app``) — in-process agents,
+         freshest data including the turn that just completed.
+      2. Latest ``agent_context_snapshots`` row — subprocess agents and
+         in-process agents that have shut down.
+    Returns ``[]`` if neither source has data.
+    """
+    # 1. Live in-process agent
+    try:
+        import services.shared_state as state
+
+        agent_app = getattr(state, "agent_app", None)
+        if agent_app is not None:
+            agents_map = getattr(agent_app, "_agents", None) or {}
+            agent = agents_map.get(agent_name)
+            if agent is not None and hasattr(agent, "message_history"):
+                try:
+                    return list(agent.message_history)
+                except Exception as exc:
+                    logger.debug(
+                        "[message_stream] live history read failed for %s: %s",
+                        agent_name, exc,
+                    )
+    except Exception as exc:
+        logger.debug("[message_stream] runtime lookup failed: %s", exc)
+
+    # 2. Persisted snapshot (covers subprocess agents)
+    try:
+        from services.context_persistence import load_latest_context
+
+        snapshot = load_latest_context(agent_name)
+        if snapshot:
+            return list(snapshot)
+    except Exception as exc:
+        logger.debug("[message_stream] snapshot read failed for %s: %s", agent_name, exc)
+
+    return []
+
+
+def list_agent_messages(
+    agent_name: str,
+    *,
+    since: int = 0,
+    limit: int = 200,
+) -> dict:
+    """Return ``{turns: [{turn_idx, message}, ...], total: N}`` with trimming applied.
+
+    Resolution order:
+      1. Live ``agent.message_history`` if non-empty (covers persistent agents
+         that own their history — Jarvis, etc.)
+      2. The ``_recent_turns`` cache populated by ``emit_message_history_delta``
+         (covers ephemeral clones — e.g. ``agent__FinanceAgent`` invocations).
+      3. Latest ``agent_context_snapshots`` row (covers subprocess agents).
+
+    ``since`` is the first turn_idx to include (delta fetch on reconnect).
+    ``limit`` caps the number of turns returned (latest ``limit`` if the
+    history is longer than ``since + limit``).
+    """
+    if since < 0:
+        since = 0
+
+    # 1. Live agent.message_history
+    history = _resolve_agent_history(agent_name)
+    if history:
+        total = len(history)
+        if since >= total:
+            return {"turns": [], "total": total}
+        end = total
+        start = max(since, end - limit) if limit > 0 else since
+        turns: list[dict] = []
+        for idx in range(start, end):
+            msg = history[idx]
+            try:
+                payload = msg.model_dump(mode="json", exclude_none=True)
+            except Exception as exc:
+                logger.warning(
+                    "[message_stream] model_dump failed for %s turn %d: %s",
+                    agent_name, idx, exc,
+                )
+                continue
+            turns.append({
+                "turn_idx": idx,
+                "role": payload.get("role"),
+                "message": trim_message_for_stream(payload),
+            })
+        return {"turns": turns, "total": total, "start": start}
+
+    # 2. Recent broadcast cache — used when the live agent is a discarded clone
+    cached = get_recent_turns(agent_name)
+    if cached:
+        # cached entries are sorted by insertion order; sort by turn_idx to
+        # be safe against out-of-order replacements.
+        cached_sorted = sorted(cached, key=lambda t: t.get("turn_idx", 0))
+        total = (cached_sorted[-1].get("turn_idx", -1) + 1) if cached_sorted else 0
+        # Filter by since
+        filtered = [t for t in cached_sorted if t.get("turn_idx", -1) >= since]
+        if limit > 0 and len(filtered) > limit:
+            filtered = filtered[-limit:]
+        out_turns = []
+        for t in filtered:
+            payload = json.loads(json.dumps(t["message"]))  # copy before trim
+            out_turns.append({
+                "turn_idx": t["turn_idx"],
+                "role": payload.get("role"),
+                "message": trim_message_for_stream(payload),
+            })
+        start = out_turns[0]["turn_idx"] if out_turns else since
+        return {"turns": out_turns, "total": total, "start": start}
+
+    return {"turns": [], "total": 0}
+
+
+def get_agent_turn_full(agent_name: str, turn_idx: int) -> dict | None:
+    """Return the untruncated PromptMessageExtended dump for a single turn.
+
+    Reads cache first (covers clones), then live agent (covers persistent
+    agents and subprocess snapshots). Returns ``None`` if the turn doesn't
+    exist anywhere.
+    """
+    # Try cache first — same reasoning as list_agent_messages.
+    for entry in get_recent_turns(agent_name):
+        if entry.get("turn_idx") == turn_idx:
+            return {"turn_idx": turn_idx, "message": entry["message"]}
+
+    history = _resolve_agent_history(agent_name)
+    if turn_idx < 0 or turn_idx >= len(history):
+        return None
+    msg = history[turn_idx]
+    try:
+        return {
+            "turn_idx": turn_idx,
+            "message": msg.model_dump(mode="json", exclude_none=True),
+        }
+    except Exception as exc:
+        logger.warning(
+            "[message_stream] full dump failed for %s turn %d: %s",
+            agent_name, turn_idx, exc,
+        )
+        return None

--- a/backend/services/context_persistence.py
+++ b/backend/services/context_persistence.py
@@ -143,17 +143,94 @@ async def save_agent_context(
                 trigger, time.time(),
             ),
         )
-        conn.commit()
         snapshot_id = cursor.lastrowid
+
+        # Mirror the last assistant text into spawn_registry.result so
+        # consumers (team-completion notification, get_team_result) have
+        # a single source of truth without re-reading snapshot JSON.
+        # Resumable agents never hit isolated_spawner's update_status path
+        # after the first turn, so this hook is the only place that keeps
+        # `result` fresh across multi-turn lifetimes.
+        final_text = _extract_last_assistant_text(messages)
+        if final_text:
+            _update_spawn_registry_result(conn, run_id, final_text)
+
+        conn.commit()
         conn.close()
         logger.info(
-            "[CONTEXT] Saved %s: %d messages, trigger=%s, id=%d, size=%.0fKB",
-            resolved_name, len(messages), trigger, snapshot_id, context_size / 1024,
+            "[CONTEXT] Saved %s: %d messages, trigger=%s, id=%d, size=%.0fKB, "
+            "result_chars=%d",
+            resolved_name, len(messages), trigger, snapshot_id,
+            context_size / 1024, len(final_text),
         )
         return snapshot_id
     except Exception as exc:
         logger.error("[CONTEXT] DB write failed: %s — %s", resolved_name, exc, exc_info=True)
         return None
+
+
+def _extract_last_assistant_text(messages: list) -> str:
+    """Return concatenated text of the last assistant turn that has any
+    non-empty text content. Empty string if no such turn exists.
+
+    Used by ``save_agent_context`` to keep ``spawn_registry.result`` in
+    sync with the agent's actual final answer per turn, so notification
+    + ``get_team_result`` consumers can rely on a single field.
+    """
+    for msg in reversed(messages):
+        role = getattr(msg, "role", None)
+        if role != "assistant":
+            continue
+        parts: list[str] = []
+        for block in (getattr(msg, "content", None) or []):
+            if getattr(block, "type", None) == "text":
+                text = getattr(block, "text", "") or ""
+                if text.strip():
+                    parts.append(text)
+        body = "\n".join(parts).strip()
+        if body:
+            return body
+    return ""
+
+
+def _update_spawn_registry_result(
+    conn: sqlite3.Connection, run_id: str, result_text: str
+) -> None:
+    """Merge-upsert ``result`` into ``spawn_registry.data_json`` for run_id.
+
+    Preserves every other field already written by spawner/bridge —
+    we only overlay ``result`` + ``result_updated_at``. If the row does
+    not exist yet (race: snapshot saved before registry insert), this
+    is a no-op rather than creating a half-populated record; the next
+    turn will succeed once the spawner has written the row.
+    """
+    # spawn_registry is created by SqliteBackend in the spawner; this
+    # IF NOT EXISTS keeps the read defensive when the snapshot fires
+    # before the spawner has touched the table at all.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS spawn_registry (
+            run_id TEXT PRIMARY KEY,
+            data_json TEXT NOT NULL
+        )"""
+    )
+    row = conn.execute(
+        "SELECT data_json FROM spawn_registry WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+    if not row:
+        logger.warning(
+            "[CONTEXT] spawn_registry row missing for run_id=%s — "
+            "result not mirrored (will retry on next turn)",
+            run_id,
+        )
+        return
+    data = json.loads(row[0])
+    data["result"] = result_text
+    data["result_updated_at"] = time.time()
+    conn.execute(
+        "INSERT OR REPLACE INTO spawn_registry (run_id, data_json) VALUES (?, ?)",
+        (run_id, json.dumps(data, ensure_ascii=False)),
+    )
 
 
 def load_latest_context(

--- a/backend/services/cron_scheduler.py
+++ b/backend/services/cron_scheduler.py
@@ -364,6 +364,15 @@ class CronScheduler:
 
         logger.info("[CRON] Agent turn: '%s' → agent=%s payload='%s'", job.name, agent_name, payload[:80])
 
+        # Tag every LLM call this turn makes with a deterministic run_id
+        # so the dashboard can correlate ``token_usage`` rows back to the
+        # cron run. The always-on token-persistence hook (attached at app
+        # startup) reads this ContextVar at call time. Without setting
+        # it, rows would still be written but un-correlated.
+        from services.sse_progress import current_run_id
+        run_id = f"cron-{job.id}-{uuid.uuid4().hex[:8]}"
+        _run_token = current_run_id.set(run_id)
+
         try:
             # ``agent_name`` MUST flow through to resume_and_send. Without
             # it the call defaults to Jarvis and the configured target
@@ -401,6 +410,8 @@ class CronScheduler:
             return result
         except Exception as e:
             raise RuntimeError(f"Agent turn failed for '{agent_name}': {e}") from e
+        finally:
+            current_run_id.reset(_run_token)
 
     # ─── Lunar Calendar ───────────────────────────────────
 

--- a/backend/services/dynamic_agents.py
+++ b/backend/services/dynamic_agents.py
@@ -68,6 +68,15 @@ async def signal_reload_loop(agent_app):
                     str(AGENT_CARDS_DIR), "Jarvis"
                 )
                 logger.info("[DYNAMIC] ✓ Reloaded agents: %s", loaded)
+                # Newly loaded agents need the always-on token-persistence
+                # hook attached too — without this their LLM calls would
+                # silently bypass token_usage tracking. Idempotent per
+                # agent via the sentinel attribute set inside the helper.
+                try:
+                    from services.sse_progress import attach_token_persistence_hooks_to_all
+                    attach_token_persistence_hooks_to_all(agent_app)
+                except Exception as _e:
+                    logger.warning("[DYNAMIC] Failed to re-attach token hook after reload: %s", _e)
             except Exception as e:
                 logger.error("[DYNAMIC] Reload failed: %s", e)
 

--- a/backend/services/inject_resume.py
+++ b/backend/services/inject_resume.py
@@ -228,9 +228,9 @@ def _create_bridge_display(bridge: Any) -> Any:
     events from the child subprocess need to reach SpawnProgressBridge.
     Instead of going through the Unix socket, we forward in-process.
     """
-    from fast_agent.spawn.spawn_display import DisplayManager
+    from fast_agent.spawn.spawn_display import SpawnDisplayManager
 
-    dm = DisplayManager()
+    dm = SpawnDisplayManager()
 
     def _forward_to_bridge(event: Any) -> None:
         """Convert SpawnEvent → JSON line → bridge.process_event()."""

--- a/backend/services/pause_manager.py
+++ b/backend/services/pause_manager.py
@@ -194,13 +194,18 @@ class PauseManager:
         except Exception as e:
             logger.warning("[PAUSE] Failed to broadcast state change: %s", e)
 
-        # Update spawn_records DB
+        # Update spawn_records DB.
+        # Use find_by_name (not list_running) — list_running filters status to
+        # ('running', 'pending') so on the resume path the agent's row (still
+        # marked 'paused' from the previous pause call) is excluded → upsert
+        # is skipped → DB status stays 'paused' forever after resume. Mirrors
+        # the same fix already applied to ``_find_pid`` (see line 164).
         try:
             import services.shared_state as _state
             if _state.registry_db:
-                records = _state.registry_db.list_running()
+                records = _state.registry_db.find_by_name(agent_name)
                 for rec in records:
-                    if rec.get("agent_name") == agent_name and rec.get("run_id"):
+                    if rec.get("run_id"):
                         db_status = "paused" if new_state == "paused" else "running"
                         _state.registry_db.upsert_record(
                             rec["run_id"],

--- a/backend/services/spawn_event_socket.py
+++ b/backend/services/spawn_event_socket.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import socket
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -27,6 +29,12 @@ if TYPE_CHECKING:
     from services.spawn_progress_bridge import SpawnProgressBridge
 
 logger = logging.getLogger("spawn_activity")
+
+
+class _BackendAlreadyRunning(RuntimeError):
+    """Raised when start() finds a healthy live socket — another backend
+    is already serving on this path. Refuse to clobber it.
+    """
 
 
 class SpawnEventSocketServer:
@@ -45,13 +53,48 @@ class SpawnEventSocketServer:
         self._bridge = bridge
         self._server: asyncio.AbstractServer | None = None
         self._client_count = 0
+        # Inode of the file we bound at start() — stop() compares before
+        # unlinking, so we never wipe another backend's freshly-bound file.
+        # (See ROOT_CAUSE: 4 concurrent backends silently wiping each
+        # other's sock file, leaving all clients unable to connect.)
+        self._bound_inode: int | None = None
 
     async def start(self) -> None:
-        """Create and start the Unix domain socket server."""
-        # Clean up stale socket file from previous run
+        """Create and start the Unix domain socket server.
+
+        Ownership-aware startup:
+          1. If the path has no existing file → bind directly.
+          2. If a file exists, probe-connect to it.
+             - Connect succeeds → another live backend owns it. Raise
+               ``_BackendAlreadyRunning`` instead of silently clobbering.
+             - Connect fails → file is stale (previous backend exited
+               without ``stop()``). Unlink and bind fresh.
+
+        This prevents the previous "everyone unlinks blindly" pattern
+        where ``start()`` of backend N would wipe the file that backend
+        N-1 was actively listening on, orphaning every subprocess that
+        had already connected to N-1.
+        """
         socket_file = Path(self._socket_path)
-        socket_file.unlink(missing_ok=True)
         socket_file.parent.mkdir(parents=True, exist_ok=True)
+
+        if socket_file.exists():
+            if _is_socket_alive(self._socket_path):
+                raise _BackendAlreadyRunning(
+                    f"Another backend is already listening on "
+                    f"{self._socket_path}. Refusing to bind. Stop the "
+                    f"existing instance first, or check for zombie "
+                    f"uvicorn processes (lsof -nP -iTCP:8000 -sTCP:LISTEN)."
+                )
+            # File exists but no one is listening → stale, safe to remove.
+            logger.warning(
+                "[SOCKET] Removing stale socket file (no listener): %s",
+                self._socket_path,
+            )
+            try:
+                socket_file.unlink()
+            except OSError as exc:
+                logger.warning("[SOCKET] Failed to unlink stale: %s", exc)
 
         self._server = await asyncio.start_unix_server(
             self._handle_client,
@@ -60,7 +103,23 @@ class SpawnEventSocketServer:
             # skills + tool definitions), exceeding the default 64KB limit.
             limit=4 * 1024 * 1024,  # 4MB
         )
-        logger.info("[SOCKET] Listening on %s", self._socket_path)
+
+        # Record the inode we just bound. ``stop()`` uses this to decide
+        # whether to unlink — if a *different* inode is at the path on
+        # shutdown, a peer backend has taken over and we must not wipe it.
+        try:
+            self._bound_inode = os.stat(self._socket_path).st_ino
+        except OSError as exc:
+            logger.warning(
+                "[SOCKET] Could not record inode for %s: %s",
+                self._socket_path, exc,
+            )
+            self._bound_inode = None
+
+        logger.info(
+            "[SOCKET] Listening on %s (inode=%s)",
+            self._socket_path, self._bound_inode,
+        )
 
     async def _handle_client(
         self,
@@ -112,11 +171,80 @@ class SpawnEventSocketServer:
             logger.info("[SOCKET] Client #%d disconnected (processed %d events)", client_id, event_count)
 
     async def stop(self) -> None:
-        """Stop the socket server and clean up."""
+        """Stop the socket server and clean up.
+
+        Inode-guarded unlink: only remove the file if it matches the
+        inode recorded at start(). If a peer backend has bound a new
+        file at the same path while we were running, the inode will
+        differ — leave their file alone.
+
+        Without this guard, the previous "unlink unconditional" pattern
+        meant any backend's shutdown could erase a newer backend's live
+        socket, breaking every client that had connected to the newer
+        instance.
+        """
         if self._server:
             self._server.close()
             await self._server.wait_closed()
             self._server = None
             logger.info("[SOCKET] Server stopped")
 
-        Path(self._socket_path).unlink(missing_ok=True)
+        if self._bound_inode is None:
+            # Never bound, or inode wasn't recorded — leave the path
+            # alone to be safe. Better to leak a sock file than to
+            # delete someone else's.
+            return
+
+        try:
+            current_inode = os.stat(self._socket_path).st_ino
+        except FileNotFoundError:
+            return  # Nothing to clean up.
+        except OSError as exc:
+            logger.warning("[SOCKET] stat() failed for %s: %s",
+                           self._socket_path, exc)
+            return
+
+        if current_inode != self._bound_inode:
+            logger.warning(
+                "[SOCKET] Skip unlink — path %s now owned by a different "
+                "backend (inode %s != ours %s).",
+                self._socket_path, current_inode, self._bound_inode,
+            )
+            return
+
+        try:
+            Path(self._socket_path).unlink()
+            logger.info("[SOCKET] Cleaned up own sock file (inode=%s)",
+                        self._bound_inode)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("[SOCKET] unlink failed: %s", exc)
+
+
+def _is_socket_alive(path: str, timeout: float = 0.5) -> bool:
+    """Probe-connect to a Unix socket. Returns True iff some process is
+    actively accepting connections on the given path.
+
+    Used by ``start()`` to distinguish a stale socket file (previous
+    backend exited without cleanup) from a live one (another backend
+    instance is currently running).
+    """
+    if not Path(path).exists():
+        return False
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    try:
+        s.connect(path)
+        return True
+    except (ConnectionRefusedError, FileNotFoundError):
+        return False
+    except OSError:
+        # Includes ENOENT (race after exists() check), ECONNREFUSED
+        # variants, and ENOTSOCK if path is a regular file.
+        return False
+    finally:
+        try:
+            s.close()
+        except OSError:
+            pass

--- a/backend/services/spawn_progress_bridge.py
+++ b/backend/services/spawn_progress_bridge.py
@@ -173,17 +173,54 @@ class SpawnProgressBridge:
             "[SPAWN] [%s] %s | %s",
             agent_name,
             event_type_str,
-            json.dumps(data, ensure_ascii=False, default=str),
+            json.dumps(data, ensure_ascii=False, default=str)[:500],
         )
 
-        # 2. Persist to agent_activities DB (always, regardless of active request)
+        # 1b. message_turn — forward directly to activity stream after trimming
+        # large content blocks. Source-of-truth shape comes from the subprocess
+        # ``child_agent.message_history``; we don't synthesize anything here.
+        if event_type_str == "message_turn":
+            self._forward_message_turn(agent_name, data, event_data)
+            return
+
+        # 2. Persist to agent_activities DB (always, regardless of active request).
+        # Kept for the legacy AgentDetail "Activity" tab and audit log; no
+        # current monitor UI reads it as primary source.
         self._persist_activity(agent_name, event_type_str, data, event_data)
 
-        # 3. Broadcast via ActivityStreamManager (global SSE for monitoring)
-        self._broadcast_activity(agent_name, event_type_str, data, event_data)
+        # 3. Broadcast via ActivityStreamManager (global SSE for monitoring).
+        # tool_call / tool_result / response are intentionally NOT broadcast —
+        # the message_turn channel (handled at top of this function) is the
+        # canonical source for those. We still broadcast lifecycle events
+        # (started/idle/error/agent_paused/agent_resumed/...) and "thinking"
+        # so the running-status pulse appears between turns.
+        if event_type_str not in {"tool_call", "tool_result", "response"}:
+            self._broadcast_activity(agent_name, event_type_str, data, event_data)
 
         # 4. Upsert spawn_records on lifecycle events
         self._upsert_spawn_record(agent_name, event_type_str, data, event_data)
+
+        # 4·R2. Refresh ``last_active_at`` whenever the agent does
+        # something concrete (LLM call or tool round-trip). Lets
+        # ``get_team_status`` distinguish "agent X stuck for 60s" from
+        # "agent X actively working" — the visibility gap that left PM
+        # in incident b61af7db idling out after seeing identical
+        # ``running`` snapshots.
+        if (
+            run_id
+            and self._registry_db
+            and event_type_str in {"thinking", "response", "tool_call", "tool_result"}
+        ):
+            try:
+                import time as _time
+                self._registry_db.upsert_record(
+                    run_id, {"last_active_at": _time.time()}
+                )
+            except Exception as _exc:
+                logger.debug(
+                    "[REGISTRY] last_active_at update failed for %s: %s",
+                    agent_name, _exc,
+                )
 
         # 4a. Check team completion — notify when ALL team agents are done
         if event_type_str in ("result", "idle", "agent_completed"):
@@ -320,6 +357,49 @@ class SpawnProgressBridge:
                 db.close()
         except Exception as e:
             logger.warning("Could not import DB for activity persistence: %s", e)
+
+    def _forward_message_turn(self, agent_name: str, data: dict, raw: dict) -> None:
+        """Forward a subprocess ``message_turn`` event to the activity stream.
+
+        The subprocess sends the FULL PromptMessageExtended dump; we cache
+        that full payload, then apply truncation before broadcasting so
+        SSE chunks stay reasonable on the wire. The cache lets the
+        ``/messages`` and ``/turns/{idx}/full`` endpoints serve the
+        agent's history after the subprocess exits — same dual-track
+        contract used for in-process clones.
+        """
+        try:
+            import json as _json
+            import time
+            from services.activity_stream import activity_stream_manager
+            from services.agent_message_stream import (
+                trim_message_for_stream,
+                _record_recent_turn,
+            )
+
+            full = data.get("message") or {}
+            turn_idx = data.get("turn_idx")
+            if isinstance(turn_idx, int):
+                _record_recent_turn(agent_name, turn_idx, full)
+
+            try:
+                trimmed = trim_message_for_stream(_json.loads(_json.dumps(full)))
+            except Exception:
+                trimmed = full
+
+            activity_stream_manager.broadcast({
+                "agent_name": agent_name,
+                "event_type": "message_turn",
+                "run_id": raw.get("run_id") or data.get("run_id"),
+                "timestamp": raw.get("timestamp") or time.time(),
+                "data": {
+                    "turn_idx": turn_idx,
+                    "role": data.get("msg_role") or trimmed.get("role"),
+                    "message": trimmed,
+                },
+            })
+        except Exception as e:
+            logger.warning("[message_stream] forward failed for %s: %s", agent_name, e)
 
     def _broadcast_activity(self, role: str, event_type_str: str, data: dict, raw: dict) -> None:
         """Broadcast event via ActivityStreamManager for realtime monitoring."""
@@ -731,6 +811,123 @@ class SpawnProgressBridge:
                 agent_name, total_connected, total_configured,
             )
 
+    # ── Active-meeting awareness for completion notifications ──
+
+    @staticmethod
+    def _active_meetings_with_members(member_names: set[str]) -> list[dict]:
+        """Return active meetings (``ended=0``) whose participants overlap
+        with ``member_names``.
+
+        Used by both completion-notification paths to suppress the misleading
+        "team finished" message when the team is actually idled mid-meeting
+        (incident b61af7db: PM saw "All members finished | No output" while
+        meeting was hanging on a stuck speaker).
+
+        Returns a list of dicts with the fields needed for messaging:
+        ``meeting_id``, ``agenda``, ``current_speaker``, ``current_round``,
+        ``max_rounds``, ``last_action_at``, ``last_action_ago``,
+        ``last_3_turns``. Empty list if no overlap or DB unavailable.
+        """
+        import sqlite3 as _sqlite3
+        import time as _time
+
+        if not member_names:
+            return []
+
+        db_path = os.environ.get("SPAWN_REGISTRY_DB", "data/jarvis.db")
+        results: list[dict] = []
+
+        try:
+            with _sqlite3.connect(db_path, timeout=5) as conn:
+                conn.row_factory = _sqlite3.Row
+                rows = conn.execute(
+                    "SELECT meeting_id, config_json, state_json "
+                    "FROM meetings "
+                    "WHERE json_extract(state_json, '$.ended') = 0"
+                ).fetchall()
+
+                for r in rows:
+                    try:
+                        config = json.loads(r["config_json"]) if r["config_json"] else {}
+                        state = json.loads(r["state_json"]) if r["state_json"] else {}
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+
+                    parts = state.get("participants") or []
+                    if not (set(parts) & member_names):
+                        continue
+
+                    current_turn = state.get("current_turn", 0)
+                    speaker = parts[current_turn] if current_turn < len(parts) else "(unknown)"
+
+                    last_at = state.get("turn_started_at") or 0.0
+                    ago_sec = max(0, int(_time.time() - last_at)) if last_at else None
+
+                    # Pull last 3 turns for context preview
+                    turn_rows = conn.execute(
+                        "SELECT agent, message, round FROM meeting_transcripts "
+                        "WHERE meeting_id = ? ORDER BY id DESC LIMIT 3",
+                        (r["meeting_id"],),
+                    ).fetchall()
+                    last_3 = [
+                        {
+                            "agent": tr["agent"],
+                            "round": tr["round"],
+                            "message_preview": (tr["message"] or "")[:160].replace("\n", " "),
+                        }
+                        for tr in reversed(turn_rows)
+                    ]
+
+                    results.append({
+                        "meeting_id": r["meeting_id"],
+                        "agenda": config.get("agenda", ""),
+                        "current_speaker": speaker,
+                        "current_round": state.get("current_round", 1),
+                        "max_rounds": state.get("max_rounds", 0),
+                        "last_action_at": last_at,
+                        "last_action_ago_sec": ago_sec,
+                        "last_3_turns": last_3,
+                    })
+        except Exception as exc:
+            logger.debug("[ACTIVE_MEETING] Lookup failed: %s", exc)
+            return []
+
+        return results
+
+    @staticmethod
+    def _format_active_meetings_warning(active: list[dict]) -> str:
+        """Render the meeting-stalled warning block (markdown).
+
+        Caller embeds this into the team-completion message so the
+        orchestrator (PM) sees actionable state — bottleneck speaker,
+        time since last turn, last 3 turns — instead of "No output".
+        """
+        if not active:
+            return ""
+
+        lines = ["", "⚠️ **Active meetings detected — team is NOT done:**", ""]
+        for m in active:
+            ago_sec = m.get("last_action_ago_sec")
+            ago_str = f"{ago_sec}s ago" if ago_sec is not None else "(unknown)"
+            lines.append(
+                f"- Meeting `{m['meeting_id']}` — round {m['current_round']}/{m['max_rounds']}, "
+                f"waiting on **{m['current_speaker']}** (last action: {ago_str})"
+            )
+            agenda = (m.get("agenda") or "").strip()
+            if agenda:
+                lines.append(f"  - Agenda: {agenda[:120]}")
+            for t in m.get("last_3_turns", []):
+                lines.append(
+                    f"  - [{t['agent']} R{t['round']}] {t['message_preview']}"
+                )
+        lines.append("")
+        lines.append(
+            "Action: review transcript and either resume the bottleneck "
+            "speaker, end the meeting via verdict, or use ``leave_meeting`` "
+            "to release stuck participants."
+        )
+        return "\n".join(lines)
+
     # ── Team Completion Notification ──
 
     def _check_team_completion(self, trigger_agent: str, raw: dict) -> None:
@@ -754,8 +951,19 @@ class SpawnProgressBridge:
         if not team_name:
             return  # Solo agent, not part of a team
 
-        # Query ALL agents in this team from DB
-        members = self._registry_db.find_by_team_name(team_name)
+        # Restrict to members of THIS session — team_name is reused across
+        # spawns ("toolset-self-audit" may be re-run daily), so filtering
+        # by team_name alone would mix yesterday's idle agents into
+        # today's completion check and dedupe against an unrelated past
+        # notification. The session_id is the unique handle.
+        session_id = record.get("session_id", "")
+        if not session_id:
+            return  # Pre-session agents (very old rows) — skip safely
+
+        members = [
+            m for m in self._registry_db.find_by_team_name(team_name)
+            if m.get("session_id") == session_id
+        ]
         if not members:
             return
 
@@ -769,8 +977,10 @@ class SpawnProgressBridge:
         if not all_done:
             return
 
-        # Dedupe: skip if notification already exists for this team
-        if self._has_team_notification(team_name):
+        # Dedupe per-session, not per-team-name: a re-spawn of the same
+        # named team is a brand new completion event and deserves its
+        # own notification.
+        if self._has_team_notification(session_id):
             return
 
         # Find orchestrator result
@@ -778,7 +988,10 @@ class SpawnProgressBridge:
         result_text = orchestrator.get("result", "") if orchestrator else ""
         orch_name = orchestrator.get("agent_name", team_name) if orchestrator else team_name
 
-        self._create_team_notification(team_name, orch_name, result_text, spawned)
+        self._create_team_notification(
+            team_name, orch_name, result_text, spawned,
+            session_id=session_id,
+        )
 
     def _find_orchestrator(self, members: list[dict]) -> dict | None:
         """Find the orchestrator agent from team members.
@@ -794,15 +1007,77 @@ class SpawnProgressBridge:
         members_sorted = sorted(members, key=lambda m: m.get("started_at", 0))
         return members_sorted[0] if members_sorted else None
 
-    def _has_team_notification(self, team_name: str) -> bool:
-        """Dedupe: check if a team_completion notification already exists."""
+    def _compose_team_result_body(
+        self, *, team_name: str, agent_name: str, result: str
+    ) -> tuple[str, str]:
+        """Render notification (preview, content) from the orchestrator's
+        ``spawn_registry.result``.
+
+        Fails loud when the field is empty: emits an ERROR log so the
+        gap is visible in ops, and renders a notification body that
+        explicitly states which agent and run is missing data. We do
+        NOT substitute a generic "Team done" placeholder — that hides
+        the bug from the user. The proper data source is the per-turn
+        write hook in ``services.context_persistence.save_agent_context``;
+        if you see this body, that hook did not fire for this run.
+        """
+        if result and result.strip():
+            preview = result[:200].replace("\n", " ").strip()
+            return preview, result
+
+        logger.error(
+            "[TEAM_NOTIFY] Orchestrator result MISSING for team=%s agent=%s — "
+            "spawn_registry.result was empty at team_completion. Expected the "
+            "context_persistence write hook to have mirrored the last assistant "
+            "text on the agent's final turn. Check that save_agent_context ran "
+            "for this run and that the agent produced text content (not only "
+            "tool_calls) on its last turn.",
+            team_name, agent_name,
+        )
+        preview = (
+            f"⚠️ BUG: orchestrator result missing for {agent_name} "
+            f"(team {team_name}) — see logs"
+        )
+        content = (
+            f"## ⚠️ Orchestrator result missing\n\n"
+            f"- **Team:** `{team_name}`\n"
+            f"- **Orchestrator:** `{agent_name}`\n\n"
+            f"`spawn_registry.result` was empty when the team-completion "
+            f"notification fired. The notification creator does not fall "
+            f"back to other sources (per project policy: fail loud, no "
+            f"silent fallbacks).\n\n"
+            f"### Likely causes\n"
+            f"- The agent's last turn was a tool_call without any "
+            f"assistant text content.\n"
+            f"- `services.context_persistence.save_agent_context` did not "
+            f"run for this run (snapshot trigger missed).\n"
+            f"- `spawn_registry` row for this run was missing when the "
+            f"snapshot hook tried to mirror the result.\n\n"
+            f"Open the agent's latest snapshot in `agent_context_snapshots` "
+            f"to recover the response manually."
+        )
+        return preview, content
+
+    def _has_team_notification(self, session_id: str) -> bool:
+        """Dedupe: check if a team_completion notification already
+        exists FOR THIS SESSION.
+
+        Keyed by ``session_id`` (not ``team_name``): a reusable team
+        name ("toolset-self-audit") spawned twice on different days
+        produces two distinct completion events — each deserves its
+        own notification. Pre-2026-05-14 this dedupe was per
+        ``team_name`` and silently swallowed the second day's
+        notification.
+        """
+        if not session_id:
+            return False
         try:
             from core.database import NotificationModel, get_db_session
 
             db = get_db_session()
             try:
                 existing = db.query(NotificationModel).filter(
-                    NotificationModel.metadata_json.contains(f'"team_name": "{team_name}"'),
+                    NotificationModel.metadata_json.contains(f'"session_id": "{session_id}"'),
                     NotificationModel.metadata_json.contains('"source": "team_completion"'),
                 ).first()
                 return existing is not None
@@ -813,9 +1088,17 @@ class SpawnProgressBridge:
             return False
 
     def _create_team_notification(
-        self, team_name: str, agent_name: str, result: str, members: list[dict]
+        self, team_name: str, agent_name: str, result: str, members: list[dict],
+        *, session_id: str = "",
     ) -> None:
-        """Create notification + broadcast SSE for team completion."""
+        """Create notification + broadcast SSE for team completion.
+
+        If any team member is still a participant in an active meeting,
+        the notification is reframed from "Team finished" to "Team idled
+        with active meeting" — this surfaces meeting state (bottleneck
+        speaker, last action time, recent turns) so the user can
+        intervene instead of believing the team is done.
+        """
         try:
             import time
             from core.database import NotificationModel, get_db_session
@@ -824,12 +1107,36 @@ class SpawnProgressBridge:
             total = len(members)
             errors = sum(1 for m in members if m.get("status") == "error")
 
-            title = f"✅ Team {team_name} hoàn thành ({total} agents)"
-            if errors:
-                title = f"⚠️ Team {team_name} hoàn thành ({errors}/{total} lỗi)"
+            # Detect "idled mid-meeting" — flips the framing of this notification.
+            member_names = {
+                m.get("agent_name", "") for m in members if m.get("agent_name")
+            }
+            active_meetings = self._active_meetings_with_members(member_names)
 
-            preview = result[:200].replace("\n", " ").strip() if result else "Team đã hoàn thành công việc."
-            content = result or "Không có kết quả chi tiết từ orchestrator."
+            if active_meetings:
+                meeting_count = len(active_meetings)
+                title = (
+                    f"⏳ Team {team_name} idled with {meeting_count} active "
+                    f"meeting{'s' if meeting_count > 1 else ''} — needs intervention"
+                )
+                preview = (
+                    f"{meeting_count} meeting(s) still open — "
+                    f"last waiting on {active_meetings[0]['current_speaker']}"
+                )
+                content = (
+                    (result or "(no orchestrator result)")
+                    + self._format_active_meetings_warning(active_meetings)
+                )
+            elif errors:
+                title = f"⚠️ Team {team_name} hoàn thành ({errors}/{total} lỗi)"
+                preview, content = self._compose_team_result_body(
+                    team_name=team_name, agent_name=agent_name, result=result,
+                )
+            else:
+                title = f"✅ Team {team_name} hoàn thành ({total} agents)"
+                preview, content = self._compose_team_result_body(
+                    team_name=team_name, agent_name=agent_name, result=result,
+                )
 
             db = get_db_session()
             try:
@@ -844,6 +1151,7 @@ class SpawnProgressBridge:
                     metadata_json=json.dumps({
                         "agent": agent_name,
                         "team_name": team_name,
+                        "session_id": session_id,
                         "total_agents": total,
                         "errors": errors,
                         "source": "team_completion",
@@ -931,12 +1239,26 @@ class SpawnProgressBridge:
             return  # Already notified for this exact state
         self._orch_notify_hash[team_name] = status_hash
 
-        # 6. Build concise status report
+        # 6. Build status report — framing depends on whether the team is
+        # idled mid-meeting (b61af7db incident: "All finished | No output"
+        # was misleading because the team had stalled inside a meeting).
         status_icons = {
             "idle": "✅", "completed": "✅",
             "error": "❌", "timeout": "⏰", "cancelled": "🚫",
         }
-        lines = ["📋 **Team Status Update** — All members have finished.\n"]
+
+        member_names = {m.get("agent_name", "") for m in workers if m.get("agent_name")}
+        member_names.add(orch_name)
+        active_meetings = self._active_meetings_with_members(member_names)
+
+        if active_meetings:
+            header = (
+                f"⏳ **Team Status Update** — members are idle but {len(active_meetings)} "
+                f"meeting(s) still open. Team is NOT done."
+            )
+        else:
+            header = "📋 **Team Status Update** — All members have finished."
+        lines = [header, ""]
         lines.append("| Member | Status | Summary |")
         lines.append("|--------|--------|---------|")
         for m in workers:
@@ -950,7 +1272,10 @@ class SpawnProgressBridge:
             summary = summary.replace("\n", " ").replace("|", "/").strip()
             lines.append(f"| {name} | {icon} {status} | {summary} |")
 
-        lines.append("\nReview outputs and decide next actions.")
+        if active_meetings:
+            lines.append(self._format_active_meetings_warning(active_meetings))
+        else:
+            lines.append("\nReview outputs and decide next actions.")
         report = "\n".join(lines)
 
         # 7. Resolve messages_dir and send via MessageBus

--- a/backend/services/spawn_progress_bridge.py
+++ b/backend/services/spawn_progress_bridge.py
@@ -455,6 +455,21 @@ class SpawnProgressBridge:
                 "[LIFECYCLE] Agent removed: %s (run_id=%s, lifecycle=%s, reason=%s)",
                 agent_name, run_id, lifecycle, reason,
             )
+
+            # Drop the per-agent turn cache for this name. Without this
+            # the global ``_recent_turns`` keyset grows unbounded across
+            # team spawns (each new team adds N agent names; old names
+            # never get evicted). Per-agent bucket is already capped at
+            # 200 turns, but keyset growth across weeks of spawns adds
+            # up. Clearing on lifecycle removal is the natural pairing.
+            try:
+                from services.agent_message_stream import reset_recent_turns
+                reset_recent_turns(agent_name)
+            except Exception as _evict_exc:
+                logger.warning(
+                    "Failed to evict _recent_turns for %s: %s",
+                    agent_name, _evict_exc,
+                )
         except Exception as e:
             logger.warning("Failed to broadcast agent_removed: %s", e)
 
@@ -1148,6 +1163,21 @@ class SpawnProgressBridge:
                     content_type="markdown",
                     is_read=0,
                     created_at=time.time(),
+                    # ⚠️ JSON SPACING IS LOAD-BEARING — do NOT change separators.
+                    #
+                    # ``json.dumps()`` default is ``separators=(', ', ': ')``.
+                    # ``routes/agents.delete_team`` and
+                    # ``_has_team_notification`` both query this column with
+                    # ``metadata_json.contains('"team_name": "X"')`` (note the
+                    # space after the colon). If you switch to
+                    # ``separators=(',', ':')`` here, BOTH queries silently
+                    # match nothing → dedupe breaks (duplicate notifs) AND
+                    # delete_team cleanup breaks (orphan notifs blocking
+                    # re-spawn of same team_name).
+                    #
+                    # Future migration: switch both sides to a real JSON1
+                    # query (``json_extract(metadata_json, '$.team_name')``)
+                    # so spacing becomes irrelevant.
                     metadata_json=json.dumps({
                         "agent": agent_name,
                         "team_name": team_name,

--- a/backend/services/sse_progress.py
+++ b/backend/services/sse_progress.py
@@ -15,13 +15,33 @@ import json
 import time
 import logging
 import re
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Optional
 
 from fast_agent.agents.tool_runner import ToolRunnerHooks
 from fast_agent.types import PromptMessageExtended
 
+from services.agent_message_stream import emit_message_history_delta
+
 logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────
+# Token-persistence is always-on (a default hook attached at app
+# startup — see ``server.py`` lifespan). The default hook needs
+# a ``run_id`` to tag each ``token_usage`` row so the dashboard
+# can correlate rows back to the request/job that produced them.
+#
+# Callers (chat.py, ws_voice.py, inject.py, cron_scheduler.py)
+# set this ContextVar around their ``agent_app.send`` / ``resume_and_send``
+# / ``agent.generate`` call. The default hook reads it at call
+# time. ContextVar is asyncio-aware: each request task sees only
+# its own value even when many requests are inflight in parallel.
+#
+# Empty string is OK when no caller set it (legacy path): the row
+# still gets written, just without run_id correlation.
+# ──────────────────────────────────────────────────────────────
+current_run_id: ContextVar[str] = ContextVar("current_run_id", default="")
 
 # Lazy import to avoid circular — resolved at first use
 _activity_stream = None
@@ -212,6 +232,64 @@ def _persist_and_broadcast_token_usage(
         logger.warning(f"[TOKEN] Failed to persist token usage: {e}", exc_info=True)
 
 
+def create_token_persistence_hooks() -> ToolRunnerHooks:
+    """Always-on hook that persists every LLM call's token usage to SQLite.
+
+    Attached at app startup to every in-process agent (see ``server.py``
+    lifespan + ``attach_token_persistence_hooks_to_all``). Reads ``run_id``
+    from the ``current_run_id`` ContextVar set by the caller (chat / voice
+    / inject / cron). If no caller set it, the row is still written with
+    an empty ``run_id`` — better than silently losing the LLM call.
+
+    Why a separate factory (vs reusing ``create_progress_hooks``):
+      - ``create_progress_hooks`` requires a per-request ``request_id`` and
+        pushes events to the chat-stream SSE queue. That queue only has a
+        listener for chat / voice / inject — scheduler-triggered calls have
+        no SSE listener.
+      - Token persistence must run for EVERY LLM call (chat, voice, inject,
+        cron, future-callers). Decoupling it from the chat-stream UI lets
+        every in-process LLM call get tracked exactly once, regardless of
+        caller.
+    """
+    async def on_after_llm_call(runner, message: PromptMessageExtended) -> None:
+        agent = runner._agent
+        raw_name = getattr(agent, 'name', 'Agent')
+        agent_name = normalize_agent_name(raw_name)
+        tokens = _get_token_info(agent)
+        run_id = current_run_id.get() or ""
+        _persist_and_broadcast_token_usage(agent_name, run_id, tokens)
+
+    return ToolRunnerHooks(after_llm_call=on_after_llm_call)
+
+
+def attach_token_persistence_hooks_to_all(agent_app) -> int:
+    """Idempotently attach the always-on token-persistence hook to every
+    in-process agent in ``agent_app._agents``.
+
+    Idempotency is per-agent: a sentinel attribute ``_jarvis_token_hook``
+    is set so re-running this (e.g. after dynamic-agent reload) does not
+    stack duplicate hooks. Returns the number of agents NEWLY hooked.
+    """
+    token_hook = create_token_persistence_hooks()
+    newly = 0
+    try:
+        agents = getattr(agent_app, "_agents", {}) or {}
+    except Exception:
+        agents = {}
+    for name, ag in agents.items():
+        if getattr(ag, "_jarvis_token_hook", False):
+            continue
+        existing = getattr(ag, "tool_runner_hooks", None)
+        if existing:
+            ag.tool_runner_hooks = merge_hooks(existing, token_hook)
+        else:
+            ag.tool_runner_hooks = token_hook
+        ag._jarvis_token_hook = True
+        newly += 1
+        logger.debug("[TOKEN] Attached default token-persistence hook to '%s'", name)
+    return newly
+
+
 def _get_model_name(agent) -> str:
     """Get model name from agent."""
     try:
@@ -350,59 +428,52 @@ def create_progress_hooks(request_id: str, session_id: str | None = None) -> Too
         agent_name = normalize_agent_name(raw_name)
         display = humanize_agent_name(raw_name)
         tokens = _get_token_info(agent)
-        
-        # ── Persist + broadcast token usage (exactly once per LLM call) ──
-        _persist_and_broadcast_token_usage(agent_name, request_id, tokens)
-        
+
+        # Stream the new turn(s) appended to agent.message_history.
+        emit_message_history_delta(agent, agent_name, request_id)
+
+        # NOTE: token-usage persistence is NOT done here anymore. It's
+        # handled by the always-on ``create_token_persistence_hooks``
+        # attached at app startup (see ``server.py`` lifespan). Doing
+        # it here would double-count when both hook chains fire.
+        # The ``tokens`` dict above is still passed to progress events
+        # below so the chat UI can show realtime token usage.
+
+        # ── chat-stream progress events (powers the chat UI progress widgets) ──
+        # Activity-stream tool_call/response broadcasts were removed: the
+        # message_turn channel above is the canonical source for monitor UI.
+        # ``_persist_activity`` rows are still written for the legacy
+        # AgentDetail "Activity" tab and for audit.
         if message.tool_calls:
             tools_info = _extract_tool_info(message)
             tool_names_str = ", ".join(t["name"] for t in tools_info)
-            
-            # Store for duration tracking
+
             _tool_start_times[agent_name] = time.time()
             _tool_names[agent_name] = tools_info
-            
+
             progress_manager.push(request_id, "tool_request", {
                 "agent": agent_name,
                 "tools": tools_info,
                 "tokens": tokens,
                 "message": _make_message(display, "tool_request", tool_names_str),
             })
-            # Broadcast to central event bus for dashboard SSE
             tool_call_msg = f"🔧 {display} calling {tool_names_str}"
-            _get_activity_stream().broadcast({
-                "agent_name": agent_name,
-                "event_type": "tool_call",
-                "message": tool_call_msg,
-                "run_id": request_id,
-                "timestamp": time.time(),
-                "data": {"tools": tools_info},  # Include args for live dashboard
-            })
             _persist_activity(
                 agent_name, "tool_call", tool_call_msg,
                 run_id=request_id, session_id=session_id,
-                data={"tools": tools_info},  # Persist full tool info with args
+                data={"tools": tools_info},
             )
         else:
-            # Agent responded without tools
             preview = message.last_text()
             preview_short = (preview[:300] + "...") if preview and len(preview) > 300 else preview
-            
+
             progress_manager.push(request_id, "responding", {
                 "agent": agent_name,
                 "preview": preview_short,
                 "tokens": tokens,
                 "message": f"{display} responded",
             })
-            # Broadcast to central event bus for dashboard SSE
             response_msg = preview_short or f"{display} responded"
-            _get_activity_stream().broadcast({
-                "agent_name": agent_name,
-                "event_type": "response",
-                "message": response_msg,
-                "run_id": request_id,
-                "timestamp": time.time(),
-            })
             _persist_activity(agent_name, "response", response_msg, run_id=request_id, session_id=session_id)
     
     async def on_before_tool_call(runner, message: PromptMessageExtended) -> None:
@@ -425,7 +496,10 @@ def create_progress_hooks(request_id: str, session_id: str | None = None) -> Too
         raw_name = getattr(agent, 'name', 'Agent')
         agent_name = normalize_agent_name(raw_name)
         display = humanize_agent_name(raw_name)
-        
+
+        # Stream the tool_result turn appended after the tool ran.
+        emit_message_history_delta(agent, agent_name, request_id)
+
         # Calculate duration
         start = _tool_start_times.pop(agent_name, None)
         duration_ms = int((time.time() - start) * 1000) if start else None
@@ -436,6 +510,9 @@ def create_progress_hooks(request_id: str, session_id: str | None = None) -> Too
         tools_done = _tool_names.pop(agent_name, [])
         tool_str = ", ".join(t["name"] for t in tools_done) if tools_done else "tools"
         
+        # chat-stream progress event for the chat UI's per-tool progress widget.
+        # Activity-stream tool_result broadcast was removed — message_turn covers
+        # the monitor UI. Persistence kept for AgentDetail's audit history tab.
         progress_manager.push(request_id, "tool_done", {
             "agent": agent_name,
             "tools": tools_done,
@@ -443,22 +520,13 @@ def create_progress_hooks(request_id: str, session_id: str | None = None) -> Too
             "duration_ms": duration_ms,
             "message": f"{display} completed {tool_str}" + (f" ({duration_ms/1000:.1f}s)" if duration_ms else ""),
         })
-        # Broadcast to central event bus for dashboard SSE
         tool_done_msg = f"✅ {display} completed {tool_str}"
-        _get_activity_stream().broadcast({
-            "agent_name": agent_name,
-            "event_type": "tool_result",
-            "message": tool_done_msg,
-            "run_id": request_id,
-            "timestamp": time.time(),
-            "data": {"duration_ms": duration_ms, "result_preview": result_preview},
-        })
         _persist_activity(
             agent_name, "tool_result", tool_done_msg,
             run_id=request_id, session_id=session_id,
             data={
                 "duration_ms": duration_ms,
-                "tools": tools_done,  # Includes names + args
+                "tools": tools_done,
                 "result_preview": result_preview,
             },
         )

--- a/backend/team_templates/agile_team.yaml
+++ b/backend/team_templates/agile_team.yaml
@@ -71,7 +71,9 @@ roles:
       5. **Spawn team** — `spawn_team_members(roles="ba,dev,qe", first_task="...")`
          - Include meeting_id + Jira link in `first_task` so members have everything they need
          - ⚠️ Do NOT send a separate email after spawning — `first_task` already delivers the assignment!
-      6. **Join and lead** — present agenda, assign work, get acknowledgments
+      6. **Join and lead** — present agenda, assign work, get acknowledgments.
+         Follow the two-speak verdict contract from `project-management`
+         skill (present first, verdict in a separate later speak).
       7. End with: `[DECISION] VERDICT: PASS — <summary>. Next actions: <list>`
 
       ### Phase 3: Execution & Monitoring
@@ -111,6 +113,7 @@ roles:
         team-roster,
         team-communication,
         jarvis-knowledge,
+        self-audit-tools,
       ]
     servers:
       [
@@ -161,7 +164,7 @@ roles:
       - Long-form analysis = Confluence page
       - DO NOT write standalone .md files to workspace as final deliverables
 
-    skills: [ba-workflow, team-roster, team-communication, jarvis-knowledge]
+    skills: [ba-workflow, team-roster, team-communication, jarvis-knowledge, self-audit-tools]
     servers:
       [
         filesystem,
@@ -212,7 +215,7 @@ roles:
       - Architecture comparison = Confluence page
 
     skills:
-      [software-architecture, team-roster, team-communication, jarvis-knowledge]
+      [software-architecture, team-roster, team-communication, jarvis-knowledge, self-audit-tools]
     servers:
       [
         filesystem,
@@ -285,6 +288,7 @@ roles:
         team-communication,
         jarvis-knowledge,
         jarvis-infra,
+        self-audit-tools,
       ]
     servers:
       [
@@ -335,7 +339,7 @@ roles:
       - Component specifications for Dev (spacing, responsive notes)
       - Screenshot of completed design (via figma_read screenshot)
 
-    skills: [figma-designer, team-roster, team-communication]
+    skills: [figma-designer, team-roster, team-communication, self-audit-tools]
     servers:
       [filesystem, meeting_room, email, github, mcp-atlassian, figma-ui-mcp]
     server_overrides:
@@ -393,6 +397,7 @@ roles:
         team-roster,
         team-communication,
         jarvis-knowledge,
+        self-audit-tools,
       ]
     servers:
       [
@@ -443,6 +448,7 @@ roles:
         team-communication,
         jarvis-knowledge,
         jarvis-infra,
+        self-audit-tools,
       ]
     servers:
       [

--- a/backend/tests/e2e/fixtures/meeting_ba_speak_once.yaml
+++ b/backend/tests/e2e/fixtures/meeting_ba_speak_once.yaml
@@ -1,0 +1,11 @@
+# Devon [BA] — single speak() in round 1 after receiving YOUR_TURN.
+turns:
+  - tool_calls:
+      c_speak:
+        name: speak
+        arguments:
+          meeting_id: "b61af7db"
+          message: "Devon [BA] here. I'll create the test-case matrix and Jira stories under JXCC-19."
+          agent_name: "Devon [BA]"
+
+  - content: "Spoken."

--- a/backend/tests/e2e/fixtures/meeting_dev_speak_once.yaml
+++ b/backend/tests/e2e/fixtures/meeting_dev_speak_once.yaml
@@ -1,0 +1,11 @@
+# Reese [Dev] — single speak() in round 1 after receiving YOUR_TURN.
+turns:
+  - tool_calls:
+      c_speak:
+        name: speak
+        arguments:
+          meeting_id: "b61af7db"
+          message: "Reese [Dev] here. I'll execute the tests on each MCP server once BA's stories are ready."
+          agent_name: "Reese [Dev]"
+
+  - content: "Spoken."

--- a/backend/tests/e2e/fixtures/meeting_pm_full_flow.yaml
+++ b/backend/tests/e2e/fixtures/meeting_pm_full_flow.yaml
@@ -1,0 +1,44 @@
+# PM (creator) full flow: create_meeting → speak kickoff → speak [DECISION] VERDICT: PASS.
+#
+# Drives two separate agent.generate() calls:
+#   1st generate("Run the kickoff"):
+#       turn 1: create_meeting(...)        — auto-prepends PM into participants
+#       turn 2: speak(kickoff message)     — turn 0 of round 1
+#       turn 3: END_TURN                    — PM done speaking for now
+#   2nd generate(YOUR_TURN inbox content for round 2):
+#       turn 4: speak("[DECISION] VERDICT: PASS — ...") — ends meeting
+#       turn 5: END_TURN
+#
+# meeting_id is fixed via monkeypatch on uuid.uuid4 in the test (see test file).
+
+turns:
+  - tool_calls:
+      c_create:
+        name: create_meeting
+        arguments:
+          agenda: "Sprint 1 kickoff"
+          # Creator deliberately omits self — exercising the auto-include fix
+          participants: "Devon [BA], Reese [Dev], Devon [QE]"
+          max_rounds: 2
+          my_name: "Cameron [PM]"
+          workspace_dir: ""
+
+  - tool_calls:
+      c_speak_kickoff:
+        name: speak
+        arguments:
+          meeting_id: "b61af7db"
+          message: "Welcome team. Goal today: align on the audit plan and produce action items by end of meeting."
+          agent_name: "Cameron [PM]"
+
+  - content: "Kickoff sent. Waiting for team responses."
+
+  - tool_calls:
+      c_speak_verdict:
+        name: speak
+        arguments:
+          meeting_id: "b61af7db"
+          message: "[DECISION] VERDICT: PASS — Plan accepted. BA owns story creation, Dev runs tests, QE compiles audit report."
+          agent_name: "Cameron [PM]"
+
+  - content: "Meeting concluded with verdict PASS."

--- a/backend/tests/e2e/fixtures/meeting_qe_speak_once.yaml
+++ b/backend/tests/e2e/fixtures/meeting_qe_speak_once.yaml
@@ -1,0 +1,11 @@
+# Devon [QE] — single speak() in round 1 after receiving YOUR_TURN.
+turns:
+  - tool_calls:
+      c_speak:
+        name: speak
+        arguments:
+          meeting_id: "b61af7db"
+          message: "Devon [QE] here. I'll review test coverage and compile the audit report on Confluence."
+          agent_name: "Devon [QE]"
+
+  - content: "Spoken."

--- a/backend/tests/e2e/fixtures/orchestrator_rollup.yaml
+++ b/backend/tests/e2e/fixtures/orchestrator_rollup.yaml
@@ -1,0 +1,43 @@
+# Orchestrator-style script for the orchestrator-final-response E2E.
+#
+# Models the post-aggregation behaviour of Morgan [PM] in a self-audit run:
+# a single text turn that contains the complete roll-up. No tool calls —
+# we're exercising the save_agent_context → spawn_registry mirror path,
+# not the tool dispatch.
+
+turns:
+  - content: |
+      # Self-audit — Team Roll-up
+
+      Submissions: 3 of 3 (including yourself).
+      - Replied: Morgan [PM] (orchestrator, inline), Ryan [BA], Dakota [SA]
+      - Did not reply: none
+
+      Verdict: **PASS** — every member produced a non-trivial inventory and
+      the per-report self-reconcile holds.
+
+      ## Self-audit — Morgan [PM] (orchestrator)
+
+      Summary: **12** tools — **8** ok / **4** skipped (write/destructive) / **0** error.
+
+      ## Tool inventory
+
+      | # | Tool | Class | Status | Note / Usage |
+      |---:|---|---|---|---|
+      | 1 | filesystem__list_directory | READ | ok |  |
+      | 2 | agent_spawner__get_team_status | READ | ok |  |
+      | 3 | email__send_email | WRITE | skipped | used for follow-ups |
+
+      ## Per-member reports
+
+      ---
+
+      # Self-audit — Ryan [BA]
+
+      Summary: **15** tools — **10** ok / **5** skipped / **0** error.
+
+      ---
+
+      # Self-audit — Dakota [SA]
+
+      Summary: **18** tools — **12** ok / **6** skipped / **0** error.

--- a/backend/tests/e2e/harness.py
+++ b/backend/tests/e2e/harness.py
@@ -127,6 +127,13 @@ async def build_scripted_agent(
     """Build a ToolAgent whose LLM replays the given fixture.
 
     The agent is wired for in-process execution (no MCP server spawn).
+
+    ``tool_only=True`` keeps ``save_session_history`` (the after-turn hook
+    in fast-agent) from writing scripted runs into the host project's
+    ``.fast-agent/sessions/`` directory. Without it, every e2e test
+    leaks a real session and the chat UI fills up with rows like
+    "Run the kickoff for the audit project." — see hooks/session_history.py
+    line 39-40 for the early-return contract.
     """
     agent = ToolAgent(
         config=AgentConfig(
@@ -134,6 +141,7 @@ async def build_scripted_agent(
             instruction=instruction,
             servers=[],
             human_input=False,
+            tool_only=True,
         ),
         tools=list(tools),
         context=None,

--- a/backend/tests/e2e/test_effective_status_e2e.py
+++ b/backend/tests/e2e/test_effective_status_e2e.py
@@ -1,0 +1,364 @@
+"""E2E regression for ``_compute_effective_status`` with REAL Unix
+sockets, REAL SQLite, and the REAL ``AgentChannel.is_alive`` probe.
+
+Why this exists in addition to the unit suite:
+The unit tests in ``tests/test_services/test_effective_status.py``
+patch ``AgentChannel.is_alive`` directly. That isolates the decision
+tree but does not catch regressions in the underlying probe (e.g. the
+2026-05-13 ``is_alive`` connect-probe fix — file-stat alone returns
+True for orphan sock files left by SIGKILL'd subprocesses, and the
+helper relied on a truthful liveness signal). This file exercises both
+ends of the contract together: real probe + real DB + real lifecycle
+invariant.
+
+What this DOES NOT cover (intentionally):
+* Spawning a real isolated_runner subprocess and watching it transition
+  through running → idle. That path is covered by ``test_team_spawn``
+  and ``test_subprocess_spawn``.
+* The HTTP layer (``/api/agents`` route). Adding a full FastAPI test
+  would only test JSON shape; the status invariants are entirely the
+  helper's domain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Make backend/ importable so we can hit ``routes.agents`` and the
+# real ``AgentChannel`` from the vendored fast-agent submodule.
+_BACKEND = Path(__file__).resolve().parent.parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+_FA_SRC = _BACKEND / "fast-agent" / "src"
+if _FA_SRC.exists() and str(_FA_SRC) not in sys.path:
+    sys.path.insert(0, str(_FA_SRC))
+
+from routes.agents import _compute_effective_status  # noqa: E402
+
+
+# ─── Real snapshot DB helpers ─────────────────────────────────────────
+
+
+def _init_snapshot_db(db_path: Path) -> None:
+    """Create the ``agent_context_snapshots`` table matching the
+    production schema closely enough for the helper to read.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS agent_context_snapshots ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "run_id TEXT, agent_name TEXT, session_id TEXT, "
+            "team_name TEXT, context_json TEXT, "
+            "message_count INTEGER, total_input_tokens INTEGER, "
+            "total_output_tokens INTEGER, trigger TEXT, created_at REAL)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _write_snapshot(
+    db_path: Path,
+    agent_name: str,
+    trigger: str,
+    created_at: float,
+) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO agent_context_snapshots "
+            "(agent_name, trigger, created_at, run_id, message_count, "
+            " total_input_tokens, total_output_tokens, context_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (agent_name, trigger, created_at, "test-run", 0, 0, 0, "[]"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ─── Real channel sock fixtures ──────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_channel_dir(tmp_path, monkeypatch):
+    """Point ``AgentChannel`` at a tmp dir so we don't collide with the
+    real project's channels. The fixture cleans up via tmp_path teardown.
+    """
+    # _get_sock_dir reads TEAM_WORKSPACE then walks up for .runtime; the
+    # test bypass is to set SPAWN_PROJECT_DIR which the resolver also
+    # honours (and which doesn't require a .runtime ancestor).
+    monkeypatch.setenv("SPAWN_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("TEAM_WORKSPACE", raising=False)
+    return tmp_path
+
+
+async def _start_real_channel(agent_name: str):
+    """Start a real ``AgentChannel`` listener bound to a real Unix
+    socket in the test's isolated channel dir. Returns the channel —
+    the caller must await ``channel.stop()`` in finally.
+    """
+    from fast_agent.spawn.agent_channel import AgentChannel
+
+    channel = AgentChannel(agent_name)
+    await channel.start_server()
+    return channel
+
+
+def _create_orphan_sock(agent_name: str) -> Path:
+    """Reproduce the SIGKILL-orphan-sock state: a sock FILE exists at
+    the canonical path but no listener is bound. The pre-2026-05-13
+    file-stat ``is_alive`` lied to the helper here.
+    """
+    from fast_agent.spawn.agent_channel import _get_sock_dir, _sanitize_name
+
+    sock_path = _get_sock_dir() / f"{_sanitize_name(agent_name)}.sock"
+    if sock_path.exists():
+        sock_path.unlink()
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        s.bind(str(sock_path))
+    finally:
+        s.close()
+    return sock_path
+
+
+# ─── Real-channel-alive: keep-alive subprocess ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_real_channel_alive_with_fresh_idle_snapshot_returns_idle(
+    isolated_channel_dir, tmp_path,
+):
+    """The happy-path keep-alive case, exercised against real
+    everything: bind a real channel socket, write a fresh idle
+    snapshot, ask the helper, assert ``idle``.
+    """
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)
+    agent = "E2E_Agent_Alive_Idle"
+    _write_snapshot(db, agent, "idle", created_at=time.time())
+
+    channel = await _start_real_channel(agent)
+    try:
+        # last_active_at older than snapshot → fresh idle.
+        record = {
+            "agent_name": agent,
+            "status": "running",
+            "lifecycle": "resumable",
+            "last_active_at": time.time() - 60,
+        }
+        assert _compute_effective_status(record, snapshots_db_path=str(db)) == "idle"
+    finally:
+        await channel.stop()
+
+
+@pytest.mark.asyncio
+async def test_real_channel_alive_with_stale_snapshot_keeps_running(
+    isolated_channel_dir, tmp_path,
+):
+    """Real channel listening, but the bridge has bumped
+    ``last_active_at`` more recently than the snapshot was written —
+    agent is mid-turn. Helper must keep raw ``running``.
+    """
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)
+    agent = "E2E_Agent_Alive_Active"
+    # Snapshot from a turn that ended long ago.
+    _write_snapshot(db, agent, "task_complete", created_at=time.time() - 300)
+
+    channel = await _start_real_channel(agent)
+    try:
+        record = {
+            "agent_name": agent,
+            "status": "running",
+            "lifecycle": "resumable",
+            "last_active_at": time.time(),  # bridge just saw a thinking event
+        }
+        assert _compute_effective_status(record, snapshots_db_path=str(db)) == "running"
+    finally:
+        await channel.stop()
+
+
+# ─── Real-channel-dead: lifecycle invariant ──────────────────────────
+
+
+def test_real_channel_missing_resumable_idle_returns_idle(
+    isolated_channel_dir, tmp_path,
+):
+    """No sock file at all + resumable + idle snapshot.
+
+    The canonical "agile team finished its turn, subprocess hibernating"
+    case the user surfaced on 2026-05-13. Helper must return ``idle``,
+    matching ``spawn_progress_bridge`` / ``mark_stale_running``.
+    """
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)
+    agent = "E2E_Agent_Resumable_Dead"
+    _write_snapshot(db, agent, "idle", created_at=time.time())
+
+    record = {
+        "agent_name": agent,
+        "status": "running",
+        "lifecycle": "resumable",
+        "last_active_at": 0,
+    }
+    # No sock file written for this agent — real is_alive returns False.
+    assert _compute_effective_status(record, snapshots_db_path=str(db)) == "idle"
+
+
+def test_real_orphan_sock_resumable_idle_returns_idle(
+    isolated_channel_dir, tmp_path,
+):
+    """The exact SIGKILL trap from 2026-05-12. An orphan sock file
+    exists on disk (bind+close without unlink) — pre-fix
+    ``is_alive`` returned True from file-stat alone. With the
+    connect-probe ``is_alive`` and the lifecycle-aware helper, the
+    result must still be ``idle`` for a resumable team agent.
+    """
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)
+    agent = "E2E_Agent_Orphan_Sock"
+    _write_snapshot(db, agent, "idle", created_at=time.time())
+
+    sock_path = _create_orphan_sock(agent)
+    try:
+        assert sock_path.exists(), "test setup: orphan sock missing"
+        record = {
+            "agent_name": agent,
+            "status": "running",
+            "lifecycle": "resumable",
+            "last_active_at": 0,
+        }
+        assert _compute_effective_status(record, snapshots_db_path=str(db)) == "idle"
+    finally:
+        sock_path.unlink(missing_ok=True)
+
+
+def test_real_channel_dead_oneshot_returns_completed(
+    isolated_channel_dir, tmp_path,
+):
+    """Companion to the resumable test — oneshot must still terminalise
+    as ``completed`` to keep the canonical lifecycle invariant.
+    """
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)
+    agent = "E2E_Agent_Oneshot_Dead"
+    _write_snapshot(db, agent, "task_complete", created_at=time.time())
+
+    record = {
+        "agent_name": agent,
+        "status": "running",
+        "lifecycle": "oneshot",
+        "last_active_at": 0,
+    }
+    assert _compute_effective_status(record, snapshots_db_path=str(db)) == "completed"
+
+
+def test_real_channel_dead_error_snapshot_returns_error(
+    isolated_channel_dir, tmp_path,
+):
+    """Error snapshot supersedes lifecycle: regardless of resumable or
+    oneshot, the helper must return ``error`` so the dashboard can
+    flag the agent for inspection.
+    """
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)
+    agent = "E2E_Agent_Error"
+    _write_snapshot(db, agent, "error", created_at=time.time())
+
+    for lifecycle in ("resumable", "oneshot", ""):
+        record = {
+            "agent_name": agent,
+            "status": "running",
+            "lifecycle": lifecycle,
+            "last_active_at": 0,
+        }
+        out = _compute_effective_status(record, snapshots_db_path=str(db))
+        assert out == "error", f"lifecycle={lifecycle!r}: got {out!r}"
+
+
+# ─── Spawn race: channel not yet bound, no snapshot ──────────────────
+
+
+def test_real_fresh_spawn_no_snapshot_keeps_raw_running(
+    isolated_channel_dir, tmp_path,
+):
+    """Brand-new spawn: channel hasn't bound yet, no snapshot written.
+    Helper must NOT misclassify this as terminal. It must trust raw
+    (``running``) so the UI shows the still-initialising agent. The
+    next backend restart's ``mark_stale_running`` will catch any true
+    crashes.
+    """
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)  # empty DB, no rows
+    record = {
+        "agent_name": "E2E_Agent_Fresh_Spawn",
+        "status": "running",
+        "lifecycle": "resumable",
+        "last_active_at": 0,
+    }
+    assert _compute_effective_status(record, snapshots_db_path=str(db)) == "running"
+
+
+# ─── Canonical-value contract ────────────────────────────────────────
+
+
+def test_real_helper_only_returns_canonical_statuses(
+    isolated_channel_dir, tmp_path,
+):
+    """Sweep every combination that has well-defined behaviour and
+    verify the helper only returns members of the canonical
+    ``SpawnStatus`` set. Pre-fix the helper invented
+    ``completed_unknown`` which broke downstream consumers.
+    """
+    from fast_agent.spawn.spawn_registry import SpawnStatus
+
+    canonical = {s.value for s in SpawnStatus} | {
+        # Also accept raw pass-throughs the helper may surface.
+        "starting", "resumed", "paused", "unknown", "failed",
+    }
+    db = tmp_path / "snapshots.db"
+    _init_snapshot_db(db)
+    agent = "E2E_Agent_Sweep"
+
+    matrix = [
+        # (trigger, lifecycle, raw, last_active_at)
+        ("idle", "resumable", "running", 0),
+        ("idle", "oneshot", "running", 0),
+        ("task_complete", "resumable", "running", 0),
+        ("task_complete", "oneshot", "running", 0),
+        ("error", "resumable", "running", 0),
+        ("idle", "", "idle", 0),
+        ("task_complete", "resumable", "running", time.time() * 2),  # stale snap
+    ]
+    for trigger, lifecycle, raw, last_active in matrix:
+        # Use fresh DB per case so each test sees only its own snapshot.
+        single_db = tmp_path / f"sweep_{trigger}_{lifecycle or 'none'}_{raw}.db"
+        _init_snapshot_db(single_db)
+        _write_snapshot(single_db, agent, trigger, created_at=time.time())
+        record = {
+            "agent_name": agent,
+            "status": raw,
+            "lifecycle": lifecycle,
+            "last_active_at": last_active,
+        }
+        out = _compute_effective_status(record, snapshots_db_path=str(single_db))
+        assert out in canonical, (
+            f"Helper returned non-canonical value {out!r} for "
+            f"trigger={trigger!r}, lifecycle={lifecycle!r}, raw={raw!r}, "
+            f"last_active={last_active}"
+        )
+        assert out != "completed_unknown", (
+            "completed_unknown is a deprecated, non-canonical state — "
+            "the helper must not surface it."
+        )

--- a/backend/tests/e2e/test_meeting_full_flow.py
+++ b/backend/tests/e2e/test_meeting_full_flow.py
@@ -1,0 +1,289 @@
+"""E2E: PM-as-creator drives a full meeting through to verdict.
+
+Guards the meeting-flow contract that broke production (b61af7db incident):
+
+* Creator (PM) is auto-prepended to ``participants`` so they speak first.
+* Round-robin order matches ``participants`` exactly: PM → BA → Dev → QE → PM.
+* PM's second turn carrying ``[DECISION] VERDICT: PASS`` ends the meeting and
+  fires ``meeting_ended`` notifications to **every** participant including PM.
+* Each ``speak()`` enforces "current speaker only" — if turn order is wrong
+  the test fails loudly with the actual error JSON.
+
+Real components used: ``meeting_room_server`` tools (create_meeting, speak),
+``JsonFileMeetingStorage`` (real workspace dir), ``MessageBus`` (real inbox
+files). Only ``_auto_wake_if_idle`` and ``uuid.uuid4`` are patched — the
+former relies on a live AgentChannel socket, the latter to make meeting_id
+deterministic so fixtures can reference it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.harness import ToolCallRecorder, build_scripted_agent
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+MEETING_ID = "b61af7db"  # mirrors fixtures' hardcoded meeting_id
+
+
+@pytest.fixture
+def real_meeting_env(tmp_path, monkeypatch):
+    """Wire real JsonFileMeetingStorage + real MessageBus into meeting_room_server.
+
+    Yields ``(storage, bus)`` for direct inspection.
+    """
+    from fast_agent.spawn.message_bus import MessageBus
+    from fast_agent.spawn.servers.meeting_storage import SqliteMeetingStorage
+    import fast_agent.spawn.servers.meeting_room_server as mrs
+
+    workspace = tmp_path / "workspace"
+    messages_dir = tmp_path / "messages"
+    workspace.mkdir()
+    messages_dir.mkdir()
+
+    # Production uses SqliteMeetingStorage (see meeting_room_server.__main__).
+    # JsonFileMeetingStorage is only the library default for standalone use
+    # and lacks the ``_conn`` kwarg the production speak() code path requires.
+    storage = SqliteMeetingStorage(db_path=str(tmp_path / "meetings.db"))
+    bus = MessageBus(messages_dir=str(messages_dir))
+
+    monkeypatch.setattr(mrs, "_storage", storage)
+    monkeypatch.setattr(mrs, "_get_bus", lambda: bus)
+    # AgentChannel socket / spawn registry not available in test process —
+    # no-op auto-wake (the inbox write itself is what we verify).
+    monkeypatch.setattr(mrs, "_auto_wake_if_idle", lambda *a, **kw: None)
+    # Fallback name when an explicit one isn't passed (fixtures pass explicit).
+    monkeypatch.setattr(mrs, "_get_my_name", lambda: "system")
+
+    # Deterministic meeting_id so fixture YAML can hardcode "b61af7db".
+    fake_uuid = type("FakeUUID", (), {"hex": MEETING_ID + "0" * 24})()
+    monkeypatch.setattr(uuid, "uuid4", lambda: fake_uuid)
+
+    return storage, bus
+
+
+def _last_inbox_msg_of_type(bus, agent_name, message_type):
+    """Pop the most recent message of ``message_type`` from ``agent_name`` inbox."""
+    msgs = bus.read_inbox(agent_name)
+    matches = [m for m in msgs if m.message_type == message_type]
+    assert matches, (
+        f"Expected at least one {message_type!r} in {agent_name!r} inbox, "
+        f"got types={[m.message_type for m in msgs]}"
+    )
+    return matches[-1]
+
+
+@pytest.mark.asyncio
+async def test_pm_creates_speaks_first_then_verdict_ends_meeting(real_meeting_env):
+    """Full happy-path: creator speaks first, round-robin completes, PM verdict ends."""
+    storage, bus = real_meeting_env
+
+    from fast_agent.spawn.servers.meeting_room_server import create_meeting, speak
+
+    pm_recorder = ToolCallRecorder()
+    pm_agent = await build_scripted_agent(
+        fixture_path=FIXTURES / "meeting_pm_full_flow.yaml",
+        tools=[create_meeting, speak],
+        agent_name="Cameron [PM]",
+        recorder=pm_recorder,
+    )
+    ba_agent = await build_scripted_agent(
+        fixture_path=FIXTURES / "meeting_ba_speak_once.yaml",
+        tools=[speak],
+        agent_name="Devon [BA]",
+    )
+    dev_agent = await build_scripted_agent(
+        fixture_path=FIXTURES / "meeting_dev_speak_once.yaml",
+        tools=[speak],
+        agent_name="Reese [Dev]",
+    )
+    qe_agent = await build_scripted_agent(
+        fixture_path=FIXTURES / "meeting_qe_speak_once.yaml",
+        tools=[speak],
+        agent_name="Devon [QE]",
+    )
+
+    # ── Step 1: PM kicks off (create_meeting + speak round 1) ──
+    await pm_agent.generate("Run the kickoff for the audit project.")
+
+    config = storage.get_config(MEETING_ID)
+    state = storage.get_state(MEETING_ID)
+    assert config is not None, "PM's create_meeting tool call did not persist a meeting"
+
+    # Post-B1: participants live in state_json (mutable bucket).
+    # config_json holds only write-once metadata.
+    assert "participants" not in config, (
+        "participants must NOT be in config_json — design contract"
+    )
+    assert state["participants"] == [
+        "Cameron [PM]",
+        "Devon [BA]",
+        "Reese [Dev]",
+        "Devon [QE]",
+    ], (
+        f"Creator must be at index 0 (auto-prepend). Got: {state['participants']}"
+    )
+    assert config["created_by"] == "Cameron [PM]"
+
+    # PM's first speak() must succeed — implicit proof PM is current_speaker[0].
+    transcript = storage.get_transcript(MEETING_ID)
+    assert len(transcript) == 1, f"After PM kickoff, expected 1 turn; got {len(transcript)}"
+    assert transcript[0]["agent"] == "Cameron [PM]"
+    assert transcript[0]["round"] == 1
+
+    # ── Step 2: BA reads YOUR_TURN, speaks ──
+    ba_turn_msg = _last_inbox_msg_of_type(bus, "Devon [BA]", "meeting_turn")
+    assert MEETING_ID in ba_turn_msg.content, "YOUR_TURN must reference meeting_id"
+    await ba_agent.generate(ba_turn_msg.content)
+
+    transcript = storage.get_transcript(MEETING_ID)
+    assert len(transcript) == 2 and transcript[1]["agent"] == "Devon [BA]"
+
+    # ── Step 3: Dev's turn ──
+    dev_turn_msg = _last_inbox_msg_of_type(bus, "Reese [Dev]", "meeting_turn")
+    await dev_agent.generate(dev_turn_msg.content)
+
+    transcript = storage.get_transcript(MEETING_ID)
+    assert len(transcript) == 3 and transcript[2]["agent"] == "Reese [Dev]"
+
+    # ── Step 4: QE's turn closes round 1 ──
+    qe_turn_msg = _last_inbox_msg_of_type(bus, "Devon [QE]", "meeting_turn")
+    await qe_agent.generate(qe_turn_msg.content)
+
+    transcript = storage.get_transcript(MEETING_ID)
+    assert len(transcript) == 4 and transcript[3]["agent"] == "Devon [QE]"
+
+    # State must show round wrapped to 2 with PM up next.
+    state = storage.get_state(MEETING_ID)
+    assert state["current_round"] == 2 and state["current_turn"] == 0
+    assert not state["ended"], "Meeting should still be open at start of round 2"
+
+    # ── Step 5: PM speaks with [DECISION] VERDICT — meeting ends ──
+    pm_turn_msg = _last_inbox_msg_of_type(bus, "Cameron [PM]", "meeting_turn")
+    # The third meeting_turn for PM = round 2 cue (first was kickoff self-notify).
+    await pm_agent.generate(pm_turn_msg.content)
+
+    state = storage.get_state(MEETING_ID)
+    transcript = storage.get_transcript(MEETING_ID)
+
+    assert state["ended"] is True, f"Meeting should be ended; state={state}"
+    assert state["outcome"] == "verdict_pass", (
+        f"Verdict PASS should map to outcome 'verdict_pass'; got {state['outcome']!r}"
+    )
+
+    # Full transcript shape — proves round-robin order held end-to-end.
+    speakers = [(t["agent"], t["round"]) for t in transcript]
+    assert speakers == [
+        ("Cameron [PM]", 1),
+        ("Devon [BA]", 1),
+        ("Reese [Dev]", 1),
+        ("Devon [QE]", 1),
+        ("Cameron [PM]", 2),
+    ], f"Round-robin order broke. Got: {speakers}"
+
+    # PM's verdict message survived intact (not stripped/mutated by speak()).
+    assert "[DECISION]" in transcript[-1]["message"]
+    assert "VERDICT: PASS" in transcript[-1]["message"]
+
+    # ── Step 6: meeting_ended notification went to ALL participants (PM included) ──
+    for participant in [
+        "Cameron [PM]",
+        "Devon [BA]",
+        "Reese [Dev]",
+        "Devon [QE]",
+    ]:
+        ended = _last_inbox_msg_of_type(bus, participant, "meeting_ended")
+        assert MEETING_ID in ended.content, (
+            f"{participant} meeting_ended must reference meeting_id"
+        )
+        # Transcript embedded so PM can synthesize without a second tool call.
+        assert "Welcome team" in ended.content, (
+            f"{participant} meeting_ended should embed full transcript "
+            f"(PM kickoff line missing). Got: {ended.content[:200]}"
+        )
+
+    # ── Step 7: PM tool-call sequence matches the fixture exactly ──
+    pm_recorder.assert_matches([
+        ("create_meeting", {
+            "agenda": "Sprint 1 kickoff",
+            "participants": "Devon [BA], Reese [Dev], Devon [QE]",
+            "max_rounds": 2,
+            "my_name": "Cameron [PM]",
+            "workspace_dir": "",
+        }),
+        ("speak", {
+            "meeting_id": MEETING_ID,
+            "message": "Welcome team. Goal today: align on the audit plan and produce action items by end of meeting.",
+            "agent_name": "Cameron [PM]",
+        }),
+        ("speak", {
+            "meeting_id": MEETING_ID,
+            "message": "[DECISION] VERDICT: PASS — Plan accepted. BA owns story creation, Dev runs tests, QE compiles audit report.",
+            "agent_name": "Cameron [PM]",
+        }),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_speak_rejects_wrong_speaker(real_meeting_env):
+    """Negative control: BA cannot speak when it's PM's turn.
+
+    Proves the round-robin enforcement is real (not just fixture coincidence).
+    Without the auto-prepend fix this would fail differently — BA might be
+    participants[0] and the test would silently pass with the wrong contract.
+    """
+    storage, bus = real_meeting_env
+
+    from fast_agent.spawn.servers.meeting_room_server import create_meeting, speak
+
+    # Use a tiny fixture that just creates the meeting — PM doesn't speak.
+    create_only_path = FIXTURES / "_meeting_pm_create_only.yaml"
+    create_only_path.write_text(
+        "turns:\n"
+        "  - tool_calls:\n"
+        "      c_create:\n"
+        "        name: create_meeting\n"
+        "        arguments:\n"
+        "          agenda: \"Test\"\n"
+        "          participants: \"Devon [BA]\"\n"
+        "          max_rounds: 2\n"
+        "          my_name: \"Cameron [PM]\"\n"
+        "          workspace_dir: \"\"\n"
+        "  - content: \"created\"\n",
+        encoding="utf-8",
+    )
+
+    pm_agent = await build_scripted_agent(
+        fixture_path=create_only_path,
+        tools=[create_meeting, speak],
+        agent_name="Cameron [PM]",
+    )
+
+    await pm_agent.generate("Create the meeting.")
+    create_only_path.unlink()
+
+    state = storage.get_state(MEETING_ID)
+    assert state["participants"] == ["Cameron [PM]", "Devon [BA]"]
+
+    # Direct call to speak as BA — PM is current_speaker, BA should be rejected.
+    import json
+
+    result = json.loads(
+        await speak(
+            meeting_id=MEETING_ID,
+            message="BA jumping the queue.",
+            agent_name="Devon [BA]",
+        )
+    )
+    assert "error" in result, f"Expected rejection, got: {result}"
+    assert "Not your turn" in result["error"]
+    assert "Cameron [PM]" in result["error"], (
+        f"Error must name the actual current speaker; got: {result['error']}"
+    )
+
+    # Transcript must remain empty — rejected speak() must not write anything.
+    assert storage.get_transcript(MEETING_ID) == []

--- a/backend/tests/e2e/test_orchestrator_result_flow.py
+++ b/backend/tests/e2e/test_orchestrator_result_flow.py
@@ -1,0 +1,355 @@
+"""E2E for the orchestrator-final-response flow.
+
+Models the post-2026-05-13 contract: ScriptedLLM drives a fake
+orchestrator (Morgan [PM]) through one turn that emits a roll-up
+markdown block. The test then walks every downstream consumer that
+the 2026-05-13 incident broke and asserts they all surface the same
+roll-up text — no silent fallbacks, no error_state.
+
+What this proves end-to-end:
+
+1. **Write path** — ``save_agent_context`` mirrors the last assistant
+   text into ``spawn_registry.data_json.result`` (single source of
+   truth for orchestrator output).
+2. **Read path: ``get_team_result``** — returns the roll-up via
+   ``agents[name].result`` and omits the ``error_state`` block.
+3. **Notification body** — ``_create_team_notification`` renders the
+   roll-up verbatim in the DB notification, with no BUG indicator
+   in title / preview / content.
+4. **Status semantics** — ``get_team_status`` reports a stuck agent
+   loudly (``status="stuck"``, ``sprint_status="stuck"``) when the
+   registry says it's idle but last_active_at is stale.
+
+Uses real SQLite (no ORM mocks). The only "fake" piece is the LLM
+itself, which ScriptedLLM replays from the YAML fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.harness import build_scripted_agent
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ── DB fixture helpers ──────────────────────────────────────────────
+
+
+def _init_schema(db_path: Path) -> None:
+    """Create the three tables our flow touches.
+
+    These are normally created by ``services.context_persistence``
+    (snapshots), ``fast_agent.spawn.registry_backends.SqliteBackend``
+    (spawn_registry), and ``TeamSessionStore`` (team_sessions). We
+    create them up front so the test can pre-seed rows without
+    racing the production code's CREATE TABLE IF NOT EXISTS calls.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS spawn_registry (
+                run_id TEXT PRIMARY KEY,
+                data_json TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS team_sessions (
+                session_id TEXT PRIMARY KEY,
+                data_json TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS agent_context_snapshots (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                session_id TEXT,
+                team_name TEXT,
+                context_json TEXT NOT NULL,
+                message_count INTEGER DEFAULT 0,
+                total_input_tokens INTEGER DEFAULT 0,
+                total_output_tokens INTEGER DEFAULT 0,
+                trigger TEXT DEFAULT 'manual',
+                created_at REAL NOT NULL
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_orchestrator(db_path: Path, *, run_id: str, agent_name: str,
+                        session_id: str, team_name: str) -> None:
+    """Pre-create the spawn_registry + team_sessions rows.
+
+    Matches the shape the real spawner would write — minimum keys
+    needed for the read-side consumers to find the orchestrator.
+    """
+    spawn_row = {
+        "run_id": run_id,
+        "agent_name": agent_name,
+        "role": "pm",
+        "status": "running",
+        "lifecycle": "resumable",
+        "team_name": team_name,
+        "result": "",
+        "started_at": time.time(),
+        "last_active_at": time.time(),
+    }
+    team_row = {
+        "session_id": session_id,
+        "template": {"name": "agile-team", "roles": {}},
+        "workspace": "/tmp/audit-ws",
+        "project_brief": "self-audit",
+        "parent_session_id": "",
+        "team_name": team_name,
+        "conversation_id": "",
+        "agents": {
+            agent_name: {
+                "run_id": run_id,
+                "role": "pm",
+                "agent_name": agent_name,
+                "status": "running",
+            },
+        },
+        "sprint_status": "orchestrator_running",
+    }
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO spawn_registry (run_id, data_json) VALUES (?, ?)",
+            (run_id, json.dumps(spawn_row, ensure_ascii=False)),
+        )
+        conn.execute(
+            "INSERT INTO team_sessions (session_id, data_json) VALUES (?, ?)",
+            (session_id, json.dumps(team_row, ensure_ascii=False)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_spawn_registry(db_path: Path, run_id: str) -> dict:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT data_json FROM spawn_registry WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, f"spawn_registry row {run_id!r} not found"
+    return json.loads(row[0])
+
+
+# ── E2E tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_rollup_flows_through_full_consumer_stack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whole stack: scripted PM emits roll-up → mirror writes it →
+    notification + get_team_result both surface it verbatim.
+
+    Failure of any link manifests as either an empty
+    ``spawn_registry.result`` (mirror broken), a notification body
+    containing the BUG indicator (read path falling loud against a
+    populated registry — would mean we read the wrong column), or an
+    ``error_state`` in ``get_team_result`` (same).
+    """
+    db_path = tmp_path / "jarvis.db"
+    _init_schema(db_path)
+    monkeypatch.setenv("SPAWN_REGISTRY_DB", str(db_path))
+
+    run_id = "run-pm-e2e"
+    agent_name = "Morgan [PM]"
+    session_id = "sess-audit-e2e"
+    team_name = "audit-team-e2e"
+    _seed_orchestrator(
+        db_path, run_id=run_id, agent_name=agent_name,
+        session_id=session_id, team_name=team_name,
+    )
+
+    # 1. Drive a scripted agent through one orchestrator-style turn.
+    agent = await build_scripted_agent(
+        fixture_path=FIXTURES / "orchestrator_rollup.yaml",
+        tools=[],
+        agent_name="orchestrator",
+        instruction="You are Morgan [PM], the audit orchestrator.",
+    )
+    final = await agent.generate("Run the self-audit aggregation.")
+
+    # Sanity: the scripted final message contains the roll-up header.
+    final_text = "".join(
+        c.text for c in (final.content or [])
+        if getattr(c, "type", "") == "text"
+    )
+    assert "Team Roll-up" in final_text, (
+        "Scripted agent did not produce the roll-up text — fixture "
+        f"may be malformed.\nGot:\n{final_text[:400]}"
+    )
+
+    # 2. Fire the lifecycle hook that production runs on turn-end.
+    #    The agent has a fresh in-process history; we feed it through
+    #    save_agent_context exactly the way isolated_runner does.
+    from services.context_persistence import save_agent_context
+    snap_id = await save_agent_context(
+        agent, run_id, "idle",
+        agent_name=agent_name,
+        session_id=session_id,
+        team_name=team_name,
+    )
+    assert snap_id, "save_agent_context must have written a snapshot row"
+
+    # 3. The mirror must have populated spawn_registry.result.
+    stored = _read_spawn_registry(db_path, run_id)
+    assert "Team Roll-up" in stored["result"], (
+        "Mirror did not write the orchestrator's final text into "
+        f"spawn_registry.result.\nresult={stored.get('result')!r}"
+    )
+    assert stored["agent_name"] == agent_name, "merge-upsert lost other fields"
+    assert stored["team_name"] == team_name
+    assert "result_updated_at" in stored, "mirror must stamp the write time"
+
+    # 4. Read path #1 — get_team_result returns the roll-up, no error_state.
+    from fast_agent.spawn.servers import agent_spawner_server as srv
+    from fast_agent.spawn.spawn_registry import SpawnRegistry
+    # Reset cached singletons so they pick up our temp DB path. Without
+    # this, a sibling test's earlier import has cached an empty _data
+    # snapshot and the read-side sync sees no result even though the
+    # write half wrote one.
+    import fast_agent.spawn.team_spawner as ts
+    monkeypatch.setattr(ts, "_team_store", None)
+    fresh_registry = SpawnRegistry(registry_file=str(tmp_path / "unused.json"))
+    monkeypatch.setattr(srv, "_registry", fresh_registry)
+    payload = json.loads(srv.get_team_result(session_id))
+    assert "error_state" not in payload, (
+        f"orchestrator_result_missing fired against a populated registry: "
+        f"{payload.get('error_state')!r}"
+    )
+    assert "Team Roll-up" in payload["agents"][agent_name]["result"]
+
+    # 5. Read path #2 — _create_team_notification renders the roll-up
+    #    as the notification body (no BUG indicator).
+    from unittest.mock import MagicMock, patch as _patch
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    bridge = SpawnProgressBridge(
+        progress_manager=MagicMock(), registry_db=None,
+    )
+    captured = {}
+
+    class _Notif:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.id = 1
+
+    with _patch("core.database.NotificationModel", _Notif), \
+            _patch("core.database.get_db_session", return_value=MagicMock()), \
+            _patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()):
+        bridge._create_team_notification(
+            team_name=team_name,
+            agent_name=agent_name,
+            result=stored["result"],
+            members=[{"agent_name": agent_name, "status": "idle"}],
+        )
+
+    assert "BUG" not in captured["preview"], (
+        "Fail-loud body leaked into the happy path — read path is "
+        "ignoring spawn_registry.result"
+    )
+    assert "Team Roll-up" in captured["content"]
+    assert captured["title"].startswith("✅"), "title must mark success"
+
+
+@pytest.mark.asyncio
+async def test_hung_running_agent_surfaced_as_status_stuck(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end stuck-detection: an agent whose registry status is
+    ``running`` but whose ``last_active_at`` is older than the
+    threshold (LLM call / tool dispatch is hung) must surface as
+    ``sprint_status="stuck"`` with per-agent ``status="stuck"``.
+
+    Important counter-case: a long-idle resumable agent is NOT stuck.
+    That branch is covered by the unit suite
+    (``test_idle_is_never_reclassified_as_stuck_no_matter_how_old``);
+    here we just pin the genuine hang.
+    """
+    db_path = tmp_path / "jarvis.db"
+    _init_schema(db_path)
+    monkeypatch.setenv("SPAWN_REGISTRY_DB", str(db_path))
+
+    run_id = "run-hang-e2e"
+    agent_name = "Hung [Dev]"
+    session_id = "sess-hang-e2e"
+    team_name = "hang-team-e2e"
+
+    # Seed: registry says running with stale last_active (LLM hang).
+    spawn_row = {
+        "run_id": run_id,
+        "agent_name": agent_name,
+        "role": "dev",
+        "status": "running",
+        "lifecycle": "resumable",
+        "team_name": team_name,
+        "result": "",
+        "started_at": time.time() - 1300,
+        "last_active_at": time.time() - 1200,
+    }
+    team_row = {
+        "session_id": session_id,
+        "template": {"name": "agile-team", "roles": {}},
+        "workspace": "/tmp/hang-ws",
+        "project_brief": "demo",
+        "parent_session_id": "",
+        "team_name": team_name,
+        "conversation_id": "",
+        "agents": {
+            agent_name: {
+                "run_id": run_id, "role": "dev",
+                "agent_name": agent_name, "status": "running",
+            },
+        },
+        "sprint_status": "running",
+    }
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO spawn_registry (run_id, data_json) VALUES (?, ?)",
+        (run_id, json.dumps(spawn_row)),
+    )
+    conn.execute(
+        "INSERT INTO team_sessions (session_id, data_json) VALUES (?, ?)",
+        (session_id, json.dumps(team_row)),
+    )
+    conn.commit()
+    conn.close()
+
+    # Bypass the team_store singleton's lazy init so it picks up our temp DB.
+    import fast_agent.spawn.team_spawner as ts
+    monkeypatch.setattr(ts, "_team_store", None)
+
+    # And give the spawner server a registry that resolves by run_id.
+    from fast_agent.spawn.servers import agent_spawner_server as srv
+    from fast_agent.spawn.spawn_registry import SpawnRegistry
+    real_registry = SpawnRegistry(
+        registry_file=str(tmp_path / "unused.json"),
+    )
+    monkeypatch.setattr(srv, "_registry", real_registry)
+
+    payload = json.loads(srv.get_team_status(session_id))
+
+    dev = payload["agents"][agent_name]
+    assert dev["status"] == "stuck", (
+        f"hung-running agent must surface as 'stuck', got {dev['status']!r}"
+    )
+    assert dev["raw_status"] == "running"
+    assert dev["stuck_seconds"] >= 30
+    assert payload["sprint_status"] == "stuck"
+    assert "1 stuck" in payload["progress"]

--- a/backend/tests/test_context_persistence.py
+++ b/backend/tests/test_context_persistence.py
@@ -653,3 +653,150 @@ async def test_save_large_context_warns_but_saves(ctx_db):
 
     assert result is not None
     assert result > 0
+
+
+# ═══════════════════════════════════════════════
+# 9. Orchestrator-result mirror into spawn_registry
+#    (single source of truth for notification + get_team_result)
+# ═══════════════════════════════════════════════
+
+
+def _seed_spawn_registry_row(db_path: str, run_id: str, base_data: dict) -> None:
+    """Pre-create a spawn_registry row so the mirror hook can UPDATE it.
+
+    Real spawner writes this row at spawn time. Tests seed it directly so
+    the helper has a row to merge into.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS spawn_registry (
+            run_id TEXT PRIMARY KEY,
+            data_json TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO spawn_registry (run_id, data_json) VALUES (?, ?)",
+        (run_id, json.dumps(base_data, ensure_ascii=False)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read_spawn_registry_row(db_path: str, run_id: str) -> dict | None:
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT data_json FROM spawn_registry WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+    conn.close()
+    return json.loads(row[0]) if row else None
+
+
+def test_extract_last_assistant_text_helper_walks_backwards():
+    """Helper returns the most recent assistant text turn, skipping
+    later user/tool turns and earlier assistant turns."""
+    from services.context_persistence import _extract_last_assistant_text
+
+    msgs = [
+        FakeMessage(role="assistant", text="early answer"),
+        FakeMessage(role="user", text="user follow-up"),
+        FakeMessage(role="assistant", text="LATEST ROLL-UP"),
+        FakeMessage(role="user", text="another user msg"),
+    ]
+    assert _extract_last_assistant_text(msgs) == "LATEST ROLL-UP"
+
+
+def test_extract_last_assistant_text_returns_empty_when_only_tool_calls():
+    """Assistant turns with no text content (only tool_calls in real
+    payloads) yield empty string — caller must NOT overwrite registry."""
+    from services.context_persistence import _extract_last_assistant_text
+
+    # Assistant turn with content=[] simulates tool_call-only turn
+    tool_only = FakeMessage(role="assistant", text="")
+    tool_only.content = []  # no text parts
+    user_msg = FakeMessage(role="user", text="hello")
+    assert _extract_last_assistant_text([user_msg, tool_only]) == ""
+
+
+def test_extract_last_assistant_text_returns_empty_for_no_assistant():
+    """Conversation with only user turns → empty."""
+    from services.context_persistence import _extract_last_assistant_text
+
+    assert _extract_last_assistant_text([FakeMessage(role="user", text="hi")]) == ""
+    assert _extract_last_assistant_text([]) == ""
+
+
+@pytest.mark.asyncio
+async def test_save_mirrors_last_assistant_text_into_spawn_registry(ctx_db):
+    """save_agent_context UPDATEs spawn_registry.data_json.result with
+    the agent's last assistant text — this is the write half of the
+    single-source-of-truth contract for orchestrator response."""
+    _seed_spawn_registry_row(
+        ctx_db, "run-mirror",
+        {"run_id": "run-mirror", "agent_name": "Morgan [PM]", "status": "running",
+         "result": "", "team_name": "demo-team"},
+    )
+
+    agent = FakeAgent(messages=[
+        FakeMessage(role="user", text="kickoff brief"),
+        FakeMessage(role="assistant", text="# Roll-up\nVerdict: PARTIAL"),
+    ])
+    with patch(_TO_JSON_PATCH, return_value='[{"m":1}]'):
+        from services.context_persistence import save_agent_context
+
+        snap_id = await save_agent_context(agent, "run-mirror", "idle")
+    assert snap_id is not None
+
+    row = _read_spawn_registry_row(ctx_db, "run-mirror")
+    assert row is not None
+    assert row["result"] == "# Roll-up\nVerdict: PARTIAL"
+    assert "result_updated_at" in row
+    # Other fields preserved (merge-upsert, not full replace)
+    assert row["agent_name"] == "Morgan [PM]"
+    assert row["team_name"] == "demo-team"
+
+
+@pytest.mark.asyncio
+async def test_save_does_not_overwrite_existing_result_with_empty(ctx_db):
+    """If the latest turn is tool-call only (no assistant text), the
+    helper returns "" and we MUST leave registry.result untouched —
+    otherwise a successful roll-up could be wiped by the next idle
+    turn that happens to be a tool call."""
+    _seed_spawn_registry_row(
+        ctx_db, "run-keep",
+        {"run_id": "run-keep", "result": "PREVIOUS ROLL-UP TEXT"},
+    )
+
+    tool_only = FakeMessage(role="assistant", text="")
+    tool_only.content = []
+    agent = FakeAgent(messages=[FakeMessage(role="user", text="ping"), tool_only])
+    with patch(_TO_JSON_PATCH, return_value='[{"m":1}]'):
+        from services.context_persistence import save_agent_context
+
+        await save_agent_context(agent, "run-keep", "idle")
+
+    row = _read_spawn_registry_row(ctx_db, "run-keep")
+    assert row is not None
+    assert row["result"] == "PREVIOUS ROLL-UP TEXT"
+
+
+@pytest.mark.asyncio
+async def test_save_skips_mirror_when_spawn_registry_row_missing(ctx_db, caplog):
+    """Race: snapshot fires before spawner has written the registry row.
+    Helper must log a warning and skip — never insert a half-populated
+    row that breaks the spawner's merge-upsert on first real write."""
+    # NO seed — spawn_registry row absent.
+    agent = FakeAgent(messages=[FakeMessage(role="assistant", text="hello")])
+    with patch(_TO_JSON_PATCH, return_value='[{"m":1}]'), \
+            caplog.at_level("WARNING"):
+        from services.context_persistence import save_agent_context
+
+        snap_id = await save_agent_context(agent, "run-noreg", "idle")
+
+    # Snapshot still saved
+    assert snap_id is not None
+    # No registry row was created by the mirror helper
+    row = _read_spawn_registry_row(ctx_db, "run-noreg")
+    assert row is None
+    # Warning surfaced loud — easy to grep in ops logs
+    assert any("spawn_registry row missing" in r.message for r in caplog.records)

--- a/backend/tests/test_meeting_room_transcript.py
+++ b/backend/tests/test_meeting_room_transcript.py
@@ -42,6 +42,184 @@ async def test_create_meeting_auto_joins_all():
     assert initial_state["started"] is True
 
 
+@pytest.mark.asyncio
+async def test_create_meeting_auto_includes_creator():
+    """Creator (my_name) is the chair — auto-prepended to participants."""
+    mock_storage = MagicMock()
+    mock_storage.create_meeting = MagicMock()
+
+    with patch("fast_agent.spawn.servers.meeting_room_server._storage", mock_storage):
+        with patch("fast_agent.spawn.servers.meeting_room_server._get_my_name", return_value="Cameron [PM]"):
+            with patch("fast_agent.spawn.servers.meeting_room_server._get_bus") as mock_bus:
+                mock_bus.return_value = MagicMock()
+                with patch("fast_agent.spawn.servers.meeting_room_server._auto_wake_if_idle"):
+                    with patch("fast_agent.spawn.servers.meeting_room_server._fire_hook"):
+                        from fast_agent.spawn.servers.meeting_room_server import create_meeting
+                        # Creator passes only OTHERS — should still be added at index 0
+                        result = await create_meeting(
+                            agenda="Sprint kickoff",
+                            participants="Devon [BA], Reese [Dev], Devon [QE]",
+                        )
+
+    result_data = json.loads(result)
+    parts = result_data["participants"]
+    assert parts[0] == "Cameron [PM]", f"Creator must speak first, got order: {parts}"
+    assert parts == ["Cameron [PM]", "Devon [BA]", "Reese [Dev]", "Devon [QE]"]
+
+    # Storage state must reflect the same ordered list with creator joined.
+    # Post-B1: participants live in state_json (mutable bucket), config_json
+    # only carries write-once setup (agenda, created_by, created_at).
+    call_args = mock_storage.create_meeting.call_args
+    stored_config, initial_state = call_args[0][1], call_args[0][2]
+    assert "participants" not in stored_config, (
+        "participants must NOT live in config_json (write-once bucket)"
+    )
+    assert initial_state["participants"][0] == "Cameron [PM]"
+    assert "Cameron [PM]" in initial_state["joined"]
+
+
+@pytest.mark.asyncio
+async def test_create_meeting_does_not_duplicate_creator():
+    """If creator is already in participants, don't add a duplicate."""
+    mock_storage = MagicMock()
+    mock_storage.create_meeting = MagicMock()
+
+    with patch("fast_agent.spawn.servers.meeting_room_server._storage", mock_storage):
+        with patch("fast_agent.spawn.servers.meeting_room_server._get_my_name", return_value="PM"):
+            with patch("fast_agent.spawn.servers.meeting_room_server._get_bus") as mock_bus:
+                mock_bus.return_value = MagicMock()
+                with patch("fast_agent.spawn.servers.meeting_room_server._auto_wake_if_idle"):
+                    with patch("fast_agent.spawn.servers.meeting_room_server._fire_hook"):
+                        from fast_agent.spawn.servers.meeting_room_server import create_meeting
+                        # Creator explicitly listed mid-list — preserve given position
+                        result = await create_meeting(
+                            agenda="Test",
+                            participants="BA, PM, Dev",
+                        )
+
+    parts = json.loads(result)["participants"]
+    assert parts.count("PM") == 1
+    assert parts == ["BA", "PM", "Dev"], f"Existing position preserved, got: {parts}"
+
+
+@pytest.mark.asyncio
+async def test_create_meeting_truncates_long_agenda():
+    """Agenda > 120 chars is truncated + warning surfaced.
+
+    Guards the b61af7db incident: PM stuffed a 50-line markdown brief
+    into ``agenda``, breaking the dashboard title clamp.
+    """
+    long_agenda = (
+        "## Project Context\n**Epic:** JXCC-19 - Tools & MCP Servers\n"
+        "## Objective\nComprehensive audit of all tools and MCP servers\n"
+        "## Scope — extensive list of every tool category goes here, "
+        "way past the 120 char limit on purpose to verify truncation"
+    )
+    assert len(long_agenda) > 120
+
+    mock_storage = MagicMock()
+    mock_storage.create_meeting = MagicMock()
+
+    with patch("fast_agent.spawn.servers.meeting_room_server._storage", mock_storage):
+        with patch("fast_agent.spawn.servers.meeting_room_server._get_my_name", return_value="PM"):
+            with patch("fast_agent.spawn.servers.meeting_room_server._get_bus") as mock_bus:
+                mock_bus.return_value = MagicMock()
+                with patch("fast_agent.spawn.servers.meeting_room_server._auto_wake_if_idle"):
+                    with patch("fast_agent.spawn.servers.meeting_room_server._fire_hook"):
+                        from fast_agent.spawn.servers.meeting_room_server import create_meeting
+                        result = await create_meeting(
+                            agenda=long_agenda,
+                            participants="BA, Dev",
+                            description="Long-form context belongs HERE, not in agenda.",
+                        )
+
+    payload = json.loads(result)
+    # Truncated agenda preserved in result + warning explains why.
+    assert len(payload["agenda"]) <= 121, (  # 120 + ellipsis "…"
+        f"Agenda must be truncated to ≤120 chars (+ ellipsis), got {len(payload['agenda'])}"
+    )
+    assert payload["agenda"].endswith("…"), "Truncation must use ellipsis marker"
+    assert "warning" in payload
+    assert "agenda truncated" in payload["warning"]
+    assert "description" in payload["warning"], (
+        "Warning must hint at the description param so the LLM corrects itself"
+    )
+
+    # Storage saw the truncated agenda; description preserved separately.
+    stored_config = mock_storage.create_meeting.call_args[0][1]
+    assert len(stored_config["agenda"]) <= 121
+    assert stored_config["description"] == "Long-form context belongs HERE, not in agenda."
+
+
+@pytest.mark.asyncio
+async def test_create_meeting_short_agenda_no_warning():
+    """Short agenda passes through unchanged, no warning field set."""
+    mock_storage = MagicMock()
+    mock_storage.create_meeting = MagicMock()
+
+    with patch("fast_agent.spawn.servers.meeting_room_server._storage", mock_storage):
+        with patch("fast_agent.spawn.servers.meeting_room_server._get_my_name", return_value="PM"):
+            with patch("fast_agent.spawn.servers.meeting_room_server._get_bus") as mock_bus:
+                mock_bus.return_value = MagicMock()
+                with patch("fast_agent.spawn.servers.meeting_room_server._auto_wake_if_idle"):
+                    with patch("fast_agent.spawn.servers.meeting_room_server._fire_hook"):
+                        from fast_agent.spawn.servers.meeting_room_server import create_meeting
+                        result = await create_meeting(
+                            agenda="Sprint 1 kickoff",
+                            participants="BA, Dev",
+                        )
+
+    payload = json.loads(result)
+    assert payload["agenda"] == "Sprint 1 kickoff"
+    assert "warning" not in payload
+    assert "…" not in payload["agenda"]
+
+
+@pytest.mark.asyncio
+async def test_create_meeting_description_persisted():
+    """Optional ``description`` parameter lands in config_json."""
+    mock_storage = MagicMock()
+    mock_storage.create_meeting = MagicMock()
+
+    with patch("fast_agent.spawn.servers.meeting_room_server._storage", mock_storage):
+        with patch("fast_agent.spawn.servers.meeting_room_server._get_my_name", return_value="PM"):
+            with patch("fast_agent.spawn.servers.meeting_room_server._get_bus") as mock_bus:
+                mock_bus.return_value = MagicMock()
+                with patch("fast_agent.spawn.servers.meeting_room_server._auto_wake_if_idle"):
+                    with patch("fast_agent.spawn.servers.meeting_room_server._fire_hook"):
+                        from fast_agent.spawn.servers.meeting_room_server import create_meeting
+                        await create_meeting(
+                            agenda="Audit",
+                            participants="BA, Dev",
+                            description="Full project brief with markdown links etc.",
+                        )
+
+    stored_config = mock_storage.create_meeting.call_args[0][1]
+    assert stored_config["description"] == "Full project brief with markdown links etc."
+
+
+@pytest.mark.asyncio
+async def test_create_meeting_solo_creator_rejected():
+    """Need at least 2 participants — creator alone is not enough."""
+    mock_storage = MagicMock()
+    mock_storage.create_meeting = MagicMock()
+
+    with patch("fast_agent.spawn.servers.meeting_room_server._storage", mock_storage):
+        with patch("fast_agent.spawn.servers.meeting_room_server._get_my_name", return_value="PM"):
+            with patch("fast_agent.spawn.servers.meeting_room_server._get_bus") as mock_bus:
+                mock_bus.return_value = MagicMock()
+                with patch("fast_agent.spawn.servers.meeting_room_server._auto_wake_if_idle"):
+                    with patch("fast_agent.spawn.servers.meeting_room_server._fire_hook"):
+                        from fast_agent.spawn.servers.meeting_room_server import create_meeting
+                        result = await create_meeting(
+                            agenda="Test",
+                            participants="",  # No others — only creator
+                        )
+
+    assert "error" in json.loads(result)
+    mock_storage.create_meeting.assert_not_called()
+
+
 # ── Test short meeting IDs ──
 
 @pytest.mark.asyncio

--- a/backend/tests/test_routes/test_inject_path_a_feedback.py
+++ b/backend/tests/test_routes/test_inject_path_a_feedback.py
@@ -1,0 +1,134 @@
+"""Regression tests for inject Path A (MessageBus) UI feedback.
+
+2026-05-15 incident: user injected a prompt at Bailey [PM] via the
+dashboard. The agent's process was alive (Path A — MessageBus queue
+delivery), and the inject API returned ``status=queued`` in ~50ms.
+
+But the user saw no visual feedback in the AgentTerminal:
+  - Agent status stayed at "idle" → no pulse dot, no "Running" label.
+  - The injected message sat unread in the inbox indefinitely.
+  - Eventually the agent did process it (after an unrelated wake),
+    but for several minutes the UI was completely silent.
+
+Two contracts pinned by this file:
+
+  1. Path A MUST broadcast a ``started`` activity-stream event so the
+     dashboard reflects "running" immediately on submit (parity with
+     Path B and Path C which already do this).
+
+  2. Path A MUST call ``auto_wake_if_idle(agent_name)`` so the alive
+     agent picks up the inbox message NOW via the AgentChannel socket
+     signal — instead of waiting indefinitely for some other event to
+     trigger an LLM call (and thus an inbox check inside
+     ``InboxWatcherHook.before_llm_call``).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_path_a_broadcasts_started_event_immediately():
+    """The inject Path A handler must broadcast a ``started`` event right
+    after queueing the message, so the dashboard's agent-status badge
+    flips from idle → running BEFORE the user looks for feedback.
+
+    Pinned because previously only Path B (resume) and Path C (generate)
+    broadcasted ``started``; Path A was silent, leaving the UI stuck on
+    ``idle`` for the full duration between submit and the agent's first
+    ``thinking`` event.
+    """
+    from routes.inject import _inject_via_message_bus
+
+    spawn_record = {
+        "agent_name": "Bailey [PM]",
+        "session_id": "test-sid",
+        "workspace": "",  # force the fallback path that uses session_id
+        "status": "idle",
+    }
+
+    broadcasted: list[dict] = []
+
+    def _capture(event):
+        broadcasted.append(event)
+
+    # Patch the modules ``_inject_via_message_bus`` actually imports
+    # from to avoid hitting real MessageBus / activity_stream / wake.
+    with patch("routes.inject.activity_stream_manager") as mock_asm, \
+            patch("fast_agent.spawn.message_bus.MessageBus") as mock_bus_cls, \
+            patch("fast_agent.spawn.servers._team_helpers.auto_wake_if_idle") as mock_wake, \
+            patch.dict("os.environ", {"SPAWN_PROJECT_DIR": "/tmp/fake-project"}):
+        mock_asm.broadcast.side_effect = _capture
+        mock_bus = MagicMock()
+        mock_bus_cls.return_value = mock_bus
+
+        result = await _inject_via_message_bus(
+            agent_name="Bailey [PM]",
+            message="please advance the retro meeting",
+            spawn_record=spawn_record,
+        )
+
+    # API returns queued (Path A characteristic).
+    assert result.status == "queued"
+    assert result.path == "message_bus"
+
+    # Wake signal must fire so the alive agent picks up the inbox.
+    assert mock_wake.called, (
+        "auto_wake_if_idle was NOT called. Without it the agent's "
+        "InboxWatcherHook only sees the message on the next "
+        "before_llm_call tick — which never fires while the agent "
+        "is idle. The inject would sit unread indefinitely."
+    )
+    assert mock_wake.call_args[0][0] == "Bailey [PM]"
+
+    # Started event must be broadcast so the UI flips status.
+    started = [e for e in broadcasted if e.get("event_type") == "started"]
+    assert started, (
+        "No ``started`` event broadcast. Frontend store only flips "
+        "agent.status to 'running' on started/thinking/tool_call/resumed "
+        "events. Without this, the dashboard shows no feedback after "
+        "the inject API returns."
+    )
+    assert started[0]["agent_name"] == "Bailey [PM]"
+    assert "Processing inject" in started[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_path_a_inject_does_not_fail_when_wake_raises():
+    """``auto_wake_if_idle`` is best-effort — if it raises (e.g. registry
+    unavailable in a degraded environment), the inject API call must
+    still succeed because the message is already queued in the inbox.
+
+    A regression here would mean transient wake-path failures cause
+    HTTP 500 responses for the user even though the underlying
+    delivery was fine.
+    """
+    from routes.inject import _inject_via_message_bus
+
+    spawn_record = {
+        "agent_name": "Bailey [PM]",
+        "session_id": "test-sid",
+        "workspace": "",
+    }
+
+    with patch("routes.inject.activity_stream_manager"), \
+            patch("fast_agent.spawn.message_bus.MessageBus"), \
+            patch(
+                "fast_agent.spawn.servers._team_helpers.auto_wake_if_idle",
+                side_effect=RuntimeError("registry not loaded"),
+            ), \
+            patch.dict("os.environ", {"SPAWN_PROJECT_DIR": "/tmp/fake-project"}):
+        # Should NOT raise — wake failure is logged and swallowed.
+        result = await _inject_via_message_bus(
+            agent_name="Bailey [PM]",
+            message="ping",
+            spawn_record=spawn_record,
+        )
+
+    assert result.status == "queued", (
+        "Wake failure should not block the inject — the message is "
+        "already in the inbox and will be picked up on the next agent "
+        "trigger. Inject API must still return queued."
+    )

--- a/backend/tests/test_services/test_agent_message_stream.py
+++ b/backend/tests/test_services/test_agent_message_stream.py
@@ -1,0 +1,436 @@
+"""Unit tests for services.agent_message_stream.
+
+Covers:
+  * trim_message_for_stream — caps large text content + tool_results blocks.
+  * emit_message_history_delta — emits exactly one event per new turn,
+    keeps cursor on the agent, resets cursor when history is cleared.
+  * list_agent_messages / get_agent_turn_full — read-side helpers feeding
+    the REST endpoints.
+
+The tests use a tiny stand-in for an agent (a dataclass with
+``message_history``) plus a fake activity_stream that captures broadcasts.
+We never import fast_agent here — model_dump is exercised against a
+PromptMessageExtended built with simple TextContent blocks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# Real fast_agent types — we want round-trip dump/parse to match prod shape.
+from fast_agent.types import PromptMessageExtended
+from mcp.types import TextContent
+
+from services import agent_message_stream as ams
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+class _FakeAgent:
+    """Minimal stand-in for an in-process agent, exposing message_history."""
+
+    def __init__(self) -> None:
+        self.message_history: list[PromptMessageExtended] = []
+
+
+@pytest.fixture(autouse=True)
+def _patch_activity_stream(monkeypatch: pytest.MonkeyPatch):
+    """Replace activity_stream_manager.broadcast with a list capture.
+
+    Also clears the per-agent recent-turns cache between tests so each
+    case sees a clean slate (the cache is module-global by design).
+    """
+    captured: list[dict] = []
+
+    class _FakeStream:
+        @staticmethod
+        def broadcast(event: dict) -> None:
+            captured.append(event)
+
+    import services.activity_stream as act
+
+    monkeypatch.setattr(act, "activity_stream_manager", _FakeStream())
+    ams.reset_recent_turns()
+    yield captured
+    ams.reset_recent_turns()
+
+
+def _user_msg(text: str) -> PromptMessageExtended:
+    return PromptMessageExtended(role="user", content=[TextContent(type="text", text=text)])
+
+
+def _asst_msg(text: str) -> PromptMessageExtended:
+    return PromptMessageExtended(role="assistant", content=[TextContent(type="text", text=text)])
+
+
+# ── trim_message_for_stream ─────────────────────────────────────────────
+
+
+def test_trim_short_content_unchanged():
+    payload = {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+    out = ams.trim_message_for_stream(payload)
+    block = out["content"][0]
+    assert block["text"] == "hello"
+    assert "_truncated" not in block
+    assert "_full_size" not in block
+
+
+def test_trim_long_content_marks_truncated():
+    big = "x" * (ams.MAX_BLOCK_TEXT_BYTES + 1024)
+    payload = {"role": "assistant", "content": [{"type": "text", "text": big}]}
+    out = ams.trim_message_for_stream(payload)
+    block = out["content"][0]
+    assert len(block["text"].encode("utf-8")) <= ams.MAX_BLOCK_TEXT_BYTES
+    assert block["_truncated"] is True
+    assert block["_full_size"] == len(big.encode("utf-8"))
+
+
+def test_trim_tool_result_content_blocks():
+    big = "y" * (ams.MAX_BLOCK_TEXT_BYTES + 5)
+    payload = {
+        "role": "user",
+        "tool_results": {
+            "tid_1": {"content": [{"type": "text", "text": big}]},
+            "tid_2": {"content": [{"type": "text", "text": "small"}]},
+        },
+    }
+    out = ams.trim_message_for_stream(payload)
+    a = out["tool_results"]["tid_1"]["content"][0]
+    b = out["tool_results"]["tid_2"]["content"][0]
+    assert a["_truncated"] is True
+    assert a["_full_size"] == len(big.encode("utf-8"))
+    assert b["text"] == "small"
+    assert "_truncated" not in b
+
+
+def test_trim_handles_missing_keys_gracefully():
+    # No content key, no tool_results — should not raise.
+    payload = {"role": "assistant"}
+    out = ams.trim_message_for_stream(payload)
+    assert out is payload
+
+
+def test_trim_non_text_block_left_alone():
+    payload = {
+        "role": "user",
+        "content": [
+            {"type": "image", "data": "iVBORw0KGgo=", "mimeType": "image/png"}
+        ],
+    }
+    out = ams.trim_message_for_stream(payload)
+    assert out["content"][0]["type"] == "image"
+    assert "_truncated" not in out["content"][0]
+
+
+# ── emit_message_history_delta ─────────────────────────────────────────
+
+
+def test_emit_first_run_emits_all_turns(_patch_activity_stream):
+    captured = _patch_activity_stream
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg("hi"), _asst_msg("hello")]
+
+    n = ams.emit_message_history_delta(agent, "TestAgent", "run-1")
+
+    assert n == 2
+    assert len(captured) == 2
+    assert captured[0]["agent_name"] == "TestAgent"
+    assert captured[0]["event_type"] == "message_turn"
+    assert captured[0]["data"]["turn_idx"] == 0
+    assert captured[0]["data"]["role"] == "user"
+    assert captured[1]["data"]["turn_idx"] == 1
+    assert captured[1]["data"]["role"] == "assistant"
+    assert getattr(agent, ams.HISTORY_CURSOR_ATTR) == 2
+
+
+def test_emit_only_delta_after_initial(_patch_activity_stream):
+    captured = _patch_activity_stream
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg("a"), _asst_msg("b")]
+    ams.emit_message_history_delta(agent, "T", "r1")
+    captured.clear()
+
+    # Append two more turns
+    agent.message_history.append(_user_msg("c"))
+    agent.message_history.append(_asst_msg("d"))
+    n = ams.emit_message_history_delta(agent, "T", "r1")
+
+    assert n == 2
+    assert [e["data"]["turn_idx"] for e in captured] == [2, 3]
+    assert getattr(agent, ams.HISTORY_CURSOR_ATTR) == 4
+
+
+def test_emit_no_op_when_nothing_new(_patch_activity_stream):
+    captured = _patch_activity_stream
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg("hi")]
+    ams.emit_message_history_delta(agent, "T", "r1")
+    captured.clear()
+
+    # Same history — second call should emit nothing.
+    n = ams.emit_message_history_delta(agent, "T", "r1")
+    assert n == 0
+    assert captured == []
+
+
+def test_emit_resets_cursor_when_history_cleared(_patch_activity_stream):
+    captured = _patch_activity_stream
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg("a"), _asst_msg("b"), _user_msg("c")]
+    ams.emit_message_history_delta(agent, "T", "r1")
+    captured.clear()
+
+    # Simulate /clear or new conversation: history shrinks.
+    agent.message_history = [_user_msg("fresh")]
+    n = ams.emit_message_history_delta(agent, "T", "r2")
+
+    assert n == 1
+    assert captured[0]["data"]["turn_idx"] == 0
+    assert captured[0]["data"]["role"] == "user"
+    assert captured[0]["run_id"] == "r2"
+    assert getattr(agent, ams.HISTORY_CURSOR_ATTR) == 1
+
+
+def test_emit_truncates_large_blocks_in_payload(_patch_activity_stream):
+    captured = _patch_activity_stream
+    big = "z" * (ams.MAX_BLOCK_TEXT_BYTES + 100)
+    agent = _FakeAgent()
+    agent.message_history = [
+        PromptMessageExtended(role="assistant", content=[TextContent(type="text", text=big)])
+    ]
+
+    ams.emit_message_history_delta(agent, "T", "r1")
+
+    assert len(captured) == 1
+    block = captured[0]["data"]["message"]["content"][0]
+    assert block["_truncated"] is True
+    assert block["_full_size"] == len(big.encode("utf-8"))
+
+
+def test_emit_swallows_history_access_errors(_patch_activity_stream):
+    captured = _patch_activity_stream
+
+    class _Broken:
+        @property
+        def message_history(self):
+            raise RuntimeError("bork")
+
+    n = ams.emit_message_history_delta(_Broken(), "T", "r1")
+    assert n == 0
+    assert captured == []
+
+
+# ── list_agent_messages ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def _live_agent_app(monkeypatch: pytest.MonkeyPatch):
+    """Plug a fake agent_app into services.shared_state so the resolver picks it up."""
+    import services.shared_state as state
+
+    agents = {}
+
+    class _FakeAgentApp:
+        def __init__(self) -> None:
+            self._agents = agents
+
+    monkeypatch.setattr(state, "agent_app", _FakeAgentApp(), raising=False)
+    return agents
+
+
+def test_list_messages_uses_live_history(_live_agent_app):
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg("u1"), _asst_msg("a1"), _user_msg("u2")]
+    _live_agent_app["LiveOne"] = agent
+
+    out = ams.list_agent_messages("LiveOne")
+    assert out["total"] == 3
+    assert [t["turn_idx"] for t in out["turns"]] == [0, 1, 2]
+    assert [t["role"] for t in out["turns"]] == ["user", "assistant", "user"]
+
+
+def test_list_messages_since_returns_delta(_live_agent_app):
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg("u1"), _asst_msg("a1"), _user_msg("u2"), _asst_msg("a2")]
+    _live_agent_app["DeltaOne"] = agent
+
+    out = ams.list_agent_messages("DeltaOne", since=2)
+    assert out["total"] == 4
+    assert [t["turn_idx"] for t in out["turns"]] == [2, 3]
+
+
+def test_list_messages_limit_returns_latest_window(_live_agent_app):
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg(f"m{i}") for i in range(20)]
+    _live_agent_app["WindowOne"] = agent
+
+    out = ams.list_agent_messages("WindowOne", since=0, limit=5)
+    assert out["total"] == 20
+    assert [t["turn_idx"] for t in out["turns"]] == [15, 16, 17, 18, 19]
+    assert out["start"] == 15
+
+
+def test_list_messages_unknown_agent_returns_empty(_live_agent_app):
+    out = ams.list_agent_messages("Ghost")
+    assert out == {"turns": [], "total": 0}
+
+
+# ── get_agent_turn_full ────────────────────────────────────────────────
+
+
+def test_get_full_returns_untruncated_block(_live_agent_app):
+    big = "Q" * (ams.MAX_BLOCK_TEXT_BYTES + 200)
+    agent = _FakeAgent()
+    agent.message_history = [_asst_msg(big)]
+    _live_agent_app["FullOne"] = agent
+
+    out = ams.get_agent_turn_full("FullOne", 0)
+    assert out is not None
+    assert out["turn_idx"] == 0
+    block = out["message"]["content"][0]
+    assert len(block["text"].encode("utf-8")) == len(big.encode("utf-8"))
+    assert "_truncated" not in block
+
+
+def test_get_full_returns_none_for_out_of_range(_live_agent_app):
+    agent = _FakeAgent()
+    agent.message_history = [_user_msg("only")]
+    _live_agent_app["TinyOne"] = agent
+
+    assert ams.get_agent_turn_full("TinyOne", 5) is None
+    assert ams.get_agent_turn_full("TinyOne", -1) is None
+    assert ams.get_agent_turn_full("Missing", 0) is None
+
+
+# ── Recent-turns cache (covers ephemeral clone agents) ─────────────────
+
+
+def test_emit_records_full_payload_in_cache(_patch_activity_stream):
+    """Each emitted turn lands in the per-agent cache — used by the read
+    endpoints after the live (clone) agent has been discarded."""
+    big = "Q" * (ams.MAX_BLOCK_TEXT_BYTES + 100)
+    agent = _FakeAgent()
+    agent.message_history = [
+        _user_msg("ask"),
+        PromptMessageExtended(role="assistant", content=[TextContent(type="text", text=big)]),
+    ]
+    ams.emit_message_history_delta(agent, "FinanceClone", "run-1")
+
+    cached = ams.get_recent_turns("FinanceClone")
+    assert [t["turn_idx"] for t in cached] == [0, 1]
+    # The cached blob is the FULL untruncated text — we expose it via
+    # ``/turns/{idx}/full`` so users can read the whole tool_result on demand.
+    assistant_text = cached[1]["message"]["content"][0]["text"]
+    assert len(assistant_text.encode("utf-8")) == len(big.encode("utf-8"))
+    assert "_truncated" not in cached[1]["message"]["content"][0]
+
+
+def test_list_messages_falls_back_to_cache_when_live_history_empty(_patch_activity_stream, _live_agent_app):
+    """Reproducer for the FinanceAgent bug: live agent has empty history
+    (because each tool call ran on a discarded clone) but emitted turns
+    are in the cache. ``list_agent_messages`` must serve from there."""
+    # Persistent template lives in the registry but its history is empty
+    # — this mirrors how ``agent__FinanceAgent`` runs against a clone.
+    template = _FakeAgent()
+    _live_agent_app["FinanceClone"] = template
+
+    # A clone ran and emitted history; the cache captured everything.
+    clone = _FakeAgent()
+    clone.message_history = [_user_msg("hi"), _asst_msg("response")]
+    ams.emit_message_history_delta(clone, "FinanceClone", "run-1")
+
+    # The persistent template is still empty; the read endpoint must serve
+    # the cached turns instead of returning a misleading empty list.
+    assert template.message_history == []
+    out = ams.list_agent_messages("FinanceClone")
+    assert out["total"] == 2
+    assert [t["turn_idx"] for t in out["turns"]] == [0, 1]
+    assert out["turns"][0]["role"] == "user"
+    assert out["turns"][1]["role"] == "assistant"
+
+
+def test_get_full_serves_cache_when_live_history_empty(_patch_activity_stream, _live_agent_app):
+    template = _FakeAgent()
+    _live_agent_app["FinanceClone"] = template
+
+    big = "B" * (ams.MAX_BLOCK_TEXT_BYTES + 50)
+    clone = _FakeAgent()
+    clone.message_history = [
+        PromptMessageExtended(role="assistant", content=[TextContent(type="text", text=big)])
+    ]
+    ams.emit_message_history_delta(clone, "FinanceClone", "run-1")
+
+    out = ams.get_agent_turn_full("FinanceClone", 0)
+    assert out is not None
+    assert out["turn_idx"] == 0
+    block = out["message"]["content"][0]
+    # The full endpoint serves UNTRUNCATED content (cache stores the full payload).
+    assert len(block["text"].encode("utf-8")) == len(big.encode("utf-8"))
+    assert "_truncated" not in block
+
+
+def test_list_messages_prefers_live_history_over_cache(_patch_activity_stream, _live_agent_app):
+    """Persistent agents (e.g. Jarvis) own their history; cache is only
+    consulted as a fallback. We must prefer live data so we don't ever
+    serve stale cached entries when the live source is authoritative."""
+    live = _FakeAgent()
+    live.message_history = [_user_msg("live-1"), _asst_msg("live-2")]
+    _live_agent_app["Persistent"] = live
+
+    # Pollute cache with stale turns under the same name
+    ams._record_recent_turn("Persistent", 0, {"role": "user", "content": [{"type": "text", "text": "stale"}]})
+
+    out = ams.list_agent_messages("Persistent")
+    assert out["total"] == 2
+    assert out["turns"][0]["message"]["content"][0]["text"] == "live-1"
+
+
+def test_emit_truncates_broadcast_but_keeps_cache_full(_patch_activity_stream):
+    """The broadcast version is trimmed (small SSE chunks); the cached
+    version stays full so /turns/{idx}/full can recover the original."""
+    captured = _patch_activity_stream
+    big = "T" * (ams.MAX_BLOCK_TEXT_BYTES + 1000)
+    agent = _FakeAgent()
+    agent.message_history = [
+        PromptMessageExtended(role="assistant", content=[TextContent(type="text", text=big)])
+    ]
+    ams.emit_message_history_delta(agent, "X", "r1")
+
+    broadcast_block = captured[0]["data"]["message"]["content"][0]
+    assert broadcast_block["_truncated"] is True
+    assert len(broadcast_block["text"].encode("utf-8")) <= ams.MAX_BLOCK_TEXT_BYTES
+
+    cached_block = ams.get_recent_turns("X")[0]["message"]["content"][0]
+    assert "_truncated" not in cached_block
+    assert len(cached_block["text"].encode("utf-8")) == len(big.encode("utf-8"))
+
+
+def test_recent_turn_cache_caps_size():
+    """Cache must not grow unbounded — emitting more turns than the cap
+    drops the oldest entries while keeping turn_idx sortable."""
+    name = "BigOne"
+    cap = ams._RECENT_TURNS_PER_AGENT_CAP
+    for i in range(cap + 25):
+        ams._record_recent_turn(name, i, {"role": "user", "content": [{"type": "text", "text": f"m{i}"}]})
+
+    cached = ams.get_recent_turns(name)
+    assert len(cached) == cap
+    # Oldest 25 dropped, latest cap kept.
+    assert cached[0]["turn_idx"] == 25
+    assert cached[-1]["turn_idx"] == cap + 24
+
+
+def test_recent_turn_cache_replaces_existing_idx():
+    """Re-recording the same turn_idx (e.g. a clone re-ran from idx 0)
+    overwrites in place rather than appending duplicates."""
+    name = "Replacing"
+    ams._record_recent_turn(name, 0, {"role": "user", "content": [{"text": "v1"}]})
+    ams._record_recent_turn(name, 1, {"role": "assistant", "content": [{"text": "old"}]})
+    ams._record_recent_turn(name, 1, {"role": "assistant", "content": [{"text": "new"}]})
+
+    cached = ams.get_recent_turns(name)
+    assert len(cached) == 2
+    assert cached[1]["message"]["content"][0]["text"] == "new"

--- a/backend/tests/test_services/test_auto_wake_probe_dispatch.py
+++ b/backend/tests/test_services/test_auto_wake_probe_dispatch.py
@@ -1,0 +1,191 @@
+"""Probe-then-dispatch contract for ``auto_wake_if_idle``.
+
+The previous implementation used "Tier 1 → fall back to Tier 2" semantics:
+first try the AgentChannel socket signal, and if it returns False try
+the spawner instead. That hid a real ambiguity: ``send_signal`` returns
+False on (sock missing) AND (connect refused) AND (write error) — three
+very different states. The Tier 2 path then had to re-probe ``is_alive``
+to avoid duplicate spawn when the process was actually alive but
+mid-call.
+
+The refactor enforces a single source of truth for liveness — one
+``AgentChannel.is_alive`` probe — and dispatches to ONE strategy:
+
+  - alive → ``_wake_alive_agent`` (socket signal)
+  - dead  → ``_respawn_dead_agent`` (snapshot spawn)
+
+No "fall back" anywhere. These tests pin the contract.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_fast_agent_log_propagation():
+    """``fast_agent.context.configure_logger`` sets ``propagate=False`` on
+    the ``fast_agent`` logger when an agent's context boots (e.g. via an
+    earlier e2e test that called ``agent.generate(...)``). That breaks
+    ``caplog`` for ALL descendant loggers, including the one we assert
+    against here. Force propagation on for the duration of the test.
+    """
+    fa_logger = logging.getLogger("fast_agent")
+    prev = fa_logger.propagate
+    fa_logger.propagate = True
+    try:
+        yield
+    finally:
+        fa_logger.propagate = prev
+
+
+def test_alive_branch_calls_wake_strategy_only():
+    """When liveness probe says alive, ``auto_wake_if_idle`` must take
+    the wake-via-socket strategy and MUST NOT touch the respawn path
+    (which would duplicate the live process)."""
+    from fast_agent.spawn.servers._team_helpers import auto_wake_if_idle
+
+    with patch(
+        "fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+        return_value=True,
+    ), patch(
+        "fast_agent.spawn.agent_channel.AgentChannel.send_signal",
+        return_value=True,
+    ) as mock_signal, patch(
+        "fast_agent.spawn.servers._team_helpers._respawn_dead_agent",
+    ) as mock_respawn:
+        auto_wake_if_idle("Adrian [BA]")
+
+    mock_signal.assert_called_once_with("Adrian [BA]", "wake")
+    mock_respawn.assert_not_called()
+
+
+def test_dead_branch_calls_respawn_strategy_only():
+    """When liveness probe says dead, ``auto_wake_if_idle`` must take
+    the respawn-from-snapshot strategy and MUST NOT call send_signal
+    (which would silently fail and waste a syscall)."""
+    from fast_agent.spawn.servers._team_helpers import auto_wake_if_idle
+
+    with patch(
+        "fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+        return_value=False,
+    ), patch(
+        "fast_agent.spawn.agent_channel.AgentChannel.send_signal",
+    ) as mock_signal, patch(
+        "fast_agent.spawn.servers._team_helpers._respawn_dead_agent",
+    ) as mock_respawn:
+        auto_wake_if_idle("Adrian [BA]")
+
+    mock_respawn.assert_called_once_with("Adrian [BA]")
+    mock_signal.assert_not_called()
+
+
+def test_alive_race_logs_warning_when_signal_fails_after_alive_probe(caplog):
+    """If liveness says alive but ``send_signal`` returns False (race:
+    process exited between probe and send), we MUST NOT silently
+    respawn (the process could still be mid-shutdown and a respawn
+    would duplicate it). The race is logged at WARNING so the next
+    missed inbox can be correlated back to this event.
+    """
+    from fast_agent.spawn.servers._team_helpers import auto_wake_if_idle
+
+    with patch(
+        "fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+        return_value=True,
+    ), patch(
+        "fast_agent.spawn.agent_channel.AgentChannel.send_signal",
+        return_value=False,
+    ), patch(
+        "fast_agent.spawn.servers._team_helpers._respawn_dead_agent",
+    ) as mock_respawn, caplog.at_level(
+        logging.WARNING, logger="fast_agent.spawn.servers._team_helpers"
+    ):
+        auto_wake_if_idle("Adrian [BA]")
+
+    # Respawn must NOT be called — that's the whole point of the
+    # liveness-first dispatch (no silent fall-through that could
+    # duplicate a still-terminating process).
+    mock_respawn.assert_not_called()
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "Adrian [BA]" in r.getMessage()
+    ]
+    assert warnings, (
+        "Expected a WARNING describing the alive→send-failed race. "
+        f"Got: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_liveness_probe_failure_is_loud_and_aborts(caplog):
+    """If the liveness probe itself raises (e.g. socket subsystem
+    error), we MUST log at ERROR and refuse to act — neither strategy
+    is safe without a reliable probe.
+    """
+    from fast_agent.spawn.servers._team_helpers import auto_wake_if_idle
+
+    with patch(
+        "fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+        side_effect=OSError("socket subsystem dead"),
+    ), patch(
+        "fast_agent.spawn.servers._team_helpers._wake_alive_agent",
+    ) as mock_wake, patch(
+        "fast_agent.spawn.servers._team_helpers._respawn_dead_agent",
+    ) as mock_respawn, caplog.at_level(
+        logging.ERROR, logger="fast_agent.spawn.servers._team_helpers"
+    ):
+        auto_wake_if_idle("Adrian [BA]")
+
+    mock_wake.assert_not_called()
+    mock_respawn.assert_not_called()
+    errors = [
+        r for r in caplog.records
+        if r.levelname == "ERROR" and "Adrian [BA]" in r.getMessage()
+    ]
+    assert errors, (
+        "Expected an ERROR when liveness probe raised. "
+        f"Got: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_respawn_dead_agent_loud_when_no_registry(caplog):
+    """``_respawn_dead_agent`` must log a WARNING when registry is
+    unavailable — silently returning is how stale env vars in
+    production cause invisible failures.
+    """
+    from fast_agent.spawn.servers import _team_helpers
+
+    with patch.object(_team_helpers, "get_project_registry", return_value=None), \
+            caplog.at_level(logging.WARNING, logger="fast_agent.spawn.servers._team_helpers"):
+        _team_helpers._respawn_dead_agent("Adrian [BA]")
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "Adrian [BA]" in r.getMessage()
+        and "no registry" in r.getMessage().lower()
+    ]
+    assert warnings, "Expected WARNING about missing registry"
+
+
+def test_respawn_dead_agent_loud_when_record_missing(caplog):
+    """``_respawn_dead_agent`` must log a WARNING when the agent has
+    no record in the registry — silently skipping was the 2026-05-15
+    incident root cause.
+    """
+    from fast_agent.spawn.servers import _team_helpers
+
+    fake_registry = MagicMock()
+    fake_registry.find_by_name.return_value = None
+
+    with patch.object(_team_helpers, "get_project_registry", return_value=fake_registry), \
+            caplog.at_level(logging.WARNING, logger="fast_agent.spawn.servers._team_helpers"):
+        _team_helpers._respawn_dead_agent("Adrian [BA]")
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "Adrian [BA]" in r.getMessage()
+        and "not found in registry" in r.getMessage().lower()
+    ]
+    assert warnings, "Expected WARNING about agent not in registry"

--- a/backend/tests/test_services/test_auto_wake_session_path.py
+++ b/backend/tests/test_services/test_auto_wake_session_path.py
@@ -1,0 +1,229 @@
+"""Regression tests for the 2026-05-15 ``5612e8f3`` retro-meeting deadlock.
+
+Production incident: PM (Bailey [PM]) was inject-resumed to run a sprint
+retro. PM created a 7-participant meeting, did the kickoff speak, and
+advanced the turn to Adrian [BA]. The meeting then deadlocked for
+~20 minutes waiting for Adrian — who had been ``completed`` 48 minutes
+earlier and never got respawned.
+
+Root cause (path-asymmetry between writer and reader):
+  - WRITER (``_team_helpers.get_bus``) reads ``TEAM_MESSAGES_DIR`` env
+    var → session-scoped path like ``.runtime/state/messages/{sid}/``.
+  - READER (``isolated_spawner._check_and_resume_on_inbox``) ignored
+    ``TEAM_MESSAGES_DIR`` and only walked up ``TEAM_WORKSPACE`` to find
+    ``.runtime/state/messages`` — WITHOUT the session segment.
+  - Inbox messages were written to the session folder but read from the
+    parent folder → ``bus.read_unread`` returned empty → silent return →
+    no respawn → meeting stuck on Adrian's turn forever.
+
+These tests pin two contracts that, taken together, would have
+prevented the incident:
+
+  1. ``_check_and_resume_on_inbox`` MUST read ``TEAM_MESSAGES_DIR``
+     first (matching the writer side) before falling back to the
+     workspace walk-up.
+  2. When the function exits without spawning, it MUST log a warning
+     describing *why* — silent returns are how we lost 20 minutes
+     diagnosing this incident from scratch.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_fast_agent_log_propagation():
+    """``fast_agent.context.configure_logger`` sets ``propagate=False`` on
+    the ``fast_agent`` logger when an agent's context boots (e.g. anywhere
+    a prior e2e test called ``agent.generate(...)``). That breaks pytest's
+    ``caplog`` for ALL descendant loggers (``fast_agent.spawn.*``) — log
+    records emitted by the code under test never reach the root handler
+    that caplog hooks, so the assertion that we logged a warning falsely
+    fails.
+
+    Each test in this file probes a fail-loud contract on a fast_agent
+    descendant logger, so we MUST guarantee the propagation chain is
+    intact regardless of leaked state from prior tests.
+    """
+    fa_logger = logging.getLogger("fast_agent")
+    prev = fa_logger.propagate
+    fa_logger.propagate = True
+    try:
+        yield
+    finally:
+        fa_logger.propagate = prev
+
+
+@pytest.mark.asyncio
+async def test_check_and_resume_reads_session_scoped_messages_dir(tmp_path, caplog):
+    """When ``TEAM_MESSAGES_DIR`` env_vars points to a session-scoped folder
+    that has unread inbox messages, the function MUST find them and
+    proceed to spawn (instead of returning silently from the wrong path).
+    """
+    from fast_agent.spawn.message_bus import MessageBus
+    from fast_agent.spawn.isolated_spawner import _check_and_resume_on_inbox
+
+    # Lay out the EXACT structure used in production: session-scoped
+    # subfolder under .runtime/state/messages/.
+    backend_root = tmp_path / "backend"
+    session_id = "deadbeef"
+    workspace = backend_root / ".runtime" / "data" / "workspaces" / f"agile-team_{session_id}"
+    workspace.mkdir(parents=True)
+    session_msg_dir = backend_root / ".runtime" / "state" / "messages" / session_id
+    session_msg_dir.mkdir(parents=True)
+
+    # Writer side: drop an "unread" message into the session-scoped
+    # inbox via the same MessageBus the production code uses. This is
+    # how ``_notify_meeting_started`` would have written for a member.
+    writer_bus = MessageBus(messages_dir=str(session_msg_dir))
+    writer_bus.send(
+        from_name="Meeting [test-meet]",
+        to_name="Adrian [BA]",
+        content="📋 Meeting started — your turn coming",
+        message_type="meeting_started",
+    )
+    # Sanity: the file is where we expect.
+    assert (session_msg_dir / "adrian__ba_inbox.jsonl").exists()
+
+    # Build a fake registry with Adrian's stored env_vars matching
+    # production (TEAM_MESSAGES_DIR present and session-scoped).
+    fake_registry = MagicMock()
+    fake_registry.has_running_resume.return_value = False
+    fake_record = MagicMock()
+    fake_record.run_id = "old-run-id"
+    fake_record.original_config = {
+        "agent_name": "Adrian [BA]",
+        "role": "ba",
+        "workspace_dir": str(workspace),
+        "project_dir": str(backend_root),
+        "env_vars": {
+            "TEAM_WORKSPACE": str(workspace),
+            "TEAM_SESSION_ID": session_id,
+            "TEAM_MESSAGES_DIR": str(session_msg_dir),  # ← session-scoped
+            "TEAM_MY_NAME": "Adrian [BA]",
+        },
+        "servers": [],
+        "instruction": "",
+        "task": "",
+        "context": "",
+        "model": "",
+    }
+    fake_registry.get.return_value = fake_record
+
+    # Patch ``run_isolated_agent_background`` to verify the function
+    # reached the spawn step (which means the inbox was correctly
+    # located and ``unread`` was non-empty — the assertion that pins
+    # the fix).
+    spawn_called: dict = {}
+
+    async def _fake_run_iso(*args, **kwargs):
+        spawn_called["agent_name"] = kwargs.get("agent_name")
+        spawn_called["task"] = kwargs.get("task")
+        return "new-run-id"
+
+    with patch(
+        "fast_agent.spawn.isolated_spawner.run_isolated_agent_background",
+        side_effect=_fake_run_iso,
+    ):
+        await _check_and_resume_on_inbox(
+            run_id="old-run-id",
+            agent_name="Adrian [BA]",
+            registry=fake_registry,
+            env_vars=fake_record.original_config["env_vars"],
+        )
+
+    assert spawn_called.get("agent_name") == "Adrian [BA]", (
+        "Expected respawn to be triggered. Either the path resolution "
+        "ignored TEAM_MESSAGES_DIR and read from the wrong folder "
+        "(silent return on 0 unread), or another guard fired. "
+        f"spawn_called={spawn_called!r}"
+    )
+    assert "📬 NEW MESSAGES" not in (spawn_called.get("task") or "") or "meeting_started" in (
+        spawn_called.get("task") or ""
+    ), "Inbox content should appear in the follow-up task"
+
+
+@pytest.mark.asyncio
+async def test_check_and_resume_warns_when_messages_dir_missing(tmp_path, caplog):
+    """If no TEAM_MESSAGES_DIR and no workspace path can be resolved, the
+    function must NOT exit silently — it must emit a WARNING explaining
+    why the agent will not be respawned. This is the fail-loud contract:
+    silent returns are how we wasted 20+ minutes diagnosing the retro
+    meeting incident.
+    """
+    from fast_agent.spawn.isolated_spawner import _check_and_resume_on_inbox
+
+    fake_registry = MagicMock()
+    fake_registry.has_running_resume.return_value = False
+    fake_record = MagicMock()
+    fake_record.run_id = "old-run-id"
+    fake_record.original_config = {"context": ""}  # no workspace path anywhere
+    fake_registry.get.return_value = fake_record
+
+    with caplog.at_level(logging.WARNING, logger="fast_agent.spawn.isolated_spawner"):
+        await _check_and_resume_on_inbox(
+            run_id="old-run-id",
+            agent_name="Adrian [BA]",
+            registry=fake_registry,
+            env_vars={},  # neither TEAM_MESSAGES_DIR nor TEAM_WORKSPACE
+        )
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "Adrian [BA]" in r.getMessage()
+    ]
+    assert warnings, (
+        f"Expected a WARNING log explaining why Adrian will not be "
+        f"respawned. Actual records: {[(r.levelname, r.getMessage()) for r in caplog.records]}. "
+        "Silent return = lost diagnose time when production breaks."
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_and_resume_warns_when_inbox_empty(tmp_path, caplog):
+    """When messages_dir is correctly resolved but the inbox is empty
+    (no unread), the function must log an INFO/WARNING line saying so.
+    Previously this was a silent return. With fail-loud, future
+    investigations can see exactly which agent was checked and found
+    no work.
+    """
+    from fast_agent.spawn.isolated_spawner import _check_and_resume_on_inbox
+
+    backend_root = tmp_path / "backend"
+    session_id = "emptysid"
+    session_msg_dir = backend_root / ".runtime" / "state" / "messages" / session_id
+    session_msg_dir.mkdir(parents=True)
+    # NB: NO inbox file written — bus.read_unread returns []
+
+    fake_registry = MagicMock()
+    fake_registry.has_running_resume.return_value = False
+    fake_record = MagicMock()
+    fake_record.run_id = "old-run-id"
+    fake_record.original_config = {
+        "env_vars": {"TEAM_MESSAGES_DIR": str(session_msg_dir)},
+    }
+    fake_registry.get.return_value = fake_record
+
+    with caplog.at_level(logging.INFO, logger="fast_agent.spawn.isolated_spawner"):
+        await _check_and_resume_on_inbox(
+            run_id="old-run-id",
+            agent_name="Adrian [BA]",
+            registry=fake_registry,
+            env_vars={"TEAM_MESSAGES_DIR": str(session_msg_dir)},
+        )
+
+    # We accept INFO or WARNING — the contract is "not silent".
+    relevant = [
+        r for r in caplog.records
+        if "Adrian [BA]" in r.getMessage()
+        and ("0 unread" in r.getMessage() or "no unread" in r.getMessage().lower()
+             or "nothing to resume" in r.getMessage().lower())
+    ]
+    assert relevant, (
+        f"Expected an INFO log saying Adrian has 0 unread / nothing to resume. "
+        f"Got: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )

--- a/backend/tests/test_services/test_delete_team_drops_notifications.py
+++ b/backend/tests/test_services/test_delete_team_drops_notifications.py
@@ -1,0 +1,132 @@
+"""Regression test for ``DELETE /api/teams/{team_name}`` cascading
+into the ``notifications`` table.
+
+The 2026-05-14 toolset-self-audit incident: a user deleted the
+previous day's run via the API, started a fresh team with the same
+``team_name``, and never got a completion notification for the new
+team. Why: the delete route cleaned spawn_registry, team_sessions,
+workspace, messages, and activities — but NOT notifications. The
+stale notification carried ``team_name: "toolset-self-audit"`` in
+its metadata, and the team-completion bridge's dedupe (pre-fix:
+keyed on team_name) matched it and skipped emitting a new one.
+
+This test pins the cleanup contract on the delete route directly so
+the dedupe fix and the cleanup fix can both stay healthy
+independently.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def test_delete_team_cleans_notifications_for_that_team_name(tmp_path, monkeypatch):
+    """DELETE /api/teams/{name} must drop any ``team_completion``
+    notification whose metadata carries that ``team_name`` — without
+    this, the next run that reuses the team name has its notification
+    silently swallowed by the dedupe."""
+    # Build an isolated SQLite engine bound to a temp file. We do NOT
+    # reload core.database — that would corrupt the model registry for
+    # every test that runs afterwards in the same pytest session.
+    # Instead we monkeypatch get_db_session to hand the route a session
+    # against our temp engine; the model classes stay intact.
+    import core.database as db_mod
+    db_file = tmp_path / "jarvis.db"
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    db_mod.Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, future=True)
+    monkeypatch.setattr(db_mod, "get_db_session", lambda: SessionLocal())
+
+    # Seed two team_completion notifications: one for the team we're
+    # about to delete, one for an unrelated team that must survive.
+    sess = SessionLocal()
+    try:
+        stale = db_mod.NotificationModel(
+            type="agent_result",
+            title="✅ Team toolset-self-audit hoàn thành",
+            preview="...",
+            content="Không có kết quả chi tiết từ orchestrator.",
+            content_type="markdown",
+            is_read=0,
+            created_at=time.time(),
+            metadata_json=json.dumps({
+                "agent": "Morgan [PM]",
+                "team_name": "toolset-self-audit",
+                "session_id": "oldsess",
+                "source": "team_completion",
+            }),
+        )
+        keep = db_mod.NotificationModel(
+            type="agent_result",
+            title="✅ Team unrelated-team hoàn thành",
+            preview="...",
+            content="ok",
+            content_type="markdown",
+            is_read=0,
+            created_at=time.time(),
+            metadata_json=json.dumps({
+                "agent": "Other [PM]",
+                "team_name": "unrelated-team",
+                "session_id": "othersess",
+                "source": "team_completion",
+            }),
+        )
+        sess.add_all([stale, keep])
+        sess.commit()
+        sess.refresh(stale)
+        sess.refresh(keep)
+        stale_id, keep_id = stale.id, keep.id
+    finally:
+        sess.close()
+
+    # Stub registry / team_session lookups the route makes.
+    fake_registry = MagicMock()
+    fake_registry.get_all.return_value = {
+        "run-1": {
+            "team_name": "toolset-self-audit",
+            "agent_name": "Morgan [PM]",
+            "session_id": "oldsess",
+        }
+    }
+    fake_registry.delete_by_team.return_value = (1, None)
+    fake_registry.delete_by_name.return_value = 0
+
+    import routes.agents as agents_route
+    app = FastAPI()
+    app.include_router(agents_route.router)
+    app.dependency_overrides[agents_route.verify_api_key] = lambda: True
+
+    with patch.object(agents_route, "_trigger_reload", lambda: None), \
+            patch("services.shared_state.registry_db", fake_registry, create=True), \
+            patch.object(agents_route, "activity_stream_manager", MagicMock()), \
+            patch("fast_agent.spawn.team_spawner.list_team_sessions",
+                  return_value=[]), \
+            patch("fast_agent.spawn.team_spawner.delete_team_session",
+                  return_value=True), \
+            patch("fast_agent.spawn.team_spawner.delete_team_sessions_by_team_name",
+                  return_value=0):
+        client = TestClient(app)
+        r = client.delete("/api/agents/teams/toolset-self-audit")
+
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert "1 notification(s)" in payload["cleaned"], (
+        f"Notifications were not cleaned. cleanup_log={payload['cleaned']!r}"
+    )
+
+    # Confirm in the DB: stale gone, unrelated survives.
+    sess = SessionLocal()
+    try:
+        remaining = {n.id for n in sess.query(db_mod.NotificationModel).all()}
+    finally:
+        sess.close()
+    assert stale_id not in remaining, "stale notification not deleted"
+    assert keep_id in remaining, "unrelated team's notification was wrongly dropped"

--- a/backend/tests/test_services/test_effective_status.py
+++ b/backend/tests/test_services/test_effective_status.py
@@ -1,0 +1,361 @@
+"""Regression tests for the multi-signal status derivation
+(``routes/agents.py::_compute_effective_status``).
+
+Background: ``spawn_registry.status`` is updated only by the spawn-event
+bridge. If the bridge socket dies (R1/R2 race) or the subprocess is
+SIGKILL'd before emitting its terminal event, the value can stay frozen
+at ``"running"`` indefinitely. The UI then shows agents as ``running``
+forever even though they are idle or have exited.
+
+The helper cross-references three independent signals:
+
+  1. **Channel sock probe** — connect-test against the agent's Unix
+     socket. Alive ⇒ subprocess is in keep-alive ``listen()``.
+  2. **Latest snapshot** — ``trigger`` AND ``created_at`` the subprocess
+     wrote directly to SQLite. Bypasses the bridge entirely.
+  3. **``record.last_active_at``** — bridge-fed timestamp of the agent's
+     last LLM-side event. Used to distinguish a fresh idle-snapshot
+     from a stale one captured before a new turn started.
+
+Lifecycle invariant enforced everywhere else (see
+``spawn_progress_bridge`` line ~607, ``isolated_spawner`` line ~932,
+``agent_registry_db.mark_stale_running`` line ~284): for a dead-channel
+agent that last wrote idle/task_complete, **resumable → "idle"**
+(respawnable on demand), **oneshot → "completed"** (one-and-done).
+This file pins that invariant for the inferred-state path too.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make routes/ importable without running the full FastAPI app.
+_BACKEND = Path(__file__).parent.parent.parent
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from routes.agents import _compute_effective_status  # noqa: E402
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_snapshot_db(
+    tmp_path: Path,
+    agent_name: str,
+    trigger: str,
+    created_at: float | None = None,
+) -> str:
+    """Create a tiny SQLite DB with a single ``agent_context_snapshots``
+    row for ``agent_name``. ``trigger`` and ``created_at`` go in
+    verbatim. Returns the DB path string.
+    """
+    db = tmp_path / "snapshots.db"
+    conn = sqlite3.connect(db)
+    # IF NOT EXISTS so the helper can be called multiple times in one
+    # test (parametrize loops, multi-case sanity tests) against the
+    # same tmp_path. Each call appends a new row with a unique id.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS agent_context_snapshots ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, agent_name TEXT, "
+        "trigger TEXT, created_at REAL)"
+    )
+    conn.execute(
+        "INSERT INTO agent_context_snapshots "
+        "(agent_name, trigger, created_at) VALUES (?, ?, ?)",
+        (agent_name, trigger, created_at if created_at is not None else 1.0),
+    )
+    conn.commit()
+    conn.close()
+    return str(db)
+
+
+# ─── Trust-as-is: terminal / overlay statuses pass through unchanged ─
+
+
+@pytest.mark.parametrize("terminal", [
+    "completed", "error", "killed", "failed", "cancelled", "paused", "timeout",
+])
+def test_terminal_status_passes_through(terminal):
+    """Once an agent is in a terminal/overlay state, the helper must
+    NOT second-guess it. Bridge / cleanup / PauseManager are
+    authoritative for these.
+    """
+    record = {"agent_name": "X", "status": terminal}
+    assert _compute_effective_status(record) == terminal
+
+
+def test_unrecognized_status_passes_through():
+    """A future status value the helper doesn't know about returns as-is.
+    Lets the codebase introduce new statuses without surgery here.
+    """
+    record = {"agent_name": "X", "status": "spawning_v2_experimental"}
+    assert _compute_effective_status(record) == "spawning_v2_experimental"
+
+
+# ─── Channel alive (subprocess in keep-alive) ────────────────────────
+
+
+def test_channel_alive_idle_snapshot_newer_than_last_active_returns_idle(
+    tmp_path: Path,
+):
+    """The canonical "agent finished a turn, sitting idle" case.
+
+    Subprocess wrote ``idle`` snapshot at t=100 AFTER the bridge last
+    saw activity at t=50. Snapshot is fresh ⇒ subprocess is really idle.
+    UI must NOT show ``running`` here.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "task_complete", created_at=100.0)
+    record = {"agent_name": "Sasha", "status": "running", "last_active_at": 50.0}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=True):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "idle"
+
+
+def test_channel_alive_idle_snapshot_no_last_active_returns_idle(tmp_path: Path):
+    """When ``last_active_at`` is missing (first turn, or pre-R2 record),
+    a present-and-correct idle snapshot is enough to conclude idle.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "idle", created_at=100.0)
+    record = {"agent_name": "Sasha", "status": "running"}  # no last_active_at
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=True):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "idle"
+
+
+def test_channel_alive_stale_snapshot_during_active_turn_keeps_raw(tmp_path: Path):
+    """Critical mid-turn case. Snapshot ``task_complete`` is from the
+    PREVIOUS turn (t=50). A new turn has started and the bridge has
+    bumped ``last_active_at`` to t=100. The fresh activity timestamp
+    proves the snapshot is stale → trust raw ``running``.
+
+    Without this check the UI would falsely flip a working agent to
+    ``idle`` between snapshot writes, hiding mid-LLM-call activity.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "task_complete", created_at=50.0)
+    record = {"agent_name": "Sasha", "status": "running", "last_active_at": 100.0}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=True):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "running"
+
+
+def test_channel_alive_no_snapshot_keeps_raw(tmp_path: Path):
+    """No snapshot for this agent yet — likely first turn in progress.
+    Keep raw ``running``; don't guess idle without evidence.
+    """
+    db = _make_snapshot_db(tmp_path, "OtherAgent", "task_complete")
+    record = {"agent_name": "Sasha", "status": "running"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=True):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "running"
+
+
+def test_channel_alive_unrelated_trigger_keeps_raw(tmp_path: Path):
+    """Snapshot trigger is something other than idle/task_complete
+    (e.g. ``error`` from a prior turn that the agent has since
+    recovered from). Don't override raw based on that — wait for a
+    fresh idle snapshot.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "tool_call_recovered")
+    record = {"agent_name": "Sasha", "status": "running"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=True):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "running"
+
+
+# ─── Channel dead (subprocess exited) ────────────────────────────────
+
+
+def test_channel_dead_oneshot_task_complete_returns_completed(tmp_path: Path):
+    """Oneshot agent ran its single task, wrote ``task_complete``,
+    subprocess exited. UI must reflect ``completed`` — no further
+    activity expected.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "task_complete")
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "oneshot"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "completed"
+
+
+def test_channel_dead_oneshot_idle_trigger_returns_completed(tmp_path: Path):
+    """Oneshot whose last snapshot was ``idle`` (rare but possible if
+    cleanup wrote idle before final exit). Still ``completed`` —
+    oneshot is one-and-done regardless of last-snapshot label.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "idle")
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "oneshot"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "completed"
+
+
+def test_channel_dead_resumable_idle_trigger_returns_idle(tmp_path: Path):
+    """The whole reason the helper got rewritten on 2026-05-13.
+
+    Resumable team agent: subprocess exited (backend restart, SIGKILL,
+    or normal hibernation flow) after writing ``idle``. The agent is
+    NOT terminal — ``auto_wake_if_idle`` will respawn it from snapshot
+    on the next inbound message. UI must show ``idle`` so the user
+    (and other agents) treat it as available, matching the canonical
+    rule already used by ``spawn_progress_bridge`` and
+    ``mark_stale_running``.
+
+    Previously this branch returned ``completed`` and the dashboard
+    silently hid 7 resumable team agents that should have stayed
+    visible as ``idle``.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "idle")
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "resumable"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "idle"
+
+
+def test_channel_dead_resumable_task_complete_returns_idle(tmp_path: Path):
+    """Resumable agents finish many tasks across their lifetime;
+    ``task_complete`` means "current task done" not "agent done". Still
+    respawnable → ``idle``.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "task_complete")
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "resumable"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "idle"
+
+
+def test_channel_dead_missing_lifecycle_defaults_to_idle(tmp_path: Path):
+    """Defensive: missing/empty ``lifecycle`` field (pre-R2 records, or
+    records written before the field existed). Default to the safer
+    ``idle`` — keeps the agent visible and treats it as respawnable.
+    Defaulting to ``completed`` would prematurely hide agents from the
+    dashboard.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "idle")
+    record = {"agent_name": "Sasha", "status": "running"}  # no lifecycle
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "idle"
+
+
+def test_channel_dead_persistent_lifecycle_returns_idle(tmp_path: Path):
+    """The ``persistent`` lifecycle (defined in the enum, not heavily
+    used yet) — should behave like resumable for the idle case
+    (long-running, manual cleanup). Use ``idle`` not ``completed``.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "idle")
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "persistent"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "idle"
+
+
+def test_channel_dead_and_error_trigger_returns_error(tmp_path: Path):
+    """Subprocess died after writing an error snapshot — regardless of
+    lifecycle, ``error`` is the right terminal label.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "error")
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "resumable"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "error"
+
+
+def test_channel_dead_no_snapshot_returns_raw(tmp_path: Path):
+    """SIGKILL'd before any snapshot was written — OR — fresh-spawn
+    race where channel hasn't bound yet. These are indistinguishable
+    from a single probe.
+
+    Previously this returned ``completed_unknown`` (a NEW state not
+    in the canonical ``SpawnStatus`` enum, unknown to the frontend
+    and to bridge logic). We now return raw and let
+    ``mark_stale_running`` reconcile on the next backend restart —
+    which is what was already happening pre-helper.
+    """
+    db = _make_snapshot_db(tmp_path, "OtherAgent", "task_complete")
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "resumable"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "running"
+
+
+# ─── Probe failures: fall back gracefully ────────────────────────────
+
+
+def test_probe_exception_falls_back_to_raw_status(tmp_path: Path):
+    """If the channel probe throws (import error, OS error), don't
+    invent a status — return raw. Better to display a potentially
+    stale ``running`` than to randomly guess.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "task_complete")
+    record = {"agent_name": "Sasha", "status": "running"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               side_effect=RuntimeError("probe broken")):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "running"
+
+
+def test_missing_agent_name_returns_raw():
+    """Defensive: record with no agent_name — can't probe, return raw."""
+    record = {"status": "running"}
+    assert _compute_effective_status(record) == "running"
+
+
+def test_no_snapshot_db_returns_raw_for_dead_channel():
+    """When the DB path is None (e.g. snapshot DB not yet created in
+    a fresh project), there is no trigger to read. Channel dead +
+    no trigger → trust raw. Previously returned ``completed_unknown``
+    which leaked a non-canonical value to the UI.
+    """
+    record = {"agent_name": "Sasha", "status": "running", "lifecycle": "resumable"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=None) == "running"
+
+
+# ─── Mutable-status set: pending / starting / resumed / idle ─────────
+
+
+@pytest.mark.parametrize("raw", ["running", "starting", "resumed", "pending", "idle", "unknown"])
+def test_mutable_raw_states_are_evaluated_by_helper(raw, tmp_path: Path):
+    """All values in the mutable set go through the decision tree.
+    A resumable+dead+idle-snapshot must resolve to ``idle`` regardless
+    of which mutable raw state the bridge happened to write last.
+    """
+    db = _make_snapshot_db(tmp_path, "Sasha", "idle")
+    record = {"agent_name": "Sasha", "status": raw, "lifecycle": "resumable"}
+    with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+               return_value=False):
+        assert _compute_effective_status(record, snapshots_db_path=db) == "idle"
+
+
+# ─── Sanity: helper never returns the deprecated ``completed_unknown`` ──
+
+
+def test_helper_never_returns_completed_unknown(tmp_path: Path):
+    """Pin the contract: ``completed_unknown`` was a value the helper
+    once invented; it is NOT in ``SpawnStatus`` enum, bridge,
+    cleanup, or frontend. The helper must never resurface it.
+    """
+    forbidden = "completed_unknown"
+    cases = [
+        ({"agent_name": "A", "status": "running", "lifecycle": "resumable"}, False, None),
+        ({"agent_name": "A", "status": "running", "lifecycle": "oneshot"}, False, None),
+        ({"agent_name": "A", "status": "running"}, False, None),
+        ({"agent_name": "A", "status": "running"}, True, "task_complete"),
+        ({"agent_name": "A", "status": "running"}, True, None),
+    ]
+    for record, alive, trigger in cases:
+        db = _make_snapshot_db(tmp_path, "A", trigger or "noop")
+        with patch("fast_agent.spawn.agent_channel.AgentChannel.is_alive",
+                   return_value=alive):
+            out = _compute_effective_status(record, snapshots_db_path=db)
+            assert out != forbidden, (
+                f"Helper resurfaced deprecated value for case "
+                f"alive={alive}, trigger={trigger}, record={record}: {out!r}"
+            )

--- a/backend/tests/test_services/test_get_team_result_fail_loud.py
+++ b/backend/tests/test_services/test_get_team_result_fail_loud.py
@@ -1,0 +1,160 @@
+"""Fail-loud contract for ``agent_spawner__get_team_result``.
+
+When the orchestrator's ``spawn_registry.result`` is empty, the tool
+MUST surface that fault via an ``error_state`` block so the calling
+agent (Jarvis) can tell the user. Per project policy, no silent
+fallback — the read path returns what it has, plus an explicit error
+marker when the single source of truth is empty.
+
+See ``services.context_persistence._update_spawn_registry_result``
+for the write half of this contract.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _make_session(agents: dict, *, template_name: str = "agile-team", workspace="/tmp/ws"):
+    """Build a TeamSession-like stub that ``get_team_result`` will accept."""
+    session = MagicMock()
+    session.agents = agents
+    session.template = {"name": template_name}
+    session.workspace = Path(workspace)
+    return session
+
+
+def _make_registry_record(status: str, result: str = ""):
+    rec = MagicMock()
+    rec.status = status
+    rec.result = result
+    return rec
+
+
+# ── Tests ───────────────────────────────────────────────────────────
+
+
+def test_get_team_result_emits_error_state_when_orchestrator_result_empty():
+    """Empty result for the PM/orchestrator → ``error_state`` block
+    names the agent, role, and points at the fix location."""
+    from fast_agent.spawn.servers import agent_spawner_server as srv
+
+    agents = {
+        "Morgan [PM]": {
+            "run_id": "run-pm", "role": "pm", "status": "idle",
+            "result": "", "agent_name": "Morgan [PM]",
+        },
+        "Ryan [BA]": {
+            "run_id": "run-ba", "role": "ba", "status": "idle",
+            "result": "Ryan's audit summary", "agent_name": "Ryan [BA]",
+        },
+    }
+    session = _make_session(agents)
+
+    fake_registry = MagicMock()
+    fake_registry.get_latest.side_effect = lambda rid: {
+        "run-pm": _make_registry_record("idle", ""),
+        "run-ba": _make_registry_record("idle", "Ryan's audit summary"),
+    }.get(rid)
+
+    with patch.object(srv, "get_team_session", return_value=session), \
+            patch.object(srv, "_registry", fake_registry), \
+            patch.object(srv, "get_workspace_summary",
+                         return_value={"directories": {"specs": [], "src": []}}):
+        payload = json.loads(srv.get_team_result("session-1"))
+
+    assert "error_state" in payload, "fail-loud marker missing"
+    es = payload["error_state"]
+    assert es["code"] == "orchestrator_result_missing"
+    assert es["orchestrator"] == "Morgan [PM]"
+    assert "pm" in es["role"]
+    # detail must point a future reader at the proper write hook
+    assert "save_agent_context" in es["detail"]
+    assert "agent_context_snapshots" in es["detail"]
+
+    # Other agents' results still come through unchanged
+    assert payload["agents"]["Ryan [BA]"]["result"] == "Ryan's audit summary"
+
+
+def test_get_team_result_omits_error_state_when_orchestrator_result_present():
+    """Happy path: PM has a real roll-up → no error_state, payload is
+    the same shape it was before this change."""
+    from fast_agent.spawn.servers import agent_spawner_server as srv
+
+    rollup = "# Self-audit — Team Roll-up\nVerdict: PARTIAL"
+    agents = {
+        "Morgan [PM]": {
+            "run_id": "run-pm", "role": "pm", "status": "idle",
+            "result": rollup, "agent_name": "Morgan [PM]",
+        },
+    }
+    session = _make_session(agents)
+
+    fake_registry = MagicMock()
+    fake_registry.get_latest.return_value = _make_registry_record("idle", rollup)
+
+    with patch.object(srv, "get_team_session", return_value=session), \
+            patch.object(srv, "_registry", fake_registry), \
+            patch.object(srv, "get_workspace_summary",
+                         return_value={"directories": {}}):
+        payload = json.loads(srv.get_team_result("session-2"))
+
+    assert "error_state" not in payload
+    assert payload["agents"]["Morgan [PM]"]["result"].startswith("# Self-audit")
+
+
+def test_get_team_result_falls_back_to_first_agent_when_no_pm_role():
+    """Some templates don't have an explicit ``pm`` role — the
+    notification path picks the first spawned agent in that case, and
+    so must ``get_team_result`` so both surfaces always point at the
+    same "orchestrator" when surfacing the fault."""
+    from fast_agent.spawn.servers import agent_spawner_server as srv
+
+    agents = {
+        "Lead [Coord]": {
+            "run_id": "run-lead", "role": "coordinator", "status": "idle",
+            "result": "", "agent_name": "Lead [Coord]", "started_at": 1.0,
+        },
+        "Helper [Worker]": {
+            "run_id": "run-worker", "role": "worker", "status": "idle",
+            "result": "did stuff", "agent_name": "Helper [Worker]",
+            "started_at": 2.0,
+        },
+    }
+    session = _make_session(agents, template_name="no-pm-team")
+
+    fake_registry = MagicMock()
+    fake_registry.get_latest.side_effect = lambda rid: {
+        "run-lead": _make_registry_record("idle", ""),
+        "run-worker": _make_registry_record("idle", "did stuff"),
+    }.get(rid)
+
+    with patch.object(srv, "get_team_session", return_value=session), \
+            patch.object(srv, "_registry", fake_registry), \
+            patch.object(srv, "get_workspace_summary",
+                         return_value={"directories": {}}):
+        payload = json.loads(srv.get_team_result("session-3"))
+
+    assert "error_state" in payload
+    # First spawned agent is the "orchestrator" surrogate when no PM exists.
+    assert payload["error_state"]["orchestrator"] == "Lead [Coord]"
+
+
+def test_get_team_result_session_not_found_returns_error():
+    """Existing behaviour preserved: missing session → ``error`` field."""
+    from fast_agent.spawn.servers import agent_spawner_server as srv
+
+    with patch.object(srv, "get_team_session", return_value=None):
+        payload = json.loads(srv.get_team_result("does-not-exist"))
+
+    assert "error" in payload
+    assert "does-not-exist" in payload["error"]
+    # No error_state on top of error — the session lookup short-circuits earlier.
+    assert "error_state" not in payload

--- a/backend/tests/test_services/test_get_team_status_fail_loud.py
+++ b/backend/tests/test_services/test_get_team_status_fail_loud.py
@@ -1,0 +1,239 @@
+"""Fail-loud contract for ``agent_spawner__get_team_status``.
+
+The orchestrator (and Jarvis) reads ``get_team_status`` to decide
+whether to resume / wake / kill agents. The post-fix contract:
+
+* An agent whose registry status is ``running`` but has had no
+  LLM/tool activity in > 30s is reported as ``status="stuck"`` —
+  that's a genuine hang mid-turn.
+* ``idle`` is NEVER reclassified as stuck. Resumable agents
+  legitimately go idle between turns and park there for hours
+  waiting for inbox messages; flagging them as stuck makes the
+  dashboard scream right after a healthy kickoff. The "Devon" case
+  (turn returns idle but with no useful output) is detected on the
+  READ paths (``get_team_result`` / notification) where an empty
+  ``spawn_registry.result`` raises ``error_state``.
+* Sprint-level ``sprint_status`` is ``"stuck"`` whenever any agent is
+  stuck — never ``"completed"`` — so the orchestrator does not
+  declare victory on a half-frozen team.
+* ``progress`` includes a ``"N stuck"`` suffix when any agent is
+  stuck, so callers reading the one-line summary still see the gap.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _make_session(agents: dict, *, template_name: str = "agile-team",
+                  workspace="/tmp/ws"):
+    session = MagicMock()
+    session.agents = agents
+    session.template = {"name": template_name}
+    session.workspace = Path(workspace)
+    return session
+
+
+def _record(status: str, *, last_active_at: float | None,
+            result: str = "") -> MagicMock:
+    rec = MagicMock()
+    rec.status = status
+    rec.result = result
+    rec.last_active_at = last_active_at
+    return rec
+
+
+def _call(session, registry_map):
+    """Wire mocks, call get_team_status, parse JSON."""
+    from fast_agent.spawn.servers import agent_spawner_server as srv
+
+    fake_registry = MagicMock()
+    fake_registry.get_latest.side_effect = lambda rid: registry_map.get(rid)
+
+    with patch.object(srv, "get_team_session", return_value=session), \
+            patch.object(srv, "_registry", fake_registry):
+        return json.loads(srv.get_team_status("s1"))
+
+
+# ── Tests ───────────────────────────────────────────────────────────
+
+
+def test_idle_with_recent_activity_stays_idle():
+    """Agent that went idle moments ago must NOT be flagged stuck —
+    "idle" is normal for resumable agents between turns."""
+    now = time.time()
+    agents = {
+        "Morgan [PM]": {
+            "run_id": "run-pm", "role": "pm", "status": "running",
+            "agent_name": "Morgan [PM]",
+        },
+    }
+    payload = _call(
+        _make_session(agents),
+        {"run-pm": _record("idle", last_active_at=now - 5)},  # 5s ago
+    )
+
+    pm = payload["agents"]["Morgan [PM]"]
+    assert pm["status"] == "idle"
+    assert "stuck_seconds" not in pm
+    assert payload["sprint_status"] == "completed"
+
+
+def test_idle_is_never_reclassified_as_stuck_no_matter_how_old():
+    """Resumable agents park in ``idle`` indefinitely between turns —
+    a 20-minute-old idle agent is normal, not stuck. Reclassifying it
+    as stuck (the 2026-05-14 over-eager first attempt) made the
+    dashboard show "7 agents stuck" right after a healthy kickoff."""
+    now = time.time()
+    agents = {
+        "Parked [BA]": {
+            "run_id": "run-parked", "role": "ba", "status": "running",
+            "agent_name": "Parked [BA]",
+        },
+    }
+    payload = _call(
+        _make_session(agents),
+        {"run-parked": _record("idle", last_active_at=now - 1200)},  # 20 min
+    )
+
+    parked = payload["agents"]["Parked [BA]"]
+    assert parked["status"] == "idle"
+    assert "stuck_seconds" not in parked
+    assert "raw_status" not in parked
+    assert payload["sprint_status"] == "completed", (
+        "all-idle team after kickoff must NOT scream 'stuck'"
+    )
+
+
+def test_running_with_stale_last_active_is_stuck():
+    """``status="running"`` past the threshold IS a genuine hang
+    (LLM call or post-tool processing got stuck). Surface it loudly
+    so the orchestrator can resume / kill the agent."""
+    now = time.time()
+    agents = {
+        "Hung [Dev]": {
+            "run_id": "run-hang", "role": "dev", "status": "pending",
+            "agent_name": "Hung [Dev]",
+        },
+    }
+    payload = _call(
+        _make_session(agents),
+        {"run-hang": _record("running", last_active_at=now - 90)},
+    )
+
+    hung = payload["agents"]["Hung [Dev]"]
+    assert hung["status"] == "stuck"
+    assert hung["raw_status"] == "running"
+    assert hung["stuck_seconds"] >= 89  # account for clock drift in test
+    assert payload["sprint_status"] == "stuck"
+    assert "1 stuck" in payload["progress"]
+
+
+def test_idle_team_with_one_running_hang_surfaces_only_the_hung():
+    """6 normally-idle members + 1 stuck-running member. The 6 idle
+    stay idle (parked, healthy); only the running-hang flips to
+    stuck. Sprint status reflects the hang."""
+    now = time.time()
+    agents = {}
+    registry = {}
+    for i, name in enumerate(["A", "B", "C", "D", "E", "F"]):
+        rid = f"run-ok-{i}"
+        agents[f"{name} [Member]"] = {
+            "run_id": rid, "role": "member",
+            "agent_name": f"{name} [Member]", "status": "running",
+        }
+        registry[rid] = _record(
+            "idle", last_active_at=now - 5,
+            result=f"Audit report from {name}",
+        )
+    agents["Hung [Dev]"] = {
+        "run_id": "run-hang", "role": "dev",
+        "agent_name": "Hung [Dev]", "status": "running",
+    }
+    registry["run-hang"] = _record(
+        "running", last_active_at=now - 1200,  # 20 min hang
+    )
+
+    payload = _call(_make_session(agents), registry)
+
+    assert payload["sprint_status"] == "stuck"
+    assert payload["agents"]["Hung [Dev]"]["status"] == "stuck"
+    assert payload["agents"]["A [Member]"]["status"] == "idle"
+    assert "6/7" in payload["progress"]
+    assert "1 stuck" in payload["progress"]
+
+
+def test_terminal_status_never_reclassified_as_stuck():
+    """``completed`` / ``error`` / ``cancelled`` are terminal — they
+    have no upstream activity and must not be flagged stuck even if
+    last_active_at is old."""
+    now = time.time()
+    agents = {
+        "Done [QE]": {
+            "run_id": "run-done", "role": "qe", "status": "running",
+            "agent_name": "Done [QE]",
+        },
+        "Err [BA]": {
+            "run_id": "run-err", "role": "ba", "status": "running",
+            "agent_name": "Err [BA]",
+        },
+    }
+    payload = _call(_make_session(agents), {
+        "run-done": _record("completed", last_active_at=now - 9999,
+                            result="done"),
+        "run-err": _record("error", last_active_at=now - 9999),
+    })
+
+    assert payload["agents"]["Done [QE]"]["status"] == "completed"
+    assert payload["agents"]["Err [BA]"]["status"] == "error"
+    # All terminal → sprint completed (but errors flagged)
+    assert payload["sprint_status"] == "completed"
+    assert "1 errors" in payload["progress"]
+
+
+def test_no_last_active_at_does_not_crash_and_does_not_flag_stuck():
+    """Fresh-spawn race: registry row exists but ``last_active_at`` is
+    None because the first turn hasn't reported activity yet. Must
+    fall through to the raw status (idle/running), not crash and not
+    falsely flag stuck."""
+    agents = {
+        "Fresh [Dev]": {
+            "run_id": "run-fresh", "role": "dev", "status": "pending",
+            "agent_name": "Fresh [Dev]",
+        },
+    }
+    payload = _call(
+        _make_session(agents),
+        {"run-fresh": _record("running", last_active_at=None)},
+    )
+
+    fresh = payload["agents"]["Fresh [Dev]"]
+    assert fresh["status"] == "running"
+    assert "stuck_seconds" not in fresh
+
+
+def test_progress_string_omits_stuck_suffix_when_no_one_stuck():
+    """Don't pollute the progress string with ", 0 stuck" when no
+    agent is stuck — the orchestrator scans this line and we want
+    the absence of stuck to be visually obvious."""
+    now = time.time()
+    agents = {
+        "Ok [Dev]": {
+            "run_id": "run-ok", "role": "dev", "status": "running",
+            "agent_name": "Ok [Dev]",
+        },
+    }
+    payload = _call(
+        _make_session(agents),
+        {"run-ok": _record("idle", last_active_at=now - 1)},
+    )
+
+    assert "stuck" not in payload["progress"]

--- a/backend/tests/test_services/test_inject_resume.py
+++ b/backend/tests/test_services/test_inject_resume.py
@@ -1,0 +1,73 @@
+"""Regression tests for ``services.inject_resume``.
+
+Guards the auto-wake-orchestrator path that broke production
+(b61af7db incident, 2026-05-09): when all team members went idle,
+``_trigger_orchestrator_resume`` failed silently with::
+
+    ImportError: cannot import name 'DisplayManager' from
+    'fast_agent.spawn.spawn_display'
+
+The class had been renamed to ``SpawnDisplayManager`` but
+``inject_resume._create_bridge_display`` was never updated. The exception
+was swallowed by ``_trigger_orchestrator_resume``'s try/except, surviving
+only as a WARNING in ``spawn_activity.log`` — meanwhile the orchestrator
+was never woken to read the team-status notification sitting in its inbox.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def test_create_bridge_display_imports_correct_class():
+    """Smoke-test the import path that was stale.
+
+    The bug: ``inject_resume.py`` imported ``DisplayManager`` (renamed to
+    ``SpawnDisplayManager``). This test calls ``_create_bridge_display``
+    with a mock bridge and asserts that the import + instantiation +
+    ``set_event_callback`` chain all succeed.
+    """
+    from services.inject_resume import _create_bridge_display
+
+    mock_bridge = MagicMock()
+    dm = _create_bridge_display(mock_bridge)
+
+    # Verify the right class was imported and instantiated.
+    from fast_agent.spawn.spawn_display import SpawnDisplayManager
+    assert isinstance(dm, SpawnDisplayManager), (
+        f"Expected SpawnDisplayManager, got {type(dm).__name__}"
+    )
+
+    # Verify the event callback was attached — without it, child
+    # subprocess events never reach the bridge.
+    assert dm._event_callback is not None, (
+        "set_event_callback never ran — events from resumed agent "
+        "would not flow to SpawnProgressBridge"
+    )
+
+
+def test_create_bridge_display_forwards_events_to_bridge():
+    """End-to-end: SpawnEvent fired through DM lands in bridge.process_event."""
+    import json
+
+    from services.inject_resume import _create_bridge_display
+
+    mock_bridge = MagicMock()
+    dm = _create_bridge_display(mock_bridge)
+
+    # Build a SpawnEvent-like object (duck-typed — uses getattr fallbacks).
+    fake_event = MagicMock()
+    fake_event.agent_name = "Cameron [PM]"
+    fake_event.event = "agent_ready"
+    fake_event.run_id = "abc12345"
+    fake_event.data = {"foo": "bar"}
+
+    dm._event_callback(fake_event)
+
+    mock_bridge.process_event.assert_called_once()
+    sent_line = mock_bridge.process_event.call_args[0][0]
+    payload = json.loads(sent_line)
+    assert payload["agent_name"] == "Cameron [PM]"
+    assert payload["event_type"] == "agent_ready"
+    assert payload["run_id"] == "abc12345"
+    assert payload["data"] == {"foo": "bar"}

--- a/backend/tests/test_services/test_keepalive_race.py
+++ b/backend/tests/test_services/test_keepalive_race.py
@@ -1,0 +1,317 @@
+"""Regression test for the keep-alive race-condition fix in
+``isolated_runner.py`` (Sasha 1h2m hang, 2026-05-11).
+
+Producer sequence on a turn advance is:
+
+    bus.send(recipient, "meeting_turn")     # ← persistent: writes inbox file
+    auto_wake_if_idle(recipient)            # ← transient: socket connect+send
+
+If the recipient subprocess is still inside its initial ``agent.send()``
+when the producer fires, its ``AgentChannel`` has not yet bound the
+socket. ``send_signal`` finds no sock file, returns False, and the wake
+is silently dropped. Inbox still has the message — but the old keep-alive
+went straight into ``channel.listen(timeout=None)``, which blocks forever
+because the only signal that would have woken it was just lost.
+
+The fix is in ``isolated_runner.py``: drain inbox at the top of every
+loop iteration **before** awaiting the channel. State of "is there work?"
+lives in the inbox file; the wake signal is only an optimization to
+avoid polling. This file pins three contracts that the fix relies on:
+
+1.  Producer sending wake with no listener bound returns False — proves
+    we are reproducing the race window, not testing a fixed signal.
+2.  After ``start_server`` + drain, the pre-existing inbox message is
+    visible without any wake signal arriving.
+3.  ``listen(timeout=N)`` returns None on timeout — the safety-net
+    branch in keep-alive (re-drain + ERROR log) depends on this.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the vendored fast-agent submodule importable when running tests
+# directly from ``backend/`` (matches the pattern used by other
+# fast-agent-dependent suites that need PYTHONPATH=fast-agent/src).
+_FA_SRC = Path(__file__).parent.parent.parent / "fast-agent" / "src"
+if _FA_SRC.exists() and str(_FA_SRC) not in sys.path:
+    sys.path.insert(0, str(_FA_SRC))
+
+from fast_agent.spawn.agent_channel import AgentChannel  # noqa: E402
+from fast_agent.spawn.message_bus import MessageBus  # noqa: E402
+
+
+AGENT_NAME = "Sasha [Designer]"
+
+
+@pytest.fixture
+def msgs_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "messages"
+    d.mkdir()
+    return d
+
+
+# ─── Contract 1: wake before listener = dropped signal ────────────────
+
+
+def test_wake_before_listener_returns_false(msgs_dir: Path, monkeypatch):
+    """Setup invariant: send_signal must return False when no listener
+    is bound. If this ever flips to True (e.g. someone adds persistent
+    wake queue), the rest of these tests no longer reproduce the race
+    and the keep-alive timeout safety net can be revisited.
+    """
+    # Isolate sock dir so other concurrent tests don't see our channel.
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+
+    # No channel.start_server() has been called — sock file does not
+    # exist. This is the exact state Sasha was in at 16:50:08 (still
+    # finishing agent.send, channel not yet bound).
+    delivered = AgentChannel.send_signal(AGENT_NAME, "wake")
+    assert delivered is False, (
+        "send_signal must return False when no listener is bound. "
+        "Otherwise this test is not reproducing the race window."
+    )
+
+
+# ─── Contract 2: drain catches messages sent during race window ───────
+
+
+@pytest.mark.asyncio
+async def test_drain_before_listen_catches_pre_race_message(
+    msgs_dir: Path, monkeypatch
+):
+    """The exact race that hung Sasha for 1h2m.
+
+    Sequence:
+    1. Producer fires bus.send + auto_wake while consumer's channel is
+       not yet bound. Inbox gets the message; wake is lost.
+    2. Consumer enters keep-alive: channel.start_server() binds the
+       socket — but the wake signal was sent before this and is gone.
+    3. Fix: drain inbox BEFORE listen. Message recovered.
+
+    The old code did the opposite (listen first, drain after) — so
+    after step 2 the consumer slept forever on listen() while the
+    message sat unread in the inbox.
+    """
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+
+    bus = MessageBus(messages_dir=str(msgs_dir))
+
+    # --- Producer fires while consumer still in agent.send (race) ---
+    bus.send(
+        from_name="Producer",
+        to_name=AGENT_NAME,
+        content="🎙️ YOUR TURN TO SPEAK",
+        message_type="meeting_turn",
+    )
+    wake_delivered = AgentChannel.send_signal(AGENT_NAME, "wake")
+    assert wake_delivered is False  # signal lost — race reproduced
+
+    # --- Consumer enters keep-alive: start channel, then drain ---
+    channel = AgentChannel(AGENT_NAME)
+    await channel.start_server()
+    try:
+        # Old code skipped this step and went straight to listen().
+        # Fix calls bus.read_unread() here, before any listen().
+        unread = bus.read_unread(AGENT_NAME)
+
+        assert len(unread) == 1, (
+            "Drain-before-listen must find the message that was queued "
+            "during the race window. Found %d unread." % len(unread)
+        )
+        assert unread[0].message_type == "meeting_turn"
+        assert "YOUR TURN" in unread[0].content
+    finally:
+        await channel.stop()
+
+
+# ─── Contract 3: listen timeout returns None for safety-net branch ────
+
+
+@pytest.mark.asyncio
+async def test_listen_timeout_returns_none(msgs_dir: Path, monkeypatch):
+    """Keep-alive's 30s timeout fallback relies on listen() returning
+    None on TimeoutError. The loop then runs ``last_was_timeout=True``
+    so the next drain iteration can log ``wake_signal_missed`` ERROR
+    if any unread is found.
+
+    If listen() ever raises instead of returning None (e.g., asyncio
+    API change), the safety-net path stops working and the only
+    remaining defense is the initial drain at iteration 0.
+    """
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+
+    channel = AgentChannel(AGENT_NAME)
+    await channel.start_server()
+    try:
+        signal = await channel.listen(timeout=0.1)
+        assert signal is None, (
+            "listen(timeout=N) must return None on TimeoutError — "
+            "keep-alive's wake_signal_missed safety net depends on this."
+        )
+    finally:
+        await channel.stop()
+
+
+# ─── Contract 4: signal arrives mid-listen, returns the signal ────────
+
+
+@pytest.mark.asyncio
+async def test_signal_during_listen_is_received(msgs_dir: Path, monkeypatch):
+    """Once channel.start_server() has bound the sock, an incoming wake
+    signal must be delivered to a concurrent listen() — this is the
+    fast path the keep-alive loop relies on for low-latency turn
+    notifications between team members.
+    """
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+
+    channel = AgentChannel(AGENT_NAME)
+    await channel.start_server()
+    try:
+        async def _fire_wake() -> None:
+            # Small delay so listen() is awaiting before we send.
+            await asyncio.sleep(0.05)
+            # send_signal is synchronous and blocks on recv() until the
+            # server responds. In production producer + consumer are
+            # separate processes, so this is fine. In this single-process
+            # test we must offload to a thread or the event loop is
+            # blocked and the server-side handler never runs to drain
+            # the connection (causing both listen() and send_signal to
+            # time out).
+            delivered = await asyncio.to_thread(
+                AgentChannel.send_signal, AGENT_NAME, "wake"
+            )
+            assert delivered is True
+
+        wake_task = asyncio.create_task(_fire_wake())
+        signal = await channel.listen(timeout=2.0)
+        await wake_task
+
+        assert signal == "wake", (
+            "Wake signal fired while listen() was awaiting should be "
+            "delivered (single-event-loop semantics via _wake_event). "
+            "Got signal=%r" % signal
+        )
+    finally:
+        await channel.stop()
+
+
+# ─── Contract 5: mark_done makes re-drain idempotent ──────────────────
+
+
+def test_mark_done_prevents_re_processing(msgs_dir: Path, monkeypatch):
+    """Keep-alive drains inbox on every iteration (top of loop).
+    ``mark_done`` after processing must remove the message from
+    subsequent read_unread() returns — otherwise the loop would
+    re-feed the same message into ``agent.send()`` indefinitely.
+    """
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+
+    bus = MessageBus(messages_dir=str(msgs_dir))
+    bus.send(
+        from_name="Producer",
+        to_name=AGENT_NAME,
+        content="msg1",
+        message_type="ping",
+    )
+
+    first = bus.read_unread(AGENT_NAME)
+    assert len(first) == 1
+    bus.mark_done(AGENT_NAME, first[0].message_id)
+
+    second = bus.read_unread(AGENT_NAME)
+    assert len(second) == 0, (
+        "After mark_done, read_unread must not return the same message. "
+        "Otherwise the keep-alive loop would re-feed it on every "
+        "iteration."
+    )
+
+
+# ─── Contract 6: is_alive must probe, not stat ────────────────────────
+
+
+def test_is_alive_false_when_no_socket(msgs_dir: Path, monkeypatch):
+    """No sock file at all — agent has never started or has cleanly
+    unlinked. ``is_alive`` must return False so callers
+    (``_compute_effective_status`` and ``auto_wake_if_idle``) treat the
+    agent as dead.
+    """
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+    assert AgentChannel.is_alive(AGENT_NAME) is False
+
+
+def test_is_alive_false_for_orphan_sock_after_sigkill(
+    msgs_dir: Path, monkeypatch
+):
+    """The exact case that bit us on 2026-05-12: SIGKILL'd
+    isolated_runner leaves the sock file behind because no cleanup
+    handler ran. File-stat-based ``is_alive`` returned True, so
+    ``_compute_effective_status`` falsely reported the dead agent as
+    'idle' instead of 'completed', leaving stale entries on the
+    dashboard until next refresh.
+
+    Reproducer: bind+close (mimicking a crashed listener that left the
+    file). Probe must return False because connect() now hits a path
+    with no accepting socket.
+    """
+    import socket as _socket
+
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+
+    # Build the same path AgentChannel would use, then leave a stale
+    # file behind. ``socket.bind`` then ``close`` (without unlink)
+    # mirrors the SIGKILL outcome: dirent stays, no listener.
+    from fast_agent.spawn.agent_channel import (  # noqa: E402
+        _get_sock_dir,
+        _sanitize_name,
+    )
+    sock_path = _get_sock_dir() / f"{_sanitize_name(AGENT_NAME)}.sock"
+    if sock_path.exists():
+        sock_path.unlink()
+    s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+    try:
+        s.bind(str(sock_path))
+    finally:
+        s.close()
+    # Sanity: file is present on disk (the trap that fooled the old impl).
+    assert sock_path.exists()
+
+    try:
+        assert AgentChannel.is_alive(AGENT_NAME) is False, (
+            "Orphan sock left by SIGKILL must NOT register as alive — "
+            "the multi-signal status helper relies on this to mark "
+            "killed agents as 'completed' rather than 'idle'."
+        )
+    finally:
+        sock_path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_is_alive_true_when_listener_bound(msgs_dir: Path, monkeypatch):
+    """Positive contract: a live ``start_server()`` listener must
+    register as alive — otherwise the helper would mis-label running
+    agents as 'completed' and the auto-wake gate would respawn
+    duplicates.
+    """
+    monkeypatch.setenv("TEAM_WORKSPACE", str(msgs_dir.parent))
+    monkeypatch.delenv("SPAWN_PROJECT_DIR", raising=False)
+
+    channel = AgentChannel(AGENT_NAME)
+    await channel.start_server()
+    try:
+        assert AgentChannel.is_alive(AGENT_NAME) is True
+    finally:
+        await channel.stop()
+    # And False again once cleanly stopped.
+    assert AgentChannel.is_alive(AGENT_NAME) is False

--- a/backend/tests/test_services/test_last_active_at.py
+++ b/backend/tests/test_services/test_last_active_at.py
@@ -1,0 +1,146 @@
+"""Regression tests for the R2 ``last_active_at`` visibility fix.
+
+Background (b61af7db incident, 2026-05-09): PM polled
+``list_active_spawns`` / ``get_team_status`` twice and saw identical
+``status: running`` snapshots. Without any signal of *progress*, PM
+concluded "trạng thái CHƯA THAY ĐỔI" and idled out — burying the team
+mid-meeting. The spawn_registry only carried ``started_at`` /
+``completed_at``; there was nothing to distinguish "agent is grinding
+through an LLM call right now" from "agent has been silent for 60s".
+
+R2 fix: every ``thinking``/``response``/``tool_call``/``tool_result``
+event upserts ``last_active_at = now()`` on the agent's spawn_registry
+record. ``get_team_status`` exposes both the raw timestamp and a
+``stuck_seconds`` indicator when the gap exceeds 30s.
+
+These tests guard:
+* the bridge writes ``last_active_at`` on activity events;
+* the bridge does NOT touch ``last_active_at`` on lifecycle-only events
+  (started/idle/agent_completed) — those are status changes, not work;
+* the SpawnRecord dataclass round-trips the new field through to/from_dict.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ─── SpawnRecord field round-trip ──────────────────────────────────
+
+
+def test_spawn_record_persists_last_active_at():
+    """SpawnRecord.from_dict(to_dict(...)) preserves last_active_at.
+
+    If this regresses, ``get_latest()`` would silently drop the field
+    when reconstructing the record from JSON storage.
+    """
+    from fast_agent.spawn.spawn_registry import SpawnRecord
+
+    rec = SpawnRecord(run_id="r1", agent_name="X", last_active_at=1234567.5)
+    round_tripped = SpawnRecord.from_dict(rec.to_dict())
+    assert round_tripped.last_active_at == 1234567.5
+
+
+def test_spawn_record_default_last_active_at_is_none():
+    """Default value: None — distinguishes "never active" from "active at t=0"."""
+    from fast_agent.spawn.spawn_registry import SpawnRecord
+
+    rec = SpawnRecord(run_id="r1", agent_name="X")
+    assert rec.last_active_at is None
+
+
+# ─── Bridge updates last_active_at on activity events ──────────────
+
+
+@pytest.fixture
+def bridge_with_mock_registry():
+    """SpawnProgressBridge wired to a mock registry_db that records upserts."""
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    mock_registry = MagicMock()
+    bridge = SpawnProgressBridge(
+        progress_manager=MagicMock(), registry_db=mock_registry,
+    )
+    return bridge, mock_registry
+
+
+@pytest.mark.parametrize("event_type", ["thinking", "response", "tool_call", "tool_result"])
+def test_bridge_updates_last_active_on_activity_events(
+    bridge_with_mock_registry, event_type,
+):
+    """Each activity event upserts last_active_at with a fresh timestamp."""
+    bridge, mock_registry = bridge_with_mock_registry
+    mock_registry.get_record.return_value = {"run_id": "r1"}
+
+    line = json.dumps({
+        "agent_name": "BA",
+        "event_type": event_type,
+        "run_id": "r1",
+        "data": {},
+    })
+
+    before = time.time()
+    bridge.process_event(line)
+    after = time.time()
+
+    # Find the upsert call that carried last_active_at (other upserts
+    # may happen too via _upsert_spawn_record).
+    last_active_calls = [
+        c for c in mock_registry.upsert_record.call_args_list
+        if "last_active_at" in (c.args[1] if len(c.args) > 1 else {})
+    ]
+    assert len(last_active_calls) >= 1, (
+        f"Expected ≥1 upsert with last_active_at for event {event_type!r}, "
+        f"got calls: {mock_registry.upsert_record.call_args_list}"
+    )
+    ts = last_active_calls[-1].args[1]["last_active_at"]
+    assert before <= ts <= after, (
+        f"last_active_at ({ts}) must fall within [{before}, {after}]"
+    )
+
+
+@pytest.mark.parametrize("event_type", ["started", "idle", "agent_completed", "lifecycle_registered"])
+def test_bridge_does_not_update_last_active_on_lifecycle_events(
+    bridge_with_mock_registry, event_type,
+):
+    """Lifecycle-only events MUST NOT bump last_active_at — they're status
+    changes, not work. Otherwise an "idle" event would falsely look like
+    activity and mask the real stall.
+    """
+    bridge, mock_registry = bridge_with_mock_registry
+    mock_registry.get_record.return_value = {"run_id": "r1"}
+
+    line = json.dumps({
+        "agent_name": "BA",
+        "event_type": event_type,
+        "run_id": "r1",
+        "data": {},
+    })
+    bridge.process_event(line)
+
+    last_active_calls = [
+        c for c in mock_registry.upsert_record.call_args_list
+        if "last_active_at" in (c.args[1] if len(c.args) > 1 else {})
+    ]
+    assert last_active_calls == [], (
+        f"Lifecycle event {event_type!r} should NOT touch last_active_at, "
+        f"but got: {last_active_calls}"
+    )
+
+
+def test_bridge_skips_last_active_when_no_run_id(bridge_with_mock_registry):
+    """Defensive: missing run_id → no upsert, no crash."""
+    bridge, mock_registry = bridge_with_mock_registry
+
+    line = json.dumps({"agent_name": "BA", "event_type": "thinking", "data": {}})
+    bridge.process_event(line)
+
+    last_active_calls = [
+        c for c in mock_registry.upsert_record.call_args_list
+        if "last_active_at" in (c.args[1] if len(c.args) > 1 else {})
+    ]
+    assert last_active_calls == []

--- a/backend/tests/test_services/test_meeting_storage_lock.py
+++ b/backend/tests/test_services/test_meeting_storage_lock.py
@@ -1,0 +1,351 @@
+"""Regression tests for ``SqliteMeetingStorage`` lock behaviour
+post-B1 refactor (mutable fields moved into ``state_json``).
+
+History: production hit a self-deadlock on 2026-05-09 (incident
+b61af7db) when ``leave_meeting`` called ``update_config`` to mutate
+``participants`` while holding ``acquire_lock``. ``update_config``
+opened a fresh connection and tried to write — same-process write/write
+contention against the outer ``BEGIN IMMEDIATE`` exhausted busy_timeout
+and raised ``OperationalError: database is locked``.
+
+The B1 refactor removes the dual-write window structurally: all mutable
+fields (participants, max_rounds, current_turn, etc.) live in
+``state_json``. ``update_config`` was deleted. There is now exactly one
+write path (``update_state``) inside the lock, so the deadlock class is
+no longer reachable.
+
+These tests guard the post-B1 contract:
+
+* speak()'s FAIL-verdict path extends ``state.max_rounds`` inside a
+  single ``acquire_lock`` without timing out.
+* leave_meeting() removes ``state.participants`` inside a single
+  ``acquire_lock`` without timing out.
+* The deleted ``update_config`` is genuinely gone (so a future commit
+  can't reintroduce the bug class by adding a second write path).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+def test_update_config_method_was_removed():
+    """Structural guard: update_config must not exist on either storage impl.
+
+    Post-B1, all mutable fields live in state_json. Anyone reintroducing
+    update_config likely is also reintroducing the deadlock class —
+    fail loudly here so the PR never lands.
+    """
+    from fast_agent.spawn.servers.meeting_storage import (
+        JsonFileMeetingStorage,
+        SqliteMeetingStorage,
+    )
+
+    assert not hasattr(JsonFileMeetingStorage, "update_config"), (
+        "JsonFileMeetingStorage.update_config came back — see B1 refactor "
+        "rationale in meeting_storage.py header"
+    )
+    assert not hasattr(SqliteMeetingStorage, "update_config"), (
+        "SqliteMeetingStorage.update_config came back — see B1 refactor "
+        "rationale in meeting_storage.py header"
+    )
+
+
+def test_speak_fail_verdict_extends_max_rounds_inside_lock(tmp_path: Path):
+    """Integration: speak()'s FAIL-verdict path now mutates state.max_rounds
+    inside the single ``acquire_lock`` transaction without deadlock.
+    """
+    from fast_agent.spawn.message_bus import MessageBus
+    from fast_agent.spawn.servers.meeting_storage import SqliteMeetingStorage
+    import fast_agent.spawn.servers.meeting_room_server as mrs
+
+    db = SqliteMeetingStorage(db_path=str(tmp_path / "m.db"))
+    bus = MessageBus(messages_dir=str(tmp_path / "messages"))
+    Path(str(tmp_path / "messages")).mkdir(exist_ok=True)
+
+    # Tight max_rounds + current_round=2 so FAIL extends (remaining < 3).
+    db.create_meeting(
+        "abc12345",
+        config={"agenda": "Test", "created_by": "PM"},
+        state={
+            "participants": ["PM", "Dev"],
+            "max_rounds": 2,
+            "current_turn": 0, "current_round": 2,
+            "joined": ["PM", "Dev"], "ended": False, "started": True,
+            "read_cursors": {},
+        },
+    )
+
+    import asyncio
+
+    orig_storage = mrs._storage
+    orig_get_bus = mrs._get_bus
+    orig_wake = mrs._auto_wake_if_idle
+    mrs._storage = db
+    mrs._get_bus = lambda: bus
+    mrs._auto_wake_if_idle = lambda *a, **kw: None
+
+    try:
+        start = time.monotonic()
+        result = asyncio.run(
+            mrs.speak(
+                meeting_id="abc12345",
+                message="[DECISION] VERDICT: FAIL — needs more analysis",
+                agent_name="PM",
+            )
+        )
+        elapsed = time.monotonic() - start
+    finally:
+        mrs._storage = orig_storage
+        mrs._get_bus = orig_get_bus
+        mrs._auto_wake_if_idle = orig_wake
+
+    assert elapsed < 2.0, f"speak FAIL path took {elapsed:.2f}s — deadlock?"
+
+    payload = json.loads(result)
+    assert payload.get("verdict") == "fail"
+    assert payload.get("meeting_ended") is False, "FAIL should NOT end meeting"
+
+    # max_rounds extended (2 → 5) and lives in state_json now.
+    assert db.get_state("abc12345")["max_rounds"] == 5
+    # config_json must NOT carry max_rounds — would reintroduce dual write.
+    assert "max_rounds" not in db.get_config("abc12345")
+
+
+def test_leave_meeting_inside_lock_completes(tmp_path: Path):
+    """Integration: leave_meeting — the exact tool that 32-second-hung in
+    production — now completes promptly because participants lives in
+    state_json (single update path).
+    """
+    from fast_agent.spawn.message_bus import MessageBus
+    from fast_agent.spawn.servers.meeting_storage import SqliteMeetingStorage
+    import fast_agent.spawn.servers.meeting_room_server as mrs
+
+    db = SqliteMeetingStorage(db_path=str(tmp_path / "m.db"))
+    bus = MessageBus(messages_dir=str(tmp_path / "messages"))
+    Path(str(tmp_path / "messages")).mkdir(exist_ok=True)
+
+    # current_turn=0 → PM is speaker. BA (index 1) leaves as non-current
+    # speaker so R3 guard does not trigger. (R3 guard is exercised by
+    # ``test_leave_meeting_rejected_for_current_speaker`` below.)
+    db.create_meeting(
+        "abc12345",
+        config={"agenda": "Test", "created_by": "PM"},
+        state={
+            "participants": ["PM", "BA", "Dev"],
+            "max_rounds": 3,
+            "current_turn": 0, "current_round": 1,
+            "joined": ["PM", "BA", "Dev"], "ended": False, "started": True,
+            "read_cursors": {},
+        },
+    )
+
+    import asyncio
+
+    orig_storage = mrs._storage
+    orig_get_bus = mrs._get_bus
+    orig_wake = mrs._auto_wake_if_idle
+    mrs._storage = db
+    mrs._get_bus = lambda: bus
+    mrs._auto_wake_if_idle = lambda *a, **kw: None
+
+    try:
+        start = time.monotonic()
+        result = asyncio.run(
+            mrs.leave_meeting(
+                meeting_id="abc12345",
+                agent_name="BA",
+                reason="testing",
+            )
+        )
+        elapsed = time.monotonic() - start
+    finally:
+        mrs._storage = orig_storage
+        mrs._get_bus = orig_get_bus
+        mrs._auto_wake_if_idle = orig_wake
+
+    assert elapsed < 2.0, (
+        f"leave_meeting took {elapsed:.2f}s — production saw 32s here, "
+        f"would mean the B1 refactor regressed"
+    )
+
+    payload = json.loads(result)
+    assert payload.get("status") == "left"
+    assert "BA" not in db.get_state("abc12345")["participants"]
+    # config_json must remain untouched (write-once after create).
+    assert "participants" not in db.get_config("abc12345")
+
+
+def test_leave_meeting_rejected_for_current_speaker(tmp_path: Path):
+    """R3 guard: leave_meeting MUST refuse when caller is current_speaker.
+
+    The b61af7db incident hung for 24h because BA's LLM picked
+    ``leave_meeting`` over ``speak()`` mid-turn, stranding the next
+    speaker. This guard forces the LLM back onto the speak/skip/verdict
+    protocol rail.
+    """
+    from fast_agent.spawn.message_bus import MessageBus
+    from fast_agent.spawn.servers.meeting_storage import SqliteMeetingStorage
+    import fast_agent.spawn.servers.meeting_room_server as mrs
+
+    db = SqliteMeetingStorage(db_path=str(tmp_path / "m.db"))
+    bus = MessageBus(messages_dir=str(tmp_path / "messages"))
+    Path(str(tmp_path / "messages")).mkdir(exist_ok=True)
+
+    # current_turn=0 → BA is current speaker
+    db.create_meeting(
+        "abc12345",
+        config={"agenda": "Test", "created_by": "PM"},
+        state={
+            "participants": ["BA", "PM", "Dev"],
+            "max_rounds": 3,
+            "current_turn": 0, "current_round": 1,
+            "joined": ["BA", "PM", "Dev"], "ended": False, "started": True,
+            "read_cursors": {},
+        },
+    )
+
+    import asyncio
+
+    orig_storage, orig_get_bus, orig_wake = mrs._storage, mrs._get_bus, mrs._auto_wake_if_idle
+    mrs._storage = db
+    mrs._get_bus = lambda: bus
+    mrs._auto_wake_if_idle = lambda *a, **kw: None
+
+    try:
+        result = asyncio.run(
+            mrs.leave_meeting(
+                meeting_id="abc12345",
+                agent_name="BA",          # ← current_speaker
+                reason="going to do work",
+            )
+        )
+    finally:
+        mrs._storage = orig_storage
+        mrs._get_bus = orig_get_bus
+        mrs._auto_wake_if_idle = orig_wake
+
+    payload = json.loads(result)
+    assert "error" in payload
+    assert "your turn" in payload["error"].lower()
+    assert payload["current_speaker"] == "BA"
+    assert "speak" in payload["next_action"]
+    assert "VERDICT" in payload["next_action"]
+    assert "skip_turn" in payload["next_action"]
+
+    # State unchanged — participants list and turn pointer must be intact.
+    state = db.get_state("abc12345")
+    assert state["participants"] == ["BA", "PM", "Dev"]
+    assert state["current_turn"] == 0
+    assert not state["ended"]
+    # And no "leave" entry written to the transcript.
+    assert db.get_transcript("abc12345") == []
+
+
+def test_leave_meeting_allowed_for_non_current_speaker(tmp_path: Path):
+    """R3 guard: non-current speakers can still leave normally."""
+    from fast_agent.spawn.message_bus import MessageBus
+    from fast_agent.spawn.servers.meeting_storage import SqliteMeetingStorage
+    import fast_agent.spawn.servers.meeting_room_server as mrs
+
+    db = SqliteMeetingStorage(db_path=str(tmp_path / "m.db"))
+    bus = MessageBus(messages_dir=str(tmp_path / "messages"))
+    Path(str(tmp_path / "messages")).mkdir(exist_ok=True)
+
+    # current_turn=0 → BA. Dev is index 2 — safe to leave.
+    db.create_meeting(
+        "abc12345",
+        config={"agenda": "Test", "created_by": "PM"},
+        state={
+            "participants": ["BA", "PM", "Dev"],
+            "max_rounds": 3,
+            "current_turn": 0, "current_round": 1,
+            "joined": ["BA", "PM", "Dev"], "ended": False, "started": True,
+            "read_cursors": {},
+        },
+    )
+
+    import asyncio
+
+    orig_storage, orig_get_bus, orig_wake = mrs._storage, mrs._get_bus, mrs._auto_wake_if_idle
+    mrs._storage = db
+    mrs._get_bus = lambda: bus
+    mrs._auto_wake_if_idle = lambda *a, **kw: None
+
+    try:
+        result = asyncio.run(
+            mrs.leave_meeting(
+                meeting_id="abc12345",
+                agent_name="Dev",
+                reason="reassigned",
+            )
+        )
+    finally:
+        mrs._storage = orig_storage
+        mrs._get_bus = orig_get_bus
+        mrs._auto_wake_if_idle = orig_wake
+
+    assert json.loads(result)["status"] == "left"
+    assert "Dev" not in db.get_state("abc12345")["participants"]
+
+
+def test_add_participant_inside_lock_completes(tmp_path: Path):
+    """Integration: add_participant uses the same single-write path.
+
+    Pre-B1 this also called update_config (would have shown the deadlock
+    on second invocation under load). Now it's a state-only update.
+    """
+    from fast_agent.spawn.message_bus import MessageBus
+    from fast_agent.spawn.servers.meeting_storage import SqliteMeetingStorage
+    import fast_agent.spawn.servers.meeting_room_server as mrs
+
+    db = SqliteMeetingStorage(db_path=str(tmp_path / "m.db"))
+    bus = MessageBus(messages_dir=str(tmp_path / "messages"))
+    Path(str(tmp_path / "messages")).mkdir(exist_ok=True)
+
+    db.create_meeting(
+        "abc12345",
+        config={"agenda": "Test", "created_by": "PM"},
+        state={
+            "participants": ["PM", "Dev"],
+            "max_rounds": 3,
+            "current_turn": 0, "current_round": 1,
+            "joined": ["PM", "Dev"], "ended": False, "started": True,
+            "read_cursors": {},
+        },
+    )
+
+    import asyncio
+
+    orig_storage = mrs._storage
+    orig_get_bus = mrs._get_bus
+    orig_wake = mrs._auto_wake_if_idle
+    orig_my_name = mrs._get_my_name
+    mrs._storage = db
+    mrs._get_bus = lambda: bus
+    mrs._auto_wake_if_idle = lambda *a, **kw: None
+    mrs._get_my_name = lambda: "PM"
+
+    try:
+        start = time.monotonic()
+        result = asyncio.run(
+            mrs.add_participant(meeting_id="abc12345", agent_name="QE")
+        )
+        elapsed = time.monotonic() - start
+    finally:
+        mrs._storage = orig_storage
+        mrs._get_bus = orig_get_bus
+        mrs._auto_wake_if_idle = orig_wake
+        mrs._get_my_name = orig_my_name
+
+    assert elapsed < 2.0
+    payload = json.loads(result)
+    assert payload.get("status") == "added"
+
+    state = db.get_state("abc12345")
+    assert "QE" in state["participants"]
+    assert "QE" in state["joined"]

--- a/backend/tests/test_services/test_pause_manager.py
+++ b/backend/tests/test_services/test_pause_manager.py
@@ -1,0 +1,129 @@
+"""Regression tests for ``services.pause_manager.PauseManager``.
+
+Guards the resume-doesn't-update-DB-status bug observed during the
+2026-05-10 dev session: ``_broadcast_state_change`` looked up the
+agent via ``registry_db.list_running()``, which filters to
+``status IN ('running', 'pending')``. The resume path runs while the
+agent is still ``paused`` in the DB, so the lookup returned no rows
+→ ``upsert_record`` was skipped → DB status stayed ``"paused"``
+forever. SSE consumers / UI badges then showed the agent as paused
+even after in-memory state had flipped back to running.
+
+Fix: use ``find_by_name`` (no status filter), mirroring the pattern
+already in ``_find_pid``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fresh_manager():
+    """Module-level singleton ``pause_manager`` survives across tests; we
+    need a clean instance for deterministic assertions.
+    """
+    from services.pause_manager import PauseManager
+    return PauseManager()
+
+
+@pytest.fixture
+def fake_registry(monkeypatch):
+    """Stub ``services.shared_state.registry_db`` with a recording mock."""
+    import services.shared_state as state
+
+    original = state.registry_db
+    fake = MagicMock()
+    fake.upsert_record = MagicMock()
+    state.registry_db = fake
+
+    yield fake
+
+    state.registry_db = original
+
+
+def test_resume_updates_db_status_to_running(fresh_manager, fake_registry):
+    """Resume MUST upsert status='running' on the agent's spawn_registry row.
+
+    Pre-fix this failed because ``list_running()`` skipped the paused row.
+    Post-fix the manager uses ``find_by_name`` which returns paused rows too.
+    """
+    # Registry has a paused row for the agent (the realistic state at the
+    # moment resume() is called).
+    fake_registry.find_by_name.return_value = [{
+        "run_id": "run-123",
+        "agent_name": "PM",
+        "status": "paused",
+    }]
+    fake_registry.list_running.return_value = []  # paused row excluded — that was the bug
+
+    # Manager must be in "paused" state before resume can flip it.
+    fresh_manager.pause("PM")
+    fake_registry.upsert_record.reset_mock()
+
+    fresh_manager.resume("PM")
+
+    fake_registry.upsert_record.assert_called_once_with(
+        "run-123", {"status": "running"}
+    )
+
+
+def test_pause_updates_db_status_to_paused(fresh_manager, fake_registry):
+    """Pause path: agent's row is found regardless of which lookup is used —
+    keep the contract intact while we're at it.
+    """
+    fake_registry.find_by_name.return_value = [{
+        "run_id": "run-456",
+        "agent_name": "Dev",
+        "status": "running",
+    }]
+
+    fresh_manager.pause("Dev")
+
+    fake_registry.upsert_record.assert_called_once_with(
+        "run-456", {"status": "paused"}
+    )
+
+
+def test_resume_handles_in_process_agent_with_no_registry_row(
+    fresh_manager, fake_registry,
+):
+    """In-process agents (Jarvis) have no spawn_registry row.
+
+    Resume must NOT crash and MUST still flip in-memory pause state.
+    """
+    fake_registry.find_by_name.return_value = []  # no row — Jarvis is in-process
+
+    fresh_manager.pause("Jarvis")
+    assert fresh_manager.is_paused("Jarvis") is True
+
+    result = fresh_manager.resume("Jarvis")
+    assert result is True
+    assert fresh_manager.is_paused("Jarvis") is False
+    # No upsert because no row to update — but no exception either.
+    fake_registry.upsert_record.assert_not_called()
+
+
+def test_resume_uses_find_by_name_not_list_running(fresh_manager, fake_registry):
+    """Pin the lookup contract: must call ``find_by_name``, must NOT call
+    ``list_running`` (the original buggy implementation).
+
+    If a future refactor reverts to ``list_running``, this test fails loudly
+    pointing back at the 2026-05-10 incident.
+    """
+    fake_registry.find_by_name.return_value = [{
+        "run_id": "run-789",
+        "agent_name": "QE",
+        "status": "paused",
+    }]
+
+    fresh_manager.pause("QE")
+    fake_registry.find_by_name.reset_mock()
+    fake_registry.list_running.reset_mock()
+
+    fresh_manager.resume("QE")
+
+    fake_registry.find_by_name.assert_called_with("QE")
+    fake_registry.list_running.assert_not_called()

--- a/backend/tests/test_services/test_spawn_event_socket_lifecycle.py
+++ b/backend/tests/test_services/test_spawn_event_socket_lifecycle.py
@@ -171,14 +171,23 @@ async def test_stop_skips_unlink_when_inode_does_not_match(short_sock):
     await server_a._server.wait_closed()
     server_a._server = None  # Prevent stop() from re-closing.
 
-    # asyncio cleaned up the socket file. Place a sentinel file with a
-    # different inode — this represents a peer backend's freshly-bound
-    # file at the same path.
+    # asyncio cleaned up the socket file. Place a sentinel file at
+    # the same path — this represents a peer backend's freshly-bound
+    # file. To make the inode mismatch deterministic on every
+    # filesystem (Linux ext4 can recycle freshly-freed inodes; macOS
+    # APFS allocates new ones), we force ``_bound_inode`` to a value
+    # that can never collide with a real inode: 0. The kernel never
+    # hands out inode 0 — POSIX reserves it as a sentinel for
+    # "no inode" / unallocated. This keeps the assertion focused on
+    # ``stop()``'s mismatch-handling logic, not on the underlying
+    # filesystem's inode-recycling policy.
     sentinel = Path(short_sock)
     sentinel.touch()
+    server_a._bound_inode = 0
     sentinel_inode = sentinel.stat().st_ino
     assert sentinel_inode != server_a._bound_inode, (
-        "Setup: sentinel must have a different inode than what A bound."
+        "Setup: sentinel must have a different inode than what A bound. "
+        f"sentinel_inode={sentinel_inode}, bound_inode={server_a._bound_inode}"
     )
 
     # stop() now: should see inode mismatch and skip the unlink.

--- a/backend/tests/test_services/test_spawn_event_socket_lifecycle.py
+++ b/backend/tests/test_services/test_spawn_event_socket_lifecycle.py
@@ -1,0 +1,203 @@
+"""Regression test for spawn-event socket ownership cleanup.
+
+Background: ``services/spawn_event_socket.py`` previously used
+unconditional ``unlink(missing_ok=True)`` in both ``start()`` and
+``stop()``. When two backend instances ran concurrently (user typed
+``uv run uvicorn`` twice without killing the first), this caused:
+
+* **start() clobber** — backend N's ``start()`` would unlink the file
+  bound by backend N-1, orphaning every subprocess client connected
+  to N-1 (their FD still pointed to N-1's inode, but the path → inode
+  mapping in the filesystem now pointed elsewhere or nowhere).
+* **stop() clobber** — backend N-1's ``stop()`` would unlink the path
+  even though backend N had already taken it over, leaving N with an
+  orphan FD and no path that new clients could connect to.
+
+Verified state at fix time (2026-05-12): 4 concurrent uvicorn
+processes, ``lsof`` showed 4 different inodes bound to the same path,
+``ls`` showed the path did not exist — every subprocess emit_event
+was a silent drop, causing the 1h2m Sasha hang root-cause chain.
+
+This file pins the fix:
+
+1. ``start()`` refuses to bind if a live listener already owns the path.
+2. ``start()`` removes a stale file (no listener) and binds fresh.
+3. ``stop()`` only unlinks if the inode at the path still matches what
+   we bound. If a peer has taken over, leave it alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure vendored fast-agent submodule is importable (matches the path
+# trick used by ``test_keepalive_race.py``).
+_FA_SRC = Path(__file__).parent.parent.parent / "fast-agent" / "src"
+if _FA_SRC.exists() and str(_FA_SRC) not in sys.path:
+    sys.path.insert(0, str(_FA_SRC))
+
+from services.spawn_event_socket import (  # noqa: E402
+    SpawnEventSocketServer,
+    _BackendAlreadyRunning,
+    _is_socket_alive,
+)
+
+
+@pytest.fixture
+def short_sock(tmp_path: Path) -> str:
+    """Return a path safely under the macOS 104-byte sun_path limit.
+
+    The repo path is long; we use /tmp directly so the test can bind
+    AF_UNIX sockets without ENAMETOOLONG.
+    """
+    d = Path(tempfile.mkdtemp(prefix="ses_", dir="/tmp"))
+    return str(d / "spawn_events.sock")
+
+
+# ─── Contract 1: liveness probe ──────────────────────────────────────
+
+
+def test_is_socket_alive_returns_false_for_missing_file(short_sock):
+    assert _is_socket_alive(short_sock) is False
+
+
+def test_is_socket_alive_returns_false_for_stale_file(short_sock):
+    """A leftover file with no listener should be detected as stale.
+    ``start()`` relies on this to safely unlink stale files.
+    """
+    Path(short_sock).touch()
+    assert _is_socket_alive(short_sock) is False
+    Path(short_sock).unlink()
+
+
+@pytest.mark.asyncio
+async def test_is_socket_alive_returns_true_for_live_listener(short_sock):
+    """A real listener should be detected as alive — used by start()
+    to refuse to clobber a peer backend that's still serving clients.
+    """
+    server = SpawnEventSocketServer(short_sock, bridge=MagicMock())
+    await server.start()
+    try:
+        assert _is_socket_alive(short_sock) is True
+    finally:
+        await server.stop()
+
+
+# ─── Contract 2: start() — clobber prevention ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_refuses_to_clobber_live_peer(short_sock):
+    """If a peer is alive on the path, start() must NOT silently
+    overwrite. Raise ``_BackendAlreadyRunning`` so the user/operator
+    can fix the multi-instance situation explicitly.
+    """
+    peer = SpawnEventSocketServer(short_sock, bridge=MagicMock())
+    await peer.start()
+    try:
+        intruder = SpawnEventSocketServer(short_sock, bridge=MagicMock())
+        with pytest.raises(_BackendAlreadyRunning):
+            await intruder.start()
+        # Peer's file must still be intact (not unlinked by intruder).
+        assert Path(short_sock).exists()
+        assert _is_socket_alive(short_sock) is True
+    finally:
+        await peer.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_recovers_from_stale_file(short_sock):
+    """If a previous backend exited without cleanup, start() removes
+    the stale file and binds fresh. This is the "happy reboot" path.
+    """
+    Path(short_sock).touch()  # Stale file from dead backend.
+    server = SpawnEventSocketServer(short_sock, bridge=MagicMock())
+    await server.start()
+    try:
+        assert _is_socket_alive(short_sock) is True
+    finally:
+        await server.stop()
+
+
+# ─── Contract 3: stop() — inode-guarded unlink ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stop_unlinks_own_file(short_sock):
+    """Happy path: server binds, stops, file is gone."""
+    server = SpawnEventSocketServer(short_sock, bridge=MagicMock())
+    await server.start()
+    bound_inode = server._bound_inode
+    assert bound_inode is not None
+
+    await server.stop()
+    assert not Path(short_sock).exists()
+
+
+@pytest.mark.asyncio
+async def test_stop_skips_unlink_when_inode_does_not_match(short_sock):
+    """The inode-guard branch of stop(): when the file at the path no
+    longer matches what we bound (peer took over after we crashed /
+    were forced shut), don't unlink.
+
+    asyncio's ``Server.close()`` already happens to be inode-aware
+    (verified empirically: it skips unlink if the file at the path
+    has a different inode than the one it bound). Our explicit guard
+    is defense-in-depth: it documents the intent and guards the case
+    where asyncio internals might not catch it (e.g., partial-shutdown
+    paths, future asyncio behavior changes).
+
+    Approach: bind A, then fake ``_bound_inode`` to a sentinel that
+    can never match a real file. Drop a fresh sentinel file at the
+    path. ``stop()`` must see the mismatch and refuse to unlink the
+    sentinel file.
+    """
+    server_a = SpawnEventSocketServer(short_sock, bridge=MagicMock())
+    await server_a.start()
+
+    # Replace asyncio's bound file with a sentinel regular file so we
+    # can observe whether stop() unlinks "the wrong file".
+    # First, manually close the asyncio server to release the bind
+    # (asyncio will unlink its own file as part of close()).
+    server_a._server.close()
+    await server_a._server.wait_closed()
+    server_a._server = None  # Prevent stop() from re-closing.
+
+    # asyncio cleaned up the socket file. Place a sentinel file with a
+    # different inode — this represents a peer backend's freshly-bound
+    # file at the same path.
+    sentinel = Path(short_sock)
+    sentinel.touch()
+    sentinel_inode = sentinel.stat().st_ino
+    assert sentinel_inode != server_a._bound_inode, (
+        "Setup: sentinel must have a different inode than what A bound."
+    )
+
+    # stop() now: should see inode mismatch and skip the unlink.
+    await server_a.stop()
+    assert sentinel.exists(), (
+        "Inode-guarded stop() must NOT unlink a file with a different "
+        "inode (would corrupt a peer backend's freshly-bound socket)."
+    )
+
+    # Cleanup the sentinel.
+    sentinel.unlink()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent(short_sock):
+    """Calling stop() twice must not raise — common during shutdown
+    races where multiple cleanup paths converge.
+    """
+    server = SpawnEventSocketServer(short_sock, bridge=MagicMock())
+    await server.start()
+    await server.stop()
+    await server.stop()  # Should be a no-op, not raise.

--- a/backend/tests/test_services/test_spawn_progress_bridge.py
+++ b/backend/tests/test_services/test_spawn_progress_bridge.py
@@ -22,6 +22,95 @@ class TestSpawnProgressBridge:
 
     # ─── Event mapping tests (via _process_event_line) ───
 
+    def test_message_turn_forwards_to_activity_stream(self, monkeypatch):
+        """A subprocess ``message_turn`` event is forwarded directly to the
+        activity stream — no synth mapping, just trim + broadcast."""
+        captured: list[dict] = []
+
+        class _Stream:
+            @staticmethod
+            def broadcast(event: dict) -> None:
+                captured.append(event)
+
+        import services.activity_stream as act
+        monkeypatch.setattr(act, "activity_stream_manager", _Stream())
+
+        bridge, _pm = self._make_bridge()
+        line = json.dumps({
+            "agent_name": "FinanceAgent",
+            "event_type": "message_turn",
+            "run_id": "run-9",
+            "data": {
+                "turn_idx": 3,
+                "msg_role": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "summary"}],
+                    "stop_reason": "endTurn",
+                },
+            },
+        })
+        bridge._process_event_line(line)
+
+        assert len(captured) == 1
+        evt = captured[0]
+        assert evt["agent_name"] == "FinanceAgent"
+        assert evt["event_type"] == "message_turn"
+        assert evt["run_id"] == "run-9"
+        assert evt["data"]["turn_idx"] == 3
+        assert evt["data"]["role"] == "assistant"
+        assert evt["data"]["message"]["content"][0]["text"] == "summary"
+
+    def test_message_turn_truncates_large_blocks(self, monkeypatch):
+        """Large content blocks are trimmed before broadcast to keep SSE chunks small."""
+        from services.agent_message_stream import MAX_BLOCK_TEXT_BYTES
+
+        captured: list[dict] = []
+
+        class _Stream:
+            @staticmethod
+            def broadcast(event: dict) -> None:
+                captured.append(event)
+
+        import services.activity_stream as act
+        monkeypatch.setattr(act, "activity_stream_manager", _Stream())
+
+        big = "Z" * (MAX_BLOCK_TEXT_BYTES + 5000)
+        bridge, _pm = self._make_bridge()
+        line = json.dumps({
+            "agent_name": "ResearchAgent",
+            "event_type": "message_turn",
+            "run_id": "run-10",
+            "data": {
+                "turn_idx": 2,
+                "msg_role": "user",
+                "message": {
+                    "role": "user",
+                    "tool_results": {"tid": {"content": [{"type": "text", "text": big}]}},
+                },
+            },
+        })
+        bridge._process_event_line(line)
+
+        assert len(captured) == 1
+        block = captured[0]["data"]["message"]["tool_results"]["tid"]["content"][0]
+        assert block["_truncated"] is True
+        assert block["_full_size"] == len(big.encode("utf-8"))
+        assert len(block["text"].encode("utf-8")) <= MAX_BLOCK_TEXT_BYTES
+
+    def test_message_turn_does_not_push_to_chat_sse(self):
+        """message_turn lives on the global activity stream, not the per-request chat-stream."""
+        bridge, pm = self._make_bridge()
+        bridge.set_request_id("req-123")
+
+        line = json.dumps({
+            "agent_name": "Dev",
+            "event_type": "message_turn",
+            "data": {"turn_idx": 0, "message": {"role": "user", "content": []}},
+        })
+        bridge._process_event_line(line)
+        pm.push.assert_not_called()
+
     def test_thinking_event_is_filtered(self):
         """thinking events are intentionally filtered from chat SSE (no useful content)."""
         bridge, pm = self._make_bridge()

--- a/backend/tests/test_services/test_team_completion_meeting_aware.py
+++ b/backend/tests/test_services/test_team_completion_meeting_aware.py
@@ -1,0 +1,485 @@
+"""Regression tests for the meeting-aware team-completion notifications.
+
+Background (b61af7db incident, 2026-05-09): when a team idled mid-meeting
+the orchestrator received two misleading "team finished" messages:
+
+* MessageBus inbox: "📋 Team Status Update — All members have finished. |
+  Reese [Dev] | ✅ idle | No output |..."
+* DB notification: "✅ Team tools-audit-team hoàn thành (4 agents) — Không
+  có kết quả chi tiết từ orchestrator."
+
+Both fired purely off spawn_registry status (idle ⇒ "finished"). They
+ignored the open meeting in jarvis.db where the team was actually stuck
+waiting for a speaker. The PM, seeing the misleading "all finished"
+verdict, gave up — burying the meeting transcript and stalling the work.
+
+These tests guard the post-fix contract:
+
+* ``_active_meetings_with_members`` correctly identifies open meetings
+  whose ``state.participants`` overlap with given member names.
+* ``_create_team_notification`` reframes title/content when active
+  meetings exist.
+* The MessageBus inbox path uses the reframed header too.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ─── Helpers ────────────────────────────────────────────────────────
+
+
+def _seed_meeting(db_path: Path, *, meeting_id: str, participants: list[str],
+                  ended: bool, current_turn: int = 0, max_rounds: int = 3,
+                  agenda: str = "Test agenda") -> None:
+    """Insert one meeting row + a few transcript turns for last-3 preview."""
+    import sqlite3 as _sqlite3
+
+    from fast_agent.spawn.servers.meeting_storage import SqliteMeetingStorage
+
+    # Initialise schema via storage (idempotent CREATE TABLE).
+    SqliteMeetingStorage(db_path=str(db_path))
+
+    config = {
+        "agenda": agenda,
+        "created_by": participants[0] if participants else "PM",
+        "created_at": "2026-05-09T23:04:43",
+    }
+    state = {
+        "participants": participants,
+        "max_rounds": max_rounds,
+        "current_turn": current_turn,
+        "current_round": 1,
+        "joined": list(participants),
+        "ended": ended,
+        "outcome": None,
+        "started": True,
+        "read_cursors": {},
+        "turn_started_at": time.time() - 60,  # last action ~60s ago
+    }
+
+    with _sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meetings (meeting_id, config_json, state_json, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (meeting_id, json.dumps(config), json.dumps(state), time.time()),
+        )
+        for i, p in enumerate(participants[:3], start=1):
+            conn.execute(
+                "INSERT INTO meeting_transcripts "
+                "(meeting_id, turn, round, agent, message, type, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (meeting_id, i, 1, p, f"{p} message {i}", "speak", time.time()),
+            )
+        conn.commit()
+
+
+@pytest.fixture
+def env_db(tmp_path, monkeypatch):
+    """Point SPAWN_REGISTRY_DB at a temp DB and yield its path."""
+    db_path = tmp_path / "jarvis.db"
+    monkeypatch.setenv("SPAWN_REGISTRY_DB", str(db_path))
+    return db_path
+
+
+# ─── _active_meetings_with_members ──────────────────────────────────
+
+
+def test_active_meetings_finds_overlap(env_db):
+    """Meeting with overlapping participants is returned with last-3 turns."""
+    _seed_meeting(
+        env_db, meeting_id="m_open",
+        participants=["PM", "BA", "Dev"], ended=False,
+        agenda="Sprint kickoff",
+    )
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    matches = SpawnProgressBridge._active_meetings_with_members({"BA", "QE"})
+    assert len(matches) == 1
+    m = matches[0]
+    assert m["meeting_id"] == "m_open"
+    assert m["agenda"] == "Sprint kickoff"
+    assert m["current_speaker"] == "PM"  # current_turn=0 → participants[0]
+    assert m["last_action_ago_sec"] is not None
+    assert m["last_action_ago_sec"] >= 0
+    assert len(m["last_3_turns"]) == 3
+    assert m["last_3_turns"][0]["agent"] == "PM"
+
+
+def test_active_meetings_skips_ended(env_db):
+    """Ended meetings are excluded — they're done, not stalled."""
+    _seed_meeting(
+        env_db, meeting_id="m_done",
+        participants=["PM", "BA"], ended=True,
+    )
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    assert SpawnProgressBridge._active_meetings_with_members({"PM", "BA"}) == []
+
+
+def test_active_meetings_skips_no_overlap(env_db):
+    """Meeting with disjoint participants is irrelevant to this team."""
+    _seed_meeting(
+        env_db, meeting_id="m_other",
+        participants=["X", "Y"], ended=False,
+    )
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    assert SpawnProgressBridge._active_meetings_with_members({"PM", "BA"}) == []
+
+
+def test_active_meetings_empty_member_set_returns_empty(env_db):
+    """Defensive: empty input must short-circuit (no DB scan)."""
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    assert SpawnProgressBridge._active_meetings_with_members(set()) == []
+
+
+def test_active_meetings_handles_missing_db(tmp_path, monkeypatch):
+    """If the DB doesn't exist yet, return [] without crashing."""
+    monkeypatch.setenv("SPAWN_REGISTRY_DB", str(tmp_path / "nope.db"))
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    assert SpawnProgressBridge._active_meetings_with_members({"PM"}) == []
+
+
+# ─── _format_active_meetings_warning ────────────────────────────────
+
+
+def test_format_warning_includes_bottleneck_and_turns(env_db):
+    """The warning block must surface bottleneck + last 3 turns + action hint."""
+    _seed_meeting(
+        env_db, meeting_id="m_open",
+        participants=["PM", "BA", "Dev"], ended=False,
+        agenda="Audit kickoff",
+    )
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    matches = SpawnProgressBridge._active_meetings_with_members({"BA"})
+    block = SpawnProgressBridge._format_active_meetings_warning(matches)
+
+    assert "Active meetings detected" in block
+    assert "m_open" in block
+    assert "PM" in block  # bottleneck speaker
+    assert "Audit kickoff" in block
+    # Last 3 turns rendered with [Agent Rn] preview
+    assert "[PM R1]" in block or "[BA R1]" in block
+    # Action hint helps PM know what to do
+    assert "leave_meeting" in block or "verdict" in block
+
+
+def test_format_warning_empty_when_no_active(env_db):
+    """No active meetings → empty string (no spurious section)."""
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    assert SpawnProgressBridge._format_active_meetings_warning([]) == ""
+
+
+# ─── DB notification reframing ──────────────────────────────────────
+
+
+def test_create_team_notification_reframes_when_active_meeting(env_db, monkeypatch):
+    """``_create_team_notification`` flips title/preview/content when the
+    team is idled mid-meeting. The DB notif is what the user sees in
+    /notifications — it's the user-facing version of the misleading
+    "Không có kết quả chi tiết" message.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    _seed_meeting(
+        env_db, meeting_id="m_stuck",
+        participants=["Cameron [PM]", "Devon [BA]", "Reese [Dev]"],
+        ended=False, agenda="Tools audit",
+    )
+
+    bridge = SpawnProgressBridge(progress_manager=MagicMock(), registry_db=None)
+
+    captured_notif = {}
+
+    class FakeNotificationModel:
+        def __init__(self, **kwargs):
+            captured_notif.update(kwargs)
+            self.id = 99
+
+    fake_session = MagicMock()
+    fake_session.add = MagicMock()
+    fake_session.commit = MagicMock()
+    fake_session.refresh = MagicMock()
+    fake_session.close = MagicMock()
+
+    with patch("core.database.NotificationModel", FakeNotificationModel), \
+         patch("core.database.get_db_session", return_value=fake_session), \
+         patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()):
+        members = [
+            {"agent_name": "Cameron [PM]", "status": "idle"},
+            {"agent_name": "Devon [BA]", "status": "idle"},
+            {"agent_name": "Reese [Dev]", "status": "idle"},
+        ]
+        bridge._create_team_notification(
+            team_name="audit-team",
+            agent_name="Cameron [PM]",
+            result="",
+            members=members,
+        )
+
+    # Reframed title + preview + content reflecting stalled meeting
+    assert captured_notif["title"].startswith("⏳"), (
+        f"Title must indicate stall, got: {captured_notif['title']}"
+    )
+    assert "idled" in captured_notif["title"]
+    assert "intervention" in captured_notif["title"]
+    assert "Cameron [PM]" in captured_notif["preview"]  # bottleneck surfaced
+    assert "Active meetings detected" in captured_notif["content"]
+    assert "m_stuck" in captured_notif["content"]
+
+
+def test_create_team_notification_uses_default_when_no_active(env_db, monkeypatch):
+    """No active meetings → original ✅ "hoàn thành" framing preserved."""
+    from unittest.mock import MagicMock, patch
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    bridge = SpawnProgressBridge(progress_manager=MagicMock(), registry_db=None)
+
+    captured_notif = {}
+
+    class FakeNotificationModel:
+        def __init__(self, **kwargs):
+            captured_notif.update(kwargs)
+            self.id = 100
+
+    fake_session = MagicMock()
+
+    with patch("core.database.NotificationModel", FakeNotificationModel), \
+         patch("core.database.get_db_session", return_value=fake_session), \
+         patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()):
+        members = [
+            {"agent_name": "PM", "status": "completed"},
+            {"agent_name": "Dev", "status": "completed"},
+        ]
+        bridge._create_team_notification(
+            team_name="solo-team",
+            agent_name="PM",
+            result="Built feature X.",
+            members=members,
+        )
+
+    assert captured_notif["title"].startswith("✅"), (
+        f"No active meetings → ✅ framing kept, got: {captured_notif['title']}"
+    )
+    assert "hoàn thành" in captured_notif["title"]
+
+
+# ─── Fail-loud when orchestrator result is missing ──────────────────
+
+
+def test_create_team_notification_fails_loud_when_result_empty(env_db, caplog):
+    """Per project policy (fail loud, no silent fallbacks): when the
+    orchestrator's spawn_registry.result is empty AND there is no
+    active meeting to reframe against, the notification body MUST
+    surface the bug — not a generic "Team đã hoàn thành công việc."
+
+    This is the exact incident captured in the 2026-05-13 self-audit
+    run: PM Morgan produced a roll-up but spawn_registry.result was
+    never mirrored, and the user saw "Không có kết quả chi tiết từ
+    orchestrator." in /notifications. The new contract surfaces
+    *which* agent / team is missing data so the user knows to dig.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    bridge = SpawnProgressBridge(progress_manager=MagicMock(), registry_db=None)
+
+    captured_notif = {}
+
+    class FakeNotificationModel:
+        def __init__(self, **kwargs):
+            captured_notif.update(kwargs)
+            self.id = 101
+
+    fake_session = MagicMock()
+
+    with patch("core.database.NotificationModel", FakeNotificationModel), \
+            patch("core.database.get_db_session", return_value=fake_session), \
+            patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()), \
+            caplog.at_level("ERROR"):
+        members = [
+            {"agent_name": "Morgan [PM]", "status": "idle"},
+            {"agent_name": "Ryan [BA]", "status": "idle"},
+        ]
+        bridge._create_team_notification(
+            team_name="toolset-self-audit",
+            agent_name="Morgan [PM]",
+            result="",  # ← the bug: registry never got the roll-up
+            members=members,
+        )
+
+    # ERROR log surfaces the missing-result fault so ops can grep.
+    assert any(
+        "Orchestrator result MISSING" in r.message
+        and "toolset-self-audit" in r.message
+        for r in caplog.records
+    ), "fail-loud ERROR log not emitted"
+
+    # No generic placeholder body — it must name the team + agent.
+    assert "Không có kết quả chi tiết" not in captured_notif["content"], (
+        "Old silent fallback string leaked back into the notification body"
+    )
+    assert "BUG" in captured_notif["preview"]
+    assert "Morgan [PM]" in captured_notif["preview"]
+    assert "Morgan [PM]" in captured_notif["content"]
+    assert "toolset-self-audit" in captured_notif["content"]
+    # Body must point readers at the root-cause hook so the next reader
+    # can fix it without re-discovering the design.
+    assert "save_agent_context" in captured_notif["content"]
+    assert "agent_context_snapshots" in captured_notif["content"]
+
+
+def test_create_team_notification_writes_session_id_into_metadata(env_db):
+    """The notification metadata MUST carry ``session_id`` so the
+    per-session dedupe (introduced 2026-05-14) can match the right
+    row. Without it a re-spawned team name shares the dedupe key
+    of yesterday's run and the new completion is swallowed silently."""
+    from unittest.mock import MagicMock, patch
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    bridge = SpawnProgressBridge(progress_manager=MagicMock(), registry_db=None)
+    captured: dict = {}
+
+    class _Notif:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.id = 200
+
+    with patch("core.database.NotificationModel", _Notif), \
+            patch("core.database.get_db_session", return_value=MagicMock()), \
+            patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()):
+        bridge._create_team_notification(
+            team_name="toolset-self-audit",
+            agent_name="Bailey [PM]",
+            result="# Roll-up\nVerdict: PASS",
+            members=[{"agent_name": "Bailey [PM]", "status": "idle"}],
+            session_id="newsess",
+        )
+
+    meta = json.loads(captured["metadata_json"])
+    assert meta["session_id"] == "newsess", (
+        "session_id missing from notification metadata — per-session "
+        "dedupe can't work without it"
+    )
+    assert meta["team_name"] == "toolset-self-audit"
+
+
+def test_check_team_completion_filters_members_by_session_id(env_db, monkeypatch):
+    """REGRESSION: ``_check_team_completion`` MUST scope the member
+    sweep to the session_id of the triggering agent. The team_name
+    is reused across spawns ("toolset-self-audit" yesterday and
+    today both produce rows with that ``team_name``), so a raw
+    ``find_by_team_name`` join mixes the old idle agents into the
+    new completion check.
+
+    Pre-2026-05-14 the bridge looked at all members of the team
+    name regardless of session and dedupe-skipped today's run
+    because yesterday's notification already existed under that
+    name. The fix: filter members + dedupe by session_id.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    fake_registry = MagicMock()
+    fake_registry.get_record.return_value = {
+        "run_id": "run-pm-new", "team_name": "toolset-self-audit",
+        "session_id": "newsess",
+    }
+    # The registry returns BOTH sessions' members under the name.
+    # The fix filters them down to newsess before the all-done check.
+    fake_registry.find_by_team_name.return_value = [
+        # Today's
+        {"run_id": "run-pm-new", "agent_name": "Bailey [PM]", "role": "pm",
+         "status": "idle", "session_id": "newsess",
+         "result": "# Roll-up — Verdict: PARTIAL"},
+        # Yesterday's — must be excluded
+        {"run_id": "run-pm-old", "agent_name": "Morgan [PM]", "role": "pm",
+         "status": "idle", "session_id": "oldsess", "result": ""},
+    ]
+
+    bridge = SpawnProgressBridge(
+        progress_manager=MagicMock(), registry_db=fake_registry,
+    )
+    # Force the dedupe to miss so we can observe the creation path.
+    monkeypatch.setattr(bridge, "_has_team_notification", lambda sid: False)
+
+    captured: dict = {}
+
+    class _Notif:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.id = 201
+
+    with patch("core.database.NotificationModel", _Notif), \
+            patch("core.database.get_db_session", return_value=MagicMock()), \
+            patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()):
+        bridge._check_team_completion(
+            trigger_agent="Bailey [PM]",
+            raw={"run_id": "run-pm-new"},
+        )
+
+    # Notification must surface TODAY's roll-up, not yesterday's empty.
+    assert captured, "completion check skipped — likely picked the wrong session"
+    assert "Roll-up" in captured["content"]
+    assert "Verdict" in captured["content"]
+    # Metadata carries today's session_id so future dedupe matches it.
+    meta = json.loads(captured["metadata_json"])
+    assert meta["session_id"] == "newsess"
+    assert meta["agent"] == "Bailey [PM]"
+
+
+def test_create_team_notification_keeps_full_result_when_present(env_db):
+    """Sanity check the happy path — when spawn_registry.result has
+    the roll-up text, that text becomes the notification body verbatim
+    (no truncation, no error wrapping)."""
+    from unittest.mock import MagicMock, patch
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    bridge = SpawnProgressBridge(progress_manager=MagicMock(), registry_db=None)
+
+    captured_notif = {}
+
+    class FakeNotificationModel:
+        def __init__(self, **kwargs):
+            captured_notif.update(kwargs)
+            self.id = 102
+
+    fake_session = MagicMock()
+
+    rollup = "# Self-audit — Team Roll-up\n\nVerdict: PARTIAL\n\n(per-member reports...)"
+
+    with patch("core.database.NotificationModel", FakeNotificationModel), \
+            patch("core.database.get_db_session", return_value=fake_session), \
+            patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()):
+        bridge._create_team_notification(
+            team_name="toolset-self-audit",
+            agent_name="Morgan [PM]",
+            result=rollup,
+            members=[{"agent_name": "Morgan [PM]", "status": "idle"}],
+        )
+
+    assert captured_notif["content"] == rollup
+    assert "BUG" not in captured_notif["preview"]
+    assert "Verdict" in captured_notif["preview"]  # truncated preview shows real text

--- a/backend/tests/test_services/test_team_session_cleanup.py
+++ b/backend/tests/test_services/test_team_session_cleanup.py
@@ -1,0 +1,149 @@
+"""Regression tests for team-session cleanup.
+
+Single source of truth for the ``team_sessions`` table is
+``fast_agent.spawn.registry_backends.TeamSessionStore``. The
+``team_spawner`` module owns the public CRUD API on top of it. These
+tests pin:
+
+* ``delete_team_session`` removes the row from SQLite. (Originally
+  this test also asserted "clears in-memory cache" — that cache was
+  removed on 2026-05-14 because it silently went stale whenever a
+  sibling subprocess upserted. With the store as sole SoT, every
+  read goes to SQLite, so there's nothing to evict.)
+* ``delete_team_sessions_by_team_name`` matches by stored ``team_name``
+  and deletes every match from the store.
+* The Jarvis-side ``AgentRegistryDB`` is kept as **read-only** view —
+  removed methods stay removed (no parallel write path that could
+  diverge from the SoT).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ─── Fixture: isolate team_spawner globals + stub TeamSessionStore ────
+
+
+@pytest.fixture
+def isolated_spawner(monkeypatch):
+    """Reset team_spawner singletons + swap the SQLite store with a mock."""
+    import fast_agent.spawn.team_spawner as spawner
+
+    # Snapshot then clear the store reference (the cache that used to
+    # live alongside it was removed — no need to save/restore).
+    saved_store = spawner._team_store
+    spawner._team_store = None
+
+    fake_store = MagicMock()
+    fake_store.get = MagicMock(return_value=None)
+    fake_store.list_all = MagicMock(return_value=[])
+    fake_store.delete = MagicMock()
+
+    monkeypatch.setattr(spawner, "_get_store", lambda: fake_store)
+
+    yield spawner, fake_store
+
+    # Restore.
+    spawner._team_store = saved_store
+
+
+# ─── delete_team_session ──────────────────────────────────────────
+
+
+def test_delete_team_session_drops_row(isolated_spawner):
+    spawner, fake_store = isolated_spawner
+    fake_store.get.return_value = {"session_id": "abc"}
+
+    deleted = spawner.delete_team_session("abc")
+
+    assert deleted is True, "Returns True when row existed in store"
+    fake_store.delete.assert_called_once_with("abc")
+
+
+def test_delete_team_session_returns_false_when_unknown(isolated_spawner):
+    spawner, fake_store = isolated_spawner
+    fake_store.get.return_value = None  # no such row
+
+    deleted = spawner.delete_team_session("ghost")
+
+    assert deleted is False
+    # Still call store.delete (it's idempotent — DELETE WHERE no-match)
+    # but contract is the boolean return reflecting prior existence.
+    fake_store.delete.assert_called_once_with("ghost")
+
+
+# ─── delete_team_sessions_by_team_name ────────────────────────────
+
+
+def test_delete_team_sessions_by_team_name_filters_by_team(isolated_spawner):
+    spawner, fake_store = isolated_spawner
+    fake_store.list_all.return_value = [
+        {"session_id": "a1", "team_name": "alpha"},
+        {"session_id": "a2", "team_name": "alpha"},
+        {"session_id": "b1", "team_name": "beta"},
+    ]
+
+    count = spawner.delete_team_sessions_by_team_name("alpha")
+
+    assert count == 2
+    assert fake_store.delete.call_count == 2
+    deleted_ids = {c.args[0] for c in fake_store.delete.call_args_list}
+    assert deleted_ids == {"a1", "a2"}
+
+
+def test_delete_team_sessions_by_team_name_unknown_team_is_noop(isolated_spawner):
+    spawner, fake_store = isolated_spawner
+    fake_store.list_all.return_value = [
+        {"session_id": "a1", "team_name": "alpha"},
+    ]
+
+    count = spawner.delete_team_sessions_by_team_name("ghost")
+
+    assert count == 0
+    fake_store.delete.assert_not_called()
+
+
+def test_delete_team_sessions_by_team_name_skips_rows_missing_session_id(isolated_spawner):
+    """Defensive: a malformed row without ``session_id`` must not crash
+    the sweep (and must not spuriously bump the deleted counter).
+    """
+    spawner, fake_store = isolated_spawner
+    fake_store.list_all.return_value = [
+        {"session_id": "a1", "team_name": "alpha"},
+        {"team_name": "alpha"},  # ← no session_id
+        {"session_id": "a2", "team_name": "alpha"},
+    ]
+
+    count = spawner.delete_team_sessions_by_team_name("alpha")
+
+    assert count == 2  # only the two with valid session_id
+    deleted_ids = {c.args[0] for c in fake_store.delete.call_args_list}
+    assert deleted_ids == {"a1", "a2"}
+
+
+# ─── SoT discipline: AgentRegistryDB does NOT own writes ──────────
+
+
+def test_agent_registry_db_has_no_team_session_writers():
+    """AgentRegistryDB is a read-only viewer onto ``team_sessions``.
+
+    Earlier in this debugging session a duplicate ``delete_team_session``
+    was added directly to ``AgentRegistryDB`` — that violated single
+    source of truth. Pin the contract: no writers on the registry side.
+    """
+    from core.agent_registry_db import AgentRegistryDB
+
+    forbidden = {
+        "delete_team_session",
+        "delete_team_sessions_by_team_name",
+        "upsert_team_session",
+        "save_team_session",
+    }
+    present = forbidden & set(dir(AgentRegistryDB))
+    assert not present, (
+        f"AgentRegistryDB must NOT have team_session writers — go through "
+        f"fast_agent.spawn.team_spawner instead. Found: {present}"
+    )

--- a/backend/tests/test_services/test_token_persistence_central.py
+++ b/backend/tests/test_services/test_token_persistence_central.py
@@ -1,0 +1,276 @@
+"""Regression tests for the always-on token-persistence hook.
+
+Production bug found 2026-05-15: scheduler-triggered agent_turn calls
+were silently NOT counted in the ``token_usage`` table. ``9router``
+showed 16 requests / 864K input tokens; the Jarvis dashboard showed
+3 calls / 78.8K — exactly the chat+voice+inject turns, never the cron
+ones.
+
+Root cause: token persistence used to live inside ``create_progress_hooks``
+which only chat / voice / inject routes attached. ``cron_scheduler``
+called ``session_service.resume_and_send`` directly without attaching
+those hooks, so every LLM call its scheduled jobs made bypassed the
+``token_usage`` insert path entirely.
+
+Fix: centralize token persistence as an always-on hook attached at
+app startup to every in-process agent. Callers set the
+``current_run_id`` ContextVar to tag rows with their request id; the
+hook reads the var at LLM-call time. This file pins:
+
+  1. The factory builds a hook that calls ``_persist_and_broadcast_token_usage``
+     using the run_id from ContextVar.
+  2. ``cron_scheduler._execute_agent_turn`` sets that ContextVar so the
+     hook sees a cron-shaped run_id during the agent's send call.
+  3. End-to-end: simulating an LLM call with the hook attached writes
+     exactly one ``token_usage`` row tagged with the caller's run_id.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.sse_progress import (
+    current_run_id,
+    create_token_persistence_hooks,
+    attach_token_persistence_hooks_to_all,
+)
+
+
+def _fake_agent_with_usage(input_tokens=100, output_tokens=20, model="gpt-5.5"):
+    """Build a minimal stand-in for a fast-agent ``LlmAgent`` with a
+    usage_accumulator that the hook can read like the real thing."""
+    cache = SimpleNamespace(cache_hit_tokens=0, cache_read_tokens=0, cache_write_tokens=0)
+    last_turn = SimpleNamespace(
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        cache_usage=cache,
+        reasoning_tokens=0,
+    )
+    accumulator = SimpleNamespace(turns=[last_turn])
+    return SimpleNamespace(name="Jarvis", usage_accumulator=accumulator)
+
+
+@pytest.mark.asyncio
+async def test_token_hook_reads_run_id_from_context_var():
+    """The factory builds a hook that reads ``current_run_id`` at LLM-call
+    time — proving the always-on hook can be attached once at startup and
+    still tag each row with the caller's own run_id."""
+    hooks = create_token_persistence_hooks()
+    assert hooks.after_llm_call is not None
+
+    captured = {}
+
+    def _capture(agent_name, run_id, tokens):
+        captured["agent_name"] = agent_name
+        captured["run_id"] = run_id
+        captured["tokens"] = tokens
+
+    with patch("services.sse_progress._persist_and_broadcast_token_usage", side_effect=_capture):
+        runner = SimpleNamespace(_agent=_fake_agent_with_usage())
+        token = current_run_id.set("chat-abc12345")
+        try:
+            await hooks.after_llm_call(runner, MagicMock())
+        finally:
+            current_run_id.reset(token)
+
+    assert captured["run_id"] == "chat-abc12345", (
+        f"hook did not propagate ContextVar run_id; got {captured.get('run_id')!r}"
+    )
+    assert captured["tokens"]["input"] == 100
+    assert captured["tokens"]["output"] == 20
+
+
+@pytest.mark.asyncio
+async def test_token_hook_uses_empty_run_id_when_context_var_not_set():
+    """If no caller set the ContextVar (legacy / direct internal call),
+    the hook still writes a row with empty run_id — better than silently
+    losing the LLM call."""
+    hooks = create_token_persistence_hooks()
+    captured = {}
+
+    def _capture(agent_name, run_id, tokens):
+        captured["run_id"] = run_id
+
+    with patch("services.sse_progress._persist_and_broadcast_token_usage", side_effect=_capture):
+        runner = SimpleNamespace(_agent=_fake_agent_with_usage())
+        # Do NOT set the ContextVar — simulate a caller that bypassed
+        # the run_id ceremony. We still want the row written.
+        await hooks.after_llm_call(runner, MagicMock())
+
+    assert captured["run_id"] == "", (
+        f"expected empty run_id when ContextVar unset; got {captured.get('run_id')!r}"
+    )
+
+
+def test_attach_to_all_is_idempotent_and_merges_with_existing_hooks():
+    """Attaching twice (e.g. after dynamic-agent reload) must NOT stack
+    duplicate hooks — that would double-count every LLM call."""
+    from fast_agent.agents.tool_runner import ToolRunnerHooks
+
+    # Agent without any prior hooks — fresh attach
+    agent_a = SimpleNamespace(name="A", tool_runner_hooks=None)
+
+    # Agent with a pre-existing (non-token) hook — must be preserved
+    pre_existing_called = []
+
+    async def _pre_hook(runner, msg):
+        pre_existing_called.append(True)
+
+    agent_b = SimpleNamespace(
+        name="B",
+        tool_runner_hooks=ToolRunnerHooks(after_llm_call=_pre_hook),
+    )
+
+    fake_app = SimpleNamespace(_agents={"A": agent_a, "B": agent_b})
+
+    n1 = attach_token_persistence_hooks_to_all(fake_app)
+    assert n1 == 2, f"first attach should hook both agents; got {n1}"
+    assert agent_a.tool_runner_hooks is not None
+    assert agent_b.tool_runner_hooks is not None
+    assert getattr(agent_a, "_jarvis_token_hook") is True
+    assert getattr(agent_b, "_jarvis_token_hook") is True
+
+    # Re-attach (simulates dynamic_agents.signal_reload_loop firing a
+    # second time). Must be a no-op per agent — idempotency guard.
+    n2 = attach_token_persistence_hooks_to_all(fake_app)
+    assert n2 == 0, f"second attach must be no-op; got {n2}"
+
+
+@pytest.mark.asyncio
+async def test_cron_scheduler_sets_context_var_during_agent_turn():
+    """``_execute_agent_turn`` must set the ContextVar so the always-on
+    hook sees a cron-shaped run_id when the agent makes LLM calls.
+
+    This is the *integration contract* between cron_scheduler and the
+    centralized token-persistence hook. Without this kwarg the original
+    bug returns: every cron LLM call writes an un-tagged row, and the
+    dashboard's per-conversation breakdown is meaningless for scheduled
+    jobs."""
+    from services.cron_scheduler import CronScheduler
+
+    sched = CronScheduler()
+    sched._agent_app = MagicMock()
+    sched._session_service = MagicMock()
+
+    seen_during_call: dict = {}
+
+    async def _fake_resume(_app, _payload, **kwargs):
+        # The whole point: inside the agent send we should see the
+        # cron-shaped run_id, because the always-on hook will read this
+        # at the after_llm_call event.
+        seen_during_call["run_id"] = current_run_id.get()
+        return "ok", "sess-x"
+
+    sched._session_service.resume_and_send = _fake_resume
+
+    job = MagicMock()
+    job.id = 42
+    job.name = "test"
+    job.exec_agent = "Jarvis"
+    job.exec_payload = "hello"
+
+    # Pre-condition: outside the call, ContextVar is its default empty.
+    assert current_run_id.get() == ""
+
+    await sched._execute_agent_turn(job)
+
+    assert seen_during_call.get("run_id", "").startswith("cron-42-"), (
+        f"cron did not stamp run_id; saw {seen_during_call.get('run_id')!r}. "
+        "Without this stamping the always-on token hook writes rows with "
+        "empty run_id and the dashboard loses cron-job correlation."
+    )
+
+    # Post-condition: ContextVar is reset after the call returns, so a
+    # concurrent task doesn't accidentally inherit the cron run_id.
+    assert current_run_id.get() == "", (
+        "ContextVar leaked past _execute_agent_turn — concurrent in-process "
+        "calls would now mis-tag their token rows with this cron's run_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cron_scheduler_resets_context_var_on_exception():
+    """If the agent send raises, the ContextVar must still reset.
+    Otherwise the next task picked off the asyncio loop would inherit
+    the failed cron's run_id and mis-tag its tokens."""
+    from services.cron_scheduler import CronScheduler
+
+    sched = CronScheduler()
+    sched._agent_app = MagicMock()
+    sched._session_service = MagicMock()
+
+    async def _fake_resume_boom(_app, _payload, **kwargs):
+        raise RuntimeError("provider blew up")
+
+    sched._session_service.resume_and_send = _fake_resume_boom
+
+    job = MagicMock()
+    job.id = 99
+    job.name = "boom job"
+    job.exec_agent = "Jarvis"
+    job.exec_payload = "x"
+
+    with pytest.raises(RuntimeError, match="Agent turn failed"):
+        await sched._execute_agent_turn(job)
+
+    assert current_run_id.get() == "", (
+        "ContextVar leaked after exception path — failure should NEVER "
+        "leave the var dirty for the next task in the loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_hook_writes_row_to_token_usage_table(tmp_path, monkeypatch):
+    """End-to-end: with the hook attached, firing an after_llm_call event
+    writes exactly one row to the SQLite ``token_usage`` table tagged
+    with the ContextVar's run_id. This pins the full path that was
+    broken for scheduler before this fix."""
+    import core.database as db_mod
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    db_file = tmp_path / "jarvis.db"
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    db_mod.Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, future=True)
+
+    # Route the hook's ``get_db`` call to our isolated engine. We use a
+    # generator function so it matches the real ``get_db`` signature
+    # (which yields a session and closes it after).
+    def _fake_get_db():
+        s = SessionLocal()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    monkeypatch.setattr(db_mod, "get_db", _fake_get_db)
+
+    hooks = create_token_persistence_hooks()
+    runner = SimpleNamespace(_agent=_fake_agent_with_usage(input_tokens=555, output_tokens=42))
+
+    token = current_run_id.set("cron-42-deadbeef")
+    try:
+        await hooks.after_llm_call(runner, MagicMock())
+    finally:
+        current_run_id.reset(token)
+
+    # Verify the row landed
+    sess = SessionLocal()
+    try:
+        rows = sess.query(db_mod.TokenUsageRecord).all()
+    finally:
+        sess.close()
+
+    assert len(rows) == 1, f"expected exactly 1 row; got {len(rows)}"
+    row = rows[0]
+    assert row.run_id == "cron-42-deadbeef"
+    assert row.agent_name == "Jarvis"
+    assert row.input_tokens == 555
+    assert row.output_tokens == 42
+    assert row.total_tokens == 597

--- a/backend/tests/test_team_session.py
+++ b/backend/tests/test_team_session.py
@@ -5,7 +5,7 @@ Covers:
 - create_team_store(): RuntimeError without SPAWN_REGISTRY_DB
 - TeamSession: project_brief required, from_dict/to_dict roundtrip, strict KeyError
 - get_team_session(): cache hit, DB fallback, not-found, corrupt-delete
-- list_team_sessions(): store + cache merged, in-memory authoritative
+- list_team_sessions(): reads SQLite only (cache removed 2026-05-14)
 - spawn_team_members_for_session(): ValueError when brief and first_task both empty
 """
 
@@ -226,30 +226,20 @@ class TestTeamSession:
 
 
 class TestGetTeamSession:
-    def test_returns_from_cache(self, monkeypatch):
-        import fast_agent.spawn.team_spawner as ts_module
-        from fast_agent.spawn.team_spawner import TeamSession
+    """``get_team_session`` reads SQLite on every call — there is no
+    in-memory cache. The original cache was a perf optimisation that
+    silently went stale when a sibling subprocess upserted (see the
+    2026-05-13 incident below), so it was removed entirely; the store
+    is now the only source of truth.
+    """
 
-        session = TeamSession("ses-cached", {}, Path("/tmp"), "brief")
-        monkeypatch.setattr(ts_module, "_team_sessions", {"ses-cached": session})
-
-        store_mock = MagicMock()
-        monkeypatch.setattr(ts_module, "_team_store", store_mock)
-
-        from fast_agent.spawn.team_spawner import get_team_session
-        result = get_team_session("ses-cached")
-
-        assert result is session
-        store_mock.get.assert_not_called()  # cache hit, no DB access
-
-    def test_falls_back_to_db(self, tmp_path, monkeypatch):
+    def test_reads_from_db(self, tmp_path, monkeypatch):
+        """Stored session deserialises into a fresh TeamSession."""
         import fast_agent.spawn.team_spawner as ts_module
         from fast_agent.spawn.registry_backends import TeamSessionStore
 
         store = TeamSessionStore(str(tmp_path / "test.db"))
         store.upsert("ses-db", _minimal_session_dict(session_id="ses-db"))
-
-        monkeypatch.setattr(ts_module, "_team_sessions", {})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         from fast_agent.spawn.team_spawner import get_team_session
@@ -258,14 +248,12 @@ class TestGetTeamSession:
         assert result is not None
         assert result.session_id == "ses-db"
         assert result.project_brief == "Build a REST API"
-        assert "ses-db" in ts_module._team_sessions
 
     def test_returns_none_when_not_found(self, tmp_path, monkeypatch):
         import fast_agent.spawn.team_spawner as ts_module
         from fast_agent.spawn.registry_backends import TeamSessionStore
 
         store = TeamSessionStore(str(tmp_path / "test.db"))
-        monkeypatch.setattr(ts_module, "_team_sessions", {})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         from fast_agent.spawn.team_spawner import get_team_session
@@ -279,8 +267,6 @@ class TestGetTeamSession:
         corrupt = {"session_id": "ses-bad", "template": {}, "workspace": "/tmp",
                    "agents": {}, "sprint_status": "pending"}
         store.upsert("ses-bad", corrupt)
-
-        monkeypatch.setattr(ts_module, "_team_sessions", {})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         from fast_agent.spawn.team_spawner import get_team_session
@@ -288,6 +274,69 @@ class TestGetTeamSession:
 
         assert result is None
         assert store.get("ses-bad") is None
+
+    def test_cross_process_agents_visible_after_child_upsert(
+        self, tmp_path, monkeypatch
+    ):
+        """REGRESSION (2026-05-13 incident): Jarvis (parent) saw
+        ``1/1 agents done`` because its in-memory cache from the
+        initial spawn held only the orchestrator. Morgan (child) had
+        since spawned 6 members and upserted SQLite, but the parent's
+        cache never refreshed — and the notification + Jarvis tool
+        both reported a "completed" team that hadn't finished kickoff.
+
+        Post-refactor the cache is gone; every call reads SQLite,
+        so the parent automatically sees whatever the child wrote.
+        """
+        import fast_agent.spawn.team_spawner as ts_module
+        from fast_agent.spawn.registry_backends import TeamSessionStore
+
+        store = TeamSessionStore(str(tmp_path / "test.db"))
+        monkeypatch.setattr(ts_module, "_team_store", store)
+
+        # Parent: writes session with only the orchestrator.
+        store.upsert("ses-cross", _minimal_session_dict(
+            session_id="ses-cross",
+            agents={"Morgan [PM]": {"run_id": "run-pm", "role": "pm", "status": "running"}},
+        ))
+
+        # Child: loads, mutates, upserts (simulated cross-process write).
+        from_db = store.get("ses-cross")
+        from_db["agents"].update({
+            "Ryan [BA]": {"run_id": "run-ba", "role": "ba", "status": "running"},
+            "Dakota [SA]": {"run_id": "run-sa", "role": "sa", "status": "running"},
+        })
+        from_db["sprint_status"] = "running"
+        store.upsert("ses-cross", from_db)
+
+        # Parent's next read sees the full roster.
+        from fast_agent.spawn.team_spawner import get_team_session
+        refreshed = get_team_session("ses-cross")
+        assert refreshed is not None
+        assert set(refreshed.agents.keys()) == {
+            "Morgan [PM]", "Ryan [BA]", "Dakota [SA]",
+        }
+        assert refreshed.sprint_status == "running"
+
+    def test_returns_fresh_instance_each_call(self, tmp_path, monkeypatch):
+        """Without a cache, two successive calls return distinct
+        TeamSession objects — callers that need a persistent reference
+        must keep their own, and any in-memory mutation must be
+        followed by ``_get_store().upsert(...)`` to be visible to
+        subsequent reads.
+        """
+        import fast_agent.spawn.team_spawner as ts_module
+        from fast_agent.spawn.registry_backends import TeamSessionStore
+
+        store = TeamSessionStore(str(tmp_path / "test.db"))
+        store.upsert("ses-fresh", _minimal_session_dict(session_id="ses-fresh"))
+        monkeypatch.setattr(ts_module, "_team_store", store)
+
+        from fast_agent.spawn.team_spawner import get_team_session
+        first = get_team_session("ses-fresh")
+        second = get_team_session("ses-fresh")
+        assert first is not second
+        assert first.session_id == second.session_id == "ses-fresh"
 
 
 # ── list_team_sessions ────────────────────────────────────────────────────────
@@ -301,8 +350,6 @@ class TestListTeamSessions:
         store = TeamSessionStore(str(tmp_path / "test.db"))
         store.upsert("s1", _minimal_session_dict(session_id="s1"))
         store.upsert("s2", _minimal_session_dict(session_id="s2"))
-
-        monkeypatch.setattr(ts_module, "_team_sessions", {})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         from fast_agent.spawn.team_spawner import list_team_sessions
@@ -310,32 +357,30 @@ class TestListTeamSessions:
         ids = {r["session_id"] for r in result}
         assert {"s1", "s2"}.issubset(ids)
 
-    def test_in_memory_overrides_store(self, tmp_path, monkeypatch):
-        """In-memory session (with unsaved state) beats stale DB record."""
+    def test_db_state_is_authoritative(self, tmp_path, monkeypatch):
+        """The DB row is what ``list_team_sessions`` returns. Callers
+        that hold an unsaved TeamSession reference do NOT see their
+        in-process mutations reflected here — they must upsert first.
+        This codifies the post-cache-removal contract.
+        """
         import fast_agent.spawn.team_spawner as ts_module
         from fast_agent.spawn.registry_backends import TeamSessionStore
-        from fast_agent.spawn.team_spawner import TeamSession
 
         store = TeamSessionStore(str(tmp_path / "test.db"))
-        store.upsert("s1", _minimal_session_dict(session_id="s1", sprint_status="pending"))
-
-        live_session = TeamSession("s1", {"name": "sprint"}, Path("/tmp/ws"), "brief")
-        live_session.sprint_status = "orchestrator_running"
-
-        monkeypatch.setattr(ts_module, "_team_sessions", {"s1": live_session})
+        store.upsert("s1", _minimal_session_dict(session_id="s1",
+                                                 sprint_status="pending"))
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         from fast_agent.spawn.team_spawner import list_team_sessions
         result = list_team_sessions()
         s1 = next(r for r in result if r["session_id"] == "s1")
-        assert s1["sprint_status"] == "orchestrator_running"
+        assert s1["sprint_status"] == "pending"
 
     def test_returns_empty_when_nothing_stored(self, tmp_path, monkeypatch):
         import fast_agent.spawn.team_spawner as ts_module
         from fast_agent.spawn.registry_backends import TeamSessionStore
 
         store = TeamSessionStore(str(tmp_path / "test.db"))
-        monkeypatch.setattr(ts_module, "_team_sessions", {})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         from fast_agent.spawn.team_spawner import list_team_sessions
@@ -364,10 +409,9 @@ class TestSpawnTeamMembersFailLoud:
             "Minh [Dev]": {"run_id": "run-1", "role": "dev", "status": "available"},
         }
 
-        monkeypatch.setattr(ts_module, "_team_sessions", {"ses-fail": session})
-
         from fast_agent.spawn.registry_backends import TeamSessionStore
         store = TeamSessionStore(str(tmp_path / "test.db"))
+        store.upsert("ses-fail", session.to_dict())
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         registry_mock = MagicMock()
@@ -402,7 +446,6 @@ class TestSpawnTeamMembersFailLoud:
         from fast_agent.spawn.registry_backends import TeamSessionStore
         store = TeamSessionStore(str(tmp_path / "test.db"))
         store.upsert("ses-ok", session.to_dict())
-        monkeypatch.setattr(ts_module, "_team_sessions", {"ses-ok": session})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         registry_mock = MagicMock()
@@ -441,7 +484,6 @@ class TestSpawnTeamMembersFailLoud:
         from fast_agent.spawn.registry_backends import TeamSessionStore
         store = TeamSessionStore(str(tmp_path / "test.db"))
         store.upsert("ses-brief", session.to_dict())
-        monkeypatch.setattr(ts_module, "_team_sessions", {"ses-brief": session})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         registry_mock = MagicMock()
@@ -465,7 +507,6 @@ class TestSpawnTeamMembersFailLoud:
         from fast_agent.spawn.registry_backends import TeamSessionStore
 
         store = TeamSessionStore(str(tmp_path / "test.db"))
-        monkeypatch.setattr(ts_module, "_team_sessions", {})
         monkeypatch.setattr(ts_module, "_team_store", store)
 
         registry_mock = MagicMock()

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test:unit": "node --test 'src/utils/*.test.js' 'src/auth/*.test.js' 'src/stores/*.test.js'",
+    "test:unit": "node --test 'src/utils/*.test.js' 'src/auth/*.test.js' 'src/stores/*.test.js' 'src/composables/*.test.js' 'src/components/monitor/*.test.js'",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/dashboard/src/components/AppLayout.vue
+++ b/dashboard/src/components/AppLayout.vue
@@ -13,6 +13,8 @@ import { useToast } from '../composables/useToast'
 import ConnectionBanner from './ConnectionBanner.vue'
 import MiniAudioPlayer from './stories/MiniAudioPlayer.vue'
 import FullAudioPlayer from './stories/FullAudioPlayer.vue'
+import GlobalVoiceIndicator from './global/GlobalVoiceIndicator.vue'
+import FloatingChatDock from './global/FloatingChatDock.vue'
 
 const approvalsStore = useApprovalsStore()
 const audioPlayerStore = useAudioPlayerStore()
@@ -290,13 +292,37 @@ onUnmounted(() => {
         class="app-main__content"
         :style="{ paddingBottom: isAudioPlaying ? '84px' : (isMobile ? '16px' : '24px') }"
       >
-        <RouterView />
+        <!--
+          ``<keep-alive>`` caches view component instances across route nav.
+          Without it, switching from /chat to /monitor and back unmounts
+          ChatView (and VoiceBar inside it) — losing in-flight conversation
+          state, killing the active SSE stream, and stopping hands-free
+          voice mid-turn.
+
+          ``include`` is an explicit allow-list so only routes that
+          legitimately benefit from cached state opt in. Everything else
+          (Settings, Approvals, etc.) keeps the default mount-on-enter
+          behaviour.
+        -->
+        <RouterView v-slot="{ Component }">
+          <keep-alive :include="['Chat', 'TeamMonitor']">
+            <component :is="Component" />
+          </keep-alive>
+        </RouterView>
       </div>
       <MiniAudioPlayer v-if="isAudioPlaying" />
     </main>
 
   </div>
   <FullAudioPlayer />
+
+  <!--
+    Global overlays — live OUTSIDE the layout flex so they float fixed-
+    position over any route. They self-hide on /chat (where their inline
+    counterparts already render) and on bare layouts (auth/setup).
+    -->
+  <GlobalVoiceIndicator />
+  <FloatingChatDock />
 </template>
 
 <style scoped>

--- a/dashboard/src/components/chat/VoiceBar.vue
+++ b/dashboard/src/components/chat/VoiceBar.vue
@@ -10,23 +10,21 @@
  * chatStore (addUserMessage / addAgentMessagePlaceholder /
  * finalizeAgentMessage), so voice and typed turns share one UI.
  */
-import { computed, onBeforeUnmount } from 'vue'
+import { computed } from 'vue'
 import { useVoiceSession } from '../../composables/useVoiceSession.js'
 
 const session = useVoiceSession()
 
-// Tear down on real unmount so navigating away doesn't leak the mic
-// / WS / AudioContext. Diagnostic-tagged so when the user sees an
-// unexpected "Mic Off" we can tell from the console what triggered
-// it (route nav vs HMR vs explicit stop button).
-onBeforeUnmount(() => {
-  console.debug('[voice] VoiceBar onBeforeUnmount → stop()', {
-    status: session.status.value,
-    hmr: !!import.meta.hot,
-    href: location.href,
-  })
-  Promise.resolve(session.stop()).catch(() => {})
-})
+// NOTE — no onBeforeUnmount stop() here. The voice session is now a
+// module-level singleton (see useVoiceSession.js) and the host route is
+// kept alive across nav (AppLayout's <keep-alive>), so the only legitimate
+// teardown triggers are:
+//   1. user clicks the Stop button in this bar (handled by toggle())
+//   2. user clicks the Stop button on the global indicator (same singleton)
+//   3. auth expiry (handled inside the singleton itself)
+//   4. browser tab close / refresh (browser tears down WS automatically)
+// Auto-stopping on component unmount used to fire on every route change,
+// dropping the mic mid-conversation when the user switched to /monitor.
 
 const STATUS_LABELS = {
   idle: 'Off',

--- a/dashboard/src/components/global/FloatingChatDock.vue
+++ b/dashboard/src/components/global/FloatingChatDock.vue
@@ -15,7 +15,7 @@
  * Open/close state is local to this component (per browser tab) — not
  * persisted. User toggles freely.
  */
-import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useChatStore } from '../../stores/chat.js'
 import { useChatStream } from '../../composables/useChatStream.js'
@@ -54,7 +54,18 @@ const activeTitle = computed(() => chatStore.activeConversation?.title || 'Chat'
 
 function toggle() {
   expanded.value = !expanded.value
-  if (expanded.value) nextTick(() => scrollToBottom())
+  if (expanded.value) {
+    // Lazy fetch on first expand — keeps boot-time API surface clean
+    // on routes where the dock is mounted but never used (auth, setup,
+    // settings, audio-player, etc). Eager onMounted fetch was leaking
+    // ``GET /api/conversations`` requests into every page-load and
+    // breaking unrelated e2e fixtures that assert ``backend.unexpected
+    // .length === 0``.
+    if (chatStore.conversations.length === 0) {
+      chatStore.fetchConversations().catch(() => { /* ignored */ })
+    }
+    nextTick(() => scrollToBottom())
+  }
 }
 
 function popOut() {
@@ -138,14 +149,14 @@ function handleKeydown(e) {
   }
 }
 
-// Initial fetch — one-time, in case dock is the first chat surface the
-// user touches in this session. ChatView's onMounted handles it for the
-// /chat-first path.
-onMounted(() => {
-  if (chatStore.conversations.length === 0) {
-    chatStore.fetchConversations().catch(() => { /* ignored */ })
-  }
-})
+// NOTE: NO eager fetch on mount. The fetch is moved to ``toggle()``
+// (first expand) so the dock doesn't issue ``/api/conversations`` on
+// every page mount — that was leaking onto routes where the dock is
+// hidden via ``visible`` and breaking ``backend.unexpected.length===0``
+// assertions in unrelated e2e fixtures.
+// If the user goes /chat first, ChatView's own onMounted handles the
+// fetch and ``chatStore.conversations`` is populated before the dock
+// ever expands.
 </script>
 
 <template>

--- a/dashboard/src/components/global/FloatingChatDock.vue
+++ b/dashboard/src/components/global/FloatingChatDock.vue
@@ -1,0 +1,515 @@
+<script setup>
+/**
+ * FloatingChatDock — minimisable chat widget visible on every route
+ * EXCEPT /chat (where the full ChatView already takes the space).
+ *
+ * Two modes:
+ *  • collapsed: small floating button (bottom-left). Shows 🟢 streaming
+ *    indicator when the agent is mid-turn so the user knows their last
+ *    message is still being answered.
+ *  • expanded: docked panel (bottom-left, fixed) with the active
+ *    conversation's last few messages, plus a minimal input. Reuses the
+ *    same chatStore + useChatStream as ChatView so message state is
+ *    consistent.
+ *
+ * Open/close state is local to this component (per browser tab) — not
+ * persisted. User toggles freely.
+ */
+import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useChatStore } from '../../stores/chat.js'
+import { useChatStream } from '../../composables/useChatStream.js'
+import MarkdownRenderer from '../MarkdownRenderer.vue'
+
+const chatStore = useChatStore()
+const { send, isStreaming } = useChatStream()
+const route = useRoute()
+const router = useRouter()
+
+const expanded = ref(false)
+const draft = ref('')
+const scrollRef = ref(null)
+
+// Hide on /chat (full UI already there) and on bare layouts (auth/setup).
+const visible = computed(() => {
+  if (route.name === 'Chat') return false
+  if (route.meta?.layout === 'bare') return false
+  return true
+})
+
+// "Streaming" badge on the collapsed button — surfaces in-flight turns
+// so the user knows their last message is still being answered after
+// they navigated away.
+const showStreamingBadge = computed(
+  () => !expanded.value && (isStreaming.value || chatStore.isStreaming),
+)
+
+// Last 6 messages of the active conversation — keep the dock small.
+const recentMessages = computed(() => {
+  const all = chatStore.activeMessages
+  return all.length > 6 ? all.slice(-6) : all
+})
+
+const activeTitle = computed(() => chatStore.activeConversation?.title || 'Chat')
+
+function toggle() {
+  expanded.value = !expanded.value
+  if (expanded.value) nextTick(() => scrollToBottom())
+}
+
+function popOut() {
+  expanded.value = false
+  router.push({ name: 'Chat' })
+}
+
+function scrollToBottom() {
+  if (scrollRef.value) {
+    scrollRef.value.scrollTop = scrollRef.value.scrollHeight
+  }
+}
+
+// Auto-scroll when new messages arrive while expanded.
+watch(
+  () => recentMessages.value.length,
+  () => {
+    if (expanded.value) nextTick(() => scrollToBottom())
+  },
+)
+
+async function handleSend() {
+  const text = draft.value.trim()
+  if (!text || isStreaming.value) return
+  draft.value = ''
+
+  if (!chatStore.activeConversation) {
+    chatStore.createConversation(chatStore.activeAgentName)
+  }
+
+  chatStore.addUserMessage(text)
+  const msgId = chatStore.addAgentMessagePlaceholder()
+  chatStore.isStreaming = true
+
+  await send(
+    text,
+    chatStore.activeConversation?.backendConversationId,
+    (event) => {
+      switch (event.type) {
+        case 'tool_call':
+        case 'tool_request':
+          chatStore.pushToolCall(msgId, {
+            tool: event.tools?.[0]?.name || event.tool || 'tool',
+            command: event.message || '',
+            args: event.tools?.[0]?.args || null,
+          })
+          break
+        case 'tool_result':
+        case 'tool_done':
+          chatStore.pushToolCall(msgId, {
+            tool: event.tools?.[0]?.name || event.tool || 'tool',
+            command: event.message || 'result',
+            isResult: true,
+            duration: event.duration_ms ? `${(event.duration_ms / 1000).toFixed(1)}s` : undefined,
+            resultPreview: event.result_preview || null,
+          })
+          break
+        case 'done':
+          chatStore.finalizeAgentMessage(msgId, event.response || '', {
+            conversation_id: event.conversation_id,
+            audio: event.audio,
+            total_tokens: event.total_tokens,
+          })
+          break
+        case 'error':
+          chatStore.setMessageError(msgId, event.message || 'Unknown error')
+          break
+      }
+    },
+    null,
+    chatStore.activeAgentName,
+  )
+
+  chatStore.isStreaming = false
+}
+
+function handleKeydown(e) {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault()
+    handleSend()
+  }
+}
+
+// Initial fetch — one-time, in case dock is the first chat surface the
+// user touches in this session. ChatView's onMounted handles it for the
+// /chat-first path.
+onMounted(() => {
+  if (chatStore.conversations.length === 0) {
+    chatStore.fetchConversations().catch(() => { /* ignored */ })
+  }
+})
+</script>
+
+<template>
+  <div v-if="visible" class="floating-dock" :class="{ expanded }">
+    <!-- Expanded panel -->
+    <transition name="dock-slide">
+      <div v-if="expanded" class="dock-panel">
+        <header class="dock-header">
+          <span class="dock-title" :title="activeTitle">💬 {{ activeTitle }}</span>
+          <button class="dock-icon-btn" type="button" title="Open full chat" @click="popOut">↗</button>
+          <button class="dock-icon-btn" type="button" title="Minimise" @click="toggle">─</button>
+        </header>
+
+        <div ref="scrollRef" class="dock-body">
+          <div v-if="!recentMessages.length" class="dock-empty">
+            <p>No messages yet. Type below to chat with the agent — replies stream here without leaving this view.</p>
+          </div>
+          <div
+            v-for="msg in recentMessages"
+            :key="msg.id"
+            class="dock-msg"
+            :class="['dock-msg-' + msg.role, { streaming: msg.isStreaming }]"
+          >
+            <span class="dock-msg-role">{{ msg.role === 'user' ? 'You' : (msg.role === 'assistant' ? 'Agent' : msg.role) }}</span>
+            <div class="dock-msg-content">
+              <MarkdownRenderer
+                v-if="msg.content"
+                :content="msg.content"
+                content-type="markdown"
+                :enable-mermaid="false"
+              />
+              <span v-else-if="msg.isStreaming" class="dock-typing">
+                <span class="typing-dot" /><span class="typing-dot" /><span class="typing-dot" />
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="dock-input-row">
+          <textarea
+            v-model="draft"
+            class="dock-input"
+            rows="1"
+            placeholder="Type a message…"
+            :disabled="isStreaming"
+            @keydown="handleKeydown"
+          />
+          <button
+            class="dock-send"
+            type="button"
+            :disabled="!draft.trim() || isStreaming"
+            @click="handleSend"
+          >→</button>
+        </div>
+      </div>
+    </transition>
+
+    <!-- Collapsed FAB -->
+    <transition name="dock-fab">
+      <button
+        v-if="!expanded"
+        class="dock-fab"
+        :class="{ streaming: showStreamingBadge }"
+        type="button"
+        title="Open chat dock"
+        @click="toggle"
+      >
+        💬
+        <span v-if="showStreamingBadge" class="fab-badge" title="Agent is replying">●</span>
+      </button>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.floating-dock {
+  position: fixed;
+  bottom: 18px;
+  left: 18px;
+  z-index: 140;  /* below voice indicator (150) so they don't overlap badly */
+}
+
+/* ── Collapsed FAB ── */
+.dock-fab {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #1e3a5f;
+  border: 1px solid #2a3556;
+  color: #f0f2f5;
+  font-size: 18px;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.40);
+  position: relative;
+  transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+}
+
+.dock-fab:hover {
+  transform: scale(1.06);
+  background: #2a4a72;
+}
+
+.dock-fab.streaming {
+  animation: dock-fab-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes dock-fab-pulse {
+  0%, 100% { box-shadow: 0 6px 18px rgba(0,0,0,0.4); }
+  50%      { box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.20), 0 6px 18px rgba(0,0,0,0.4); }
+}
+
+.fab-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #10b981;
+  color: white;
+  font-size: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #0c0e15;
+  animation: badge-blink 1.2s infinite;
+}
+
+@keyframes badge-blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+
+/* ── Expanded panel ── */
+.dock-panel {
+  width: 360px;
+  max-width: calc(100vw - 36px);
+  height: 480px;
+  max-height: calc(100vh - 100px);
+  background: rgba(12, 14, 21, 0.97);
+  border: 1px solid #1a1d2e;
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.dock-header {
+  padding: 10px 12px;
+  border-bottom: 1px solid #1a1d2e;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #0a0d14;
+  flex-shrink: 0;
+}
+
+.dock-title {
+  flex: 1;
+  font-size: 12px;
+  font-weight: 600;
+  color: #f0f2f5;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dock-icon-btn {
+  width: 26px;
+  height: 26px;
+  background: #111318;
+  border: 1px solid #1a1d2e;
+  color: #8b8fa3;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dock-icon-btn:hover {
+  background: #1e2233;
+  color: #f0f2f5;
+}
+
+.dock-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dock-body::-webkit-scrollbar { width: 4px; }
+.dock-body::-webkit-scrollbar-thumb { background: #1a1d2e; border-radius: 4px; }
+
+.dock-empty {
+  color: #555872;
+  font-size: 12px;
+  font-style: italic;
+  text-align: center;
+  padding: 30px 10px;
+}
+
+.dock-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.dock-msg-role {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #555872;
+}
+
+.dock-msg-user .dock-msg-role { color: #3b82f6; }
+.dock-msg-assistant .dock-msg-role { color: #00d4aa; }
+
+.dock-msg-content {
+  color: #c4c8d4;
+  word-break: break-word;
+}
+
+.dock-msg-content :deep(p) { margin: 0 0 0.4em; }
+.dock-msg-content :deep(p:last-child) { margin-bottom: 0; }
+.dock-msg-content :deep(code) {
+  background: #0a0d14;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.dock-msg-content :deep(pre) {
+  background: #0a0d14;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 10.5px;
+  overflow-x: auto;
+}
+
+.dock-typing {
+  display: inline-flex;
+  gap: 3px;
+  padding: 4px 0;
+}
+
+.typing-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #8b8fa3;
+  animation: typing-bounce 1s infinite;
+}
+.typing-dot:nth-child(2) { animation-delay: 0.15s; }
+.typing-dot:nth-child(3) { animation-delay: 0.30s; }
+
+@keyframes typing-bounce {
+  0%, 100% { opacity: 0.35; transform: scale(0.85); }
+  50%      { opacity: 1;    transform: scale(1); }
+}
+
+.dock-input-row {
+  border-top: 1px solid #1a1d2e;
+  padding: 8px;
+  display: flex;
+  gap: 6px;
+  background: #0a0d14;
+  flex-shrink: 0;
+}
+
+.dock-input {
+  flex: 1;
+  background: #111318;
+  border: 1px solid #1a1d2e;
+  border-radius: 8px;
+  padding: 7px 10px;
+  color: #f0f2f5;
+  font: inherit;
+  font-size: 12px;
+  resize: none;
+  max-height: 80px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.dock-input:focus {
+  border-color: #3b82f6;
+}
+
+.dock-input:disabled {
+  opacity: 0.55;
+}
+
+.dock-send {
+  width: 34px;
+  height: 34px;
+  background: #3b82f6;
+  border: none;
+  color: white;
+  border-radius: 8px;
+  font-size: 16px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+
+.dock-send:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.dock-send:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* Mobile */
+@media (max-width: 767px) {
+  .floating-dock {
+    bottom: 78px;  /* clear bottom nav */
+    left: 12px;
+  }
+
+  .dock-fab {
+    width: 44px;
+    height: 44px;
+    font-size: 16px;
+  }
+
+  .dock-panel {
+    width: calc(100vw - 24px);
+    height: 60vh;
+    max-height: 480px;
+  }
+}
+
+/* Transitions */
+.dock-slide-enter-active,
+.dock-slide-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  transform-origin: bottom left;
+}
+.dock-slide-enter-from,
+.dock-slide-leave-to {
+  opacity: 0;
+  transform: scale(0.95) translateY(8px);
+}
+
+.dock-fab-enter-active,
+.dock-fab-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.dock-fab-enter-from,
+.dock-fab-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
+}
+</style>

--- a/dashboard/src/components/global/GlobalVoiceIndicator.vue
+++ b/dashboard/src/components/global/GlobalVoiceIndicator.vue
@@ -1,0 +1,246 @@
+<script setup>
+/**
+ * GlobalVoiceIndicator — floating pill that shows hands-free status on
+ * every route EXCEPT /chat (where VoiceBar already renders inline).
+ *
+ * Lets the user know mic is still live while they navigate to /monitor,
+ * /agents, etc., and gives them one-click access to:
+ *   • interrupt / barge-in while the agent is speaking,
+ *   • stop the session entirely,
+ *   • jump back to /chat to see the conversation.
+ *
+ * The voice session is a module-level singleton (see
+ * composables/useVoiceSession.js) so this component reads the same
+ * status refs as VoiceBar — they always agree.
+ */
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useVoiceSession } from '../../composables/useVoiceSession.js'
+
+const session = useVoiceSession()
+const route = useRoute()
+const router = useRouter()
+
+// Hide on /chat: VoiceBar is already on screen there, two indicators
+// would be redundant noise. Also hide when the session is genuinely off.
+const visible = computed(() => {
+  if (route.name === 'Chat') return false
+  const s = session.status.value
+  return s !== 'idle'
+})
+
+const statusInfo = computed(() => {
+  switch (session.status.value) {
+    case 'connecting':   return { label: 'Connecting…', color: '#f59e0b', dot: true }
+    case 'loading_stt':  return { label: 'Loading STT…', color: '#f59e0b', dot: true }
+    case 'listening':    return { label: 'Listening',   color: '#10b981', dot: true }
+    case 'thinking':     return { label: 'Thinking…',   color: '#3b82f6', dot: true, spin: true }
+    case 'speaking':     return { label: 'Speaking',    color: '#8b5cf6', dot: true, spin: true }
+    case 'error':        return { label: 'Error',       color: '#ef4444', dot: true }
+    default:             return { label: 'Off',         color: '#555872', dot: false }
+  }
+})
+
+const canInterrupt = computed(() =>
+  session.status.value === 'thinking' || session.status.value === 'speaking',
+)
+
+function goToChat() {
+  router.push({ name: 'Chat' })
+}
+
+async function handleStop() {
+  try { await session.stop() } catch { /* already torn */ }
+}
+
+function handleBargeIn() {
+  session.bargeIn()
+}
+</script>
+
+<template>
+  <transition name="indicator-fade">
+    <div v-if="visible" class="voice-indicator" :class="`status-${session.status.value}`">
+      <button
+        class="indicator-body"
+        type="button"
+        title="Open chat"
+        @click="goToChat"
+      >
+        <span class="dot" :class="{ pulse: statusInfo.dot, spinning: statusInfo.spin }" :style="{ background: statusInfo.color }" />
+        <span class="status-text">🎙️ {{ statusInfo.label }}</span>
+        <span v-if="session.partialTranscript.value" class="partial">
+          "{{ session.partialTranscript.value.slice(0, 40) }}{{ session.partialTranscript.value.length > 40 ? '…' : '' }}"
+        </span>
+      </button>
+
+      <button
+        v-if="canInterrupt"
+        type="button"
+        class="indicator-action interrupt"
+        title="Interrupt agent"
+        @click="handleBargeIn"
+      >
+        ⏸
+      </button>
+
+      <button
+        type="button"
+        class="indicator-action stop"
+        title="Stop hands-free"
+        @click="handleStop"
+      >
+        ✕
+      </button>
+    </div>
+  </transition>
+</template>
+
+<style scoped>
+.voice-indicator {
+  position: fixed;
+  bottom: 18px;
+  right: 18px;
+  z-index: 150;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 6px 6px 14px;
+  background: rgba(12, 14, 21, 0.92);
+  border: 1px solid #1a1d2e;
+  border-radius: 24px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(8px);
+  font-size: 12px;
+  color: #f0f2f5;
+  min-width: 0;
+  max-width: 380px;
+}
+
+.voice-indicator.status-listening {
+  border-color: rgba(16, 185, 129, 0.45);
+  box-shadow: 0 0 14px rgba(16, 185, 129, 0.18), 0 8px 24px rgba(0,0,0,0.4);
+}
+
+.voice-indicator.status-thinking,
+.voice-indicator.status-speaking {
+  border-color: rgba(139, 92, 246, 0.45);
+  box-shadow: 0 0 14px rgba(139, 92, 246, 0.20), 0 8px 24px rgba(0,0,0,0.4);
+}
+
+.voice-indicator.status-error {
+  border-color: rgba(239, 68, 68, 0.55);
+}
+
+.indicator-body {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 4px 8px;
+  cursor: pointer;
+  font: inherit;
+  border-radius: 18px;
+  flex: 1;
+  min-width: 0;
+}
+
+.indicator-body:hover {
+  background: rgba(255,255,255,0.04);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dot.pulse {
+  animation: dot-pulse 1.4s ease-in-out infinite;
+}
+
+.dot.spinning {
+  animation: dot-pulse 0.9s ease-in-out infinite;
+}
+
+@keyframes dot-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
+  50%      { box-shadow: 0 0 0 5px transparent; opacity: 0.55; }
+}
+
+.status-text {
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.partial {
+  font-style: italic;
+  font-weight: 400;
+  color: #8b8fa3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.indicator-action {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111318;
+  border: 1px solid #1a1d2e;
+  color: #c4c8d4;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.indicator-action:hover {
+  background: #1e2233;
+  color: #f0f2f5;
+}
+
+.indicator-action.interrupt:hover {
+  background: rgba(245, 158, 11, 0.20);
+  color: #f59e0b;
+  border-color: rgba(245, 158, 11, 0.45);
+}
+
+.indicator-action.stop:hover {
+  background: rgba(239, 68, 68, 0.20);
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+/* Mobile: smaller, hide partial transcript */
+@media (max-width: 767px) {
+  .voice-indicator {
+    bottom: 78px; /* avoid colliding with mobile bottom nav */
+    right: 12px;
+    max-width: calc(100vw - 24px);
+  }
+
+  .partial {
+    display: none;
+  }
+}
+
+.indicator-fade-enter-active,
+.indicator-fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.indicator-fade-enter-from,
+.indicator-fade-leave-to {
+  opacity: 0;
+  transform: translateY(8px);
+}
+</style>

--- a/dashboard/src/components/meetings/MeetingTranscript.vue
+++ b/dashboard/src/components/meetings/MeetingTranscript.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import MarkdownRenderer from '../MarkdownRenderer.vue'
 
 const props = defineProps({
@@ -16,6 +16,71 @@ const emit = defineEmits(['close'])
 const scrollRef = ref(null)
 const autoScroll = ref(true)
 const expandAll = ref(false)
+
+// Details drawer (long-form description from create_meeting's `description` arg)
+const showDetails = ref(false)
+
+// "Now" tick — drives the live "X ago" reading on the active-turn indicator
+// without forcing a parent rerender. 5s cadence is enough for human-scale UX.
+const nowSec = ref(Math.floor(Date.now() / 1000))
+let nowTimer = null
+onMounted(() => {
+  nowTimer = setInterval(() => {
+    nowSec.value = Math.floor(Date.now() / 1000)
+  }, 5000)
+})
+onUnmounted(() => {
+  if (nowTimer) clearInterval(nowTimer)
+})
+
+// Current speaker (the participant whose turn it currently is). Derived
+// from meetingState; empty string if meeting is ended or state not loaded.
+const currentSpeaker = computed(() => {
+  if (props.meetingState?.ended) return ''
+  const parts = props.meetingState?.participants || props.meeting?.participants || []
+  const idx = props.meetingState?.current_turn ?? 0
+  return parts[idx] || ''
+})
+
+// Time-since-last-action for the current turn — surfaces when a meeting
+// is hung waiting on someone to speak (b61af7db incident: 24h hang).
+// Falls back to the most recent transcript entry's timestamp.
+const lastActionAgo = computed(() => {
+  if (props.meetingState?.ended) return ''
+  // Prefer turn_started_at from state (set by speak/skip_turn), fall back
+  // to the latest transcript entry timestamp.
+  let ts = props.meeting?.turn_started_at || props.meetingState?.turn_started_at
+  if (!ts && props.transcript.length) {
+    const last = props.transcript[props.transcript.length - 1]
+    const t = last?.timestamp
+    if (t) {
+      const parsed = typeof t === 'number' ? t : Date.parse(t) / 1000
+      if (!Number.isNaN(parsed)) ts = parsed
+    }
+  }
+  if (!ts) return ''
+  const sec = Math.max(0, nowSec.value - Math.floor(Number(ts)))
+  if (sec < 5) return 'just now'
+  if (sec < 60) return `${sec}s ago`
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ${sec % 60}s ago`
+  return `${Math.floor(sec / 3600)}h ${Math.floor((sec % 3600) / 60)}m ago`
+})
+
+// Bottleneck warning — flag turns that have been waiting longer than 60s.
+const isStalled = computed(() => {
+  if (props.meetingState?.ended || !currentSpeaker.value) return false
+  let ts = props.meeting?.turn_started_at || props.meetingState?.turn_started_at
+  if (!ts && props.transcript.length) {
+    const last = props.transcript[props.transcript.length - 1]
+    const t = last?.timestamp
+    if (t) {
+      const parsed = typeof t === 'number' ? t : Date.parse(t) / 1000
+      if (!Number.isNaN(parsed)) ts = parsed
+    }
+  }
+  if (!ts) return false
+  return (nowSec.value - Math.floor(Number(ts))) > 60
+})
 
 // Auto-scroll to bottom when new entries arrive
 watch(
@@ -91,8 +156,14 @@ function toggleExpand(turn) {
   expandedEntries.value = s
 }
 
+// Threshold above which a single transcript entry gets a max-height + "Show
+// more" toggle. Bigger than the old 300-char hard cut — lets short-medium
+// agent messages render fully (no more "..." everywhere) while still
+// protecting the scroll viewport from a single 5KB wall of text.
+const LONG_MESSAGE_CHARS = 1200
+
 function isLong(message) {
-  return message && message.length > 300
+  return message && message.length > LONG_MESSAGE_CHARS
 }
 
 // Connection status
@@ -113,51 +184,104 @@ const connectionColor = computed(() => {
 
 <template>
   <div class="transcript-panel">
-    <!-- Header -->
+    <!-- ─── Header ─── -->
     <div class="transcript-header">
-      <!-- Row 1: Back + Title -->
+      <!-- Row 1: back + title + connection + actions -->
       <div class="transcript-header-row1">
         <button class="back-btn" @click="emit('close')" title="Back to list">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M19 12H5"/><polyline points="12 19 5 12 12 5"/>
           </svg>
         </button>
-        <h3 class="transcript-title">{{ meeting?.agenda || 'Meeting' }}</h3>
+        <h3 class="transcript-title" :title="meeting?.agenda">{{ meeting?.agenda || 'Meeting' }}</h3>
         <span class="connection-badge" :style="{ background: connectionColor + '20', color: connectionColor, borderColor: connectionColor + '40' }">
           <span class="connection-dot" :style="{ background: connectionColor }"></span>
           {{ connectionLabel }}
         </span>
-      </div>
-
-      <!-- Row 2: Meta + Expand All -->
-      <div class="transcript-header-row2">
-        <span class="meta-item">R{{ meetingState.current_round || 1 }}</span>
-        <span class="meta-sep">•</span>
-        <span class="meta-item">{{ transcript.length }} msgs</span>
         <button
-          class="expand-all-toggle"
+          v-if="meeting?.description || meeting?.agenda"
+          class="header-icon-btn"
+          :class="{ active: showDetails }"
+          @click="showDetails = !showDetails"
+          :title="showDetails ? 'Hide details' : 'Show full details (description)'"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="9"/><path d="M12 8v4"/><circle cx="12" cy="16" r="0.5" fill="currentColor"/>
+          </svg>
+        </button>
+        <button
+          class="header-icon-btn"
           :class="{ active: expandAll }"
           @click="expandAll = !expandAll"
-          title="Toggle expand all messages"
+          :title="expandAll ? 'Collapse all messages' : 'Expand all messages'"
         >
           {{ expandAll ? '⊟' : '⊞' }}
         </button>
       </div>
 
-      <!-- Row 3: Participants scroll -->
-      <div class="transcript-participants-row">
-        <div
-          v-for="p in (meetingState.participants || meeting?.participants || [])"
-          :key="p"
-          class="transcript-participant"
-          :class="{ speaking: !meetingState.ended && meetingState.participants?.[meetingState.current_turn] === p }"
-          :style="{ '--agent-color': agentColor(p) }"
-        >
-          <div class="tp-avatar" :style="{ background: agentColor(p) + '25', color: agentColor(p) }">
-            {{ agentInitial(p) }}
+      <!-- Row 2: live meta + bottleneck indicator + participants -->
+      <div class="transcript-header-row2">
+        <span class="meta-pill">R{{ meetingState.current_round || meeting?.current_round || 1 }}<span v-if="meeting?.max_rounds">/{{ meeting.max_rounds }}</span></span>
+        <span class="meta-pill">{{ transcript.length }} msgs</span>
+        <span v-if="currentSpeaker" class="meta-pill speaking-pill" :class="{ 'pill-stalled': isStalled }">
+          🎙️ {{ currentSpeaker }}
+          <span v-if="lastActionAgo" class="pill-time">· {{ lastActionAgo }}</span>
+        </span>
+        <span v-if="meetingState.ended" class="meta-pill ended-pill">
+          ✅ ended<span v-if="meetingState.outcome"> · {{ meetingState.outcome }}</span>
+        </span>
+
+        <div class="participant-strip" aria-label="Participants">
+          <div
+            v-for="p in (meetingState.participants || meeting?.participants || [])"
+            :key="p"
+            class="participant-pill"
+            :class="{ speaking: !meetingState.ended && currentSpeaker === p }"
+            :style="{ '--agent-color': agentColor(p) }"
+            :title="p"
+          >
+            <span class="pp-avatar" :style="{ background: agentColor(p) + '25', color: agentColor(p) }">
+              {{ agentInitial(p) }}
+            </span>
+            <span class="pp-name">{{ p }}</span>
           </div>
-          <span class="tp-name">{{ p }}</span>
-          <span v-if="meetingState.joined?.includes(p)" class="tp-joined">✓</span>
+        </div>
+      </div>
+
+      <!-- Optional: details drawer (description + agenda full) -->
+      <div v-if="showDetails" class="details-drawer">
+        <div class="details-header">
+          <span class="details-icon">📋</span>
+          <span class="details-title">Meeting details</span>
+          <button class="details-close" @click="showDetails = false" title="Close">×</button>
+        </div>
+        <div class="details-body">
+          <div class="details-block">
+            <div class="details-label">Agenda</div>
+            <div class="details-value">{{ meeting?.agenda || '(no agenda)' }}</div>
+          </div>
+          <div v-if="meeting?.description" class="details-block">
+            <div class="details-label">Description</div>
+            <div class="details-value details-markdown">
+              <MarkdownRenderer :content="meeting.description" content-type="markdown" />
+            </div>
+          </div>
+          <div v-else class="details-block">
+            <div class="details-label">Description</div>
+            <div class="details-value details-empty">
+              No description was provided. Tip: pass <code>description="…"</code>
+              to <code>create_meeting</code> for long-form context (links, scope,
+              deliverables) — keeps agenda short for the dashboard title.
+            </div>
+          </div>
+          <div v-if="meeting?.created_by" class="details-block">
+            <div class="details-label">Created by</div>
+            <div class="details-value">{{ meeting.created_by }}</div>
+          </div>
+          <div v-if="meeting?.meeting_id" class="details-block">
+            <div class="details-label">Meeting ID</div>
+            <div class="details-value details-mono">{{ meeting.meeting_id }}</div>
+          </div>
         </div>
       </div>
     </div>
@@ -206,21 +330,22 @@ const connectionColor = computed(() => {
 
             <div
               class="entry-message"
-              :class="{ truncated: isLong(entry.message) && !expandAll && !expandedEntries.has(entry.turn) }"
-              @click="!expandAll && isLong(entry.message) && toggleExpand(entry.turn)"
+              :class="{
+                'is-long-collapsed':
+                  isLong(entry.message) && !expandAll && !expandedEntries.has(entry.turn),
+              }"
             >
               <MarkdownRenderer
-                :content="expandAll || expandedEntries.has(entry.turn) || !isLong(entry.message)
-                  ? (entry.message || '')
-                  : (entry.message?.slice(0, 300) || '') + '…'"
+                :content="entry.message || ''"
                 content-type="markdown"
                 :enable-mermaid="expandAll || expandedEntries.has(entry.turn)"
               />
               <button
                 v-if="isLong(entry.message) && !expandAll"
                 class="expand-btn"
+                @click="toggleExpand(entry.turn)"
               >
-                {{ expandedEntries.has(entry.turn) ? 'Show less' : 'Show more' }}
+                {{ expandedEntries.has(entry.turn) ? '↑ Show less' : '↓ Show more' }}
               </button>
             </div>
           </div>
@@ -256,7 +381,7 @@ const connectionColor = computed(() => {
   position: relative;
 }
 
-/* Header */
+/* Header — single compact stack: row1 (title + actions) + row2 (live meta) */
 .transcript-header {
   padding: 10px 12px 8px;
   border-bottom: 1px solid #1a1d2e;
@@ -267,7 +392,6 @@ const connectionColor = computed(() => {
   gap: 6px;
 }
 
-/* Row 1: Back button + title + connection badge */
 .transcript-header-row1 {
   display: flex;
   align-items: center;
@@ -288,7 +412,6 @@ const connectionColor = computed(() => {
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.15s;
-  /* Increase tap area with pseudo content trick */
   position: relative;
 }
 
@@ -306,16 +429,16 @@ const connectionColor = computed(() => {
 
 .transcript-title {
   flex: 1;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: #f0f2f5;
   margin: 0;
-  line-height: 1.35;
-  /* Clamp to 2 lines max — keeps header compact */
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  line-height: 1.4;
+  /* Single-line ellipsis — agenda is now ≤120 chars (Bug 5 enforcement),
+     full markdown details available via the drawer. */
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .connection-badge {
@@ -338,103 +461,251 @@ const connectionColor = computed(() => {
   flex-shrink: 0;
 }
 
-/* Row 2: meta info */
-.transcript-header-row2 {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 11px;
-  color: #8b8fa3;
-  padding-left: 40px; /* indent to align with title (past back-btn) */
-}
-
-.meta-item {
-  color: #8b8fa3;
-}
-
-.meta-sep {
-  color: #333;
-}
-
-.expand-all-toggle {
-  margin-left: auto;
+.header-icon-btn {
+  flex-shrink: 0;
   background: #111318;
   border: 1px solid #1a1d2e;
   color: #8b8fa3;
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1;
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.15s;
-  flex-shrink: 0;
 }
 
-.expand-all-toggle:hover {
+.header-icon-btn:hover {
   background: #1e2233;
   color: #c4c8d4;
   border-color: #2a3556;
 }
 
-.expand-all-toggle.active {
+.header-icon-btn.active {
   background: #1e3a5f;
   color: #3b82f6;
   border-color: #2a3556;
 }
 
-/* Row 3: Participants — always horizontal scroll */
-.transcript-participants-row {
+/* Row 2: live meta — round, msg count, current speaker, participants */
+.transcript-header-row2 {
   display: flex;
+  align-items: center;
   gap: 6px;
+  font-size: 11px;
+  color: #8b8fa3;
+  padding-left: 40px;
+  flex-wrap: wrap;
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: #111318;
+  border: 1px solid #1a1d2e;
+  border-radius: 12px;
+  color: #8b8fa3;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.speaking-pill {
+  background: rgba(0, 212, 170, 0.10);
+  border-color: rgba(0, 212, 170, 0.35);
+  color: #00d4aa;
+}
+
+.speaking-pill.pill-stalled {
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(245, 158, 11, 0.45);
+  color: #f59e0b;
+  /* Soft pulse — draws attention to a hung turn without being noisy. */
+  animation: stalled-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes stalled-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0); }
+  50%      { box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.18); }
+}
+
+.pill-time {
+  opacity: 0.75;
+  font-weight: 400;
+}
+
+.ended-pill {
+  background: rgba(85, 88, 114, 0.20);
+  border-color: rgba(85, 88, 114, 0.40);
+  color: #8b8fa3;
+}
+
+.participant-strip {
+  display: flex;
+  gap: 4px;
   flex-wrap: nowrap;
   overflow-x: auto;
   scrollbar-width: none;
-  padding-bottom: 1px;
+  margin-left: auto;
+  max-width: 60%;
 }
 
-.transcript-participants-row::-webkit-scrollbar { display: none; }
+.participant-strip::-webkit-scrollbar { display: none; }
 
-.transcript-participant {
-  display: flex;
+.participant-pill {
+  display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 4px 8px;
+  gap: 4px;
+  padding: 2px 7px 2px 2px;
   background: #111318;
-  border-radius: 16px;
+  border-radius: 14px;
   border: 1px solid #1a1d2e;
+  flex-shrink: 0;
   transition: all 0.2s ease;
 }
 
-.transcript-participant.speaking {
+.participant-pill.speaking {
   border-color: var(--agent-color, #3b82f6);
   background: color-mix(in srgb, var(--agent-color) 10%, #111318);
-  box-shadow: 0 0 8px color-mix(in srgb, var(--agent-color) 20%, transparent);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--agent-color) 20%, transparent);
 }
 
-.tp-avatar {
-  width: 20px;
-  height: 20px;
+.pp-avatar {
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 600;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-.tp-name {
-  font-size: 11px;
+.pp-name {
+  font-size: 10px;
   color: #c4c8d4;
   font-weight: 500;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.tp-joined {
+/* Details drawer — collapsible, holds the full agenda + description */
+.details-drawer {
+  margin-top: 4px;
+  background: #111318;
+  border: 1px solid #1e2233;
+  border-radius: 8px;
+  overflow: hidden;
+  animation: drawer-slide 0.2s ease;
+}
+
+@keyframes drawer-slide {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.details-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #0c0e15;
+  border-bottom: 1px solid #1a1d2e;
+  font-size: 12px;
+  font-weight: 600;
+  color: #c4c8d4;
+}
+
+.details-icon { font-size: 13px; }
+.details-title { flex: 1; }
+
+.details-close {
+  background: transparent;
+  border: none;
+  color: #8b8fa3;
+  font-size: 18px;
+  line-height: 1;
+  width: 22px;
+  height: 22px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.details-close:hover {
+  background: #1e2233;
+  color: #f0f2f5;
+}
+
+.details-body {
+  padding: 10px 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.details-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.details-label {
   font-size: 10px;
-  color: #10b981;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  color: #555872;
+}
+
+.details-value {
+  font-size: 13px;
+  color: #c4c8d4;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.details-markdown :deep(p) { margin: 0 0 0.5em; }
+.details-markdown :deep(h1),
+.details-markdown :deep(h2),
+.details-markdown :deep(h3) {
+  font-size: 13px;
+  margin: 0.6em 0 0.3em;
+  color: #f0f2f5;
+}
+.details-markdown :deep(code) {
+  font-size: 12px;
+  padding: 1px 4px;
+  background: #0a0d14;
+  border-radius: 3px;
+}
+
+.details-empty {
+  font-size: 12px;
+  color: #8b8fa3;
+  font-style: italic;
+}
+
+.details-empty code {
+  font-style: normal;
+  background: #0a0d14;
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: #c4c8d4;
+  font-size: 11px;
+}
+
+.details-mono {
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 12px;
 }
 
 /* Transcript scroll area */
@@ -553,10 +824,26 @@ const connectionColor = computed(() => {
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
+  position: relative;
 }
 
-.entry-message.truncated {
-  cursor: pointer;
+/* Long-message collapse: cap the height + soft fade-out at the bottom +
+   "Show more" button. Replaces the old hard 300-char truncate with "…".
+   User can still scroll inside the message OR click expand. */
+.entry-message.is-long-collapsed {
+  max-height: 320px;
+  overflow: hidden;
+}
+
+.entry-message.is-long-collapsed::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 60px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(10,13,20,0), rgba(10,13,20,0.95));
 }
 
 .expand-btn {
@@ -626,15 +913,26 @@ const connectionColor = computed(() => {
 
 /* ─── Mobile overrides ─── */
 @media (max-width: 767px) {
-  /* Participant pills: smaller tap, flush */
-  .transcript-participant {
-    flex-shrink: 0;
-    padding: 3px 7px;
+  /* Header row 2: drop indent, allow wrapping into 2 lines */
+  .transcript-header-row2 {
+    padding-left: 0;
+    gap: 4px;
   }
 
-  .tp-name {
-    font-size: 10px;
-    white-space: nowrap;
+  /* Participant strip: cap width so other meta pills get room */
+  .participant-strip {
+    max-width: 100%;
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .pp-name {
+    max-width: 70px;
+  }
+
+  /* Title gets full width on its row */
+  .transcript-title {
+    font-size: 13px;
   }
 
   /* Transcript entries: tighter padding */
@@ -651,10 +949,37 @@ const connectionColor = computed(() => {
   .entry-agent { font-size: 12px; }
   .entry-message { font-size: 12px; }
 
+  /* Long-collapse threshold a bit shorter on mobile (less vertical room) */
+  .entry-message.is-long-collapsed {
+    max-height: 260px;
+  }
+
+  /* Drawer body shorter so it doesn't eat the transcript */
+  .details-body {
+    max-height: 220px;
+  }
+
   /* FAB: above outcome footer */
   .scroll-fab {
     bottom: 70px;
     right: 14px;
   }
+}
+
+/* ─── Desktop refinements (≥1280px) ─── */
+@media (min-width: 1280px) {
+  .transcript-scroll {
+    padding: 18px 24px;
+  }
+
+  .entry-avatar {
+    width: 36px;
+    height: 36px;
+    font-size: 14px;
+  }
+
+  .entry-agent { font-size: 14px; }
+  .entry-message { font-size: 14px; line-height: 1.65; }
+  .transcript-title { font-size: 15px; }
 }
 </style>

--- a/dashboard/src/components/monitor/AgentTerminal.vue
+++ b/dashboard/src/components/monitor/AgentTerminal.vue
@@ -1,0 +1,741 @@
+<script setup>
+/**
+ * AgentTerminal — terminal-style live view of one agent's message_history.
+ *
+ * Reads turns from the ``useAgentTurns`` composable and renders them in
+ * the order the agent saw them: user turns (with optional tool_results),
+ * assistant turns (with optional tool_calls). Auto-scrolls to bottom
+ * unless the user has scrolled up — a "↓ N new" pill jumps back.
+ *
+ * Props:
+ *   agent:           AgentSummary  — { name, status, model, team_name, ... }
+ *   turns:           Array<Turn>   — sorted ascending by turn_idx
+ *   loading:         boolean       — true while initial fetch is in flight
+ *   onFetchFull:     (turnIdx) => Promise<{message}|null>
+ *   onPauseToggle:   () => void
+ *   onDelete:        () => void  (optional — hidden if not provided)
+ *   onInject:        ({text, files}) => Promise<{status, response?}>
+ *
+ * Emits navigation via the wrapping view; we just render + interact.
+ */
+import { ref, computed, nextTick, onMounted, watch } from 'vue'
+import { formatTimestamp } from '../../composables/useActivityStream'
+import {
+  buildRenderRows,
+  textContent,
+  isTextTruncated,
+  toolCallList,
+  toolResultList,
+  summarizeArgs,
+} from './agentTerminalUtils.js'
+
+const props = defineProps({
+  agent: { type: Object, required: true },
+  turns: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  onFetchFull: { type: Function, default: null },
+  onPauseToggle: { type: Function, default: null },
+  onDelete: { type: Function, default: null },
+  onInject: { type: Function, default: null },
+  onOpenFullscreen: { type: Function, default: null },
+})
+
+// ── Auto-scroll: stick to bottom unless user scrolled up ──
+const scrollEl = ref(null)
+const stickToBottom = ref(true)
+const newCount = ref(0)
+
+function isNearBottom(el) {
+  if (!el) return true
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 40
+}
+
+function onScroll() {
+  if (!scrollEl.value) return
+  const near = isNearBottom(scrollEl.value)
+  stickToBottom.value = near
+  if (near) newCount.value = 0
+}
+
+function scrollToBottom() {
+  if (!scrollEl.value) return
+  scrollEl.value.scrollTop = scrollEl.value.scrollHeight
+  stickToBottom.value = true
+  newCount.value = 0
+}
+
+watch(
+  () => props.turns.length,
+  (cur, prev) => {
+    const delta = cur - (prev || 0)
+    if (delta <= 0) return
+    if (stickToBottom.value) {
+      nextTick(() => scrollToBottom())
+    } else {
+      newCount.value += delta
+    }
+  },
+)
+
+onMounted(() => nextTick(() => scrollToBottom()))
+
+// ── Status helpers ──
+function statusColor(s) {
+  const m = { running: '#f59e0b', paused: '#8b5cf6', idle: '#10b981', error: '#ef4444', completed: '#3b82f6' }
+  return m[s] || '#555872'
+}
+function statusLabel(s) {
+  const m = { running: 'Running', paused: 'Paused', idle: 'Idle', error: 'Error', completed: 'Completed' }
+  return m[s] || 'Unknown'
+}
+
+// ── Run separators: insert a marker whenever run_id changes ──
+const renderRows = computed(() => buildRenderRows(props.turns))
+
+function turnTime(turn) {
+  return turn.ts ? formatTimestamp(turn.ts, { timeOnly: true }) : ''
+}
+
+// ── Expand truncated blocks: fetch full from backend on click ──
+const expandedTurns = ref(new Set())
+const fullCache = ref(new Map()) // turn_idx -> full message
+
+async function expandTurn(turnIdx) {
+  if (expandedTurns.value.has(turnIdx)) {
+    expandedTurns.value.delete(turnIdx)
+    expandedTurns.value = new Set(expandedTurns.value)
+    return
+  }
+  if (!fullCache.value.has(turnIdx) && props.onFetchFull) {
+    const full = await props.onFetchFull(turnIdx)
+    if (full?.message) {
+      fullCache.value.set(turnIdx, full.message)
+      fullCache.value = new Map(fullCache.value)
+    }
+  }
+  expandedTurns.value.add(turnIdx)
+  expandedTurns.value = new Set(expandedTurns.value)
+}
+
+function fullTextContent(turnIdx) {
+  const msg = fullCache.value.get(turnIdx)
+  if (!msg) return ''
+  const blocks = msg.content || []
+  return blocks.filter(b => b?.type === 'text').map(b => b.text || '').join('\n')
+}
+
+function fullToolResultText(turnIdx, toolId) {
+  const msg = fullCache.value.get(turnIdx)
+  const res = msg?.tool_results?.[toolId]
+  if (!res) return ''
+  return (res.content || []).filter(b => b?.type === 'text').map(b => b.text || '').join('\n')
+}
+
+// ── Inject bar (collapsible) ──
+const injectOpen = ref(false)
+const injectText = ref('')
+const injectFiles = ref([])
+const injectBusy = ref(false)
+const injectResult = ref(null)
+
+function attachFile(kind = 'image') {
+  const input = document.createElement('input')
+  input.type = 'file'
+  input.accept = kind === 'audio' ? 'audio/*' : 'image/*'
+  input.multiple = true
+  input.onchange = (e) => {
+    injectFiles.value = [...injectFiles.value, ...Array.from(e.target.files)]
+  }
+  input.click()
+}
+
+function removeFile(i) {
+  injectFiles.value = injectFiles.value.filter((_, idx) => idx !== i)
+}
+
+async function submitInject() {
+  if ((!injectText.value.trim() && !injectFiles.value.length) || injectBusy.value) return
+  injectBusy.value = true
+  injectResult.value = null
+  try {
+    const res = await props.onInject?.({ text: injectText.value.trim(), files: injectFiles.value })
+    injectResult.value = res || null
+    injectText.value = ''
+    injectFiles.value = []
+  } catch (e) {
+    injectResult.value = { status: 'error', response: e?.message || String(e) }
+  } finally {
+    injectBusy.value = false
+    setTimeout(() => { injectResult.value = null }, 8000)
+  }
+}
+
+// ── Status badges for header ──
+const isRunning = computed(() => props.agent.status === 'running')
+const isPaused = computed(() => props.agent.status === 'paused')
+</script>
+
+<template>
+  <section
+    class="agent-terminal"
+    :class="{
+      'is-running': isRunning,
+      'is-paused': isPaused,
+      'is-error': agent.status === 'error',
+    }"
+    :style="{ '--status-color': statusColor(agent.status) }"
+  >
+    <!-- Header -->
+    <header class="term-header">
+      <div class="term-title">
+        <span class="status-dot" :class="{ pulse: isRunning }" />
+        <span class="agent-name">{{ agent.name }}</span>
+        <span v-if="agent.team_name" class="team-tag">{{ agent.team_name }}</span>
+        <span class="agent-model">{{ agent.model || '—' }}</span>
+      </div>
+      <div class="term-controls">
+        <span class="status-label">{{ statusLabel(agent.status) }}</span>
+        <button
+          v-if="onPauseToggle && (isRunning || isPaused)"
+          class="ctrl-btn"
+          :class="{ 'is-paused': isPaused }"
+          :title="isPaused ? 'Resume' : 'Pause'"
+          @click="onPauseToggle"
+        >{{ isPaused ? '▶' : '⏸' }}</button>
+        <button
+          class="ctrl-btn"
+          title="Toggle inject"
+          :class="{ active: injectOpen }"
+          @click="injectOpen = !injectOpen"
+        >✎</button>
+        <button
+          v-if="onOpenFullscreen"
+          class="ctrl-btn"
+          title="Fullscreen"
+          @click="onOpenFullscreen"
+        >⤢</button>
+        <button
+          v-if="onDelete"
+          class="ctrl-btn ctrl-danger"
+          title="Remove agent"
+          @click="onDelete"
+        >🗑</button>
+      </div>
+    </header>
+
+    <!-- Body -->
+    <div class="term-body" ref="scrollEl" @scroll="onScroll">
+      <div v-if="loading && !turns.length" class="term-empty">Loading history…</div>
+      <div v-else-if="!turns.length" class="term-empty">No conversation yet.</div>
+
+      <template v-else>
+        <template v-for="row in renderRows" :key="row.key">
+          <!-- Run separator -->
+          <div v-if="row.kind === 'run'" class="run-divider">
+            <span class="run-time">{{ row.ts ? formatTimestamp(row.ts, { timeOnly: true }) : '' }}</span>
+            <span class="run-rule" />
+            <span class="run-tag">run {{ String(row.run_id).slice(0, 8) }}</span>
+            <span class="run-rule" />
+          </div>
+
+          <!-- Turn -->
+          <article
+            v-else
+            class="turn-row"
+            :class="{
+              'role-user': row.turn.role === 'user',
+              'role-assistant': row.turn.role === 'assistant',
+            }"
+          >
+            <header class="turn-head">
+              <span class="turn-glyph" :title="row.turn.role">{{
+                row.turn.role === 'assistant' ? '◀' : '▷'
+              }}</span>
+              <span class="turn-role-label">{{
+                row.turn.role === 'assistant' ? 'ASSISTANT' : 'USER'
+              }}</span>
+              <span class="turn-time">{{ turnTime(row.turn) }}</span>
+            </header>
+            <div class="turn-body">
+              <!-- Text content (use full if expanded, else truncated) -->
+              <pre
+                v-if="textContent(row.turn) || expandedTurns.has(row.turn.turn_idx)"
+                class="turn-text"
+              >{{ expandedTurns.has(row.turn.turn_idx) && fullCache.get(row.turn.turn_idx)
+                  ? fullTextContent(row.turn.turn_idx)
+                  : textContent(row.turn) }}</pre>
+              <button
+                v-if="isTextTruncated(row.turn)"
+                class="expand-btn"
+                @click="expandTurn(row.turn.turn_idx)"
+              >
+                {{ expandedTurns.has(row.turn.turn_idx) ? 'Collapse' : '+ Show full' }}
+              </button>
+
+              <!-- Tool calls (assistant) -->
+              <ul v-if="toolCallList(row.turn).length" class="tool-list">
+                <li v-for="tc in toolCallList(row.turn)" :key="tc.id" class="tool-call">
+                  <span class="tool-glyph">🔧</span>
+                  <span class="tool-name">{{ tc.name }}</span>
+                  <span v-if="summarizeArgs(tc.args)" class="tool-args">({{ summarizeArgs(tc.args) }})</span>
+                </li>
+              </ul>
+
+              <!-- Tool results (user) -->
+              <ul v-if="toolResultList(row.turn).length" class="tool-list">
+                <li
+                  v-for="tr in toolResultList(row.turn)"
+                  :key="tr.id"
+                  class="tool-result"
+                  :class="{ 'tool-error': tr.isError }"
+                >
+                  <span class="tool-glyph">{{ tr.isError ? '✗' : '✓' }}</span>
+                  <pre class="tool-result-text">{{
+                    expandedTurns.has(row.turn.turn_idx) && fullCache.get(row.turn.turn_idx)
+                      ? fullToolResultText(row.turn.turn_idx, tr.id)
+                      : tr.text
+                  }}</pre>
+                  <button
+                    v-if="tr.truncated"
+                    class="expand-btn"
+                    @click="expandTurn(row.turn.turn_idx)"
+                  >
+                    {{ expandedTurns.has(row.turn.turn_idx)
+                        ? 'Collapse'
+                        : `+ Show full (${Math.round(tr.fullSize / 1024)} KB)` }}
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </article>
+        </template>
+      </template>
+
+      <!-- "↓ N new" pill — visible when user is scrolled up and new turns arrive -->
+      <button
+        v-if="newCount > 0 && !stickToBottom"
+        class="new-pill"
+        @click="scrollToBottom"
+      >↓ {{ newCount }} new</button>
+    </div>
+
+    <!-- Inject bar (collapsible) -->
+    <footer v-if="injectOpen && onInject" class="term-inject">
+      <div v-if="injectFiles.length" class="inject-chips">
+        <span v-for="(f, i) in injectFiles" :key="i" class="inject-chip">
+          {{ f.type?.startsWith('image') ? '🖼' : '🎤' }} {{ f.name.slice(0, 24) }}
+          <button class="chip-x" @click="removeFile(i)">×</button>
+        </span>
+      </div>
+      <div class="inject-row">
+        <button class="ctrl-btn" title="Image" @click="attachFile('image')">📎</button>
+        <button class="ctrl-btn" title="Audio" @click="attachFile('audio')">🎤</button>
+        <input
+          v-model="injectText"
+          class="inject-input"
+          placeholder="Type a message…"
+          :disabled="injectBusy"
+          @keydown.enter="submitInject"
+        />
+        <button
+          class="inject-send"
+          :disabled="injectBusy || (!injectText.trim() && !injectFiles.length)"
+          @click="submitInject"
+        >{{ injectBusy ? '⏳' : '➤' }}</button>
+      </div>
+      <div v-if="injectResult" class="inject-feedback" :class="{ ok: injectResult.status !== 'error', err: injectResult.status === 'error' }">
+        {{ injectResult.status === 'error' ? '⚠️ ' : '✓ ' }}
+        {{ String(injectResult.response || injectResult.status || '') }}
+      </div>
+    </footer>
+  </section>
+</template>
+
+<style scoped>
+.agent-terminal {
+  display: flex;
+  flex-direction: column;
+  background: #0a0d14;
+  border: 1px solid #1a1d2e;
+  border-radius: 10px;
+  overflow: hidden;
+  border-left: 3px solid var(--status-color, #555872);
+  font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+  font-size: 12.5px;
+  min-height: 360px;
+  max-height: 560px;
+}
+
+/* Header */
+.term-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #0c0f17;
+  border-bottom: 1px solid #1a1d2e;
+  flex-shrink: 0;
+}
+
+.term-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--status-color);
+  flex-shrink: 0;
+}
+.status-dot.pulse { animation: pulse 1.6s ease-in-out infinite; }
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.agent-name {
+  font-weight: 600;
+  color: #f0f2f5;
+  font-size: 13px;
+  font-family: 'Inter', sans-serif;
+}
+.team-tag {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 6px;
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+  font-family: 'Inter', sans-serif;
+}
+.agent-model {
+  font-size: 10px;
+  color: #555872;
+}
+
+.term-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.status-label {
+  font-size: 10px;
+  color: var(--status-color);
+  font-weight: 500;
+  font-family: 'Inter', sans-serif;
+}
+.ctrl-btn {
+  background: transparent;
+  border: 1px solid #1a1d2e;
+  color: #8b8fa3;
+  font-size: 12px;
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+.ctrl-btn:hover { background: #1a1d2e; color: #c4c8d4; }
+.ctrl-btn.active { background: #1e2233; color: #fff; }
+.ctrl-btn.is-paused { background: rgba(34, 197, 94, 0.15); color: #22c55e; border-color: rgba(34, 197, 94, 0.3); }
+.ctrl-btn.ctrl-danger:hover { color: #ef4444; border-color: rgba(239,68,68,0.3); }
+
+/* Body — terminal feed */
+.term-body {
+  position: relative;
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px 12px;
+  background: #0a0d14;
+  scroll-behavior: smooth;
+}
+.term-body::-webkit-scrollbar { width: 6px; }
+.term-body::-webkit-scrollbar-thumb { background: #1a1d2e; border-radius: 3px; }
+.term-empty {
+  color: #555872;
+  text-align: center;
+  padding: 32px;
+  font-size: 12px;
+}
+
+/* Run separator */
+.run-divider {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 8px 0;
+  color: #3b82f6;
+  font-size: 10px;
+}
+.run-time { color: #555872; }
+.run-rule { flex: 1; height: 1px; background: rgba(59, 130, 246, 0.25); }
+.run-tag { color: #6b7280; }
+
+/* Turn row — compact log layout. The prefix is a tiny header row
+   (timestamp + role glyph) above full-width content. We dropped the
+   fixed 130px meta column because:
+     - "USER"/"ASSISTANT" labels were visually redundant with the
+       colored glyph + content tone, and ate ~30% of width on mobile.
+     - Long Vietnamese assistant turns wrapped every 3-4 words at
+       narrow viewports.
+*/
+.turn-row {
+  padding: 6px 8px 6px 8px;
+  border-bottom: 1px dotted rgba(26, 29, 46, 0.6);
+  border-left: 2px solid transparent;
+  border-radius: 0 4px 4px 0;
+}
+.turn-row:last-child { border-bottom: none; }
+/* Visual differentiation: assistant turns get a stronger left bar +
+   a subtle teal-tinted background; user turns are neutral. The role
+   label in .turn-head is the primary signal — these are reinforcers
+   so the eye can scan running/responding turns without reading. */
+.role-assistant {
+  border-left-color: #00d4aa;
+  background: rgba(0, 212, 170, 0.04);
+}
+.role-user {
+  border-left-color: rgba(196, 200, 212, 0.25);
+}
+
+.turn-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #6b7280;
+  font-size: 10px;
+  margin-bottom: 3px;
+  line-height: 1;
+  letter-spacing: 0.4px;
+}
+.turn-time {
+  font-variant-numeric: tabular-nums;
+  margin-left: auto;     /* push timestamp to the right */
+  color: #4b5060;
+  font-size: 10px;
+}
+.turn-glyph {
+  font-size: 11px;
+  line-height: 1;
+}
+.turn-role-label {
+  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 10px;
+}
+.role-assistant .turn-glyph,
+.role-assistant .turn-role-label { color: #00d4aa; }
+.role-user .turn-glyph,
+.role-user .turn-role-label { color: #8b8fa3; }
+
+.turn-body { min-width: 0; }
+.turn-text {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #d4d8e3;
+  font-size: 12.5px;
+  line-height: 1.5;
+  font-family: inherit;
+}
+.role-assistant .turn-text { color: #f0f2f5; }
+.role-user .turn-text { color: #c4c8d4; }
+
+.expand-btn {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 2px 8px;
+  font-size: 10px;
+  background: transparent;
+  color: #3b82f6;
+  border: 1px dashed rgba(59, 130, 246, 0.4);
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.expand-btn:hover { background: rgba(59, 130, 246, 0.08); color: #60a5fa; }
+
+/* Tool list */
+.tool-list {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0 0 0 4px;
+  border-left: 2px solid rgba(245, 158, 11, 0.35);
+}
+.tool-call, .tool-result {
+  display: block;
+  padding: 3px 0 3px 10px;
+  font-size: 11.5px;
+  color: #c4c8d4;
+}
+.tool-call .tool-glyph { color: #f59e0b; margin-right: 6px; }
+.tool-result .tool-glyph { color: #10b981; margin-right: 6px; }
+.tool-result.tool-error .tool-glyph { color: #ef4444; }
+.tool-name { color: #f59e0b; font-weight: 500; }
+.tool-args { color: #8b8fa3; }
+.tool-result-text {
+  display: block;
+  margin: 4px 0 0;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.02);
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-radius: 4px;
+  color: #a5b4fc;
+  font-size: 11px;
+  max-height: 240px;
+  overflow-y: auto;
+  font-family: inherit;
+}
+.tool-result.tool-error .tool-result-text { color: #fca5a5; }
+
+/* "N new" pill */
+.new-pill {
+  position: sticky;
+  bottom: 8px;
+  margin: 0 auto;
+  display: block;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(59, 130, 246, 0.4);
+  font-family: 'Inter', sans-serif;
+}
+.new-pill:hover { background: #2563eb; }
+
+/* Inject bar */
+.term-inject {
+  flex-shrink: 0;
+  border-top: 1px solid #1a1d2e;
+  padding: 8px 12px;
+  background: #0c0f17;
+}
+.inject-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.inject-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  background: #1e2233;
+  border-radius: 12px;
+  font-size: 10.5px;
+  color: #c4c8d4;
+}
+.chip-x {
+  background: none;
+  border: none;
+  color: #8b8fa3;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+.chip-x:hover { color: #ef4444; }
+.inject-row { display: flex; align-items: center; gap: 6px; }
+.inject-input {
+  flex: 1;
+  background: #111318;
+  border: 1px solid #1e2030;
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: #f0f2f5;
+  font-size: 12px;
+  font-family: 'Inter', sans-serif;
+  outline: none;
+}
+.inject-input:focus-within { border-color: #2a3556; }
+.inject-send {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+}
+.inject-send:disabled { opacity: 0.4; cursor: not-allowed; background: #1e2233; }
+.inject-feedback {
+  margin-top: 6px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-family: 'Inter', sans-serif;
+}
+.inject-feedback.ok { background: rgba(16, 185, 129, 0.08); color: #10b981; border: 1px solid rgba(16,185,129,0.2); }
+.inject-feedback.err { background: rgba(239, 68, 68, 0.08); color: #ef4444; border: 1px solid rgba(239,68,68,0.2); }
+
+/* Status-driven border accents */
+.is-running { border-top: 1px solid rgba(245, 158, 11, 0.3); }
+.is-error { border-top: 1px solid rgba(239, 68, 68, 0.3); }
+
+/* ─── Responsive ─── */
+
+/* Tablet: tighten the terminal a touch so 2 columns still fit. */
+@media (max-width: 900px) {
+  .agent-terminal {
+    min-height: 320px;
+    max-height: 480px;
+  }
+}
+
+/* Mobile: stack the inject row, drop the model meta, smaller fonts.
+   The grid container collapses to one column at this breakpoint
+   already (handled in TeamMonitor.vue), so we focus on per-panel
+   density here. */
+@media (max-width: 640px) {
+  .agent-terminal {
+    border-radius: 8px;
+    min-height: 280px;
+    max-height: 60vh;
+    font-size: 11.5px;
+  }
+  .term-header {
+    padding: 6px 10px;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .agent-name { font-size: 12px; }
+  /* Hide the model name in the header — it eats space and the agent
+     card view already shows it. Keep team tag + name + status. */
+  .agent-model { display: none; }
+  .status-label { font-size: 10px; }
+  .ctrl-btn { width: 22px; height: 22px; font-size: 11px; }
+
+  .term-body { padding: 6px 8px 8px; }
+  .turn-row { padding: 3px 0; padding-left: 4px; }
+  .turn-head { font-size: 10px; gap: 4px; }
+  .turn-text { font-size: 11.5px; line-height: 1.45; }
+  .tool-call, .tool-result { font-size: 10.5px; padding-left: 8px; }
+  .tool-result-text {
+    font-size: 10.5px;
+    max-height: 180px;
+    padding: 3px 6px;
+  }
+
+  .term-inject { padding: 6px 8px; }
+  .inject-input { font-size: 12px; padding: 5px 8px; }
+  .inject-send { width: 28px; height: 28px; font-size: 13px; }
+}
+
+/* Very narrow (≤380px): kill the run separator label to save a line
+   and tighten code blocks further. */
+@media (max-width: 380px) {
+  .run-divider { font-size: 9px; }
+  .run-tag { display: none; }
+  .turn-text { font-size: 11px; }
+  .tool-result-text { max-height: 140px; }
+}
+</style>

--- a/dashboard/src/components/monitor/agentTerminalUtils.js
+++ b/dashboard/src/components/monitor/agentTerminalUtils.js
@@ -1,0 +1,90 @@
+/**
+ * Pure helpers for AgentTerminal.vue — testable in isolation.
+ *
+ * Each helper takes a turn (or list of turns) and returns a derived
+ * shape used for rendering. Keeping them out of the SFC lets us run
+ * them under ``node --test`` without a Vue render context.
+ */
+
+/**
+ * Insert a "run separator" row whenever ``run_id`` changes between
+ * consecutive turns. Returns a flat list of ``{kind:'run'|'turn', ...}``.
+ */
+export function buildRenderRows(turns) {
+  const rows = []
+  let prevRun = null
+  for (const t of turns || []) {
+    if (t.run_id && t.run_id !== prevRun) {
+      rows.push({ kind: 'run', run_id: t.run_id, ts: t.ts, key: `run_${t.turn_idx}` })
+      prevRun = t.run_id
+    }
+    rows.push({ kind: 'turn', turn: t, key: `t_${t.turn_idx}` })
+  }
+  return rows
+}
+
+/** Concat all text content blocks of a turn (preserves newlines). */
+export function textContent(turn) {
+  const blocks = turn?.message?.content || []
+  const parts = []
+  for (const b of blocks) {
+    if (b?.type === 'text' && typeof b.text === 'string' && b.text) parts.push(b.text)
+  }
+  return parts.join('\n')
+}
+
+/** True if any text block in this turn was truncated by the backend. */
+export function isTextTruncated(turn) {
+  const blocks = turn?.message?.content || []
+  return blocks.some(b => b?.type === 'text' && b._truncated === true)
+}
+
+/** Extract tool_calls into a render-friendly shape. */
+export function toolCallList(turn) {
+  const tc = turn?.message?.tool_calls
+  if (!tc) return []
+  return Object.entries(tc).map(([id, call]) => {
+    const params = call?.params || {}
+    return {
+      id,
+      name: params.name || '?',
+      args: params.arguments || {},
+    }
+  })
+}
+
+/** Extract tool_results, flagging truncated blocks for "Show full". */
+export function toolResultList(turn) {
+  const tr = turn?.message?.tool_results
+  if (!tr) return []
+  return Object.entries(tr).map(([id, res]) => {
+    const blocks = res?.content || []
+    let text = ''
+    let truncated = false
+    let fullSize = 0
+    for (const b of blocks) {
+      if (b?.type === 'text') {
+        text += (text ? '\n' : '') + (b.text || '')
+        if (b._truncated) {
+          truncated = true
+          fullSize = Math.max(fullSize, b._full_size || 0)
+        }
+      }
+    }
+    return { id, text, truncated, fullSize, isError: !!res?.isError }
+  })
+}
+
+/** Compact preview of tool_call arguments — shown inline next to tool name. */
+export function summarizeArgs(args) {
+  if (!args || typeof args !== 'object') return ''
+  const parts = []
+  for (const [k, v] of Object.entries(args).slice(0, 3)) {
+    let s = typeof v === 'string' ? v : JSON.stringify(v)
+    if (s.length > 60) s = s.slice(0, 60) + '…'
+    parts.push(`${k}=${s}`)
+  }
+  const rest = Object.keys(args).length - 3
+  if (rest > 0) parts.push(`+${rest} more`)
+  return parts.join(', ')
+}

--- a/dashboard/src/components/monitor/agentTerminalUtils.test.js
+++ b/dashboard/src/components/monitor/agentTerminalUtils.test.js
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for agentTerminalUtils — render-side derivations
+ * for AgentTerminal.vue. Run via ``npm run test:unit``.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildRenderRows,
+  textContent,
+  isTextTruncated,
+  toolCallList,
+  toolResultList,
+  summarizeArgs,
+} from './agentTerminalUtils.js'
+
+
+// ── buildRenderRows ─────────────────────────────────────────────────
+
+
+test('buildRenderRows inserts a run separator at the first turn', () => {
+  const turns = [
+    { turn_idx: 0, role: 'user', run_id: 'r1' },
+    { turn_idx: 1, role: 'assistant', run_id: 'r1' },
+  ]
+  const rows = buildRenderRows(turns)
+  assert.equal(rows.length, 3)
+  assert.equal(rows[0].kind, 'run')
+  assert.equal(rows[0].run_id, 'r1')
+  assert.equal(rows[1].kind, 'turn')
+  assert.equal(rows[2].kind, 'turn')
+})
+
+test('buildRenderRows adds a separator only when run_id changes', () => {
+  const turns = [
+    { turn_idx: 0, role: 'user', run_id: 'r1' },
+    { turn_idx: 1, role: 'assistant', run_id: 'r1' },
+    { turn_idx: 2, role: 'user', run_id: 'r2' },
+  ]
+  const rows = buildRenderRows(turns)
+  const seps = rows.filter(r => r.kind === 'run')
+  assert.equal(seps.length, 2)
+  assert.deepEqual(seps.map(s => s.run_id), ['r1', 'r2'])
+})
+
+test('buildRenderRows skips separator for turns missing run_id', () => {
+  const turns = [
+    { turn_idx: 0, role: 'user' },           // no run_id
+    { turn_idx: 1, role: 'assistant' },      // no run_id
+  ]
+  const rows = buildRenderRows(turns)
+  assert.equal(rows.length, 2)
+  assert.ok(rows.every(r => r.kind === 'turn'))
+})
+
+test('buildRenderRows handles empty input', () => {
+  assert.deepEqual(buildRenderRows([]), [])
+  assert.deepEqual(buildRenderRows(null), [])
+})
+
+
+// ── textContent ─────────────────────────────────────────────────────
+
+
+test('textContent joins multi-block text with newlines', () => {
+  const turn = {
+    message: {
+      content: [
+        { type: 'text', text: 'first' },
+        { type: 'text', text: 'second' },
+      ],
+    },
+  }
+  assert.equal(textContent(turn), 'first\nsecond')
+})
+
+test('textContent ignores non-text blocks', () => {
+  const turn = {
+    message: {
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'image', data: '...' },
+      ],
+    },
+  }
+  assert.equal(textContent(turn), 'hello')
+})
+
+test('textContent returns empty for missing content', () => {
+  assert.equal(textContent({}), '')
+  assert.equal(textContent({ message: {} }), '')
+  assert.equal(textContent({ message: { content: [] } }), '')
+})
+
+
+// ── isTextTruncated ────────────────────────────────────────────────
+
+
+test('isTextTruncated true when any text block has _truncated', () => {
+  const turn = {
+    message: {
+      content: [
+        { type: 'text', text: 'small' },
+        { type: 'text', text: 'big', _truncated: true, _full_size: 99999 },
+      ],
+    },
+  }
+  assert.equal(isTextTruncated(turn), true)
+})
+
+test('isTextTruncated false when no block is truncated', () => {
+  const turn = { message: { content: [{ type: 'text', text: 'small' }] } }
+  assert.equal(isTextTruncated(turn), false)
+})
+
+
+// ── toolCallList ───────────────────────────────────────────────────
+
+
+test('toolCallList extracts name and args from tool_calls dict', () => {
+  const turn = {
+    message: {
+      tool_calls: {
+        'tu_1': {
+          params: { name: 'search', arguments: { q: 'jarvis' } },
+        },
+        'tu_2': {
+          params: { name: 'fetch', arguments: { url: 'https://x.com' } },
+        },
+      },
+    },
+  }
+  const list = toolCallList(turn)
+  assert.equal(list.length, 2)
+  assert.deepEqual(list.map(t => t.name).sort(), ['fetch', 'search'])
+  const search = list.find(t => t.name === 'search')
+  assert.deepEqual(search.args, { q: 'jarvis' })
+})
+
+test('toolCallList returns empty for non-assistant turns', () => {
+  assert.deepEqual(toolCallList({ message: {} }), [])
+  assert.deepEqual(toolCallList({}), [])
+})
+
+
+// ── toolResultList ─────────────────────────────────────────────────
+
+
+test('toolResultList carries _truncated/_full_size flags through', () => {
+  const turn = {
+    message: {
+      tool_results: {
+        'tu_1': {
+          content: [
+            { type: 'text', text: 'first chunk', _truncated: true, _full_size: 200_000 },
+          ],
+        },
+      },
+    },
+  }
+  const list = toolResultList(turn)
+  assert.equal(list.length, 1)
+  assert.equal(list[0].truncated, true)
+  assert.equal(list[0].fullSize, 200_000)
+  assert.equal(list[0].text, 'first chunk')
+})
+
+test('toolResultList flags isError', () => {
+  const turn = {
+    message: {
+      tool_results: {
+        'tu_1': {
+          isError: true,
+          content: [{ type: 'text', text: 'EACCES' }],
+        },
+      },
+    },
+  }
+  const [r] = toolResultList(turn)
+  assert.equal(r.isError, true)
+})
+
+test('toolResultList concatenates multiple text blocks', () => {
+  const turn = {
+    message: {
+      tool_results: {
+        'tu_1': {
+          content: [
+            { type: 'text', text: 'line1' },
+            { type: 'text', text: 'line2' },
+          ],
+        },
+      },
+    },
+  }
+  assert.equal(toolResultList(turn)[0].text, 'line1\nline2')
+})
+
+
+// ── summarizeArgs ──────────────────────────────────────────────────
+
+
+test('summarizeArgs handles short string args', () => {
+  assert.equal(summarizeArgs({ q: 'jarvis' }), 'q=jarvis')
+})
+
+test('summarizeArgs truncates long string values to 60 chars + ellipsis', () => {
+  const big = 'X'.repeat(100)
+  const out = summarizeArgs({ q: big })
+  // 60 chars of X + ellipsis '…'
+  assert.match(out, /^q=X{60}…$/)
+})
+
+test('summarizeArgs JSON-stringifies non-string values', () => {
+  const out = summarizeArgs({ data: { key: 1 } })
+  assert.equal(out, 'data={"key":1}')
+})
+
+test('summarizeArgs lists at most 3 keys with "+N more" tail', () => {
+  const out = summarizeArgs({ a: 1, b: 2, c: 3, d: 4, e: 5 })
+  assert.match(out, /\+2 more/)
+})
+
+test('summarizeArgs handles empty / non-object', () => {
+  assert.equal(summarizeArgs({}), '')
+  assert.equal(summarizeArgs(null), '')
+  assert.equal(summarizeArgs(undefined), '')
+})

--- a/dashboard/src/composables/agentTurnsUtils.js
+++ b/dashboard/src/composables/agentTurnsUtils.js
@@ -1,0 +1,56 @@
+/**
+ * Pure helpers for the per-agent turn buffer.
+ *
+ * Extracted from useAgentTurns so the dedup / insert / reset logic can
+ * be unit-tested with plain ``node --test`` (no Vue reactivity needed).
+ */
+
+/**
+ * Insert a turn into a sorted-by-turn_idx array, deduplicating by turn_idx.
+ *
+ * @param {Array<{turn_idx:number}>} arr — current bucket (caller's snapshot)
+ * @param {{turn_idx:number}} turn
+ * @param {number} maxPerAgent — cap on returned size
+ * @returns {Array} a new array (does not mutate the input)
+ */
+export function insertTurn(arr, turn, maxPerAgent) {
+  const next = arr.slice()
+  const existingIdx = next.findIndex(t => t.turn_idx === turn.turn_idx)
+  if (existingIdx >= 0) {
+    next[existingIdx] = turn
+  } else {
+    let i = next.length
+    while (i > 0 && next[i - 1].turn_idx > turn.turn_idx) i--
+    next.splice(i, 0, turn)
+  }
+  if (next.length > maxPerAgent) next.splice(0, next.length - maxPerAgent)
+  return next
+}
+
+/**
+ * Detect a "history was cleared" signal: a delta arriving at turn_idx 0
+ * when the bucket already has higher turn_idx entries means the agent
+ * started a new conversation; the old turns are stale.
+ */
+export function isResetSignal(arr, turn) {
+  return (
+    !!turn &&
+    turn.turn_idx === 0 &&
+    arr.length > 0 &&
+    arr[arr.length - 1].turn_idx > 0
+  )
+}
+
+/**
+ * Last assistant text-content preview from a sorted bucket.
+ */
+export function lastAssistantText(arr) {
+  for (let i = arr.length - 1; i >= 0; i--) {
+    const t = arr[i]
+    if (t.role === 'assistant') {
+      const block = (t.message?.content || [])[0]
+      return block?.text || ''
+    }
+  }
+  return ''
+}

--- a/dashboard/src/composables/agentTurnsUtils.test.js
+++ b/dashboard/src/composables/agentTurnsUtils.test.js
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for agentTurnsUtils — pure helpers feeding useAgentTurns.
+ * Run via ``npm run test:unit`` (Node's built-in test runner).
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { insertTurn, isResetSignal, lastAssistantText } from './agentTurnsUtils.js'
+
+
+// ── insertTurn ──────────────────────────────────────────────────────
+
+
+test('insertTurn appends in sorted order', () => {
+  let arr = []
+  arr = insertTurn(arr, { turn_idx: 0, role: 'user' }, 100)
+  arr = insertTurn(arr, { turn_idx: 1, role: 'assistant' }, 100)
+  arr = insertTurn(arr, { turn_idx: 2, role: 'user' }, 100)
+  assert.deepEqual(arr.map(t => t.turn_idx), [0, 1, 2])
+})
+
+test('insertTurn places out-of-order deltas in correct slot', () => {
+  let arr = [
+    { turn_idx: 0, role: 'user' },
+    { turn_idx: 2, role: 'user' },
+  ]
+  arr = insertTurn(arr, { turn_idx: 1, role: 'assistant' }, 100)
+  assert.deepEqual(arr.map(t => t.turn_idx), [0, 1, 2])
+})
+
+test('insertTurn replaces a duplicate turn_idx (idempotent SSE replay)', () => {
+  let arr = [
+    { turn_idx: 0, role: 'user', message: { content: [{ text: 'old' }] } },
+  ]
+  arr = insertTurn(arr, { turn_idx: 0, role: 'user', message: { content: [{ text: 'new' }] } }, 100)
+  assert.equal(arr.length, 1)
+  assert.equal(arr[0].message.content[0].text, 'new')
+})
+
+test('insertTurn drops oldest entries when above maxPerAgent', () => {
+  let arr = []
+  for (let i = 0; i < 7; i++) {
+    arr = insertTurn(arr, { turn_idx: i, role: 'user' }, 5)
+  }
+  assert.equal(arr.length, 5)
+  assert.deepEqual(arr.map(t => t.turn_idx), [2, 3, 4, 5, 6])
+})
+
+test('insertTurn does not mutate the input array', () => {
+  const arr = [{ turn_idx: 0, role: 'user' }]
+  const next = insertTurn(arr, { turn_idx: 1, role: 'assistant' }, 100)
+  assert.equal(arr.length, 1, 'input should remain length 1')
+  assert.equal(next.length, 2, 'output should be length 2')
+})
+
+
+// ── isResetSignal ───────────────────────────────────────────────────
+
+
+test('isResetSignal true: turn_idx=0 arriving while bucket has higher idx', () => {
+  const arr = [
+    { turn_idx: 0 },
+    { turn_idx: 1 },
+    { turn_idx: 2 },
+  ]
+  assert.equal(isResetSignal(arr, { turn_idx: 0 }), true)
+})
+
+test('isResetSignal false: turn_idx=0 on empty bucket (initial load)', () => {
+  assert.equal(isResetSignal([], { turn_idx: 0 }), false)
+})
+
+test('isResetSignal false: bucket only has turn_idx=0', () => {
+  const arr = [{ turn_idx: 0 }]
+  assert.equal(isResetSignal(arr, { turn_idx: 0 }), false)
+})
+
+test('isResetSignal false: non-zero turn_idx delta', () => {
+  const arr = [{ turn_idx: 0 }, { turn_idx: 1 }]
+  assert.equal(isResetSignal(arr, { turn_idx: 2 }), false)
+})
+
+
+// ── lastAssistantText ───────────────────────────────────────────────
+
+
+test('lastAssistantText returns text of latest assistant turn', () => {
+  const arr = [
+    { turn_idx: 0, role: 'user', message: { content: [{ type: 'text', text: 'hi' }] } },
+    { turn_idx: 1, role: 'assistant', message: { content: [{ type: 'text', text: 'old reply' }] } },
+    { turn_idx: 2, role: 'user', message: { content: [{ type: 'text', text: 'follow up' }] } },
+    { turn_idx: 3, role: 'assistant', message: { content: [{ type: 'text', text: 'new reply' }] } },
+  ]
+  assert.equal(lastAssistantText(arr), 'new reply')
+})
+
+test('lastAssistantText returns empty when no assistant turns', () => {
+  const arr = [
+    { turn_idx: 0, role: 'user', message: { content: [{ text: 'hi' }] } },
+  ]
+  assert.equal(lastAssistantText(arr), '')
+})
+
+test('lastAssistantText handles missing content gracefully', () => {
+  const arr = [
+    { turn_idx: 0, role: 'assistant', message: {} },
+  ]
+  assert.equal(lastAssistantText(arr), '')
+})
+
+test('lastAssistantText handles empty array', () => {
+  assert.equal(lastAssistantText([]), '')
+})

--- a/dashboard/src/composables/useAgentTurns.js
+++ b/dashboard/src/composables/useAgentTurns.js
@@ -1,0 +1,168 @@
+/**
+ * useAgentTurns — per-agent ring buffer of PromptMessageExtended turns.
+ *
+ * Source of truth for the Team Monitor v2 UI. Each entry is a turn from
+ * the agent's ``message_history``, tagged with a stable ``turn_idx``.
+ * Live deltas arrive via the ``message_turn`` SSE event (see
+ * ``stores/agents.js`` ingest); initial history is fetched from
+ * ``GET /api/agents/{name}/messages`` per agent on demand.
+ *
+ * Dedup is by ``(agent_name, turn_idx)``. The store keeps the latest
+ * ``maxPerAgent`` turns to bound memory; older entries are dropped.
+ *
+ * Why not just read ``store.recentEvents``? That array only carries
+ * synthesized lifecycle events (started/idle/error/...). The new
+ * ``message_turn`` channel is shape-stable and frequency-bounded
+ * (one per agent per turn), so it lives in its own keyed map.
+ */
+
+import { ref, shallowRef, triggerRef, computed, onMounted, onUnmounted, watch } from 'vue'
+import { apiFetch } from '../api'
+import { useAgentsStore } from '../stores/agents'
+import { insertTurn, isResetSignal, lastAssistantText } from './agentTurnsUtils.js'
+
+export function useAgentTurns(options = {}) {
+  const maxPerAgent = options.maxPerAgent ?? 200
+
+  // Map<agentName, Turn[]> where Turn = { turn_idx, role, message, run_id, ts }
+  // Each agent's array is sorted ascending by turn_idx.
+  // shallowRef so Vue doesn't deep-watch every nested message blob.
+  const turns = shallowRef(new Map())
+
+  // Set of agent names whose initial history fetch is in flight or complete.
+  const fetched = ref(new Set())
+
+  // Map<agentName, Promise> dedup of in-flight history fetches.
+  const _pendingFetches = new Map()
+
+  const store = useAgentsStore()
+
+  /** Internal: get-or-create the array for an agent, returning a fresh copy. */
+  function _bucket(agentName) {
+    return turns.value.get(agentName) || []
+  }
+
+  /** Insert/replace a turn keyed by turn_idx. Sorted ascending. Bounded by maxPerAgent. */
+  function ingestTurn(agentName, turn) {
+    if (!agentName || !turn || typeof turn.turn_idx !== 'number') return
+    const arr = insertTurn(_bucket(agentName), turn, maxPerAgent)
+    const next = new Map(turns.value)
+    next.set(agentName, arr)
+    turns.value = next
+  }
+
+  /** If the delta is a reset signal, drop the bucket so old turns don't linger. */
+  function handlePossibleReset(agentName, turn) {
+    if (isResetSignal(_bucket(agentName), turn)) {
+      const next = new Map(turns.value)
+      next.set(agentName, [])
+      turns.value = next
+    }
+  }
+
+  /** Fetch initial message history for an agent (idempotent). */
+  async function fetchInitial(agentName) {
+    if (!agentName) return
+    if (fetched.value.has(agentName)) return
+    if (_pendingFetches.has(agentName)) return _pendingFetches.get(agentName)
+
+    const p = (async () => {
+      try {
+        const data = await apiFetch(`/api/agents/${encodeURIComponent(agentName)}/messages?limit=200`)
+        const items = data?.turns || []
+        const arr = items.map(t => ({
+          turn_idx: t.turn_idx,
+          role: t.role,
+          message: t.message,
+          run_id: t.run_id || null,
+          ts: t.timestamp || null,
+        })).sort((a, b) => a.turn_idx - b.turn_idx)
+
+        const next = new Map(turns.value)
+        next.set(agentName, arr.slice(-maxPerAgent))
+        turns.value = next
+        fetched.value = new Set([...fetched.value, agentName])
+      } catch (e) {
+        console.warn(`[useAgentTurns] initial fetch failed for ${agentName}:`, e?.message || e)
+      } finally {
+        _pendingFetches.delete(agentName)
+      }
+    })()
+
+    _pendingFetches.set(agentName, p)
+    return p
+  }
+
+  /** Fetch the untruncated content for one turn (used by "Show full" UX). */
+  async function fetchTurnFull(agentName, turnIdx) {
+    if (!agentName || typeof turnIdx !== 'number') return null
+    try {
+      return await apiFetch(
+        `/api/agents/${encodeURIComponent(agentName)}/turns/${turnIdx}/full`,
+      )
+    } catch (e) {
+      console.warn(`[useAgentTurns] full fetch failed for ${agentName}#${turnIdx}:`, e?.message || e)
+      return null
+    }
+  }
+
+  /** Reactive accessor: turns for one agent, ascending. */
+  function getTurns(agentName) {
+    return turns.value.get(agentName) || []
+  }
+
+  /** Last assistant text — useful for header preview. */
+  function getLastAssistantText(agentName) {
+    return lastAssistantText(getTurns(agentName))
+  }
+
+  // ── Bridge: pull message_turn events from the store as they arrive ──
+  //
+  // The agents store already invokes processEvent() on every SSE event.
+  // We watch its ``recentEvents`` queue and pick out ``message_turn``
+  // entries for ingest. (recentEvents is a 50-cap FIFO of all event types.)
+
+  let _lastSeenEvent = null
+  const stopWatch = watch(
+    () => store.recentEvents,
+    (events) => {
+      if (!events?.length) return
+      const batch = []
+      for (let i = 0; i < events.length; i++) {
+        if (events[i] === _lastSeenEvent) break
+        batch.push(events[i])
+      }
+      // Process oldest first so turn_idx ordering is preserved.
+      for (let i = batch.length - 1; i >= 0; i--) {
+        const evt = batch[i]
+        if (evt?.event_type !== 'message_turn') continue
+        const d = evt.data || {}
+        if (typeof d.turn_idx !== 'number') continue
+        const turn = {
+          turn_idx: d.turn_idx,
+          role: d.role || d.message?.role || null,
+          message: d.message || {},
+          run_id: evt.run_id || null,
+          ts: evt.timestamp || null,
+        }
+        handlePossibleReset(evt.agent_name, turn)
+        ingestTurn(evt.agent_name, turn)
+      }
+      _lastSeenEvent = events[0]
+    },
+    { flush: 'post' },
+  )
+
+  onUnmounted(() => stopWatch())
+
+  return {
+    turns,
+    fetched,
+    fetchInitial,
+    fetchTurnFull,
+    getTurns,
+    getLastAssistantText,
+    ingestTurn, // exposed for tests
+    _internal_handleReset: handlePossibleReset, // exposed for tests
+  }
+}

--- a/dashboard/src/composables/useMeetingList.js
+++ b/dashboard/src/composables/useMeetingList.js
@@ -82,6 +82,7 @@ export function useMeetingList() {
         meetings.value.unshift({
           meeting_id: meetingId,
           agenda: config.agenda || '',
+          description: config.description || '',
           participants: config.participants || [],
           max_rounds: config.max_rounds,
           created_by: config.created_by || '',
@@ -90,6 +91,7 @@ export function useMeetingList() {
           started: false,
           joined: [],
           turn_count: 0,
+          turn_started_at: null,
           participant_count: config.participants?.length || 0,
           current_speaker: null,
         })
@@ -129,6 +131,13 @@ export function useMeetingList() {
             agent: entry.agent || '',
             content: (entry.message || '').slice(0, 100),
             timestamp: entry.timestamp || '',
+          }
+          // Refresh "last action" anchor so the stalled-pulse indicator
+          // resets after each turn (R2 visibility).
+          const ts = entry.timestamp
+          if (ts) {
+            const parsed = typeof ts === 'number' ? ts : Date.parse(ts) / 1000
+            if (!Number.isNaN(parsed)) m.turn_started_at = parsed
           }
           meetings.value[idx] = m
         }

--- a/dashboard/src/composables/useVoiceSession.js
+++ b/dashboard/src/composables/useVoiceSession.js
@@ -26,7 +26,21 @@ import { EVENTS, on } from '../auth/bus.js'
 
 const PCM_PLAYBACK_RATE = 24000  // RealtimeTTS engines emit 24 kHz mono
 
+// ── Singleton ─────────────────────────────────────────────────────────────
+// Voice session must persist across route nav so the user can keep talking
+// while looking at /monitor, and so the global hands-free indicator (in
+// AppLayout) shares state with VoiceBar (in /chat). Without this, every
+// call to ``useVoiceSession()`` would create independent state and the
+// indicator would always show "Off" even when the mic was actually live.
+let _singleton = null
+
 export function useVoiceSession() {
+  if (_singleton) return _singleton
+  _singleton = _createVoiceSession()
+  return _singleton
+}
+
+function _createVoiceSession() {
   const chatStore = useChatStore()
   const status = ref('idle')  // 'idle' | 'connecting' | 'loading_stt' | 'listening' | 'thinking' | 'speaking' | 'error'
   const error = ref('')
@@ -531,13 +545,13 @@ export function useVoiceSession() {
   // Auth expiry: voice sessions are long-lived WebSockets that won't
   // notice a key rotation until the user speaks again. Tear down on
   // EXPIRED so the AuthGate doesn't have a ghost-streaming session
-  // behind it.
-  const offExpired = on(EVENTS.EXPIRED, () => {
+  // behind it. Registered at module-singleton init time — never
+  // unsubscribed (singleton lives for the page lifetime).
+  on(EVENTS.EXPIRED, () => {
     if (status.value !== 'idle') {
       stop().catch(() => { /* already torn */ })
     }
   })
-  onScopeDispose(() => offExpired())
 
   return {
     status, error,

--- a/dashboard/src/stores/agents.js
+++ b/dashboard/src/stores/agents.js
@@ -76,10 +76,37 @@ export const useAgentsStore = defineStore('agents', () => {
   }
 
   function upsertAgent(name, updates) {
-    const existing = agents.value.get(name) || { name }
-    agents.value.set(name, { ...existing, ...updates })
+    const existing = agents.value.get(name)
+    const isNew = !existing
+    agents.value.set(name, { ...(existing || { name }), ...updates })
     // Trigger reactivity
     agents.value = new Map(agents.value)
+
+    // SSE-only spawn path: bridge broadcasts ``started`` /
+    // ``lifecycle_registered`` for team members but does NOT broadcast
+    // ``agent_added`` (only manually-created cards via POST /api/agents
+    // get that). Without this self-heal, new team agents appear on the
+    // monitor without their ``team_name`` / ``description`` / ``tools``
+    // metadata until the user hard-refreshes — incident 2026-05-11:
+    // PM (Elliot [PM]) spawned but only visible after Cmd+Shift+R.
+    //
+    // Trigger a single coalesced refetch when an unknown name shows up.
+    // ``fetchAgents()`` preserves existing realtime state so this is
+    // safe even for the agent we just upserted.
+    if (isNew) {
+      _scheduleAgentRefetch()
+    }
+  }
+
+  // Coalesce burst of "agent_added" detections from a single team-spawn
+  // wave (PM + N members fire within ~50ms) into one /api/agents call.
+  let _refetchTimer = null
+  function _scheduleAgentRefetch() {
+    if (_refetchTimer) return
+    _refetchTimer = setTimeout(() => {
+      _refetchTimer = null
+      fetchAgents().catch(() => { /* ignored — store keeps realtime data */ })
+    }, 250)
   }
 
   function pushEvent(event) {
@@ -166,19 +193,58 @@ export const useAgentsStore = defineStore('agents', () => {
         agents.value = new Map(agents.value) // trigger reactivity
         break
 
-      case 'agent_paused':
+      case 'agent_paused': {
+        // Snapshot the pre-pause status so resume can restore it. Without
+        // this, resume blindly flips to 'running' even when the agent had
+        // already finished its turn before the pause click landed — UX
+        // confusion: user sees "running" badge after resume and assumes
+        // work is in progress, then is unsure whether to pause again.
+        const current = agents.value.get(agent_name)
+        const prior = current?.status
+        // Only remember statuses that make sense to restore — never restore
+        // back into 'paused' (would loop) or undefined.
+        const restorable = (prior && prior !== 'paused') ? prior : 'idle'
         upsertAgent(agent_name, {
           status: 'paused',
+          prePauseStatus: restorable,
           lastAction: { message: event.message || 'Paused', timestamp: event.timestamp },
         })
         break
+      }
 
-      case 'agent_resumed':
+      case 'agent_resumed': {
+        // Restore the pre-pause status (idle/running/completed/...) instead
+        // of forcing 'running'. If the agent has actual pending work, the
+        // next 'thinking' / 'tool_call' / 'message_turn' event arrives
+        // moments later and naturally bumps status to 'running' again — no
+        // need to lie about it here.
+        const current = agents.value.get(agent_name)
+        const restored = current?.prePauseStatus || 'idle'
         upsertAgent(agent_name, {
-          status: 'running',
+          status: restored,
+          prePauseStatus: undefined,
           lastAction: { message: event.message || 'Resumed', timestamp: event.timestamp },
         })
         break
+      }
+
+      case 'message_turn': {
+        // Source-of-truth event derived from agent.message_history.
+        // Subscribers (useAgentTurns composable) read it from
+        // recentEvents — the store only needs to keep status in sync.
+        const msg = event.data?.message
+        const stop = msg?.stop_reason
+        if (msg?.role === 'assistant' && msg?.tool_calls) {
+          // assistant turn that triggered a tool — agent is still working
+          const current = agents.value.get(agent_name)
+          const newStatus = current?.status === 'paused' ? 'paused' : 'running'
+          upsertAgent(agent_name, { status: newStatus })
+        } else if (msg?.role === 'assistant' && stop && stop !== 'toolUse') {
+          // Final assistant turn — agent is now idle
+          upsertAgent(agent_name, { status: 'idle' })
+        }
+        break
+      }
 
       case 'token_usage': {
         // Accumulate token metrics per agent from SSE

--- a/dashboard/src/views/ChatView.vue
+++ b/dashboard/src/views/ChatView.vue
@@ -11,6 +11,10 @@ import ChatMessages from '../components/chat/ChatMessages.vue'
 import ChatInput from '../components/chat/ChatInput.vue'
 import VoiceBar from '../components/chat/VoiceBar.vue'
 
+// Explicit name so AppLayout's `<keep-alive include="['Chat', ...]">` can
+// match this component and preserve in-flight chat state across nav.
+defineOptions({ name: 'Chat' })
+
 const { isMobile } = useBreakpoint()
 const showMobileConversations = ref(false)
 

--- a/dashboard/src/views/TeamMonitor.vue
+++ b/dashboard/src/views/TeamMonitor.vue
@@ -1,22 +1,41 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted, onBeforeUpdate, onUpdated } from 'vue'
-import { useRouter } from 'vue-router'
-import { useActivityStream, formatTimestamp } from '../composables/useActivityStream'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { useActivityStream } from '../composables/useActivityStream'
+import { useAgentTurns } from '../composables/useAgentTurns'
 import { apiFetch } from '../api'
 import { useAgentsStore } from '../stores/agents'
 import ConfirmModal from '../components/ConfirmModal.vue'
-import StatusBadge from '../components/StatusBadge.vue'
 import MeetingsTab from '../components/meetings/MeetingsTab.vue'
+import AgentTerminal from '../components/monitor/AgentTerminal.vue'
 import { useToast } from '../composables/useToast'
+
+// Explicit name so AppLayout's `<keep-alive include="['Chat', 'TeamMonitor']">`
+// preserves activity-stream / meeting-stream subscriptions across nav.
+defineOptions({ name: 'TeamMonitor' })
 
 const toast = useToast()
 
 // Sub-navigation: activity | meetings
 const subTab = ref('activity')
 
-const router = useRouter()
 const store = useAgentsStore()
-const { filteredAgents, filter, selectedAgents, sortLocked, allAgentNames, getEvents, getCurrentAction, toggleAgent, selectAll, toggleSortLock } = useActivityStream()
+const { filteredAgents, filter, selectedAgents, sortLocked, toggleAgent, selectAll, toggleSortLock } = useActivityStream()
+
+// Terminal-style monitor grid (the only UI now — v1 card grid was
+// removed). Per-agent turn buffer keeps history available as new
+// agents come online via activity stream.
+const agentTurns = useAgentTurns({ maxPerAgent: 200 })
+
+// Fetch each agent's initial history once when it appears in the
+// roster. Skipping fetchInitial calls past the first per-agent is
+// handled inside ``useAgentTurns.fetchInitial``.
+watch(
+  () => filteredAgents.value.map(a => a.name),
+  (names) => {
+    for (const n of names) agentTurns.fetchInitial(n)
+  },
+  { immediate: true },
+)
 
 // Dropdown state
 const showAgentDropdown = ref(false)
@@ -52,54 +71,10 @@ const dropdownLabel = computed(() => {
   return `${count} agent${count > 1 ? 's' : ''} selected`
 })
 
-// Expanded event tracking
-const expandedEvents = ref(new Set())
-
-function toggleEvent(agentName, idx) {
-  const key = `${agentName}_${idx}`
-  if (expandedEvents.value.has(key)) {
-    expandedEvents.value.delete(key)
-  } else {
-    expandedEvents.value.add(key)
-  }
-  expandedEvents.value = new Set(expandedEvents.value)
-}
-
-// ── Scroll-lock: preserve user scroll position across event updates ──
-// Plain (non-reactive) Map — we don't need Vue to track DOM element refs;
-// callback refs handle registration. Using a plain object avoids the
-// "Cannot set properties of undefined" TypeError that occurs when the reactive
-// wrapper is torn down before the template callback fires.
-const eventListRefs = {}
-const _savedScrolls = {}
-
-onBeforeUpdate(() => {
-  for (const [name, el] of Object.entries(eventListRefs)) {
-    if (el) _savedScrolls[name] = el.scrollTop
-  }
-})
-
-onUpdated(() => {
-  for (const [name, el] of Object.entries(eventListRefs)) {
-    if (el && _savedScrolls[name] !== undefined) {
-      el.scrollTop = _savedScrolls[name]
-    }
-  }
-})
-
-function isExpanded(agentName, idx) {
-  return expandedEvents.value.has(`${agentName}_${idx}`)
-}
-
-// Status helpers
+// Status helpers (used by dropdown item dots and other shared UI)
 function statusColor(status) {
   const map = { running: '#f59e0b', paused: '#8b5cf6', idle: '#10b981', error: '#ef4444', completed: '#3b82f6' }
   return map[status] || '#555872'
-}
-
-function statusLabel(status) {
-  const map = { running: 'Running', paused: 'Paused', idle: 'Idle', error: 'Error', completed: 'Completed' }
-  return map[status] || 'Unknown'
 }
 
 // Pause/Resume per-agent
@@ -219,129 +194,24 @@ async function confirmDisband() {
   }
 }
 
-function eventTypeIcon(type) {
-  const map = {
-    started: '▶',
-    thinking: '💭',
-    tool_call: '🔧',
-    tool_result: '📦',
-    result: '✅',
-    response: '💬',
-    error: '❌',
-    idle: '⏸',
-    resumed: '🔄',
-    inject: '⚡',
+/**
+ * Send a prompt injection to ``agentName``. Used by the AgentTerminal
+ * inject footer. Returns the API response so the caller can display
+ * feedback.
+ */
+async function injectToAgent(agentName, { text = '', files = [] } = {}) {
+  if (!text.trim() && !files.length) return null
+  if (files.length > 0) {
+    const formData = new FormData()
+    formData.append('message', text.trim())
+    for (const file of files) formData.append('files', file)
+    return apiFetch(`/api/agents/${agentName}/inject`, { method: 'POST', body: formData })
   }
-  return map[type] || '•'
-}
-
-function eventTypeColor(type) {
-  const map = {
-    started: '#00d4aa',
-    thinking: '#3b82f6',
-    tool_call: '#f59e0b',
-    tool_result: '#10b981',
-    result: '#3b82f6',
-    response: '#c4c8d4',
-    error: '#ef4444',
-    idle: '#555872',
-    resumed: '#00d4aa',
-    inject: '#6366f1',
-  }
-  return map[type] || '#8b8fa3'
-}
-
-function formatTime(ts) {
-  return formatTimestamp(ts)
-}
-
-function truncate(text, max = 80) {
-  if (!text) return ''
-  return text.length > max ? text.slice(0, max) + '…' : text
-}
-
-function navigateToAgent(name) {
-  router.push(`/agents/${name}`)
-}
-
-// Agent stats
-function agentEventCount(name) {
-  return getEvents(name).length
-}
-
-// Inject prompt — per-agent inline state
-const injectState = ref({}) // Map<agentName, { text, loading, result, files }>
-
-function getInjectState(name) {
-  if (!injectState.value[name]) {
-    injectState.value[name] = { text: '', loading: false, result: null, files: [] }
-  }
-  return injectState.value[name]
-}
-
-function handleFileAttach(agentName, mediaType = 'image') {
-  const input = document.createElement('input')
-  input.type = 'file'
-  input.accept = mediaType === 'audio' ? 'audio/*' : 'image/*'
-  input.multiple = true
-  input.onchange = (e) => {
-    const st = getInjectState(agentName)
-    st.files = [...st.files, ...Array.from(e.target.files)]
-    injectState.value = { ...injectState.value }
-  }
-  input.click()
-}
-
-function removeFile(agentName, idx) {
-  const st = getInjectState(agentName)
-  st.files.splice(idx, 1)
-  injectState.value = { ...injectState.value }
-}
-
-async function submitInject(agentName) {
-  const st = getInjectState(agentName)
-  if (!st.text.trim() && !st.files.length) return
-  st.loading = true
-  st.result = null
-  injectState.value = { ...injectState.value }
-
-  try {
-    let data
-    if (st.files.length > 0) {
-      // Multipart upload with files
-      const formData = new FormData()
-      formData.append('message', st.text.trim())
-      for (const file of st.files) {
-        formData.append('files', file)
-      }
-      data = await apiFetch(`/api/agents/${agentName}/inject`, {
-        method: 'POST',
-        body: formData,
-      })
-    } else {
-      // Simple JSON
-      data = await apiFetch(`/api/agents/${agentName}/inject`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: st.text.trim() }),
-      })
-    }
-    st.result = data
-    st.text = ''
-    st.files = []
-    // Auto-clear result after 8s
-    setTimeout(() => {
-      if (injectState.value[agentName]?.result === data) {
-        injectState.value[agentName].result = null
-        injectState.value = { ...injectState.value }
-      }
-    }, 8000)
-  } catch (err) {
-    st.result = { status: 'error', response: err.message }
-  } finally {
-    st.loading = false
-    injectState.value = { ...injectState.value }
-  }
+  return apiFetch(`/api/agents/${agentName}/inject`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: text.trim() }),
+  })
 }
 
 // Delete agent — modal-based confirmation
@@ -443,6 +313,7 @@ onMounted(() => {
         <span class="sub-nav-icon">📋</span>
         Meetings
       </button>
+      <span class="sub-nav-spacer" />
     </div>
 
     <!-- ═══ ACTIVITY TAB ═══ -->
@@ -535,168 +406,21 @@ onMounted(() => {
       <p>{{ filter === 'active' ? 'No active agents at the moment' : 'No agents found' }}</p>
     </div>
 
-    <!-- Agent Grid -->
-    <div class="agent-grid" v-else>
-      <div
+    <!-- ═══ Agent grid — terminal-style, message_history-driven ═══ -->
+    <div v-else class="agent-grid agent-grid-v2">
+      <AgentTerminal
         v-for="agent in filteredAgents"
         :key="agent.name"
-        class="agent-panel"
-        :class="{ 'panel-running': agent.status === 'running', 'panel-paused': agent.status === 'paused', 'panel-error': agent.status === 'error' }"
-        :style="{ borderLeft: `3px solid ${statusColor(agent.status)}` }"
-      >
-        <!-- Panel Header -->
-        <div class="panel-header">
-          <div class="panel-agent-info" @click="navigateToAgent(agent.name)">
-            <!-- No dot — status expressed via left border of the panel -->
-            <div class="panel-agent-meta">
-              <span class="panel-agent-name">{{ agent.name }}</span>
-              <span
-                v-if="agent.team_name"
-                class="panel-team-badge"
-                :style="{ background: teamColor(agent.team_name) + '22', color: teamColor(agent.team_name), borderColor: teamColor(agent.team_name) + '44' }"
-                :title="agent.team_name"
-              >{{ agent.team_name }}</span>
-              <span class="panel-agent-model">{{ agent.model || '—' }}</span>
-            </div>
-          </div>
-          <div class="panel-header-right">
-            <div class="panel-status-badge" :style="{ color: statusColor(agent.status) }">
-              {{ statusLabel(agent.status) }}
-            </div>
-            <!-- Pause/Resume toggle -->
-            <button
-              v-if="agent.status === 'running' || agent.status === 'paused'"
-              class="panel-pause-btn"
-              :class="{ 'is-paused': agent.status === 'paused' }"
-              :disabled="pauseLoading.has(agent.name)"
-              :title="agent.status === 'paused' ? 'Resume agent' : 'Pause agent'"
-              @click.stop="handlePauseToggle(agent.name, agent.status)"
-            >
-              {{ agent.status === 'paused' ? '▶' : '⏸' }}
-            </button>
-            <button
-              v-if="isDeletableAgent(agent)"
-              class="panel-delete-btn"
-              title="Remove this agent"
-              @click.stop="requestDelete(agent.name)"
-            >
-              🗑
-            </button>
-          </div>
-        </div>
-
-        <!-- Stats Bar -->
-        <div class="panel-stats-bar">
-          <span class="panel-stat">
-            <span class="stat-label">Events</span>
-            <span class="stat-value">{{ agentEventCount(agent.name) }}</span>
-          </span>
-          <span class="panel-stat" v-if="agent.type">
-            <span class="stat-label">Type</span>
-            <span class="stat-value">{{ agent.type }}</span>
-          </span>
-        </div>
-
-        <!-- Current Action -->
-        <div class="panel-current-action" v-if="getCurrentAction(agent.name)">
-          <div class="action-label">Current Action</div>
-          <div class="action-message">
-            {{ truncate(getCurrentAction(agent.name).message, 120) }}
-          </div>
-        </div>
-
-        <!-- Event Log -->
-        <div class="panel-event-log">
-          <div class="event-log-title">
-            Recent Events
-            <span class="event-log-count" v-if="getEvents(agent.name).length">
-              {{ getEvents(agent.name).length }} this hour
-            </span>
-          </div>
-          <!-- Scroll-locked list: ref keyed per-agent -->
-          <div
-            class="event-list"
-            :ref="el => { if (el) eventListRefs[agent.name] = el; else delete eventListRefs[agent.name] }"
-          >
-            <div
-              v-for="(evt, idx) in getEvents(agent.name)"
-              :key="`${evt.timestamp}_${evt.event_type}_${idx}`"
-              class="event-item"
-              :class="{ expanded: isExpanded(agent.name, idx) }"
-              @click="toggleEvent(agent.name, idx)"
-            >
-              <div class="event-summary">
-                <span class="event-icon">{{ eventTypeIcon(evt.event_type) }}</span>
-                <span class="event-type" :style="{ color: eventTypeColor(evt.event_type) }">{{ evt.event_type }}</span>
-                <!-- 2-line clamp preview — show full via expand -->
-                <span class="event-msg">{{ evt.message || '' }}</span>
-                <span class="event-time">{{ formatTime(evt.timestamp) }}</span>
-              </div>
-              <!-- Expanded Detail -->
-              <div v-if="isExpanded(agent.name, idx)" class="event-detail">
-                <div v-if="evt.full_message || evt.message" class="detail-row">
-                  <span class="detail-label">Message</span>
-                  <span class="detail-value detail-full-text">{{ evt.full_message || evt.message }}</span>
-                </div>
-                <div v-if="evt.data" class="detail-row">
-                  <span class="detail-label">Data</span>
-                  <pre class="detail-pre">{{ JSON.stringify(evt.data, null, 2) }}</pre>
-                </div>
-                <div v-if="evt.timestamp" class="detail-row">
-                  <span class="detail-label">Timestamp</span>
-                  <span class="detail-value">{{ formatTimestamp(evt.timestamp, { timeOnly: false }) }}</span>
-                </div>
-              </div>
-            </div>
-
-            <div v-if="!getEvents(agent.name).length" class="no-events">
-              No events in the last hour
-            </div>
-          </div>
-        </div>
-
-        <!-- Inline Inject Bar -->
-        <div class="panel-inject-bar">
-          <!-- Attached files preview -->
-          <div v-if="getInjectState(agent.name).files.length" class="inject-files">
-            <span v-for="(file, fi) in getInjectState(agent.name).files" :key="fi" class="inject-file-chip">
-              {{ file.type.startsWith('image') ? '🖼' : '🎤' }} {{ file.name.slice(0, 20) }}
-              <button class="file-remove" @click.stop="removeFile(agent.name, fi)">×</button>
-            </span>
-          </div>
-          <div class="inject-input-row">
-            <!-- Image attach -->
-            <button class="inject-media-btn" @click="handleFileAttach(agent.name, 'image')" title="Attach image">
-              <svg width="16" height="16" viewBox="0 0 16 14" fill="none"><rect x="1" y="1" width="14" height="12" rx="2" stroke="#8b8fa3" stroke-width="1.3"/><circle cx="5" cy="5" r="1.5" stroke="#8b8fa3" stroke-width="1.2"/><path d="M1 11L5 7L8 10L10 8L15 11" stroke="#8b8fa3" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            </button>
-            <!-- Audio attach -->
-            <button class="inject-media-btn" @click="handleFileAttach(agent.name, 'audio')" title="Attach audio">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="5.5" y="1" width="5" height="9" rx="2.5" stroke="#8b8fa3" stroke-width="1.3"/><path d="M3 8C3 11 5.5 13 8 13C10.5 13 13 11 13 8" stroke="#8b8fa3" stroke-width="1.3" stroke-linecap="round"/><line x1="8" y1="13" x2="8" y2="15" stroke="#8b8fa3" stroke-width="1.3" stroke-linecap="round"/></svg>
-            </button>
-            <!-- Text input -->
-            <div class="inject-input-wrap">
-              <input
-                type="text"
-                class="inject-input"
-                :placeholder="`Type a message...`"
-                :value="getInjectState(agent.name).text"
-                :disabled="getInjectState(agent.name).loading"
-                @input="e => getInjectState(agent.name).text = e.target.value"
-                @keydown.enter="submitInject(agent.name)"
-              />
-            </div>
-            <!-- Send button -->
-            <button
-              class="inject-send-btn"
-              :disabled="(!getInjectState(agent.name).text.trim() && !getInjectState(agent.name).files.length) || getInjectState(agent.name).loading"
-              @click="submitInject(agent.name)"
-            >
-              <svg v-if="!getInjectState(agent.name).loading" width="16" height="16" viewBox="0 0 18 18" fill="none"><path d="M2 9L16 2L9 16L8 10L2 9Z" fill="white" stroke="white" stroke-width="1.2" stroke-linejoin="round"/></svg>
-              <span v-else>⏳</span>
-            </button>
-          </div>
-        </div>
-      </div>
+        :agent="agent"
+        :turns="agentTurns.getTurns(agent.name)"
+        :loading="!agentTurns.fetched.value.has(agent.name)"
+        :on-fetch-full="(turnIdx) => agentTurns.fetchTurnFull(agent.name, turnIdx)"
+        :on-pause-toggle="(agent.status === 'running' || agent.status === 'paused')
+          ? () => handlePauseToggle(agent.name, agent.status)
+          : null"
+        :on-delete="isDeletableAgent(agent) ? () => requestDelete(agent.name) : null"
+        :on-inject="(payload) => injectToAgent(agent.name, payload)"
+      />
     </div>
 
     <!-- Delete Confirmation Modal -->
@@ -743,13 +467,15 @@ onMounted(() => {
 /* ─── Sub-navigation ─── */
 .sub-nav {
   display: flex;
+  align-items: center;
   gap: 3px;
   margin-bottom: 12px;
   background: #0c0e15;
   border: 1px solid #1a1d2e;
   border-radius: 9px;
   padding: 3px;
-  width: fit-content;
+  /* width: fit-content was here — opening up to full width so the v2 toggle
+     can align to the right edge via .sub-nav-spacer. */
 }
 
 .sub-nav-tab {
@@ -767,6 +493,8 @@ onMounted(() => {
   transition: all 0.15s ease;
   white-space: nowrap;
 }
+
+.sub-nav-spacer { flex: 1; }
 
 .sub-nav-tab:hover {
   color: #c4c8d4;
@@ -1144,9 +872,12 @@ onMounted(() => {
     flex-shrink: 0;
   }
 
-  /* Sub-nav: full width, equal tabs */
+  /* Sub-nav: full width, equal tabs. The version toggle wraps to a
+     second row on mobile so it doesn't squeeze the activity/meetings
+     tabs into a tiny strip. */
   .sub-nav {
     width: 100%;
+    flex-wrap: wrap;
     justify-content: stretch;
   }
 
@@ -1156,6 +887,8 @@ onMounted(() => {
     padding: 6px 10px;
     font-size: 12px;
   }
+
+  .sub-nav-spacer { display: none; }
 
   /* ── Filter bar: 2-row stacked layout on mobile ── */
   .filter-bar {
@@ -1228,68 +961,6 @@ onMounted(() => {
     gap: 8px;
   }
 
-  /* Agent panel: flush full-width on mobile */
-  .agent-panel {
-    border-radius: 8px;
-    margin: 0;
-  }
-
-  /* Panel header: tighter padding */
-  .panel-header {
-    padding: 10px 12px 8px;
-  }
-
-  .panel-agent-name {
-    font-size: 13px;
-  }
-
-  /* Hide model label on small screens */
-  .panel-agent-model {
-    display: none;
-  }
-
-  /* Event log: shorter max-height on mobile */
-  .panel-event-log {
-    max-height: 200px;
-  }
-
-  /* Event rows: tighter on mobile */
-  .event-row {
-    padding: 6px 12px;
-    gap: 6px;
-  }
-
-  .event-time {
-    font-size: 10px;
-    min-width: 48px;
-  }
-
-  .event-type-badge {
-    font-size: 9px;
-    padding: 1px 5px;
-  }
-
-  .event-msg {
-    font-size: 11px;
-  }
-
-  /* Inject bar */
-  .inject-bar {
-    padding: 8px 10px;
-    gap: 6px;
-  }
-
-  .inject-input {
-    font-size: 13px;
-    min-height: 36px;
-  }
-
-  .inject-btn {
-    width: 36px;
-    height: 36px;
-    flex-shrink: 0;
-  }
-
   /* Disband button: full width on mobile */
   .disband-team-btn {
     width: 100%;
@@ -1297,637 +968,6 @@ onMounted(() => {
   }
 }
 
-/* ─── Agent Panel ─── */
-.agent-panel {
-  background: #0c0e15;
-  border: 1px solid #1a1d2e;
-  border-radius: 12px;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  transition: border-color 0.3s;
-}
-
-.agent-panel.panel-running {
-  border-color: rgba(245, 158, 11, 0.3);
-}
-
-.agent-panel.panel-error {
-  border-color: rgba(239, 68, 68, 0.3);
-}
-
-/* Panel Header */
-.panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 12px 16px 10px;
-  border-bottom: 1px solid #1a1d2e;
-  min-width: 0;
-}
-
-.panel-agent-info {
-  display: flex;
-  align-items: flex-start;  /* dot aligns with name, not vertical center when there's a team */
-  gap: 8px;
-  cursor: pointer;
-  min-width: 0;
-  flex: 1;
-}
-
-.panel-agent-info:hover .panel-agent-name {
-  color: #3b82f6;
-}
-
-/* Column wrapper: name on row 1, team badge on row 2, model below */
-.panel-agent-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  min-width: 0;
-  flex: 1;
-}
-
-.panel-running .status-dot {
-  animation: pulse-dot 2s infinite;
-}
-
-@keyframes pulse-dot {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.4; }
-}
-
-.panel-agent-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: #f0f2f5;
-  transition: color 0.2s;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.panel-agent-model {
-  font-size: 11px;
-  color: #555872;
-}
-
-.panel-status-badge {
-  font-size: 11px;
-  font-weight: 500;
-}
-
-.panel-header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.panel-delete-btn {
-  background: none;
-  border: 1px solid transparent;
-  color: #555872;
-  font-size: 14px;
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
-  transition: all 0.2s;
-  line-height: 1;
-}
-
-.panel-delete-btn:hover {
-  color: #ef4444;
-}
-
-/* Pause/Resume button */
-.panel-pause-btn {
-  background: rgba(245, 158, 11, 0.15);
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  color: #f59e0b;
-  font-size: 13px;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 4px;
-  transition: all 0.2s;
-  line-height: 1;
-}
-
-.panel-pause-btn:hover {
-  background: rgba(245, 158, 11, 0.25);
-}
-
-.panel-pause-btn.is-paused {
-  background: rgba(34, 197, 94, 0.15);
-  border-color: rgba(34, 197, 94, 0.3);
-  color: #22c55e;
-}
-
-.panel-pause-btn.is-paused:hover {
-  background: rgba(34, 197, 94, 0.25);
-}
-
-.panel-pause-btn:disabled {
-  opacity: 0.5;
-  cursor: wait;
-}
-
-/* Paused panel border */
-.panel-paused {
-  border-color: rgba(245, 158, 11, 0.3) !important;
-}
-
-/* Disband Team button */
-.disband-team-btn {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
-  color: #ef4444;
-  font-size: 12px;
-  font-weight: 500;
-  padding: 6px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.2s;
-  white-space: nowrap;
-}
-
-.disband-team-btn:hover {
-  background: rgba(239, 68, 68, 0.2);
-  border-color: rgba(239, 68, 68, 0.5);
-}
-
-/* Disband dropdown */
-.disband-dropdown {
-  position: relative;
-}
-
-.disband-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  min-width: 200px;
-  background: #111318;
-  border: 1px solid #1e2030;
-  border-radius: 8px;
-  padding: 4px;
-  z-index: 100;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-}
-
-.disband-menu-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 12px;
-  background: none;
-  border: none;
-  border-radius: 6px;
-  color: #c4c8d4;
-  font-size: 13px;
-  cursor: pointer;
-  transition: all 0.15s;
-  text-align: left;
-}
-
-.disband-menu-item:hover {
-  background: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
-}
-
-.disband-menu-icon {
-  font-size: 14px;
-}
-
-.disband-menu-count {
-  margin-left: auto;
-  font-size: 11px;
-  color: #555872;
-}
-
-/* Team visual helpers */
-.team-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.team-filter-pill.active {
-  border-color: var(--team-accent) !important;
-  background: color-mix(in srgb, var(--team-accent) 15%, transparent) !important;
-  color: var(--team-accent) !important;
-}
-
-.dropdown-team-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  margin-top: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  color: #8b8fa3;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  cursor: pointer;
-  border-radius: 4px;
-  transition: background 0.15s;
-}
-
-.dropdown-team-header:first-child {
-  margin-top: 0;
-}
-
-.dropdown-team-header:hover {
-  background: rgba(99, 102, 241, 0.08);
-}
-
-.dropdown-team-count {
-  margin-left: auto;
-  font-size: 10px;
-  font-weight: 400;
-  color: #555872;
-  background: rgba(85, 88, 114, 0.15);
-  padding: 1px 6px;
-  border-radius: 8px;
-}
-
-.panel-team-badge {
-  font-size: 10px;
-  font-weight: 600;
-  padding: 1px 8px;
-  border-radius: 10px;
-  border: 1px solid;
-  white-space: nowrap;
-  letter-spacing: 0.3px;
-  /* Truncate long team names */
-  max-width: 180px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: inline-block;
-}
-
-/* Stats Bar */
-.panel-stats-bar {
-  display: flex;
-  gap: 20px;
-  padding: 8px 16px;
-  background: rgba(17, 19, 24, 0.5);
-}
-
-.panel-stat {
-  display: flex;
-  gap: 6px;
-  font-size: 11px;
-}
-
-.stat-label { color: #555872; }
-.stat-value { color: #c4c8d4; font-weight: 500; }
-
-/* Current Action */
-.panel-current-action {
-  padding: 10px 16px;
-  border-bottom: 1px solid #1a1d2e;
-}
-
-.action-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: #555872;
-  margin-bottom: 4px;
-}
-
-.action-message {
-  font-size: 12px;
-  color: #c4c8d4;
-  line-height: 1.4;
-}
-
-/* Event Log */
-.panel-event-log {
-  flex: 1;
-  padding: 10px 16px 8px;
-  min-height: 120px;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.event-log-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: #555872;
-  margin-bottom: 8px;
-}
-
-.event-log-count {
-  font-size: 10px;
-  color: #3b82f6;
-  text-transform: none;
-  letter-spacing: 0;
-  font-weight: 500;
-  background: rgba(59, 130, 246, 0.08);
-  padding: 1px 6px;
-  border-radius: 8px;
-}
-
-.event-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-height: 240px;
-  overflow-y: auto;
-}
-
-.event-item {
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.event-item:hover {
-  background: rgba(30, 34, 51, 0.5);
-}
-
-.event-summary {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  font-size: 12px;
-}
-
-.event-icon {
-  font-size: 11px;
-  flex-shrink: 0;
-  width: 16px;
-  text-align: center;
-}
-
-.event-type {
-  font-weight: 500;
-  font-size: 11px;
-  min-width: 72px;
-}
-
-.event-msg {
-  color: #8b8fa3;
-  font-size: 11px;
-  flex: 1;
-  overflow: hidden;
-  /* 2-line clamp: shows preview, tap event-item to expand full text */
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  word-break: break-word;
-  white-space: normal;
-  line-height: 1.35;
-}
-
-/* When event is expanded, show message without clamp in the event-summary too */
-.event-item.expanded .event-msg {
-  -webkit-line-clamp: unset;
-}
-
-.event-time {
-  color: #555872;
-  font-size: 10px;
-  flex-shrink: 0;
-}
-
-/* Expanded Event Detail */
-.event-detail {
-  padding: 6px 8px 8px 30px;
-  background: rgba(17, 24, 48, 0.3);
-  border-radius: 0 0 6px 6px;
-  animation: slide-in 0.15s ease-out;
-}
-
-@keyframes slide-in {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.detail-row {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 4px;
-  font-size: 11px;
-}
-
-.detail-label {
-  color: #555872;
-  min-width: 70px;
-  flex-shrink: 0;
-}
-
-.detail-value {
-  color: #c4c8d4;
-  word-break: break-word;
-}
-
-.detail-full-text {
-  max-height: 200px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  line-height: 1.5;
-}
-
-.detail-pre {
-  color: #8b8fa3;
-  font-size: 10px;
-  background: rgba(10, 13, 20, 0.5);
-  padding: 6px 8px;
-  border-radius: 4px;
-  overflow-x: auto;
-  max-height: 120px;
-  margin: 0;
-}
-
-.no-events {
-  text-align: center;
-  padding: 16px;
-  color: #555872;
-  font-size: 12px;
-}
-
-/* ─── Inline Inject Bar (Chat-style) ─── */
-.panel-inject-bar {
-  border-top: 1px solid #1a1d2e;
-  padding: 8px 12px 10px;
-  background: #0c0e15;
-}
-
-.inject-input-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.inject-media-btn {
-  width: 32px;
-  height: 32px;
-  background: #1e2233;
-  border-radius: 8px;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: background 0.2s;
-}
-
-.inject-media-btn:hover {
-  background: #2a3556;
-}
-
-.inject-media-btn:hover svg rect,
-.inject-media-btn:hover svg circle,
-.inject-media-btn:hover svg path,
-.inject-media-btn:hover svg line {
-  stroke: #c4c8d4;
-}
-
-.inject-input-wrap {
-  flex: 1;
-  height: 36px;
-  background: #111318;
-  border: 1px solid #1e2030;
-  border-radius: 10px;
-  display: flex;
-  align-items: center;
-  padding: 0 12px;
-  transition: border-color 0.2s;
-}
-
-.inject-input-wrap:focus-within {
-  border-color: #2a3556;
-}
-
-.inject-input {
-  flex: 1;
-  background: transparent;
-  border: none;
-  color: #f0f2f5;
-  font-size: 12px;
-  font-family: 'Inter', sans-serif;
-  outline: none;
-}
-
-.inject-input::placeholder {
-  color: #555872;
-  font-weight: 400;
-}
-
-.inject-send-btn {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  background: #3b82f6;
-  color: white;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: opacity 0.2s;
-  flex-shrink: 0;
-}
-
-.inject-send-btn:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-  background: #1e2233;
-}
-
-.inject-send-btn:not(:disabled):hover {
-  opacity: 0.85;
-}
-
-/* File chips */
-.inject-files {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-bottom: 6px;
-}
-
-.inject-file-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  background: #1e2233;
-  border-radius: 12px;
-  font-size: 11px;
-  color: #c4c8d4;
-}
-
-.file-remove {
-  background: none;
-  border: none;
-  color: #8b8fa3;
-  font-size: 14px;
-  cursor: pointer;
-  padding: 0 2px;
-  line-height: 1;
-}
-
-.file-remove:hover {
-  color: #ef4444;
-}
-
-/* Inline result */
-.inject-inline-result {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-  padding: 6px 8px;
-  margin-bottom: 6px;
-  background: rgba(16, 185, 129, 0.06);
-  border: 1px solid rgba(16, 185, 129, 0.15);
-  border-radius: 8px;
-  font-size: 11px;
-  color: #10b981;
-  animation: slide-in 0.15s ease-out;
-}
-
-.inject-inline-result.result-error {
-  background: rgba(239, 68, 68, 0.06);
-  border-color: rgba(239, 68, 68, 0.15);
-  color: #ef4444;
-}
-
-.result-icon {
-  flex-shrink: 0;
-}
-
-.result-text {
-  color: #c4c8d4;
-  word-break: break-word;
-  line-height: 1.4;
-}
-
-/* Scrollbar styling */
-.panel-event-log::-webkit-scrollbar {
-  width: 4px;
-}
-
-.panel-event-log::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.panel-event-log::-webkit-scrollbar-thumb {
-  background: #1a1d2e;
-  border-radius: 2px;
-}
 </style>
 
 

--- a/dashboard/tests/e2e/fixtures/agent_monitor_live.yaml
+++ b/dashboard/tests/e2e/fixtures/agent_monitor_live.yaml
@@ -43,6 +43,24 @@ responses:
     status: 200
     json: {}
 
+  # Per-agent message_history fetch fired by useAgentTurns.fetchInitial
+  # for every agent rendered in the AgentTerminal grid. Each agent in
+  # the roster triggers one of these on mount. Without the mock, the
+  # harness logs them as unexpected and ``backend.unexpected.length === 0``
+  # flips to red — same root cause as the FloatingChatDock leak: any
+  # new boot-time API call from a component the test mounts must be
+  # declared here.
+  "GET /api/agents/alpha-agent/messages":
+    status: 200
+    json:
+      agent_name: "alpha-agent"
+      turns: []
+  "GET /api/agents/beta-agent/messages":
+    status: 200
+    json:
+      agent_name: "beta-agent"
+      turns: []
+
 sse_streams:
   # Realtime activity SSE — override the noise fixture's single ping so the
   # onmessage handler receives a processable event that mutates the store.

--- a/dashboard/tests/e2e/fixtures/team_monitor_v2_terminal.yaml
+++ b/dashboard/tests/e2e/fixtures/team_monitor_v2_terminal.yaml
@@ -1,7 +1,8 @@
-# Team Monitor v2 happy path — terminal-style, message_history-driven.
+# Team Monitor happy path — terminal-style, message_history-driven.
 #
-# The view boots in v2 (?monitor=v2), fetches the agent roster + the
-# initial message_history slice for the agent, then receives a live
+# The view boots on /monitor (terminal UI is the only monitor view —
+# v1 card grid was removed), fetches the agent roster + the initial
+# message_history slice for the agent, then receives a live
 # `message_turn` SSE event that appends a new turn. We also exercise
 # the "Show full" expand path: the assistant turn carries a truncated
 # text block and clicking expand triggers GET /turns/{idx}/full.
@@ -15,7 +16,6 @@ backend_source:
   - "backend/services/sse_progress.py::emit_message_history_delta"
   - "dashboard/src/composables/useAgentTurns.js"
   - "dashboard/src/components/monitor/AgentTerminal.vue"
-  - "dashboard/src/views/TeamMonitor.vue::useV2 feature flag"
 
 notes: |
   v2 monitor reads message_turn events from the activity-stream SSE

--- a/dashboard/tests/e2e/fixtures/team_monitor_v2_terminal.yaml
+++ b/dashboard/tests/e2e/fixtures/team_monitor_v2_terminal.yaml
@@ -1,0 +1,101 @@
+# Team Monitor v2 happy path — terminal-style, message_history-driven.
+#
+# The view boots in v2 (?monitor=v2), fetches the agent roster + the
+# initial message_history slice for the agent, then receives a live
+# `message_turn` SSE event that appends a new turn. We also exercise
+# the "Show full" expand path: the assistant turn carries a truncated
+# text block and clicking expand triggers GET /turns/{idx}/full.
+
+backend_source:
+  - "backend/routes/agents.py::list_agents"
+  - "backend/routes/agents.py::activity_stream"
+  - "backend/routes/agents.py::get_agent_messages"
+  - "backend/routes/agents.py::get_agent_turn_full"
+  - "backend/services/agent_message_stream.py::list_agent_messages, get_agent_turn_full"
+  - "backend/services/sse_progress.py::emit_message_history_delta"
+  - "dashboard/src/composables/useAgentTurns.js"
+  - "dashboard/src/components/monitor/AgentTerminal.vue"
+  - "dashboard/src/views/TeamMonitor.vue::useV2 feature flag"
+
+notes: |
+  v2 monitor reads message_turn events from the activity-stream SSE
+  channel and renders each turn as a row in AgentTerminal. The
+  initial fetch hits /api/agents/{name}/messages for the agent.
+  Truncated blocks carry _truncated=true and _full_size; expanding
+  them triggers /turns/{idx}/full.
+
+responses:
+  "GET /api/agents":
+    status: 200
+    json:
+      - name: "Jarvis"
+        status: "running"
+        type: "builtin"
+        model: "claude-opus-4-7"
+        is_default: true
+
+  # Legacy endpoint still hit by useActivityStream — return empty so v1
+  # composable doesn't pollute the test (v2 doesn't read this).
+  "GET /api/agents/activities/recent":
+    status: 200
+    json: {}
+
+  # v2 initial history: one user turn, one assistant turn with a
+  # truncated content block (simulating a long response that the
+  # backend trimmed for SSE size).
+  "GET /api/agents/Jarvis/messages":
+    status: 200
+    json:
+      total: 2
+      start: 0
+      turns:
+        - turn_idx: 0
+          role: "user"
+          message:
+            role: "user"
+            content:
+              - { type: "text", text: "thời tiết Gia Lâm hôm nay" }
+        - turn_idx: 1
+          role: "assistant"
+          message:
+            role: "assistant"
+            content:
+              - type: "text"
+                text: "Tôi đang tra cứu thời tiết, dữ liệu sẽ rất dài…"
+                _truncated: true
+                _full_size: 200000
+            stop_reason: "endTurn"
+
+  # Full-fetch endpoint for the truncated turn (turn_idx=1).
+  "GET /api/agents/Jarvis/turns/1/full":
+    status: 200
+    json:
+      turn_idx: 1
+      message:
+        role: "assistant"
+        content:
+          - type: "text"
+            text: "Tôi đang tra cứu thời tiết, dữ liệu sẽ rất dài… FULL CONTENT REVEALED HERE."
+        stop_reason: "endTurn"
+
+sse_streams:
+  "/api/agents/activity-stream":
+    - data: { type: "connected", agent_filter: null }
+    - data:
+        agent_name: "Jarvis"
+        event_type: "message_turn"
+        run_id: "run-poc-1"
+        timestamp: 1714000010.0
+        data:
+          turn_idx: 2
+          role: "assistant"
+          message:
+            role: "assistant"
+            content:
+              - { type: "text", text: "Hôm nay Gia Lâm 28°C, ít mây." }
+            tool_calls:
+              "tu_xyz":
+                params:
+                  name: "search_weather"
+                  arguments: { location: "Gia Lâm", date: "today" }
+            stop_reason: "toolUse"

--- a/dashboard/tests/e2e/flows/agent-monitor.spec.ts
+++ b/dashboard/tests/e2e/flows/agent-monitor.spec.ts
@@ -36,13 +36,15 @@ test('team monitor — roster renders and SSE event flips one agent status', asy
 
   await page.goto('/monitor')
 
-  // Assertion 1: both agents render as cards. Anchor on the stable count
-  // first — the grid hydrates from /api/agents and any assertion targeting
-  // a specific card before then would race.
-  await expect(page.locator('.agent-panel')).toHaveCount(2)
+  // Assertion 1: both agents render as terminal panels. Anchor on the
+  // stable count first — the grid hydrates from /api/agents and any
+  // assertion targeting a specific panel before then would race.
+  // ``.agent-terminal`` is the canonical v2 selector (v1 ``.agent-panel``
+  // was removed in the TeamMonitor terminal-UI commit).
+  await expect(page.locator('.agent-terminal')).toHaveCount(2)
 
-  const alphaCard = page.locator('.agent-panel').filter({ hasText: 'alpha-agent' })
-  const betaCard = page.locator('.agent-panel').filter({ hasText: 'beta-agent' })
+  const alphaCard = page.locator('.agent-terminal').filter({ hasText: 'alpha-agent' })
+  const betaCard = page.locator('.agent-terminal').filter({ hasText: 'beta-agent' })
   await expect(alphaCard).toBeVisible()
   await expect(betaCard).toBeVisible()
 
@@ -53,8 +55,9 @@ test('team monitor — roster renders and SSE event flips one agent status', asy
   // Initially alpha is "running" (from GET /api/agents); the SSE event
   // processed through stores/agents.js::processEvent mutates status to "idle".
   // Beta is seeded as "idle" and should stay "idle".
-  await expect(alphaCard.locator('.panel-status-badge')).toHaveText('Idle')
-  await expect(betaCard.locator('.panel-status-badge')).toHaveText('Idle')
+  // ``.status-label`` is the AgentTerminal status text node.
+  await expect(alphaCard.locator('.status-label')).toHaveText('Idle')
+  await expect(betaCard.locator('.status-label')).toHaveText('Idle')
 
   // Assertion 4: mount-time fetches fired.
   recorder.assertContains('GET', '/api/agents')
@@ -83,8 +86,8 @@ test('team monitor — empty roster renders empty-state placeholder', async ({
   // Assertion 2: empty-state placeholder renders (default filter is 'all').
   await expect(page.locator('.empty-state')).toContainText('No agents found')
 
-  // Assertion 3: no agent card rendered.
-  await expect(page.locator('.agent-panel')).toHaveCount(0)
+  // Assertion 3: no agent terminal rendered.
+  await expect(page.locator('.agent-terminal')).toHaveCount(0)
 
   // Assertion 4: boot-time fetches still fired.
   recorder.assertContains('GET', '/api/agents')

--- a/dashboard/tests/e2e/flows/team-monitor-v2.spec.ts
+++ b/dashboard/tests/e2e/flows/team-monitor-v2.spec.ts
@@ -1,11 +1,12 @@
 /**
- * E2E flow: Team Monitor v2 — terminal-style message_history view.
+ * E2E flow: Team Monitor — terminal-style message_history view.
  *
  * Guards the rebuilt monitor pipeline: agent.message_history → SSE
  * `message_turn` channel → useAgentTurns composable → AgentTerminal
  * component. Coverage points:
  *
- *   1. URL flag ?monitor=v2 selects the v2 grid (AgentTerminal renders).
+ *   1. The terminal grid renders on /monitor (no feature flag — v1
+ *      card view was removed; AgentTerminal is the only UI).
  *   2. Initial GET /messages populates the terminal with persisted turns.
  *   3. SSE message_turn appends a delta turn live (no duplicate).
  *   4. Truncated content shows a "Show full" affordance; clicking it
@@ -33,16 +34,14 @@ test('team monitor v2 — terminal renders persisted history + SSE delta turn', 
   const recorder = new NetworkRecorder()
   await recorder.attach(page)
 
-  // Visit with the v2 feature flag in the URL.
-  await page.goto('/monitor?monitor=v2')
+  // No feature flag — terminal UI is the only monitor view since the
+  // v1 card grid was removed.
+  await page.goto('/monitor')
 
-  // ── 1. v2 grid is selected ─────────────────────────────────────────
+  // ── 1. Terminal grid renders ────────────────────────────────────────
   // The .agent-terminal class is unique to AgentTerminal.vue.
   await expect(page.locator('.agent-terminal')).toHaveCount(1)
   await expect(page.locator('.agent-name', { hasText: 'Jarvis' })).toBeVisible()
-
-  // The version toggle should reflect v2.
-  await expect(page.locator('.version-btn.active', { hasText: 'v2' })).toBeVisible()
 
   // ── 2. Initial history fetched and rendered ────────────────────────
   // Two turns from /messages: turn_idx 0 (user) + turn_idx 1 (assistant).
@@ -81,7 +80,7 @@ test('team monitor v2 — Show full expands truncated assistant turn', async ({
   const recorder = new NetworkRecorder()
   await recorder.attach(page)
 
-  await page.goto('/monitor?monitor=v2')
+  await page.goto('/monitor')
 
   // Wait for the assistant turn (turn_idx=1) carrying the truncated block.
   const truncatedRow = page.locator('.turn-row.role-assistant', {
@@ -112,26 +111,10 @@ test('team monitor v2 — Show full expands truncated assistant turn', async ({
 })
 
 
-test('team monitor v2 — version toggle persists choice', async ({ page }) => {
-  await seedApiKey(page)
-  await mockBackend(page, [
-    NOISE,
-    join(FIXTURES, 'team_monitor_v2_terminal.yaml'),
-  ])
-
-  // Land in v1 (default) first.
-  await page.goto('/monitor')
-  await expect(page.locator('.agent-panel')).toHaveCount(1) // v1 .agent-panel
-  await expect(page.locator('.agent-terminal')).toHaveCount(0)
-
-  // Click the v2 toggle.
-  await page.locator('.version-btn', { hasText: 'v2' }).click()
-
-  // v2 grid replaces v1.
-  await expect(page.locator('.agent-terminal')).toHaveCount(1)
-  await expect(page.locator('.agent-panel')).toHaveCount(0)
-
-  // Reload — choice persisted via localStorage.
-  await page.reload()
-  await expect(page.locator('.agent-terminal')).toHaveCount(1)
-})
+// Removed: "version toggle persists choice" test.
+//
+// The TeamMonitor v1/v2 toggle was deleted (see the dashboard commit
+// "TeamMonitor terminal UI..."). The terminal grid is now the only
+// monitor view — there is nothing to toggle and no localStorage flag
+// to persist. Keeping a test for non-existent UI would be a
+// false-positive regression source.

--- a/dashboard/tests/e2e/flows/team-monitor-v2.spec.ts
+++ b/dashboard/tests/e2e/flows/team-monitor-v2.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * E2E flow: Team Monitor v2 — terminal-style message_history view.
+ *
+ * Guards the rebuilt monitor pipeline: agent.message_history → SSE
+ * `message_turn` channel → useAgentTurns composable → AgentTerminal
+ * component. Coverage points:
+ *
+ *   1. URL flag ?monitor=v2 selects the v2 grid (AgentTerminal renders).
+ *   2. Initial GET /messages populates the terminal with persisted turns.
+ *   3. SSE message_turn appends a delta turn live (no duplicate).
+ *   4. Truncated content shows a "Show full" affordance; clicking it
+ *      triggers /turns/{idx}/full and reveals the untruncated text.
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, NetworkRecorder, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+
+test('team monitor v2 — terminal renders persisted history + SSE delta turn', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const backend = await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'team_monitor_v2_terminal.yaml'),
+  ])
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+
+  // Visit with the v2 feature flag in the URL.
+  await page.goto('/monitor?monitor=v2')
+
+  // ── 1. v2 grid is selected ─────────────────────────────────────────
+  // The .agent-terminal class is unique to AgentTerminal.vue.
+  await expect(page.locator('.agent-terminal')).toHaveCount(1)
+  await expect(page.locator('.agent-name', { hasText: 'Jarvis' })).toBeVisible()
+
+  // The version toggle should reflect v2.
+  await expect(page.locator('.version-btn.active', { hasText: 'v2' })).toBeVisible()
+
+  // ── 2. Initial history fetched and rendered ────────────────────────
+  // Two turns from /messages: turn_idx 0 (user) + turn_idx 1 (assistant).
+  // Then the SSE delta adds turn_idx 2.
+  await expect(page.locator('.turn-row')).toHaveCount(3)
+
+  // Initial user turn text visible.
+  await expect(
+    page.locator('.turn-row.role-user', { hasText: 'thời tiết Gia Lâm hôm nay' }),
+  ).toBeVisible()
+
+  // ── 3. SSE delta turn appears (turn_idx=2 with a tool_call) ────────
+  const deltaRow = page.locator('.turn-row.role-assistant', {
+    hasText: 'Hôm nay Gia Lâm 28°C',
+  })
+  await expect(deltaRow).toBeVisible()
+  await expect(deltaRow.locator('.tool-name')).toHaveText('search_weather')
+
+  // ── 4. Mount-time fetches fired — initial /messages is the v2 contract ──
+  recorder.assertContains('GET', '/api/agents')
+  recorder.assertContains('GET', '/api/agents/Jarvis/messages')
+
+  // No unexpected requests slipped past the mock.
+  expect(backend.unexpected.length).toBe(0)
+})
+
+
+test('team monitor v2 — Show full expands truncated assistant turn', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const backend = await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'team_monitor_v2_terminal.yaml'),
+  ])
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+
+  await page.goto('/monitor?monitor=v2')
+
+  // Wait for the assistant turn (turn_idx=1) carrying the truncated block.
+  const truncatedRow = page.locator('.turn-row.role-assistant', {
+    hasText: 'Tôi đang tra cứu thời tiết',
+  }).first()
+  await expect(truncatedRow).toBeVisible()
+
+  // The "+ Show full" button is the affordance for truncated content.
+  const expandBtn = truncatedRow.locator('button.expand-btn', { hasText: 'Show full' })
+  await expect(expandBtn).toBeVisible()
+
+  // Click → triggers GET /turns/1/full and shows the untruncated text.
+  await expandBtn.click()
+
+  // Wait for the full-content endpoint to be called.
+  await expect.poll(() => {
+    try { recorder.assertContains('GET', '/api/agents/Jarvis/turns/1/full'); return true }
+    catch { return false }
+  }).toBe(true)
+
+  // The full text from the fixture appears.
+  await expect(truncatedRow).toContainText('FULL CONTENT REVEALED HERE')
+
+  // The button label flips to "Collapse".
+  await expect(truncatedRow.locator('button.expand-btn')).toHaveText('Collapse')
+
+  expect(backend.unexpected.length).toBe(0)
+})
+
+
+test('team monitor v2 — version toggle persists choice', async ({ page }) => {
+  await seedApiKey(page)
+  await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'team_monitor_v2_terminal.yaml'),
+  ])
+
+  // Land in v1 (default) first.
+  await page.goto('/monitor')
+  await expect(page.locator('.agent-panel')).toHaveCount(1) // v1 .agent-panel
+  await expect(page.locator('.agent-terminal')).toHaveCount(0)
+
+  // Click the v2 toggle.
+  await page.locator('.version-btn', { hasText: 'v2' }).click()
+
+  // v2 grid replaces v1.
+  await expect(page.locator('.agent-terminal')).toHaveCount(1)
+  await expect(page.locator('.agent-panel')).toHaveCount(0)
+
+  // Reload — choice persisted via localStorage.
+  await page.reload()
+  await expect(page.locator('.agent-terminal')).toHaveCount(1)
+})


### PR DESCRIPTION
## Summary

Single PR consolidating ~5,000 LOC of work across orchestrator,
team/meeting orchestration, token observability, inject UX, and
monitor UI — all fixing real production incidents from the past
~1 week. Includes 1 submodule bump (fast-agent) + 5 logical
commits on the main repo. User chose option (b) "1 big PR" over
the proposed 4-PR split.

### Why 1 PR

The author prefers a single PR over splits to avoid accidental
code mixing across PR boundaries. Reviewer should walk the
commits in order; each commit message has full scope + rationale.

### Base dependency

This branch is cut from `feat/auth-silent-refresh` (PR #15). The
first 2 commits in the GitHub diff are from PR #15 (`feat(auth):
silent session refresh` + `fix(auth): address PR #15 review`) and
should NOT be reviewed here — they're already covered by PR #15.
After PR #15 merges, this PR auto-rebases and shows only the 5
new commits.

## Commits in order (review walkthrough)

| # | Commit | Scope | LOC |
|---|---|---|---|
| 1 | `feat(orchestrator): team + meeting + auto-wake stabilization` | Submodule bump (fast-agent) + backend integration: orchestrator team_completion correctness, context_persistence mirrors last assistant text into spawn_registry.result, delete_team cascades into notifications, agile_team gains self-audit-tools skill for all 7 roles, spawn_event_socket single-instance guard, agent_message_stream service (new) feeding monitor v2. | ~1500 |
| 2 | `feat(observability): centralize token persistence as always-on hook` | Token tracking moves from per-caller hook attach to startup-time default hook. ContextVar propagates run_id from chat/voice/inject/cron callers. Closes the gap where scheduler-triggered LLM calls bypassed `token_usage` SQLite insert (9Router showed 864K input; Jarvis dashboard 78.8K). | ~480 |
| 3 | `fix(inject): wake alive agent + broadcast started in Path A` | Inject Path A (MessageBus, alive agent) now sends a wake signal via AgentChannel socket + broadcasts `started` activity event for instant UI feedback. Mirrors Path B / Path C contract. | ~170 |
| 4 | `feat(dashboard): TeamMonitor terminal UI + meeting transcript + voice` | Legacy v1 card grid REMOVED entirely (-1090 LOC). Terminal-style `<AgentTerminal>` is the only monitor view. New `useAgentTurns` composable consumes the `message_turn` SSE channel. Plus meeting transcript redesign, voice resilience, global floating chat dock. | ~1800 |
| 5 | `docs: AGENTS.md — Team Monitor v2 architecture; update GitNexus stats` | Document the v2 monitor data pipeline + new SSE endpoints. Mark v1 as removed. | ~50 |

## Submodule

`backend/fast-agent` bumps to commit `ba17bfdd` on branch
`feat/orchestrator-team-stabilization` (in
[omnigentx/fast-agent](https://github.com/omnigentx/fast-agent/tree/feat/orchestrator-team-stabilization)).
The submodule commit contains the low-level changes:

- `AgentChannel.is_alive` real liveness probe (not just file-exists)
- `auto_wake_if_idle` refactor to probe-then-dispatch (SSoT)
- `_check_and_resume_on_inbox` session-scoped `TEAM_MESSAGES_DIR` path
- `get_team_result` / `get_team_status` fail-loud
- `team_spawner` cache drop (SQLite SoT)
- Meeting room pluggable storage + auto-wake on every notify path

## Production incidents addressed

| Date | Symptom | Root cause | Fix |
|---|---|---|---|
| 2026-05-15 | Retro meeting `5612e8f3` stuck on Adrian's turn forever | Writer used `TEAM_MESSAGES_DIR` (session-scoped); reader used `TEAM_WORKSPACE` walk-up (no session). Reader saw 0 unread → silent skip → no respawn. | Commit 1 (path symmetry) |
| 2026-05-15 | 9Router 864K input vs Jarvis dashboard 78.8K | Scheduler-triggered LLM calls bypassed token_usage insert | Commit 2 |
| 2026-05-15 | Inject submitted, terminal silent for seconds | Path A queued message but never woke alive agent + never broadcast `started` | Commit 3 |
| 2026-05-14 | Toolset-self-audit notification body empty | Orchestrator's roll-up not mirrored into spawn_registry.result | Commit 1 (`context_persistence` mirror) |
| 2026-05-14 | Re-running team with same name → no completion notification | `delete_team` didn't cascade into notifications → dedupe guard matched stale notification | Commit 1 (`routes/agents.py` cleanup) |

## Test plan

- [x] `pytest tests/` — 1178 passed, 1 skipped (full backend suite)
- [x] `vue-tsc --noEmit` — no new errors related to changes
- [x] `npm run build` — clean (vite ✓)
- [x] Backend restart with PID-verified protocol — listener PID 84513, `/api/health → 200`, log shows `[TOKEN] Default token-persistence hook attached to 5 agent(s)`
- [x] Manual smoke: inject prompt to alive agent → terminal pulses immediately + thinking event arrives < 200ms
- [x] Manual smoke: delete team → notifications table cleaned (no orphan)

## Out of scope (deferred to follow-up PRs)

3 root causes identified during this session but NOT fixed in this
PR (each has its own scope + risk profile, deserves a separate review):

1. **Jira `create_project` requires `lead_account_id`** — agent doesn't know how to look up its own. Proposed fix: MCP wrapper auto-resolves via `/rest/api/3/myself` when empty.
2. **Confluence `create_space` missing** — underlying lib supports it, MCP tool wrapper missing. Proposed fix: add `confluence_create_space` tool.
3. **`${VAR}` placeholders in fastagent.config.yaml MCP env not expanded** — caused approval-server runtime socket connect to literal `${JARVIS_RUNTIME_RPC_SOCKET}` string. Proposed fix: add env expansion in `mcp_connection_manager`.

These will land in a follow-up PR once this one merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)