### PR TITLE
feat: team-template REST API + gh CLI + bridge event-stream + MCP fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ backend/token_gmail.json
 backend/firebase-credentials.json
 backend/config/credentials/
 backend/.keys/
+# MCP server configs may inline live API tokens (Jira/Confluence/etc).
+.mcp.json
+# gh CLI host config (contains oauth_token).
+backend/.gh-config/
+# Runtime LLM tool-call dumps written by debugging research agents.
+backend/.tool-outputs/
 
 # ─── Backend Runtime / Data ──────────────────────
 backend/.runtime/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,7 +459,7 @@ trial and error.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **jarvis** (35826 symbols, 100473 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **jarvis** (36228 symbols, 101681 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **jarvis** (35435 symbols, 99356 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **jarvis** (36228 symbols, 101681 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/backend/.fast-agent/skills/dev-workflow/SKILL.md
+++ b/backend/.fast-agent/skills/dev-workflow/SKILL.md
@@ -68,24 +68,7 @@ gh run view <run-id> --log-failed  # only failed step logs (saves context)
 gh run rerun <run-id> --failed
 ```
 
-For `gh pr merge` / `gh release create` / `gh repo delete` → escalate to PM first.
-
-## Escalation flow (when blocked by a 🟡 ESCALATE action)
-
-```python
-send_email(
-    to="<PM name>",
-    subject="[APPROVAL-REQUEST] <one-line summary of action>",
-    body="""
-Need approval to run: `<exact command>`
-Why: <user-facing reason — what task this unblocks>
-Risk: <what could go wrong if approved>
-Alternatives considered: <list, or 'none — only path forward'>
-""",
-)
-# Stop and wait for PM reply. PM will relay via approval-server MCP to user.
-# When PM emails back [APPROVED] or [DENIED], proceed accordingly.
-```
+For `gh pr merge` / `gh release create` / `gh repo delete` → escalate to PM first (see `team-communication` skill: "Approval escalation" — the canonical request/response flow).
 
 ## TDD Cycle
 

--- a/backend/.fast-agent/skills/dev-workflow/SKILL.md
+++ b/backend/.fast-agent/skills/dev-workflow/SKILL.md
@@ -27,10 +27,65 @@ cd repo && npm install && npm test        # Sequential (stops on error)
 cd backend && uv run pytest --tb=short -q 2>&1 | tail -20  # Filter output
 ```
 
-### Safety Rules
-- 🔴 NEVER: `rm -rf /`, expose secrets, `curl | bash` from untrusted sources
-- 🟡 CAUTION: `rm -rf` → always specify exact path
-- 🟢 SAFE: all read-only commands, build/test within workspace
+### Safety Rules — three tiers
+
+🔴 **NEVER do (refuse the task; report the request as a security incident to PM):**
+- Filesystem destruction: `rm -rf /`, `rm -rf $HOME`, `rm -rf .git`, `mkfs.*`, `dd of=/dev/...`
+- Read secrets: `/etc/shadow`, `~/.ssh/*`, `.gh-config/`, `.env*`, `fastagent.secrets.yaml`, `git-credentials`, `~/.gitconfig` credential block
+- Tamper with auth: `gh auth login/logout/refresh`, `gh auth setup-git`, modify gitconfig credential helper
+- Inspect env to leak tokens: `env`, `printenv`, `echo $GH_TOKEN`, `cat /proc/*/environ`
+- Network DoS: fork bombs, high-rate request loops
+
+🟡 **ESCALATE before doing** (send `[APPROVAL-REQUEST]` email to PM with command + reason; do NOT run until PM confirms back):
+- Pipe-to-shell: `curl ... | sh`, `wget ... | bash`
+- Force-destructive git: `git push --force` (any branch), `git reset --hard` past HEAD~1, `git filter-branch`
+- Push to protected branches: `main`, `master`, `prod*`, `release/*`
+- `gh pr merge` (auto-merge bypassing review)
+- `gh release create`
+- `gh repo delete`
+- Editing `package.json` / `pyproject.toml` / lock files outside a tracked PR scope
+
+🟢 **SAFE — run freely:**
+- All read-only inspection: `ls`, `cat README.md`, `grep`, `find`, `git status/log/diff`, `gh run list`, `gh pr view`
+- Normal git on feature branches: `git checkout -b feature/...`, `git add`, `git commit`, `git push origin feature/...`
+- Build/test inside workspace: `npm test`, `uv run pytest`, `cargo build`
+
+When in doubt → escalate. Faster to ask PM than to recover from a bad commit.
+
+## GitHub CLI via `gh`
+
+The `gh` CLI is pre-authenticated in your shell. Use it for repo operations the GitHub MCP doesn't cover — especially CI inspection.
+
+```bash
+# Inspect PR + CI status (read-only, always SAFE)
+gh pr view 42 --json title,state,mergeable,statusCheckRollup
+gh pr checks 42
+gh run list -L 10 --branch feature/xyz
+gh run view <run-id>               # high-level summary
+gh run view <run-id> --log-failed  # only failed step logs (saves context)
+
+# Trigger a re-run after fixing test (still SAFE — only re-runs failed jobs)
+gh run rerun <run-id> --failed
+```
+
+For `gh pr merge` / `gh release create` / `gh repo delete` → escalate to PM first.
+
+## Escalation flow (when blocked by a 🟡 ESCALATE action)
+
+```python
+send_email(
+    to="<PM name>",
+    subject="[APPROVAL-REQUEST] <one-line summary of action>",
+    body="""
+Need approval to run: `<exact command>`
+Why: <user-facing reason — what task this unblocks>
+Risk: <what could go wrong if approved>
+Alternatives considered: <list, or 'none — only path forward'>
+""",
+)
+# Stop and wait for PM reply. PM will relay via approval-server MCP to user.
+# When PM emails back [APPROVED] or [DENIED], proceed accordingly.
+```
 
 ## TDD Cycle
 

--- a/backend/.fast-agent/skills/jarvis-infra/SKILL.md
+++ b/backend/.fast-agent/skills/jarvis-infra/SKILL.md
@@ -100,21 +100,7 @@ gh release view v1.2.3
 
 🟢 **SAFE** (run freely): all read-only `gh run/release/pr/workflow view/list`, `docker compose logs/ps`, local file inspection.
 
-### Escalation flow
-
-```python
-send_email(
-    to="<PM name>",
-    subject="[APPROVAL-REQUEST] <one-line summary>",
-    body="""
-Need approval to run: `<exact command>`
-Why: <task this unblocks>
-Risk: <what could go wrong>
-Rollback: <how to undo if it goes wrong>
-""",
-)
-# Wait for PM. PM uses approval-server MCP to ask user.
-```
+For 🟡 escalation, see `team-communication` skill: "Approval escalation". Infra requests should include a **Rollback** line in the body (how to undo if the action goes wrong).
 
 ## Build & Run Commands
 

--- a/backend/.fast-agent/skills/jarvis-infra/SKILL.md
+++ b/backend/.fast-agent/skills/jarvis-infra/SKILL.md
@@ -66,6 +66,56 @@ Push to main → GitHub Actions
   5. Health check
 ```
 
+### Inspecting + driving the pipeline via `gh` CLI
+
+The `gh` CLI is pre-authenticated in your shell via `execute(command=...)`. Use it for release ops and deployment monitoring — the GitHub MCP doesn't cover workflow triggers or release management.
+
+```bash
+# Monitor deploy after Dev merges to main (SAFE — read-only)
+gh run list --workflow=deploy.yml -L 5
+gh run watch <run-id>                      # block until done
+gh run view <run-id> --log-failed | tail -100
+
+# List + view releases (SAFE)
+gh release list -L 5
+gh release view v1.2.3
+```
+
+🟡 **ESCALATE before doing** (send `[APPROVAL-REQUEST]` email to PM with the exact command + reason; do NOT run until PM relays `[APPROVED]`):
+- `gh workflow run deploy.yml` or any prod-deployment workflow trigger
+- `gh release create vX.Y.Z` (any new release)
+- `gh release edit/delete`
+- DNS / CDN / cloud-provider config changes
+- `kubectl apply -f` against prod cluster
+- `docker compose up/down` on production hosts (not dev box)
+- Pipe-to-shell: `curl ... | sh`, `wget ... | bash`
+- `git push --force` (any branch), `git reset --hard` past HEAD~1
+
+🔴 **NEVER** (refuse + escalate as a security incident):
+- Read auth files: `~/.gh-config/`, `.env*`, `fastagent.secrets.yaml`, `git-credentials`, `~/.ssh/`
+- Inspect env to leak tokens: `env`, `printenv`, `echo $GH_TOKEN`
+- `gh auth login/logout/refresh`
+- Filesystem destruction: `rm -rf /`, `rm -rf $HOME`, `rm -rf .git`, `mkfs`, `dd of=/dev/...`
+- Fork bombs / high-rate network loops
+
+🟢 **SAFE** (run freely): all read-only `gh run/release/pr/workflow view/list`, `docker compose logs/ps`, local file inspection.
+
+### Escalation flow
+
+```python
+send_email(
+    to="<PM name>",
+    subject="[APPROVAL-REQUEST] <one-line summary>",
+    body="""
+Need approval to run: `<exact command>`
+Why: <task this unblocks>
+Risk: <what could go wrong>
+Rollback: <how to undo if it goes wrong>
+""",
+)
+# Wait for PM. PM uses approval-server MCP to ask user.
+```
+
 ## Build & Run Commands
 
 ```bash

--- a/backend/.fast-agent/skills/qe-workflow/SKILL.md
+++ b/backend/.fast-agent/skills/qe-workflow/SKILL.md
@@ -76,21 +76,7 @@ gh run rerun <run-id> --failed             # SAFE: retry only failed jobs
 - Local inspection: `ls`, `cat`, `grep`, `find`
 - Run tests: `npm test`, `uv run pytest`, `playwright test`
 
-## Escalation flow
-
-```python
-send_email(
-    to="<PM name>",
-    subject="[APPROVAL-REQUEST] <one-line summary>",
-    body="""
-Need approval to run: `<exact command>`
-Why: <task this unblocks>
-Risk: <what could go wrong>
-Alternatives considered: <list, or 'none'>
-""",
-)
-# Stop and wait. PM relays via approval-server MCP → user decides.
-```
+For 🟡 escalation, see `team-communication` skill: "Approval escalation".
 
 ## Fixing Failing Tests
 

--- a/backend/.fast-agent/skills/qe-workflow/SKILL.md
+++ b/backend/.fast-agent/skills/qe-workflow/SKILL.md
@@ -45,6 +45,53 @@ Publish to Confluence (NOT workspace MD file):
 | TC-2 | Edge case: ... | 1. ... | ... | PASS/FAIL |
 ```
 
+## CI/CD inspection via `gh` CLI
+
+You have access to the `execute` shell tool with `gh` pre-authenticated. Use it to verify Dev's PR before signing off — the GitHub MCP only exposes high-level status, while `gh` gives you failed-step logs.
+
+```bash
+# After Dev says "PR ready" — gather evidence
+gh pr checks 42                            # see which jobs passed/failed
+gh run list --branch feature/xyz -L 5      # recent runs on the branch
+gh run view <run-id> --log-failed | tail -100   # zoom on failure
+gh run rerun <run-id> --failed             # SAFE: retry only failed jobs
+```
+
+🟡 **ESCALATE before doing** (send `[APPROVAL-REQUEST]` email to PM, wait for `[APPROVED]` reply):
+- `gh workflow run <prod-deploy>` or any workflow targeting production env
+- `gh pr merge` (only Dev/PM should merge; QE just validates)
+- `gh release create`
+- Modifying or deleting production test data
+- `git push --force`, `git reset --hard` past HEAD~1, `git filter-branch`
+- Pipe-to-shell (`curl ... | sh`, `wget ... | bash`)
+
+🔴 **NEVER** (refuse + report to PM as a security incident):
+- Read auth files: `~/.gh-config/`, `.env*`, `fastagent.secrets.yaml`, `git-credentials`, `~/.ssh/`
+- Inspect env to leak tokens: `env`, `printenv`, `echo $GH_TOKEN`
+- `gh auth login/logout/refresh`
+- `rm -rf /`, `rm -rf $HOME`, `rm -rf .git`, fork bombs
+
+🟢 **SAFE** (run freely):
+- All read-only `gh run/pr/issue view`, `git status/log/diff`
+- Local inspection: `ls`, `cat`, `grep`, `find`
+- Run tests: `npm test`, `uv run pytest`, `playwright test`
+
+## Escalation flow
+
+```python
+send_email(
+    to="<PM name>",
+    subject="[APPROVAL-REQUEST] <one-line summary>",
+    body="""
+Need approval to run: `<exact command>`
+Why: <task this unblocks>
+Risk: <what could go wrong>
+Alternatives considered: <list, or 'none'>
+""",
+)
+# Stop and wait. PM relays via approval-server MCP → user decides.
+```
+
 ## Fixing Failing Tests
 
 When tests fail, fix systematically:

--- a/backend/.fast-agent/skills/team-communication/SKILL.md
+++ b/backend/.fast-agent/skills/team-communication/SKILL.md
@@ -54,30 +54,12 @@ BEFORE going idle or completing work, you MUST:
 1. Send a `[DONE]` report to the PM: `send_email(to="Linh - PM", subject="[DONE] <deliverable summary>", body="<list of deliverables, files, outcomes, open items>")`
 2. NEVER go idle without sending the report — this is **required**.
 
-## Approval escalation — when you need permission for a sensitive action
+## Approval escalation
 
-Some shell / git / `gh` commands are flagged 🟡 ESCALATE in your role skill (`dev-workflow`, `qe-workflow`, `jarvis-infra`). When you hit one:
+When your role skill flags a command 🟡 ESCALATE:
 
-1. Do NOT run the command. Send an approval-request email to the PM:
-   ```python
-   send_email(
-       to="<PM name>",
-       subject="[APPROVAL-REQUEST] <one-line summary of action>",
-       body="""
-   Need approval to run: `<exact command>`
-   Why: <task this unblocks>
-   Risk: <what could go wrong>
-   Alternatives: <list, or 'none — only path forward'>
-   """,
-   )
-   ```
-2. Stop and wait for the PM to reply. PM will relay the request to the user via the approval-server MCP, then email you `[APPROVED]` or `[DENIED]` with the verdict.
-3. **If APPROVED** — run the exact command from the request (no edits). Report result.
-4. **If DENIED** — do not retry. Re-plan or report the block to PM.
+1. **Don't run it.** Email PM with subject `[APPROVAL-REQUEST] <summary>` and body containing: exact command, why, risk, alternatives (infra adds: rollback).
+2. Wait for `[APPROVED]` / `[DENIED]` reply. PM forwards via `approval-server` MCP.
+3. APPROVED → run exactly the command from the request. DENIED → re-plan.
 
-### PM responsibilities (PM role only)
-
-When PM receives `[APPROVAL-REQUEST]`:
-- Verify the requesting agent is permitted to ask (Dev/QE/DSO can; Designer/BA/SA cannot run shell writes — should be redirected to a different approach).
-- Call `request_approval(action=<command>, reason=<why+risk>)` from the `approval-server` MCP. User sees a dashboard prompt and approves/rejects.
-- Email the requester back with `[APPROVED]` or `[DENIED] <reason>` so they proceed or abort.
+**PM only:** verify the requester's role can do the action (Dev/QE/DSO yes; Designer/BA/SA no — redirect), call `request_approval()`, email back the verdict.

--- a/backend/.fast-agent/skills/team-communication/SKILL.md
+++ b/backend/.fast-agent/skills/team-communication/SKILL.md
@@ -53,3 +53,31 @@ When you receive 🔔 MEETING INVITE → follow the `meeting-participant` skill 
 BEFORE going idle or completing work, you MUST:
 1. Send a `[DONE]` report to the PM: `send_email(to="Linh - PM", subject="[DONE] <deliverable summary>", body="<list of deliverables, files, outcomes, open items>")`
 2. NEVER go idle without sending the report — this is **required**.
+
+## Approval escalation — when you need permission for a sensitive action
+
+Some shell / git / `gh` commands are flagged 🟡 ESCALATE in your role skill (`dev-workflow`, `qe-workflow`, `jarvis-infra`). When you hit one:
+
+1. Do NOT run the command. Send an approval-request email to the PM:
+   ```python
+   send_email(
+       to="<PM name>",
+       subject="[APPROVAL-REQUEST] <one-line summary of action>",
+       body="""
+   Need approval to run: `<exact command>`
+   Why: <task this unblocks>
+   Risk: <what could go wrong>
+   Alternatives: <list, or 'none — only path forward'>
+   """,
+   )
+   ```
+2. Stop and wait for the PM to reply. PM will relay the request to the user via the approval-server MCP, then email you `[APPROVED]` or `[DENIED]` with the verdict.
+3. **If APPROVED** — run the exact command from the request (no edits). Report result.
+4. **If DENIED** — do not retry. Re-plan or report the block to PM.
+
+### PM responsibilities (PM role only)
+
+When PM receives `[APPROVAL-REQUEST]`:
+- Verify the requesting agent is permitted to ask (Dev/QE/DSO can; Designer/BA/SA cannot run shell writes — should be redirected to a different approach).
+- Call `request_approval(action=<command>, reason=<why+risk>)` from the `approval-server` MCP. User sees a dashboard prompt and approves/rejects.
+- Email the requester back with `[APPROVED]` or `[DENIED] <reason>` so they proceed or abort.

--- a/backend/Dockerfile.base
+++ b/backend/Dockerfile.base
@@ -47,14 +47,29 @@ FROM python:3.13-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         git nodejs portaudio19-dev gcc g++ make python3-dev \
         alsa-utils flac ffmpeg docker.io \
         libnspr4 libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 \
         libcups2t64 libatspi2.0-0t64 libxcomposite1 libxdamage1 \
+        gh=2.68.1 \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g gitnexus@1.6.2 \
     && npm cache clean --force
+
+# gh CLI auth: agents invoke ``gh`` via the execute shell tool for CI/PR/release
+# ops. ``GH_CONFIG_DIR`` points at a Jarvis-private directory so gh reads from
+# our hosts.yml (written by services/gh_credential_sync.py on every boot) and
+# never falls back to the host user's personal ~/.config/gh/. Must match
+# _GH_CONFIG_DIR in gh_credential_sync.py (../.gh-config relative to JARVIS_PERSIST_DIR).
+ENV GH_CONFIG_DIR=/app/.gh-config
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uvx /bin/uvx

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -170,6 +170,7 @@ if _SPAWNER_ENABLED:
         "list_active_spawns",
         "cancel_spawn_tool",
         "restart_spawn",
+        "resume_spawn",
         "remove_spawned_agent",
         "list_available_servers_tool",
         "spawn_team_tool",

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -323,6 +323,38 @@ class AgentContextSnapshot(Base):
     created_at = Column(Float, default=lambda: datetime.now().timestamp(), index=True)
 
 
+class TeamTemplateHistory(Base):
+    """Audit log for ``team_sessions.template`` edits.
+
+    Append-only: every PATCH / rollback / yaml-reset writes one row. Lets the
+    UI show "who changed what when" and supports 1-click rollback. Schema is
+    identical to the raw DDL emitted by ``scripts/patch_team_template.py``
+    (Phase 0) so audit history is continuous across the migration.
+
+    Field-level granularity (``field`` + ``before_json`` / ``after_json``)
+    means we can attribute and rollback individual server / instruction /
+    skill / override edits without serialising the whole template each time.
+    """
+    __tablename__ = "team_template_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(String(100), nullable=False, index=True)
+    # role is the key inside template.roles (e.g. "qe", "dev"). NULL means a
+    # template-level edit (e.g. team-wide setting). NOT a foreign key — team
+    # sessions can be deleted while we keep the audit trail.
+    role = Column(String(100), nullable=True)
+    # Specific field inside the role config (e.g. "servers", "instruction",
+    # "server_overrides"). NULL means whole-role replace.
+    field = Column(String(100), nullable=True)
+    before_json = Column(Text, nullable=True)  # JSON-encoded prior value
+    after_json = Column(Text, nullable=True)   # JSON-encoded new value
+    # 'ui' | 'api' | 'yaml-reset' | 'phase0-script' | 'rollback'
+    source = Column(String(50), nullable=False)
+    edited_by = Column(String(100), nullable=True, default="system")
+    edited_at = Column(Float, default=lambda: datetime.now().timestamp(), index=True)
+    comment = Column(Text, nullable=True)
+
+
 class CronJobModel(Base):
     """Cron job definition — unified cron model (solar/lunar, one-shot/recurring)."""
     __tablename__ = "cron_jobs"

--- a/backend/fastagent.config.yaml
+++ b/backend/fastagent.config.yaml
@@ -100,10 +100,26 @@ mcp:
         BRAVE_API_KEY: "${BRAVE_API_KEY}"
     filesystem:
       command: "npx"
-      args: ["-y", "@modelcontextprotocol/server-filesystem", "./data", "./jarvis_workspace"]
+      # Default allowed roots ONLY include paths guaranteed to exist after a
+      # clean install. Per-role spawns override these via team_templates
+      # (e.g. agile_team.yaml.server_overrides.filesystem.args → workspace_dir
+      # + skills dir). Adding a path here that doesn't exist on disk causes
+      # @modelcontextprotocol/server-filesystem to fail startup → MCP
+      # handshake fails → agent sees no filesystem tool (incident 2026-05-17
+      # Designer: previous default included `./jarvis_workspace` which is
+      # never created; resumed agents with dropped server_overrides fell
+      # back here and silently lost filesystem access).
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "./data"]
     chrome-devtools:
       command: "npx"
       args: ["-y", "chrome-devtools-mcp@latest"]
+    # Playwright MCP — browser automation + screenshots in headless mode.
+    # Pinned to 0.0.75 (not @latest) so upstream releases can't silently break
+    # Jarvis. Bump deliberately after verifying compatibility.
+    # First-time browser install: `npx playwright install chromium`.
+    playwright:
+      command: "npx"
+      args: ["-y", "@playwright/mcp@0.0.75", "--headless"]
     serpapi:
       url: "https://mcp.serpapi.com/${SERPAPI_API_KEY}/mcp"
     sequential-thinking:
@@ -217,3 +233,25 @@ mcp:
         CONFLUENCE_URL: "${CONFLUENCE_URL}"
         CONFLUENCE_USERNAME: "${CONFLUENCE_USERNAME}"
         CONFLUENCE_API_TOKEN: "${CONFLUENCE_API_TOKEN}"
+        # Explicit toolset allowlist — do NOT rely on upstream's default behaviour.
+        # Upstream is shifting "TOOLSETS unset" from all-enabled to 6-core-only
+        # in v0.22.0. Pinning the list here freezes Jarvis behaviour across
+        # upstream upgrades. Bump deliberately when adding new flows.
+        #   default          = jira_issues,jira_fields,jira_comments,jira_transitions,
+        #                      confluence_pages,confluence_comments
+        #   + jira_users     = get_my_account_id (PM auto-assignee), user_profile lookup
+        #   + jira_projects  = create_project / get_all_projects
+        #   + jira_agile     = boards / sprints
+        #   + jira_links     = link_to_epic / link_types
+        #   + jira_attachments     = upload/download/get images
+        #   + confluence_spaces    = create_space
+        #   + confluence_attachments = upload/download
+        #   + confluence_labels    = tag pages by agent / sprint / phase for filtering
+        # NOT enabled (intentional):
+        #   - jira_watchers  → all agents share 1 account; watchers no-op
+        #   - jira_metrics   → SLA/cycle-time tracking not required for this team
+        #   - jira_worklog   → no time-tracking discipline
+        #   - jira_service_desk, jira_forms → not a customer-support flow
+        #   - confluence_users     → duplicate of jira_users
+        #   - confluence_analytics → page-view tracking not needed
+        TOOLSETS: "default,jira_users,jira_projects,jira_agile,jira_links,jira_attachments,confluence_spaces,confluence_attachments,confluence_labels"

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -24,6 +24,7 @@ from routes.oauth import router as oauth_router
 from routes.system import router as system_router
 from routes.voice import router as voice_router
 from routes.ws_voice import router as ws_voice_router
+from routes.team_template import router as team_template_router
 
 all_routers: list[APIRouter] = [
     auth_router,
@@ -49,4 +50,5 @@ all_routers: list[APIRouter] = [
     system_router,
     voice_router,
     ws_voice_router,
+    team_template_router,
 ]

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -137,6 +137,16 @@ def _compute_effective_status(
     probe).
     """
     raw = (record.get("status") or "unknown")
+    lifecycle_raw = (record.get("lifecycle") or "").lower()
+    # ``completed`` is only authoritative for oneshot agents — they really
+    # are done forever. For resumable agents (post-2026-05-20 merge: every
+    # non-oneshot agent), ``completed`` is a stale label written by the old
+    # spawner; the canonical post-task state is ``idle`` (the agent is
+    # waiting for a follow-up via resume_spawn / auto-resume on inbox).
+    # Mirror the same rule used by ``spawn_progress_bridge`` (live result
+    # event) and ``mark_stale_running`` (startup cleanup).
+    if raw == "completed" and lifecycle_raw and lifecycle_raw != "oneshot":
+        return "idle"
     # Terminal / overlay states are authoritative — never second-guess.
     if raw in {"completed", "error", "killed", "failed", "cancelled",
                "paused", "timeout"}:
@@ -224,6 +234,61 @@ def _compute_effective_status(
 
     # Probe inconclusive (exception).
     return raw
+
+
+def _icon_for_role(record: dict, *, default: str = "smart_toy") -> str:
+    """Pick a Material Symbol icon based on whether this agent is the
+    team's orchestrator.
+
+    Why orchestrator-vs-worker and not role-name lookup? Templates are
+    user-editable and may define arbitrary role names (PM, lead,
+    scrum_master, BA, dev, designer, …). Hard-coding per-role icons
+    (the prior implementation: ``if "PM" in role: icon = ...``) only
+    worked for one specific template and silently fell back to the
+    generic icon for any other naming. The orchestrator concept is the
+    only system-wide invariant — template.orchestrator names whichever
+    role coordinates the team.
+
+    Resolution order:
+      1. ``record["is_orchestrator"]`` if the registry row was tagged
+         (forward-compatible — registry doesn't yet set this).
+      2. Lookup ``team_sessions.template.orchestrator`` for this team
+         and compare to the record's role.
+      3. Fall through to ``default`` for workers.
+    """
+    if record.get("is_orchestrator"):
+        return "assignment_ind"
+
+    team_name = record.get("team_name") or ""
+    role = (record.get("role") or "").strip()
+    if not team_name or not role:
+        return default
+
+    try:
+        # Cheap lookup — one DB read per agent card. The dashboard list
+        # already issues N reads per refresh; this adds 1 SQL query per
+        # team-managed row, so the cost stays in the same order.
+        import json
+
+        from core.agent_registry_db import _connect
+
+        with _connect() as conn:
+            row = conn.execute(
+                """SELECT data_json FROM team_sessions
+                   WHERE json_extract(data_json, '$.team_name') = ?
+                   LIMIT 1""",
+                (team_name,),
+            ).fetchone()
+        if row is None:
+            return default
+        data = json.loads(row["data_json"])
+        orch_role = ((data.get("template") or {}).get("orchestrator") or "").strip()
+        if orch_role and orch_role.lower() == role.lower():
+            return "assignment_ind"
+    except Exception:
+        # Best-effort cosmetic — never block the response on an icon.
+        pass
+    return default
 
 
 def _snapshots_db_path() -> str | None:
@@ -637,15 +702,13 @@ async def list_agents(include_completed: bool = False):
             )
 
             role = record.get("role", "")
-            icon = "smart_toy"
-            if "PM" in role:
-                icon = "assignment_ind"
-            elif "BA" in role:
-                icon = "analytics"
-            elif "Dev" in role:
-                icon = "code"
-            elif "QE" in role or "test" in role.lower():
-                icon = "bug_report"
+            # Icon based on whether this agent is the team's
+            # orchestrator (per template.orchestrator). Worker roles
+            # share a generic icon — adding role-specific icons here
+            # would re-introduce the hard-code we removed in the
+            # 2026-05-19 audit (templates can define arbitrary role
+            # names; only "orchestrator" is a system-wide concept).
+            icon = _icon_for_role(record, default="smart_toy")
             
             model = record.get("original_config", {}).get("model", "")
             if not model:
@@ -827,16 +890,8 @@ def _build_spawn_agent_detail(name: str) -> dict | None:
     role = record.get("role", "")
     team_name = record.get("team_name") or ""
     
-    # Icon based on role
-    icon = "smart_toy"
-    if "PM" in role or "pm" in role:
-        icon = "assignment_ind"
-    elif "BA" in role or "ba" in role:
-        icon = "analytics"
-    elif "Dev" in role or "dev" in role:
-        icon = "code"
-    elif "QE" in role or "test" in role.lower():
-        icon = "bug_report"
+    # Icon by orchestrator-or-not (see _icon_for_role).
+    icon = _icon_for_role(record, default="smart_toy")
     
     # Extract model
     model = orig_cfg.get("model", "")

--- a/backend/routes/skills.py
+++ b/backend/routes/skills.py
@@ -153,3 +153,79 @@ async def detach_skill_route(name: str, agent: str):
         return await svc.detach_skill_from_agent(agent, name)
     except svc.SkillValidationError as exc:
         _raise(exc)
+
+
+# ----- Reload (blast radius + force-kill respawn) -------------------------
+#
+# Skills are file-based; agents read them at spawn time. After ``PUT /api/skills/{name}``
+# the content on disk is updated but every alive agent still holds the
+# pre-edit version in memory. These two endpoints give the dashboard:
+#
+#   GET  /{name}/reload-preview  → who would be affected, no side-effects
+#   POST /{name}/reload          → force-kill + respawn (requires confirm)
+#
+# Per user decision 2026-05-17: no wait-for-idle; explicit confirm dialog.
+# Cross-team operation: one skill is typically referenced by many roles in
+# many sessions (e.g. team-communication). We reload across all of them.
+
+
+class SkillReloadBody(BaseModel):
+    confirm: bool = Field(False, description="MUST be true; UI shows blast-radius warning before set.")
+    inject_message: str | None = Field(
+        None,
+        description="Override the default sentinel sent to each respawned agent.",
+    )
+
+
+@router.get(
+    "/{name}/reload-preview",
+    dependencies=[Depends(verify_api_key)],
+)
+async def reload_preview(name: str):
+    """Show which teams + roles + agents would be force-killed by /reload.
+
+    Pure read — no kills, no respawn. UI calls this to render the
+    confirmation dialog ("This will restart 7 agents across 2 teams").
+    """
+    from services.team_reload import find_sessions_using_skill
+
+    sessions = find_sessions_using_skill(name)
+    agent_count = sum(len(s["roles"]) for s in sessions)  # rough — 1 agent per role
+    return {
+        "skill": name,
+        "sessions": sessions,
+        "session_count": len(sessions),
+        "approx_agent_count": agent_count,
+        "warning": (
+            "Reloading will SIGKILL every running agent that has this skill "
+            "and respawn them mid-task. In-flight tool calls will abort."
+            if agent_count > 0
+            else "No alive agents use this skill — reload is a no-op."
+        ),
+    }
+
+
+@router.post(
+    "/{name}/reload",
+    dependencies=[Depends(verify_api_key)],
+)
+async def reload_skill(name: str, body: SkillReloadBody):
+    """Force-kill + respawn every agent using ``name``.
+
+    Requires ``confirm: true``. Returns per-session results so the UI can
+    show which agents successfully respawned vs. errored.
+    """
+    if not body.confirm:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "destructive operation requires {confirm: true}. Call "
+                f"GET /api/skills/{name}/reload-preview first to compute "
+                "blast radius."
+            ),
+        )
+
+    from services.team_reload import reload_by_skill
+
+    out = await reload_by_skill(name, edited_by="system", inject_message=body.inject_message)
+    return out

--- a/backend/routes/team_template.py
+++ b/backend/routes/team_template.py
@@ -1,0 +1,350 @@
+"""Team-session template REST API.
+
+Endpoints (all gated by ``verify_api_key``, all under
+``/api/team-sessions/{session_id}/``):
+
+  GET    /template                          → current template (fresh DB read)
+  PATCH  /template/roles/{role}             → edit one role's config; audits
+  GET    /template/history                  → audit log (newest first)
+  POST   /template/rollback/{audit_id}      → revert one audit row
+  POST   /template/reset/{role}             → reset role from yaml factory
+  POST   /reload                            → force-kill + respawn given roles
+
+Phase 1 (per user decisions 2026-05-17):
+  - YAML is factory default; UI edits NOT persisted to yaml automatically.
+    Warning to caller: edits are lost if the team is reset or recreated
+    without committing the equivalent change to ``team_templates/*.yaml``.
+  - Reload is force-kill-and-respawn (no wait-for-idle); explicit ``confirm``
+    flag on /reload guards against accidental clicks.
+  - Versioning from row 1; every PATCH writes an audit row; rollback writes
+    a NEW row referencing the original (never deletes).
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.auth import verify_api_key
+from core.database import get_db
+from services import team_template_service as svc
+from services.team_reload import reload_roles
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/team-sessions", tags=["team-template"])
+
+# Yaml templates dir — used by /reset/{role} to look up the factory default.
+_YAML_DIR = Path(__file__).resolve().parent.parent / "team_templates"
+
+
+def _resolve_yaml_for_session(session_id: str) -> Path:
+    """Locate the yaml template for a team session.
+
+    Reads ``team_sessions.template.name`` to find which yaml the team was
+    created from (e.g. 'agile-team' → 'agile_team.yaml').
+    """
+    template = svc.get_template(session_id)
+    name = template.get("name") or "agile-team"
+    candidate = _YAML_DIR / f"{name.replace('-', '_')}.yaml"
+    if not candidate.exists():
+        # Fallback: try literal name
+        candidate = _YAML_DIR / f"{name}.yaml"
+    return candidate
+
+
+class PatchRoleBody(BaseModel):
+    """Body for PATCH /template/roles/{role}.
+
+    Caller supplies only the fields they want to change. Unknown fields are
+    rejected by ``svc.validate_patch`` — keeps the API surface minimal.
+    """
+    patch: dict[str, Any] = Field(..., description="Partial role config, keys subset of svc.ALLOWED_ROLE_FIELDS")
+    comment: str = Field("", description="Free-text audit comment; shown in history UI")
+
+
+class ReloadBody(BaseModel):
+    """Body for POST /reload — guarded with explicit confirm flag."""
+    roles: list[str] = Field(..., description="Role keys to force-kill + respawn")
+    confirm: bool = Field(False, description="MUST be true. UI shows a warning before setting.")
+    inject_message: str | None = Field(
+        None,
+        description="Override the default sentinel message sent to each respawned agent.",
+    )
+
+
+class RollbackBody(BaseModel):
+    comment: str = Field("", description="Why rolling back")
+
+
+class ResetBody(BaseModel):
+    comment: str = Field("", description="Why resetting to yaml factory")
+
+
+@router.get(
+    "/{session_id}/template",
+    dependencies=[Depends(verify_api_key)],
+)
+async def get_template(session_id: str):
+    """Return current template dict for the session (always fresh from DB)."""
+    try:
+        return {"session_id": session_id, "template": svc.get_template(session_id)}
+    except svc.NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.patch(
+    "/{session_id}/template/roles/{role}",
+    dependencies=[Depends(verify_api_key)],
+)
+async def patch_role(
+    session_id: str,
+    role: str,
+    body: PatchRoleBody,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Apply a per-role patch. One audit row per changed field.
+
+    The change is persisted to DB SSoT but does NOT touch the yaml template.
+    To make edits survive a team-reset / recreate, the caller must commit
+    the equivalent change to ``team_templates/*.yaml``. UI should show this
+    warning.
+    """
+    edited_by = _principal(request)
+    try:
+        result = svc.apply_role_patch(
+            db,
+            session_id,
+            role,
+            body.patch,
+            edited_by=edited_by,
+            source="api",
+            comment=body.comment,
+        )
+    except svc.ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except svc.NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except svc.ConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    return {
+        "session_id": session_id,
+        "role": role,
+        **result,
+        "warning": (
+            "Edit applied to DB. To survive a team recreate / reset, also "
+            "commit the equivalent change to team_templates/<team>.yaml."
+        ),
+    }
+
+
+@router.get(
+    "/{session_id}/template/history",
+    dependencies=[Depends(verify_api_key)],
+)
+async def get_history(
+    session_id: str,
+    role: str | None = None,
+    limit: int = 50,
+    db: Session = Depends(get_db),
+):
+    """Audit log, newest first. Optionally filter by ``role``."""
+    rows = svc.get_history(db, session_id, role=role, limit=limit)
+    return {"session_id": session_id, "role": role, "count": len(rows), "rows": rows}
+
+
+@router.post(
+    "/{session_id}/template/rollback/{audit_id}",
+    dependencies=[Depends(verify_api_key)],
+)
+async def rollback(
+    session_id: str,
+    audit_id: int,
+    body: RollbackBody,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Revert the field referenced by ``audit_id`` to its prior value.
+
+    Writes a NEW history row (source='rollback'). The original row is kept.
+    Caller responsibility: choose the right audit_id — if multiple edits
+    touched the same field after the target row, rolling back to the
+    earliest will silently discard intermediate changes.
+    """
+    edited_by = _principal(request)
+    try:
+        result = svc.rollback_to(
+            db, session_id, audit_id, edited_by=edited_by, comment=body.comment,
+        )
+    except svc.NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except svc.ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except svc.ConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {"session_id": session_id, "audit_id": audit_id, **result}
+
+
+@router.post(
+    "/{session_id}/template/reset/{role}",
+    dependencies=[Depends(verify_api_key)],
+)
+async def reset_role(
+    session_id: str,
+    role: str,
+    body: ResetBody,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """Reset one role's config back to the yaml factory default.
+
+    Writes audit rows for every field that diverged. Other roles untouched.
+    """
+    edited_by = _principal(request)
+    yaml_path = _resolve_yaml_for_session(session_id)
+    try:
+        result = svc.reset_role_to_yaml(
+            db,
+            session_id,
+            role,
+            yaml_path,
+            edited_by=edited_by,
+            comment=body.comment,
+        )
+    except svc.NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except svc.ConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    return {
+        "session_id": session_id,
+        "role": role,
+        "yaml_path": str(yaml_path),
+        **result,
+    }
+
+
+@router.get(
+    "/{session_id}/template/yaml-diff",
+    dependencies=[Depends(verify_api_key)],
+)
+async def yaml_diff(session_id: str):
+    """Compare the running team's template with its yaml factory default.
+
+    READ-ONLY — never modifies the running team. Returns a per-role diff
+    so the UI can show "yaml has 3 changes since this team was created;
+    review and click Reset-to-yaml or Reload-from-yaml to apply".
+
+    Decision 2026-05-17: yaml is FACTORY DEFAULT, not continuous source.
+    This endpoint lets the user *see* drift without enforcing convergence.
+    """
+    import yaml as yaml_lib
+
+    try:
+        current_template = svc.get_template(session_id)
+    except svc.NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    yaml_path = _resolve_yaml_for_session(session_id)
+    if not yaml_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"factory yaml not found at {yaml_path}",
+        )
+
+    with yaml_path.open(encoding="utf-8") as f:
+        yaml_doc = yaml_lib.safe_load(f) or {}
+    yaml_template = yaml_doc.get("team") or yaml_doc
+    yaml_roles = yaml_template.get("roles") or {}
+    current_roles = current_template.get("roles") or {}
+
+    per_role: dict[str, dict] = {}
+    all_roles = set(yaml_roles) | set(current_roles)
+    for role in all_roles:
+        before = yaml_roles.get(role)
+        after = current_roles.get(role)
+        if before is None:
+            per_role[role] = {"status": "added_in_db", "yaml": None, "current": after}
+            continue
+        if after is None:
+            per_role[role] = {"status": "removed_from_db", "yaml": before, "current": None}
+            continue
+        diff = svc.compute_role_diff(before, after)
+        if diff:
+            per_role[role] = {"status": "diverged", "fields": diff}
+        else:
+            per_role[role] = {"status": "in_sync"}
+
+    diverged = {r: v for r, v in per_role.items() if v["status"] != "in_sync"}
+    return {
+        "session_id": session_id,
+        "yaml_path": str(yaml_path),
+        "in_sync": not diverged,
+        "diverged_count": len(diverged),
+        "per_role": per_role,
+    }
+
+
+@router.post(
+    "/{session_id}/reload",
+    dependencies=[Depends(verify_api_key)],
+)
+async def reload_team(
+    session_id: str,
+    body: ReloadBody,
+    request: Request,
+):
+    """Force-kill + respawn agents for the given roles.
+
+    Destructive: agents in the named roles are SIGKILLed mid-task if they
+    are running. Use only after a confirmation dialog. ``confirm: true``
+    must be present in the body to proceed.
+
+    For each affected agent we:
+      1. Find latest spawn record + its PID
+      2. SIGTERM, wait 2s, SIGKILL if still alive
+      3. Respawn via inject_resume → fresh team_sessions.template from DB
+    """
+    if not body.confirm:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "destructive operation requires {confirm: true}. UI should "
+                "show a warning explaining that running agents will be "
+                "force-killed mid-task."
+            ),
+        )
+    if not body.roles:
+        raise HTTPException(status_code=400, detail="'roles' must be non-empty")
+
+    edited_by = _principal(request)
+    try:
+        results = await reload_roles(
+            session_id=session_id,
+            roles=body.roles,
+            edited_by=edited_by,
+            inject_message=body.inject_message,
+        )
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return {"session_id": session_id, "results": results}
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _principal(request: Request) -> str:
+    """Best-effort actor attribution for audit rows.
+
+    The product is single-user today (per user decision: "không multi
+    tenant, default là system đi"); reserve the column for the future. If
+    a request principal becomes available we can read it from request.state
+    or from a JWT claim here without touching call sites.
+    """
+    actor = getattr(request.state, "principal", None)
+    return actor or "system"

--- a/backend/scripts/cleanup_jlp_artifacts.py
+++ b/backend/scripts/cleanup_jlp_artifacts.py
@@ -1,0 +1,466 @@
+"""One-shot cleanup: drop all artifacts the prior ``agile-team`` session
+created so the user can re-test the team flow from a clean slate.
+
+Scope of cleanup
+----------------
+1. Delete every remaining Jira issue in project ``JLP``.
+2. Delete the Jira project ``JLP`` itself (Cloud REST API — requires
+   admin permission on the project).
+3. Delete every page in Confluence space ``JLP`` (then optionally
+   delete the space itself).
+4. Drop the stale ``team_sessions`` row ``be885ae8`` from the local
+   jarvis SQLite — the team is gone, the row should be gone too. This
+   also removes the orchestrator session id from the next
+   ``list_team_sessions`` call and from the dashboard team list.
+5. Print a clear next-step (restart backend) so the user can re-spawn
+   the team with the fresh code paths.
+
+Why a script instead of inline tool calls
+-----------------------------------------
+Cleanup hits 3 external systems + 1 local DB and is destructive. Doing
+it inline via N separate MCP tool calls failed the agent's
+auto-classifier (mass-deletion guard fires on per-call basis when the
+caller doesn't bundle the work into one explicit batch). A single
+script with ``--dry-run`` / ``--apply`` is auditable, reviewable, and
+fits the project's existing pattern (see ``cleanup_orphan_spawns.py``
+for the same idiom applied to spawn registry rows).
+
+Credentials
+-----------
+The script reads Jira/Confluence credentials in the following order
+(first hit wins):
+
+  1. Process env: ``JIRA_URL`` / ``JIRA_USERNAME`` / ``JIRA_API_TOKEN``
+     and the matching ``CONFLUENCE_*`` variants. Use this when running
+     outside of Claude Code (e.g. CI).
+  2. ``~/.claude.json`` → ``mcpServers.mcp-atlassian.env`` — the same
+     bag of variables Claude Code's MCP atlassian server already uses.
+     If Confluence credentials are missing, Atlassian Cloud convention
+     applies: ``CONFLUENCE_URL = JIRA_URL + '/wiki'`` and the same
+     account/token is reused (one token serves both Jira + Confluence
+     for a Cloud account).
+
+The script does NOT prompt for tokens at runtime — that would leak
+into terminal history. If neither source above has credentials, the
+script exits cleanly and prints the env variables the operator must
+export.
+
+Usage
+-----
+::
+
+    # Preview only (no writes)
+    python scripts/cleanup_jlp_artifacts.py --dry-run
+
+    # Execute
+    python scripts/cleanup_jlp_artifacts.py --apply
+
+    # Skip a particular phase (e.g. keep the team_sessions row)
+    python scripts/cleanup_jlp_artifacts.py --apply --skip-db
+
+    # Also delete the Confluence space (default: only pages)
+    python scripts/cleanup_jlp_artifacts.py --apply --delete-space
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+logger = logging.getLogger("cleanup_jlp")
+
+PROJECT_KEY = "JLP"
+SPACE_KEY = "JLP"
+TEAM_SESSION_ID = "be885ae8"  # the team session whose artifacts we're dropping
+JARVIS_DB_DEFAULT = (
+    Path(__file__).resolve().parent.parent / "data" / "jarvis.db"
+)
+
+
+# ── credential resolution ──────────────────────────────────────────────────
+
+
+def _load_claude_mcp_env() -> dict[str, str]:
+    """Read ``mcpServers.mcp-atlassian.env`` from ``~/.claude.json``.
+
+    Returns ``{}`` if the file is unreadable or the key path is absent.
+    No exception is raised — fall through to env vars in that case.
+    """
+    path = Path.home() / ".claude.json"
+    if not path.exists():
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        env = (
+            data.get("mcpServers", {})
+            .get("mcp-atlassian", {})
+            .get("env", {})
+        ) or {}
+        return {k: str(v) for k, v in env.items() if v}
+    except Exception as exc:
+        logger.debug("could not read claude.json mcp env: %s", exc)
+        return {}
+
+
+def _resolve_creds() -> tuple[dict[str, str], list[str]]:
+    """Resolve Jira + Confluence credentials.
+
+    Returns ``(creds, missing)``. ``creds`` carries the keys we
+    successfully filled; ``missing`` is the list of env vars the caller
+    still has to export. If ``missing`` is non-empty the caller MUST
+    abort before touching any external system.
+    """
+    claude_env = _load_claude_mcp_env()
+    creds: dict[str, str] = {}
+
+    # Jira: env first, then claude.json.
+    for key in ("JIRA_URL", "JIRA_USERNAME", "JIRA_API_TOKEN"):
+        val = os.getenv(key) or claude_env.get(key)
+        if val:
+            creds[key] = val.rstrip("/") if key == "JIRA_URL" else val
+
+    # Confluence: env, then claude.json, then Atlassian Cloud default
+    # (same account, JIRA_URL + /wiki, same token).
+    creds.setdefault(
+        "CONFLUENCE_URL",
+        os.getenv("CONFLUENCE_URL")
+        or claude_env.get("CONFLUENCE_URL")
+        or (f"{creds['JIRA_URL']}/wiki" if creds.get("JIRA_URL") else ""),
+    )
+    creds.setdefault(
+        "CONFLUENCE_USERNAME",
+        os.getenv("CONFLUENCE_USERNAME")
+        or claude_env.get("CONFLUENCE_USERNAME")
+        or creds.get("JIRA_USERNAME", ""),
+    )
+    creds.setdefault(
+        "CONFLUENCE_API_TOKEN",
+        os.getenv("CONFLUENCE_API_TOKEN")
+        or claude_env.get("CONFLUENCE_API_TOKEN")
+        or creds.get("JIRA_API_TOKEN", ""),
+    )
+
+    missing = [k for k in (
+        "JIRA_URL", "JIRA_USERNAME", "JIRA_API_TOKEN",
+        "CONFLUENCE_URL", "CONFLUENCE_USERNAME", "CONFLUENCE_API_TOKEN",
+    ) if not creds.get(k)]
+    return creds, missing
+
+
+# ── Jira phase ─────────────────────────────────────────────────────────────
+
+
+def _jira_list_issues(creds: dict[str, str]) -> list[dict[str, Any]]:
+    """List every issue in PROJECT_KEY via the JQL search endpoint.
+
+    Uses the new ``/rest/api/3/search/jql`` endpoint (Atlassian Cloud
+    2024 migration — the legacy ``/search`` returns 410 Gone). The new
+    endpoint paginates with ``nextPageToken`` instead of ``startAt``.
+    """
+    issues: list[dict[str, Any]] = []
+    token: str | None = None
+    auth = HTTPBasicAuth(creds["JIRA_USERNAME"], creds["JIRA_API_TOKEN"])
+    while True:
+        params: dict[str, Any] = {
+            "jql": f"project = {PROJECT_KEY}",
+            "fields": "summary,issuetype",
+            "maxResults": 100,
+        }
+        if token:
+            params["nextPageToken"] = token
+        resp = requests.get(
+            f"{creds['JIRA_URL']}/rest/api/3/search/jql",
+            params=params,
+            auth=auth,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        batch = data.get("issues", [])
+        issues.extend(batch)
+        token = data.get("nextPageToken")
+        if not token or not batch:
+            break
+    return issues
+
+
+def _jira_delete_issue(creds: dict[str, str], key: str) -> None:
+    auth = HTTPBasicAuth(creds["JIRA_USERNAME"], creds["JIRA_API_TOKEN"])
+    resp = requests.delete(
+        f"{creds['JIRA_URL']}/rest/api/3/issue/{key}",
+        params={"deleteSubtasks": "true"},
+        auth=auth,
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+def _jira_delete_project(creds: dict[str, str]) -> None:
+    auth = HTTPBasicAuth(creds["JIRA_USERNAME"], creds["JIRA_API_TOKEN"])
+    resp = requests.delete(
+        f"{creds['JIRA_URL']}/rest/api/3/project/{PROJECT_KEY}",
+        auth=auth,
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+# ── Confluence phase ───────────────────────────────────────────────────────
+
+
+def _confluence_list_pages(creds: dict[str, str]) -> list[dict[str, Any]]:
+    """List every page in SPACE_KEY via the Cloud v1 API.
+
+    Uses the v1 ``/rest/api/content`` endpoint because it supports the
+    ``spaceKey`` filter on Cloud without needing the v2 space id. Page
+    size 100 — small spaces will fit in one round-trip.
+    """
+    auth = HTTPBasicAuth(
+        creds["CONFLUENCE_USERNAME"], creds["CONFLUENCE_API_TOKEN"],
+    )
+    pages: list[dict[str, Any]] = []
+    start = 0
+    while True:
+        resp = requests.get(
+            f"{creds['CONFLUENCE_URL']}/rest/api/content",
+            params={
+                "spaceKey": SPACE_KEY,
+                "limit": 100,
+                "start": start,
+                "expand": "version",
+            },
+            auth=auth,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        batch = data.get("results", [])
+        pages.extend(batch)
+        if not batch or len(batch) < 100:
+            break
+        start += len(batch)
+    return pages
+
+
+def _confluence_delete_page(creds: dict[str, str], page_id: str) -> None:
+    auth = HTTPBasicAuth(
+        creds["CONFLUENCE_USERNAME"], creds["CONFLUENCE_API_TOKEN"],
+    )
+    resp = requests.delete(
+        f"{creds['CONFLUENCE_URL']}/rest/api/content/{page_id}",
+        auth=auth,
+        timeout=30,
+    )
+    # 204 No Content is the success contract.
+    resp.raise_for_status()
+
+
+def _confluence_delete_space(creds: dict[str, str]) -> None:
+    auth = HTTPBasicAuth(
+        creds["CONFLUENCE_USERNAME"], creds["CONFLUENCE_API_TOKEN"],
+    )
+    # v1 space-delete kicks off an async long-running task.
+    resp = requests.delete(
+        f"{creds['CONFLUENCE_URL']}/rest/api/space/{SPACE_KEY}",
+        auth=auth,
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+# ── Local DB phase ────────────────────────────────────────────────────────
+
+
+def _db_drop_team_session(db_path: Path) -> bool:
+    """Delete the team_sessions row for TEAM_SESSION_ID.
+
+    Returns True iff a row existed and was removed.
+    """
+    if not db_path.exists():
+        return False
+    with sqlite3.connect(str(db_path)) as conn:
+        existed = conn.execute(
+            "SELECT 1 FROM team_sessions WHERE session_id = ?",
+            (TEAM_SESSION_ID,),
+        ).fetchone() is not None
+        if existed:
+            conn.execute(
+                "DELETE FROM team_sessions WHERE session_id = ?",
+                (TEAM_SESSION_ID,),
+            )
+            conn.commit()
+        return existed
+
+
+# ── orchestration ──────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument(
+        "--skip-jira", action="store_true",
+        help="leave Jira issues + project intact",
+    )
+    parser.add_argument(
+        "--skip-confluence", action="store_true",
+        help="leave Confluence pages intact",
+    )
+    parser.add_argument(
+        "--delete-space", action="store_true",
+        help="also delete the Confluence space JLP (default: pages only)",
+    )
+    parser.add_argument(
+        "--skip-db", action="store_true",
+        help="leave the team_sessions row in jarvis.db",
+    )
+    parser.add_argument("--db", default=str(JARVIS_DB_DEFAULT))
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+    )
+
+    if args.apply == args.dry_run:
+        logger.error("Pass exactly one of --dry-run or --apply.")
+        return 1
+
+    creds, missing = _resolve_creds()
+    if not args.skip_jira or not args.skip_confluence:
+        if missing:
+            logger.error(
+                "Missing credentials: %s.\n\n"
+                "Either export them as env vars and re-run, or add them "
+                "to ``~/.claude.json`` → mcpServers.mcp-atlassian.env. "
+                "(Atlassian Cloud uses the same account+token for both "
+                "Jira and Confluence; the Confluence base URL is "
+                "JIRA_URL + '/wiki'.)",
+                ", ".join(missing),
+            )
+            return 2
+
+    rc = 0
+
+    # ── Jira ──
+    if not args.skip_jira:
+        logger.info("[Jira] enumerating issues in project %s …", PROJECT_KEY)
+        try:
+            issues = _jira_list_issues(creds)
+        except Exception as exc:
+            logger.error("[Jira] list failed: %s", exc)
+            return 3
+        logger.info("[Jira] found %d issue(s)", len(issues))
+        for issue in issues:
+            key = issue["key"]
+            summary = issue.get("fields", {}).get("summary", "")
+            logger.info("  - %s — %s", key, summary[:80])
+        if args.apply:
+            for issue in issues:
+                try:
+                    _jira_delete_issue(creds, issue["key"])
+                    logger.info("[Jira] deleted %s", issue["key"])
+                except Exception as exc:
+                    logger.warning("[Jira] delete %s failed: %s", issue["key"], exc)
+                    rc = max(rc, 4)
+
+            logger.info("[Jira] deleting project %s …", PROJECT_KEY)
+            try:
+                _jira_delete_project(creds)
+                logger.info("[Jira] project %s deleted", PROJECT_KEY)
+            except Exception as exc:
+                logger.error("[Jira] project delete failed: %s", exc)
+                rc = max(rc, 5)
+        else:
+            logger.info(
+                "[Jira] DRY-RUN — %d issue(s) and project %s would be deleted",
+                len(issues), PROJECT_KEY,
+            )
+
+    # ── Confluence ──
+    if not args.skip_confluence:
+        logger.info("[Confluence] enumerating pages in space %s …", SPACE_KEY)
+        try:
+            pages = _confluence_list_pages(creds)
+        except Exception as exc:
+            logger.error("[Confluence] list failed: %s", exc)
+            return 6
+        logger.info("[Confluence] found %d page(s)", len(pages))
+        for page in pages:
+            logger.info(
+                "  - %s — %s",
+                page.get("id"), (page.get("title") or "")[:80],
+            )
+        if args.apply:
+            for page in pages:
+                pid = page.get("id")
+                if not pid:
+                    continue
+                try:
+                    _confluence_delete_page(creds, pid)
+                    logger.info("[Confluence] deleted page %s", pid)
+                except Exception as exc:
+                    logger.warning(
+                        "[Confluence] delete page %s failed: %s", pid, exc,
+                    )
+                    rc = max(rc, 7)
+            if args.delete_space:
+                logger.info("[Confluence] deleting space %s …", SPACE_KEY)
+                try:
+                    _confluence_delete_space(creds)
+                    logger.info(
+                        "[Confluence] space %s delete requested (async)",
+                        SPACE_KEY,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "[Confluence] space delete failed: %s", exc,
+                    )
+                    rc = max(rc, 8)
+        else:
+            extras = "+ space" if args.delete_space else "(pages only)"
+            logger.info(
+                "[Confluence] DRY-RUN — %d page(s) %s would be deleted",
+                len(pages), extras,
+            )
+
+    # ── Local DB ──
+    if not args.skip_db:
+        if args.apply:
+            removed = _db_drop_team_session(Path(args.db))
+            logger.info(
+                "[DB] team_sessions row %s %s",
+                TEAM_SESSION_ID,
+                "deleted" if removed else "not found (already clean)",
+            )
+        else:
+            logger.info(
+                "[DB] DRY-RUN — would drop team_sessions row %s from %s",
+                TEAM_SESSION_ID, args.db,
+            )
+
+    if args.apply and rc == 0:
+        logger.info(
+            "\n[OK] cleanup complete. Restart the backend so the next "
+            "spawn picks up a clean state:\n"
+            "  pkill -f 'uvicorn server:app' ; "
+            "nohup uv run uvicorn server:app --host 0.0.0.0 --port 8000 "
+            "> /tmp/backend.out 2>&1 &"
+        )
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/cleanup_orphan_spawns.py
+++ b/backend/scripts/cleanup_orphan_spawns.py
@@ -1,0 +1,160 @@
+"""One-time reconciliation: remove orphan ``spawn_registry`` rows where a
+team-managed agent was registered with a non-distinct identity.
+
+Why this script exists
+----------------------
+Incident 2026-05-17: a silent fallback in ``isolated_spawner.run_isolated_agent_background``
+(``agent_name=agent_name or role or "agent"``) substituted the role string
+when a caller forgot to pass ``agent_name``. The team-managed PM was
+registered twice — once as ``"Robin [PM]"`` (correct) and once as
+``"pm"`` (just the role). The dashboard, treating ``agent_name`` as the
+unique identity, rendered two separate cards for one logical agent.
+
+The runtime validator in :class:`SpawnRegistry` now rejects future writes
+of this shape. This script cleans up the historical rows that landed
+BEFORE the validator was deployed.
+
+It is intentionally Python (matches repo style), idempotent (safe to
+re-run), and supports ``--dry-run`` so an operator can preview the diff
+before deleting.
+
+After this script lands and runs once, it should NOT need to run again —
+the runtime validator prevents the bug class from recurring. Keep the
+script in-tree as documentation of the recovery operation.
+
+Usage::
+
+    # Preview which rows would be deleted (no DB writes)
+    python scripts/cleanup_orphan_spawns.py --dry-run
+
+    # Actually delete
+    python scripts/cleanup_orphan_spawns.py --apply
+
+    # Filter to a specific team
+    python scripts/cleanup_orphan_spawns.py --apply --team jarvis-landing-jira-confluence
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("cleanup_orphan_spawns")
+
+DEFAULT_DB = Path(__file__).resolve().parent.parent / "data" / "jarvis.db"
+
+
+def find_orphans(db_path: Path, team: str | None = None) -> list[dict]:
+    """Find rows where team_name is set AND agent_name equals role (or empty)."""
+    if not db_path.exists():
+        raise FileNotFoundError(db_path)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute("SELECT run_id, data_json FROM spawn_registry").fetchall()
+    finally:
+        conn.close()
+
+    orphans: list[dict] = []
+    for run_id, data_json in rows:
+        try:
+            rec = json.loads(data_json)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        tn = rec.get("team_name") or ""
+        role = rec.get("role") or ""
+        agent_name = rec.get("agent_name") or ""
+        if not tn:
+            continue  # ad-hoc spawn — out of scope
+        if team and tn != team:
+            continue
+        if not agent_name or agent_name == role:
+            orphans.append({
+                "run_id": run_id,
+                "team_name": tn,
+                "role": role,
+                "agent_name": agent_name,
+                "status": rec.get("status"),
+                "pid": rec.get("pid"),
+                "started_at": rec.get("started_at"),
+                # Surface the ORIGINAL config's agent_name — usually correct,
+                # which proves the orphan is "same logical agent, wrong row".
+                "original_config_agent_name": (
+                    (rec.get("original_config") or {}).get("agent_name")
+                ),
+            })
+    return orphans
+
+
+def delete_run_ids(db_path: Path, run_ids: list[str]) -> int:
+    if not run_ids:
+        return 0
+    conn = sqlite3.connect(str(db_path))
+    try:
+        placeholders = ",".join("?" for _ in run_ids)
+        cur = conn.execute(
+            f"DELETE FROM spawn_registry WHERE run_id IN ({placeholders})",
+            run_ids,
+        )
+        conn.commit()
+        return cur.rowcount or 0
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--db", default=str(DEFAULT_DB), help="path to jarvis.db")
+    parser.add_argument("--team", default=None, help="restrict cleanup to one team_name")
+    parser.add_argument("--dry-run", action="store_true", help="preview only, no writes")
+    parser.add_argument("--apply", action="store_true", help="actually delete")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+    )
+
+    if args.apply == args.dry_run:
+        # Either both set or neither — force the operator to pick one.
+        logger.error("Specify exactly one of --apply or --dry-run.")
+        return 1
+
+    db_path = Path(args.db)
+    try:
+        orphans = find_orphans(db_path, team=args.team)
+    except FileNotFoundError:
+        logger.error("DB not found: %s", db_path)
+        return 2
+
+    if not orphans:
+        logger.info("[OK] no orphan spawn_registry rows found")
+        return 0
+
+    logger.info("Found %d orphan row(s):", len(orphans))
+    for o in orphans:
+        logger.info(
+            "  - run_id=%s team=%s role=%s agent_name=%r (orig_config.agent_name=%r) status=%s pid=%s",
+            o["run_id"], o["team_name"], o["role"], o["agent_name"],
+            o["original_config_agent_name"], o["status"], o["pid"],
+        )
+
+    if args.dry_run:
+        logger.info("[DRY-RUN] no rows deleted. Re-run with --apply to delete.")
+        return 0
+
+    run_ids = [o["run_id"] for o in orphans]
+    deleted = delete_run_ids(db_path, run_ids)
+    logger.info("[OK] deleted %d row(s)", deleted)
+    logger.info(
+        "Reload the dashboard — the stale agent card should be gone. "
+        "Future writes of this shape are blocked by SpawnRegistry validator."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/patch_team_template.py
+++ b/backend/scripts/patch_team_template.py
@@ -1,0 +1,229 @@
+"""Phase 0 throwaway: patch a running team's template directly in DB.
+
+Why this exists
+---------------
+`team_sessions.template` is a JSON snapshot frozen at team creation time. When
+`team_templates/*.yaml` is updated AFTER a team is running, the running team
+does NOT pick up the change (e.g. 2026-05-17 incident: QE missing playwright).
+
+This script is the manual fix until Phase 1 lands the proper edit endpoints.
+It is intentionally Python (matches repo style) and idempotent so it can be
+re-run safely. Every edit writes an audit row to ``team_template_history`` —
+the same table Phase 1's REST API will use, so audit history stays continuous
+across the migration.
+
+Usage
+-----
+    python scripts/patch_team_template.py \\
+        --session-id be885ae8 --role qe \\
+        --add-servers playwright \\
+        --comment "phase 0 manual fix — yaml had playwright, frozen DB didn't"
+
+    # multiple ops in one call
+    python scripts/patch_team_template.py \\
+        --session-id be885ae8 --role dev \\
+        --add-servers playwright \\
+        --remove-servers some-old-server \\
+        --dry-run
+
+The script:
+  1. Reads ``team_sessions.data_json`` for the session
+  2. Walks to ``template.roles[role].servers``
+  3. Applies add/remove ops (de-duplicated, order preserved)
+  4. CREATE TABLE IF NOT EXISTS ``team_template_history`` (matches Phase 1 schema)
+  5. INSERT audit row (before_json, after_json, source='phase0-script')
+  6. UPDATE ``team_sessions`` atomically (single transaction)
+
+The script does NOT kill running agent processes. After patching, the next
+agent spawn (auto-resume / inject / restart) reads fresh from DB and picks up
+the new server list. To force immediate effect, kill the agent process tree
+manually and re-inject.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+logger = logging.getLogger("patch_team_template")
+
+# Match Phase 1 schema exactly so history persists across the migration.
+AUDIT_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS team_template_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id VARCHAR(100) NOT NULL,
+    role VARCHAR(100),
+    field VARCHAR(100),
+    before_json TEXT,
+    after_json TEXT,
+    source VARCHAR(50) NOT NULL,
+    edited_by VARCHAR(100),
+    edited_at FLOAT NOT NULL,
+    comment TEXT
+)
+"""
+AUDIT_IDX_SESSION = "CREATE INDEX IF NOT EXISTS idx_tth_session_id ON team_template_history(session_id)"
+AUDIT_IDX_TIME = "CREATE INDEX IF NOT EXISTS idx_tth_edited_at ON team_template_history(edited_at)"
+
+DEFAULT_DB = Path(__file__).resolve().parent.parent / "data" / "jarvis.db"
+
+
+def _apply_server_ops(servers: list[str], add: list[str], remove: list[str]) -> list[str]:
+    """Return new server list. Preserves order, de-duplicates, idempotent."""
+    out = list(servers)
+    for s in add:
+        if s not in out:
+            out.append(s)
+    out = [s for s in out if s not in remove]
+    return out
+
+
+def patch(
+    db_path: Path,
+    session_id: str,
+    role: str,
+    add_servers: list[str],
+    remove_servers: list[str],
+    comment: str,
+    edited_by: str = "system",
+    source: str = "phase0-script",
+    dry_run: bool = False,
+) -> int:
+    """Apply the patch. Returns 0 on success, non-zero on error."""
+    if not db_path.exists():
+        logger.error("DB file not found: %s", db_path)
+        return 2
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT data_json FROM team_sessions WHERE session_id=?", (session_id,))
+        row = cur.fetchone()
+        if not row:
+            logger.error("No team_sessions row for session_id=%r", session_id)
+            return 3
+
+        data = json.loads(row[0])
+        roles = data.get("template", {}).get("roles", {})
+        if role not in roles:
+            logger.error(
+                "Role %r not found in team template. Available: %s",
+                role, sorted(roles.keys()),
+            )
+            return 4
+
+        before_servers = list(roles[role].get("servers", []))
+        after_servers = _apply_server_ops(before_servers, add_servers, remove_servers)
+
+        if before_servers == after_servers:
+            logger.info(
+                "[NOOP] %s/%s servers already in desired state: %s",
+                session_id, role, before_servers,
+            )
+            return 0
+
+        logger.info("[%s/%s] servers", session_id, role)
+        logger.info("  BEFORE: %s", before_servers)
+        logger.info("  AFTER:  %s", after_servers)
+        added = [s for s in after_servers if s not in before_servers]
+        removed = [s for s in before_servers if s not in after_servers]
+        if added:
+            logger.info("  +ADDED: %s", added)
+        if removed:
+            logger.info("  -REMOVED: %s", removed)
+
+        if dry_run:
+            logger.info("[DRY-RUN] no changes written")
+            return 0
+
+        # Apply patch
+        roles[role]["servers"] = after_servers
+        new_json = json.dumps(data, ensure_ascii=False)
+
+        # Ensure audit table exists (idempotent)
+        cur.execute(AUDIT_TABLE_DDL)
+        cur.execute(AUDIT_IDX_SESSION)
+        cur.execute(AUDIT_IDX_TIME)
+
+        now = time.time()
+        cur.execute(
+            """
+            INSERT INTO team_template_history
+              (session_id, role, field, before_json, after_json,
+               source, edited_by, edited_at, comment)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id, role, "servers",
+                json.dumps(before_servers, ensure_ascii=False),
+                json.dumps(after_servers, ensure_ascii=False),
+                source, edited_by, now, comment,
+            ),
+        )
+        audit_id = cur.lastrowid
+
+        cur.execute(
+            "UPDATE team_sessions SET data_json=? WHERE session_id=?",
+            (new_json, session_id),
+        )
+
+        conn.commit()
+        logger.info("[OK] applied. audit_id=%d, edited_at=%.3f", audit_id, now)
+        logger.info(
+            "Next spawn (auto-resume / inject / restart) of role=%r in this "
+            "session will pick up the new server list. To force-apply now: "
+            "kill the running agent process tree.",
+            role,
+        )
+        return 0
+    except Exception as exc:
+        conn.rollback()
+        logger.error("[ERROR] %s", exc, exc_info=True)
+        return 5
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--role", required=True, help="role key in template, e.g. 'qe', 'dev'")
+    parser.add_argument("--add-servers", nargs="*", default=[], help="server names to ensure present")
+    parser.add_argument("--remove-servers", nargs="*", default=[], help="server names to remove")
+    parser.add_argument("--comment", default="", help="audit-log comment explaining the edit")
+    parser.add_argument("--edited-by", default="system")
+    parser.add_argument("--source", default="phase0-script")
+    parser.add_argument("--db", default=str(DEFAULT_DB), help="path to jarvis.db")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+    )
+
+    if not args.add_servers and not args.remove_servers:
+        logger.error("Specify at least one of --add-servers / --remove-servers")
+        return 1
+
+    return patch(
+        db_path=Path(args.db),
+        session_id=args.session_id,
+        role=args.role,
+        add_servers=args.add_servers,
+        remove_servers=args.remove_servers,
+        comment=args.comment,
+        edited_by=args.edited_by,
+        source=args.source,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/server.py
+++ b/backend/server.py
@@ -303,6 +303,12 @@ async def lifespan(app: FastAPI):
     from services.config_service import config_service as _cfg_for_git_sync
     from services import git_credential_sync
     git_credential_sync.reconcile_from_db(_cfg_for_git_sync)
+    # Companion sync: same DB token → $GH_CONFIG_DIR/hosts.yml so the gh CLI
+    # (invoked by team agents via the execute shell tool for CI/PR/release
+    # ops) authenticates from a file rather than an env var. Same fail-loud
+    # rationale as git_credential_sync above.
+    from services import gh_credential_sync
+    gh_credential_sync.reconcile_from_db(_cfg_for_git_sync)
     
     # Restore pending approvals — re-register paused agents from DB
     try:

--- a/backend/services/gh_credential_sync.py
+++ b/backend/services/gh_credential_sync.py
@@ -1,0 +1,164 @@
+"""GitHub CLI (gh) credential sync — DB → in-container ``hosts.yml`` consumed
+by the ``gh`` CLI when agents invoke it through the ``execute`` shell tool.
+
+This is a sibling of :mod:`services.git_credential_sync`. Both mirror the same
+DB row (``service.github.personal_access_token``) into different surfaces:
+
+* ``git_credential_sync`` writes ``git-credentials`` + ``gitconfig`` so the
+  ``git`` CLI can authenticate.
+* This module writes ``$GH_CONFIG_DIR/hosts.yml`` (mode 0600) so ``gh`` CLI
+  can authenticate without any ``GH_TOKEN`` env var. We deliberately avoid
+  the env-var route because env values are visible to ``env`` / ``printenv``
+  / ``ps eww`` inside the agent's shell, which would let a prompt-injected
+  agent exfiltrate the token. The file lives outside ``~/.config/gh/`` so we
+  never overwrite the developer's personal ``gh auth login`` state.
+
+Auth model: ``gh`` reads ``$GH_CONFIG_DIR/hosts.yml`` (if ``GH_CONFIG_DIR``
+is set) or ``~/.config/gh/hosts.yml`` (default). We set ``GH_CONFIG_DIR``
+to a Jarvis-private directory at backend boot via ``os.environ`` so every
+team-agent subprocess inherits it, and ``gh`` finds *our* hosts.yml rather
+than the dev user's personal one.
+
+DB key convention (reused from git_credential_sync, NOT duplicated):
+    ``service.github.personal_access_token``  — secret, encrypted at rest
+    ``service.github.user_name``              — plain (becomes ``user:`` field)
+"""
+from __future__ import annotations
+
+import errno
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from services.secret_utils import safe_get_or_none
+
+logger = logging.getLogger(__name__)
+
+
+_PERSIST_DIR = Path(os.getenv("JARVIS_PERSIST_DIR") or Path(__file__).resolve().parent.parent)
+_GH_CONFIG_DIR = _PERSIST_DIR / ".gh-config"
+_GH_HOSTS_PATH = _GH_CONFIG_DIR / "hosts.yml"
+
+# Field keys under ``service.github`` — reused from git_credential_sync.
+# Kept local so this module doesn't depend on it (and vice versa).
+FIELD_TOKEN = "personal_access_token"
+FIELD_USER_NAME = "user_name"
+_KNOWN_FIELDS = (FIELD_TOKEN, FIELD_USER_NAME)
+
+
+def _warn_skipped(exc: Exception) -> None:
+    logger.warning(
+        "[GH_SYNC] Skipped stale field: %s. "
+        "Re-set via Settings → Services to restore.", exc,
+    )
+
+
+def apply_change(key: str, new_value: Optional[str], *, action: str) -> None:
+    """Hot-reload hook called by ``runtime_config._on_config_change``.
+
+    Fields outside ``_KNOWN_FIELDS`` are ignored — this module only cares
+    about token + user_name. Other ``service.github.*`` fields (eg email)
+    belong to :mod:`services.git_credential_sync` and are wired there.
+    """
+    if key not in _KNOWN_FIELDS:
+        return
+    from services.config_service import config_service as _cfg
+    _write_from_values(
+        token=safe_get_or_none(_cfg, "service.github", FIELD_TOKEN, on_warn=_warn_skipped),
+        user_name=safe_get_or_none(_cfg, "service.github", FIELD_USER_NAME, on_warn=_warn_skipped),
+    )
+
+
+def reconcile_from_db(config_service) -> None:
+    """Push current DB state into ``hosts.yml`` at startup and export
+    ``GH_CONFIG_DIR`` so the gh CLI (and child agent subprocesses) read it.
+
+    Idempotent. Safe to call when token is missing — the file is created
+    empty/with no ``oauth_token`` field, which leaves ``gh`` unauth'd
+    (the correct signal for a fresh install).
+    """
+    # Export GH_CONFIG_DIR for every gh invocation, including those spawned
+    # by team-agent subprocesses via the fast-agent ``execute`` shell tool.
+    # Set even if token is missing so behaviour is consistent — gh will say
+    # "not authenticated" loudly rather than silently fall back to the dev
+    # user's personal ~/.config/gh/.
+    os.environ["GH_CONFIG_DIR"] = str(_GH_CONFIG_DIR)
+
+    _write_from_values(
+        token=safe_get_or_none(config_service, "service.github", FIELD_TOKEN, on_warn=_warn_skipped),
+        user_name=safe_get_or_none(config_service, "service.github", FIELD_USER_NAME, on_warn=_warn_skipped),
+    )
+
+
+def _write_from_values(*, token: Optional[str], user_name: Optional[str]) -> None:
+    """Atomically write ``hosts.yml`` from supplied field values.
+
+    Raises on filesystem errors so a half-written auth state can't trip up
+    agents later — same rationale as ``git_credential_sync._write_from_values``.
+    """
+    _GH_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    # Tighten dir perms so even read access to the directory is owner-only.
+    try:
+        os.chmod(_GH_CONFIG_DIR, 0o700)
+    except OSError:
+        # Non-fatal: some filesystems (e.g. macOS APFS with custom ACLs)
+        # may refuse chmod but the file mode itself still enforces 0600.
+        pass
+
+    _atomic_write(_GH_HOSTS_PATH, _render_hosts(token, user_name), mode=0o600)
+
+
+def _render_hosts(token: Optional[str], user_name: Optional[str]) -> str:
+    """Produce the ``hosts.yml`` body that gh's stored-token auth expects.
+
+    Schema (verified against gh 2.68.1):
+        github.com:
+            user: <username>
+            oauth_token: <PAT>
+            git_protocol: https
+
+    When token is missing we write an empty top-level so gh reads it as
+    "no hosts configured" — agents calling ``gh`` get a clear "not logged
+    in" error rather than failing on a malformed file.
+    """
+    if not token:
+        return ""
+    host_entry: dict[str, str] = {"git_protocol": "https"}
+    if user_name:
+        host_entry["user"] = user_name
+    host_entry["oauth_token"] = token
+    return yaml.safe_dump({"github.com": host_entry}, sort_keys=False)
+
+
+def _atomic_write(path: Path, text: str, *, mode: int) -> None:
+    """Mirror of :func:`services.git_credential_sync._atomic_write` — same
+    tmp → rename dance, same Docker-bind-mount EBUSY fallback, same
+    fail-loud philosophy. Duplicated rather than imported to keep the two
+    sync modules independent (one can fail without taking down the other).
+    """
+    data = text.encode("utf-8")
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(data)
+        os.chmod(tmp, mode)
+        try:
+            os.replace(tmp, path)
+        except OSError as exc:
+            if exc.errno != errno.EBUSY:
+                raise
+            path.write_bytes(data)
+            os.chmod(path, mode)
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    logger.info("[GH_SYNC] %s updated (%d bytes, mode %o)", path.name, len(data), mode)

--- a/backend/services/inject_resume.py
+++ b/backend/services/inject_resume.py
@@ -56,6 +56,28 @@ async def resume_with_inject(
             f"No original_config for agent '{agent_name}'. Cannot resume."
         )
 
+    # 0. Refresh role-level config from the live team template.
+    #
+    # Why: ``original_config`` is a FROZEN snapshot taken at first spawn.
+    # When a user edits the team template later (add an MCP server, change
+    # instruction, swap a skill), the canonical state lives in
+    # ``team_sessions.template.roles[role]`` — but unless we re-read it here,
+    # resume passes the stale 7-server list and the new tool silently
+    # disappears (incident 2026-05-18: ``playwright`` added to QE template
+    # via patch script, but every resume still got the old server list
+    # because we were reading the snapshot, not the canonical row).
+    #
+    # The /reload endpoint already kills + re-resumes the agent — but the
+    # respawn only picks up template changes if THIS function reads them.
+    # See ``services/team_reload.py`` for the kill half of the flow.
+    team_session_id = (original_config.get("env_vars") or {}).get(
+        "TEAM_SESSION_ID", ""
+    )
+    role = original_config.get("role", "")
+    fresh_role_cfg = _load_role_from_template(team_session_id, role)
+    if fresh_role_cfg is not None:
+        _log_template_drift(agent_name, original_config, fresh_role_cfg)
+
     # 1. Load context from DB — single source of truth
     context_json = _load_context_from_db(agent_name)
     history_file = None
@@ -82,11 +104,26 @@ async def resume_with_inject(
 
     # Re-inject team roster if this is a team agent
     enriched_context = inject_message
-    team_session_id = env_vars.get("TEAM_SESSION_ID", "")
     if team_session_id:
         enriched_context = _reinject_team_context(
-            inject_message, team_session_id, original_config.get("role", ""),
+            inject_message, team_session_id, role,
         )
+
+    # Resolve EACH spawn input through one helper so the SSoT rule
+    # ("prefer live template; fall back to snapshot") is in one place
+    # rather than scattered across keyword arguments.
+    def _resolve(key: str, default: Any = None) -> Any:
+        if fresh_role_cfg is not None and key in fresh_role_cfg:
+            value = fresh_role_cfg.get(key)
+            if value is not None:
+                return value
+        return original_config.get(key, default)
+
+    servers = _resolve("servers", [])
+    server_overrides = _resolve("server_overrides", None)
+    instruction = _resolve("instruction", "")
+    skills = _resolve("skills", [])
+    model = _resolve("model", "")
 
     # 3. Create SpawnRegistry (same file as MCP spawner — concurrent-safe)
     registry = _create_registry(project_dir)
@@ -100,12 +137,12 @@ async def resume_with_inject(
     new_run_id = await run_isolated_agent_background(
         task=inject_message,
         project_dir=project_dir,
-        instruction=original_config.get("instruction", ""),
+        instruction=instruction,
         context=enriched_context,
-        servers=original_config.get("servers", []),
-        model=original_config.get("model", ""),
+        servers=servers,
+        model=model,
         timeout_seconds=original_config.get("timeout_seconds", 0),
-        role=original_config.get("role", ""),
+        role=role,
         agent_name=agent_name,
         team_name=original_config.get("team_name", spawn_record.get("team_name", "")),
         workspace_dir=original_config.get("workspace_dir") or None,
@@ -113,10 +150,16 @@ async def resume_with_inject(
         registry=registry,
         display_manager=display_manager,
         env_vars=env_vars or None,
-        skills=original_config.get("skills", []),
+        skills=skills,
         history_file=history_file,
         spawn_lifecycle_hooks=None,  # Subprocess events (stderr) are sufficient
         session_id=team_session_id,
+        # Without this, every dashboard "Send message" / inject path falls back
+        # to the BASE fastagent.config.yaml filesystem args (./data only) and
+        # the agent silently loses workspace + skills access (incident
+        # 2026-05-17: Designer broken filesystem after restore — fix landed in
+        # auto-resume/restart/resume but THIS code path was missed).
+        server_overrides=server_overrides,
     )
 
     logger.info(
@@ -134,6 +177,93 @@ async def resume_with_inject(
 
 
 # ── Helper functions ─────────────────────────────────────────────────────
+
+
+def _load_role_from_template(
+    team_session_id: str,
+    role: str,
+) -> dict | None:
+    """Read the live role config from ``team_sessions.template.roles[role]``.
+
+    Returns the role dict (with keys like ``servers``, ``server_overrides``,
+    ``instruction``, ``skills``, ``model``) or ``None`` when:
+
+    - ``team_session_id`` is empty (this is an ad-hoc spawn, not team-managed)
+    - the role is empty
+    - the team session no longer exists (deleted / migrated)
+    - the role was removed from the template after the agent spawned
+
+    Callers MUST treat ``None`` as "fall back to original_config snapshot"
+    — never as an error. The point of this helper is purely to refresh
+    template-driven fields while keeping the registry snapshot as a safety
+    net for non-template fields (env_vars, workspace_dir, project_dir).
+    """
+    if not team_session_id or not role:
+        return None
+    try:
+        from fast_agent.spawn.team_spawner import get_team_session
+
+        session = get_team_session(team_session_id)
+    except Exception as exc:
+        logger.warning(
+            "[INJECT-RESUME] Failed to load team session '%s' for fresh "
+            "role refresh: %s — falling back to original_config.",
+            team_session_id, exc,
+        )
+        return None
+    if session is None:
+        return None
+    roles = (session.template or {}).get("roles") or {}
+    role_cfg = roles.get(role)
+    if not isinstance(role_cfg, dict):
+        return None
+    return role_cfg
+
+
+def _log_template_drift(
+    agent_name: str,
+    original_config: dict,
+    fresh_role_cfg: dict,
+) -> None:
+    """Log when template-driven fields differ from the snapshot.
+
+    Silent drift is exactly how the 2026-05-18 ``playwright`` incident hid
+    — patch updated the canonical template but every resume read the stale
+    snapshot. By emitting a single INFO line listing the diff, the next
+    operator who tails the log can immediately see "ah, the live template
+    is ahead of the snapshot, that's why this agent has different servers
+    after resume" instead of spelunking two tables.
+
+    Best-effort only — no exception raised. We never want this helper to
+    block a resume.
+    """
+    try:
+        changes: list[str] = []
+        for key in ("servers", "server_overrides", "instruction", "skills", "model"):
+            old = original_config.get(key)
+            new = fresh_role_cfg.get(key, old)
+            if old != new:
+                if key in ("servers", "skills"):
+                    old_set = set(old or [])
+                    new_set = set(new or [])
+                    added = sorted(new_set - old_set)
+                    removed = sorted(old_set - new_set)
+                    parts = []
+                    if added:
+                        parts.append(f"+{added}")
+                    if removed:
+                        parts.append(f"-{removed}")
+                    if parts:
+                        changes.append(f"{key} {' '.join(parts)}")
+                else:
+                    changes.append(f"{key} changed")
+        if changes:
+            logger.info(
+                "[INJECT-RESUME] Template drift for %s — using live template: %s",
+                agent_name, "; ".join(changes),
+            )
+    except Exception as exc:  # pragma: no cover — diagnostic only
+        logger.debug("[INJECT-RESUME] drift logging failed: %s", exc)
 
 
 def _load_context_from_db(agent_name: str) -> str | None:

--- a/backend/services/runtime_config.py
+++ b/backend/services/runtime_config.py
@@ -296,10 +296,11 @@ def _on_config_change(event) -> None:
         if cat == "service.github":
             # GitHub service fields (personal_access_token, user_name, user_email)
             # don't match the ENV_SHAPED_KEY pattern — they drive file sinks
-            # (git-credentials + gitconfig + fastagent.secrets.yaml) instead of
-            # os.environ. Must run before the generic service.* env branch.
-            from services import git_credential_sync
+            # (git-credentials + gitconfig + fastagent.secrets.yaml + .gh-config/hosts.yml)
+            # instead of os.environ. Must run before the generic service.* env branch.
+            from services import git_credential_sync, gh_credential_sync
             git_credential_sync.apply_change(key, new_value, action=action)
+            gh_credential_sync.apply_change(key, new_value, action=action)
             return
 
         if cat.startswith("service.") and _ENV_SHAPED_KEY_RE.match(key):

--- a/backend/services/spawn_progress_bridge.py
+++ b/backend/services/spawn_progress_bridge.py
@@ -1247,6 +1247,19 @@ class SpawnProgressBridge:
             return
         orch_name = orchestrator.get("agent_name", "")
 
+        # Skip when the trigger IS the orchestrator. The notification is for
+        # "workers finished delegated work — PM should review". PM going idle
+        # itself (e.g. after replying to a user inject, or after processing
+        # a previous notify-resume) shouldn't re-fire the notification:
+        # PM doesn't need to be told to check its own inbox right after it
+        # just acted. Without this guard, every user inject triggered one
+        # extra round-trip (User → PM responds → idle → bridge sends
+        # "Check inbox" → PM wakes → no-op → idle → dedup hash catches),
+        # which appeared to the user as "agent gets an inbox after every
+        # inject". Production trace 2026-05-16 10:18 ICT.
+        if trigger_agent == orch_name:
+            return
+
         _non_running = {"idle", "completed", "error", "timeout", "cancelled"}
         workers = [
             m for m in members

--- a/backend/services/spawn_progress_bridge.py
+++ b/backend/services/spawn_progress_bridge.py
@@ -20,7 +20,6 @@ import asyncio
 import json
 import logging
 import os
-import uuid
 from typing import Any, Protocol
 
 logger = logging.getLogger("spawn_activity")
@@ -208,7 +207,7 @@ class SpawnProgressBridge:
         # 4·R2. Refresh ``last_active_at`` whenever the agent does
         # something concrete (LLM call or tool round-trip). Lets
         # ``get_team_status`` distinguish "agent X stuck for 60s" from
-        # "agent X actively working" — the visibility gap that left PM
+        # "agent X actively working" — the visibility gap that left the orchestrator
         # in incident b61af7db idling out after seeing identical
         # ``running`` snapshots.
         if (
@@ -228,7 +227,7 @@ class SpawnProgressBridge:
                 )
 
         # 4a+b. Cycle-event dispatch — single entry point that emits
-        # ``team.worker_cycle_closed`` (PM inbox) when workers all stop
+        # ``team.worker_cycle_closed`` (orchestrator inbox) when workers all stop
         # running, and ``team.full_cycle_closed`` (user UI) when the
         # whole team stops running. Idempotent via DB event_id PK.
         # See _on_member_state_event docstring for the state machine.
@@ -843,7 +842,7 @@ class SpawnProgressBridge:
 
         Used by both completion-notification paths to suppress the misleading
         "team finished" message when the team is actually idled mid-meeting
-        (incident b61af7db: PM saw "All members finished | No output" while
+        (incident b61af7db: the orchestrator saw "All members finished | No output" while
         meeting was hanging on a stuck speaker).
 
         Returns a list of dicts with the fields needed for messaging:
@@ -922,7 +921,7 @@ class SpawnProgressBridge:
         """Render the meeting-stalled warning block (markdown).
 
         Caller embeds this into the team-completion message so the
-        orchestrator (PM) sees actionable state — bottleneck speaker,
+        orchestrator sees actionable state — bottleneck speaker,
         time since last turn, last 3 turns — instead of "No output".
         """
         if not active:
@@ -951,19 +950,74 @@ class SpawnProgressBridge:
         )
         return "\n".join(lines)
 
-    def _find_orchestrator(self, members: list[dict]) -> dict | None:
+    def _find_orchestrator(
+        self, members: list[dict], session_id: str = "",
+    ) -> dict | None:
         """Find the orchestrator agent from team members.
 
-        Preference: role containing 'pm' or 'orchestrator'.
-        Fallback: first spawned agent (orchestrator spawns first).
+        The orchestrator is whichever role the team's *template* declares
+        as the orchestrator — read from
+        ``team_sessions.template.orchestrator`` (the single source of
+        truth). The earlier implementation matched substring "pm" /
+        "orchestrator" in the role string; that broke any template whose
+        orchestrator role wasn't literally named "pm" (a hard-coded
+        assumption the rest of the architecture has long since outgrown).
+
+        Args:
+            members: registry rows for this team
+            session_id: team session id — used to look up the template's
+                ``orchestrator`` field. When empty (legacy callers), we
+                fall through to the spawn-order fallback below.
+
+        Returns:
+            The member dict whose ``role`` equals
+            ``template.orchestrator`` (case-insensitive), or — only if
+            that lookup fails or no member matches — the first member by
+            ``started_at`` (because the orchestrator spawns first).
         """
-        for m in members:
-            role = (m.get("role") or "").lower()
-            if "pm" in role or "orchestrator" in role:
-                return m
-        # Fallback: first agent by started_at (orchestrator spawns first)
+        orch_role = self._lookup_orchestrator_role(session_id) if session_id else ""
+        if orch_role:
+            target = orch_role.lower()
+            for m in members:
+                if (m.get("role") or "").lower() == target:
+                    return m
+            # Template named an orchestrator role but no member has it —
+            # likely a transient state during respawn. Log so the gap is
+            # visible, then fall through to spawn-order fallback.
+            logger.warning(
+                "[CYCLE] session=%s: template.orchestrator=%r but no "
+                "member has that role; falling back to first-spawned.",
+                session_id, orch_role,
+            )
+        # Fallback: first agent by started_at (orchestrator spawns first).
+        # Kept for: (a) ad-hoc spawns with no session_id, (b) the rare
+        # window between template edit and registry resync, (c) defensive
+        # protection so the bridge never returns None for a non-empty team.
         members_sorted = sorted(members, key=lambda m: m.get("started_at", 0))
         return members_sorted[0] if members_sorted else None
+
+    def _lookup_orchestrator_role(self, session_id: str) -> str:
+        """Return ``template.orchestrator`` (role key) for the session.
+
+        Reads through ``get_team_session`` which is the canonical accessor
+        for the team_sessions row. Returns ``""`` if the session does not
+        exist, the template is missing, or the lookup raises — callers
+        treat empty string as "fall back to heuristic".
+        """
+        try:
+            from fast_agent.spawn.team_spawner import get_team_session
+
+            session = get_team_session(session_id)
+            if session is None:
+                return ""
+            template = getattr(session, "template", None) or {}
+            return str(template.get("orchestrator", "") or "")
+        except Exception as exc:
+            logger.debug(
+                "[CYCLE] _lookup_orchestrator_role(%s) failed: %s",
+                session_id, exc,
+            )
+            return ""
 
     def _compose_team_result_body(
         self, *, team_name: str, agent_name: str, result: str
@@ -1181,7 +1235,7 @@ class SpawnProgressBridge:
     #
     # New model:
     #
-    #   * Two named cycles per session: ``worker_cycle`` (PM-facing) and
+    #   * Two named cycles per session: ``worker_cycle`` (orchestrator-facing) and
     #     ``team_cycle`` (user-facing). Open when at least one relevant
     #     agent is ``running``; close when all are non-running.
     #   * On every member state-change event, recompute both cycles
@@ -1226,51 +1280,243 @@ class SpawnProgressBridge:
                         updated_at    REAL NOT NULL
                     )"""
                 )
+                # 2026-05-19 migration — see _on_member_state_event docstring.
+                # Adds:
+                #   * orch_running       — tracks whether the team's
+                #     orchestrator (per template.orchestrator — the
+                #     system makes no role-name assumption; every
+                #     template names its own orchestrator role) is
+                #     currently ``running``. With the
+                #     old gating ``team_open = any(spawned running)``,
+                #     full_cycle_closed fired the moment workers stopped
+                #     even though the orchestrator had not yet had a
+                #     chance to process the worker reports pushed via
+                #     _trigger_orchestrator_resume — producing a bogus
+                #     "team done" notify (incident 2026-05-19 notify
+                #     #39) which the real "orchestrator idled after
+                #     work" notify (#40) then duplicated.
+                #   * team_close_seq / worker_close_seq — replace the
+                #     uuid-in-event_id dedupe key that was silently
+                #     defeating ``team_events`` PK conflict detection.
+                #     Counters increment atomically inside a guarded
+                #     UPDATE so the cycle's canonical close handler is
+                #     race-free.
+                # ``ALTER TABLE ADD COLUMN`` is idempotent across SQLite
+                # restarts because we swallow ``duplicate column name``
+                # OperationalError. NOT NULL DEFAULT 0 backfills existing
+                # rows so old sessions resume cleanly without crash.
+                for ddl in (
+                    "ALTER TABLE team_cycle_state ADD COLUMN orch_running INTEGER NOT NULL DEFAULT 0",
+                    "ALTER TABLE team_cycle_state ADD COLUMN team_close_seq INTEGER NOT NULL DEFAULT 0",
+                    "ALTER TABLE team_cycle_state ADD COLUMN worker_close_seq INTEGER NOT NULL DEFAULT 0",
+                ):
+                    try:
+                        conn.execute(ddl)
+                    except Exception as exc:
+                        # SQLite raises OperationalError("duplicate column name")
+                        # when the column already exists. Anything else is a
+                        # real schema problem worth surfacing — but never a
+                        # reason to crash the bridge.
+                        if "duplicate column" not in str(exc).lower():
+                            logger.warning(
+                                "[CYCLE] migration %r failed: %s",
+                                ddl, exc, exc_info=True,
+                            )
         except Exception as e:
             logger.warning("[CYCLE] _ensure_event_tables failed: %s", e, exc_info=True)
 
     def _load_cycle_state(self, session_id: str) -> dict:
-        """Return ``{worker_open, team_open}`` for the session. Defaults
-        to both-closed when no row exists — first event after spawn will
-        update to open and persist."""
+        """Return cycle state for the session.
+
+        Keys:
+          * ``worker_open`` — bool, any non-orchestrator member is ``running``
+          * ``orch_running`` — bool, the team's orchestrator
+            (per ``template.orchestrator``) is ``running``
+          * ``team_open`` — bool, legacy ``any(spawned running)``; kept
+            for backward compat with the existing column, do NOT use
+            for the full-cycle-close gating.
+
+        Defaults to all-closed when no row exists — first event after
+        spawn will update to open and persist.
+
+        ``team_open`` is retained as a column but is no longer the
+        gating signal for ``full_cycle_closed`` — see the 2026-05-19
+        incident write-up in ``_ensure_event_tables`` for why.
+        """
         try:
             from core.agent_registry_db import _connect
 
             with _connect() as conn:
                 row = conn.execute(
-                    "SELECT worker_open, team_open FROM team_cycle_state "
-                    "WHERE session_id = ?",
+                    """SELECT worker_open, team_open, orch_running
+                       FROM team_cycle_state WHERE session_id = ?""",
                     (session_id,),
                 ).fetchone()
                 if row is None:
-                    return {"worker_open": False, "team_open": False}
+                    return {
+                        "worker_open": False,
+                        "team_open": False,
+                        "orch_running": False,
+                    }
                 return {
                     "worker_open": bool(row["worker_open"]),
                     "team_open": bool(row["team_open"]),
+                    "orch_running": bool(row["orch_running"]),
                 }
         except Exception as e:
             logger.warning("[CYCLE] _load_cycle_state(%s) failed: %s", session_id, e)
-            return {"worker_open": False, "team_open": False}
+            return {
+                "worker_open": False,
+                "team_open": False,
+                "orch_running": False,
+            }
 
     def _save_cycle_state(
-        self, session_id: str, worker_open: bool, team_open: bool,
+        self,
+        session_id: str,
+        worker_open: bool,
+        team_open: bool,
+        orch_running: bool,
     ) -> None:
+        """Persist the post-event cycle snapshot.
+
+        Called AFTER ``_try_close_team_cycle`` / ``_try_close_worker_cycle``
+        — those helpers handle the close transitions atomically. This
+        function exists for the non-close paths (reopen, no-change).
+        """
         try:
             import time
             from core.agent_registry_db import _connect
 
             with _connect() as conn:
                 conn.execute(
-                    """INSERT INTO team_cycle_state(session_id, worker_open, team_open, updated_at)
-                       VALUES(?, ?, ?, ?)
+                    """INSERT INTO team_cycle_state
+                          (session_id, worker_open, team_open, orch_running, updated_at)
+                       VALUES(?, ?, ?, ?, ?)
                        ON CONFLICT(session_id) DO UPDATE SET
-                         worker_open = excluded.worker_open,
-                         team_open   = excluded.team_open,
-                         updated_at  = excluded.updated_at""",
-                    (session_id, int(worker_open), int(team_open), time.time()),
+                         worker_open   = excluded.worker_open,
+                         team_open     = excluded.team_open,
+                         orch_running  = excluded.orch_running,
+                         updated_at    = excluded.updated_at""",
+                    (
+                        session_id,
+                        int(worker_open),
+                        int(team_open),
+                        int(orch_running),
+                        time.time(),
+                    ),
                 )
         except Exception as e:
             logger.warning("[CYCLE] _save_cycle_state(%s) failed: %s", session_id, e)
+
+    def _try_close_team_cycle(
+        self,
+        session_id: str,
+        new_worker_open: bool,
+        new_team_open: bool,
+        new_orch_running: bool,
+    ) -> int | None:
+        """Atomically close the team cycle for ``session_id`` if and only
+        if the orchestrator just transitioned ``running → not-running``.
+
+        The gating predicate ``WHERE orch_running = 1`` is the only place
+        in the code that decides "is this caller the canonical close
+        handler for this cycle?". Two concurrent callers observing the
+        same transition will race to this UPDATE; SQLite serialises
+        them, so only the first sees ``WHERE`` match → returns the new
+        ``team_close_seq``. The loser sees 0 rows updated → returns
+        ``None`` → caller skips the notify side effect.
+
+        This is the *only* primitive that should ever raise the team
+        close_seq counter or persist ``orch_running = 0``.
+
+        Returns the new ``team_close_seq`` if this caller won the close,
+        otherwise ``None``.
+        """
+        if new_orch_running:
+            return None
+        try:
+            import time
+            from core.agent_registry_db import _connect
+
+            with _connect() as conn:
+                cur = conn.execute(
+                    """UPDATE team_cycle_state
+                       SET team_close_seq = team_close_seq + 1,
+                           orch_running   = 0,
+                           worker_open    = ?,
+                           team_open      = ?,
+                           updated_at     = ?
+                       WHERE session_id = ? AND orch_running = 1
+                       RETURNING team_close_seq""",
+                    (
+                        int(new_worker_open),
+                        int(new_team_open),
+                        time.time(),
+                        session_id,
+                    ),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    return None
+                return int(row[0])
+        except Exception as exc:
+            logger.warning(
+                "[CYCLE] _try_close_team_cycle(%s) failed: %s",
+                session_id, exc, exc_info=True,
+            )
+            return None
+
+    def _try_close_worker_cycle(
+        self,
+        session_id: str,
+        new_worker_open: bool,
+        new_team_open: bool,
+        new_orch_running: bool,
+    ) -> int | None:
+        """Atomically close the worker cycle for ``session_id`` if the
+        last non-orchestrator member just stopped running.
+
+        Same race-free protocol as :py:meth:`_try_close_team_cycle`. The
+        WHERE predicate is ``worker_open = 1`` — only the caller that
+        flips it to 0 wins.
+
+        Returns the new ``worker_close_seq`` if this caller won, else
+        ``None``.
+        """
+        if new_worker_open:
+            return None
+        try:
+            import time
+            from core.agent_registry_db import _connect
+
+            with _connect() as conn:
+                cur = conn.execute(
+                    """UPDATE team_cycle_state
+                       SET worker_close_seq = worker_close_seq + 1,
+                           worker_open      = 0,
+                           team_open        = ?,
+                           orch_running     = ?,
+                           updated_at       = ?
+                       WHERE session_id = ? AND worker_open = 1
+                       RETURNING worker_close_seq""",
+                    (
+                        int(new_team_open),
+                        int(new_orch_running),
+                        time.time(),
+                        session_id,
+                    ),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    return None
+                return int(row[0])
+        except Exception as exc:
+            logger.warning(
+                "[CYCLE] _try_close_worker_cycle(%s) failed: %s",
+                session_id, exc, exc_info=True,
+            )
+            return None
 
     def _insert_event(
         self, event_id: str, event_type: str,
@@ -1306,16 +1552,36 @@ class SpawnProgressBridge:
 
           1. Load registry record for ``run_id`` → resolve ``session_id``
              and ``team_name`` (skip for solo agents).
-          2. Snapshot current cycle state from the registry: workers
-             open iff any non-orch member is ``running``; team open iff
-             any team agent is ``running``.
-          3. Compare against the last persisted cycle state. On
-             ``open → closed`` transitions, emit the matching cycle
-             event (idempotent via DB PK).
-          4. Persist the new cycle state.
+          2. Snapshot current cycle state from the registry:
+               - ``worker_open``  — any non-orchestrator member running
+               - ``orch_running`` — the orchestrator (per
+                 ``template.orchestrator``) is running
+               - ``team_open``    — legacy "any spawned member running",
+                 kept for observability but NOT the gating signal.
+          3. Compare against the last persisted cycle state and emit:
+               - ``worker_cycle_closed`` when ``worker_open`` flips T→F
+               - ``full_cycle_closed``  when ``orch_running`` flips T→F
+                 AND no workers running AND no active meetings
+          4. Atomic close primitives (``_try_close_*_cycle``) own the
+             post-close state update AND the close_seq increment, so a
+             race between two callers observing the same transition
+             produces exactly one notify (the WHERE predicate matches
+             only the first caller).
+          5. For non-close paths (reopen / no-change), persist the new
+             snapshot via ``_save_cycle_state``.
 
-        See module-level docstring for the full state machine and the
-        14-case edge-case table.
+        Why ``orch_running`` and not ``team_open``? Incident 2026-05-19:
+        with ``team_open = any(spawned running)``, the bridge fired
+        ``full_cycle_closed`` the moment the last worker idled — even
+        though the orchestrator was already idle and had not yet had a
+        chance to process the worker reports pushed via
+        ``_trigger_orchestrator_resume``. The orchestrator was then
+        woken, did its post-cycle work, and idled again → a second,
+        valid ``full_cycle_closed`` fired → user saw 2 notifications.
+        Gating on the orchestrator's OWN transition makes
+        ``full_cycle_closed`` mean exactly "the orchestrator finished
+        its turn after acknowledging workers" — which is what the user
+        is being notified about.
         """
         if not self._registry_db:
             return
@@ -1328,14 +1594,42 @@ class SpawnProgressBridge:
         if not session_id or not team_name:
             return  # Solo agent or pre-session record — not in scope
 
-        members = [
+        # Dedupe by agent_name, keep ONLY the latest run per agent. The
+        # registry uses ``run_id`` as primary key and resumable agents
+        # (the orchestrator in particular) get a NEW row on every
+        # resume — so over N injects the orchestrator accumulates N
+        # rows. Without this dedupe, ``len(members)`` and the "running"
+        # check both treat each historical row as a distinct member.
+        # Side effects observed in incident 2026-05-17 notif #28:
+        #   * "16 agents" instead of 7 (10 stale orchestrator rows + 6
+        #     worker rows).
+        #   * Premature full_cycle_closed: only the latest orchestrator
+        #     run is actually running at any time; the 9 stale rows are
+        #     idle. With dedupe, ``orch_running = (latest orchestrator
+        #     row is running)`` — which correctly stays True while it
+        #     is mid-turn.
+        # Tie-break: highest ``started_at`` wins; ``last_active_at``
+        # would also work but ``started_at`` is monotonic per row
+        # creation, so it's the safer monotonic ordering for "latest
+        # spawn".
+        raw_members = [
             m for m in self._registry_db.find_by_team_name(team_name)
             if m.get("session_id") == session_id
         ]
+        latest_by_name: dict[str, dict] = {}
+        for m in raw_members:
+            name = m.get("agent_name", "")
+            if not name:
+                continue
+            started = m.get("started_at", 0) or 0
+            prev_row = latest_by_name.get(name)
+            if prev_row is None or (prev_row.get("started_at", 0) or 0) < started:
+                latest_by_name[name] = m
+        members = list(latest_by_name.values())
         if not members:
             return
 
-        orch = self._find_orchestrator(members)
+        orch = self._find_orchestrator(members, session_id=session_id)
         orch_name = orch.get("agent_name", "") if orch else ""
         # ``available`` = registered but not spawned yet; ``None`` = legacy
         # rows. Exclude both from cycle calculations — they are not
@@ -1348,39 +1642,77 @@ class SpawnProgressBridge:
 
         worker_open = any(m.get("status") == "running" for m in workers)
         team_open = any(m.get("status") == "running" for m in spawned)
+        orch_running = bool(orch and orch.get("status") == "running")
 
         prev = self._load_cycle_state(session_id)
 
+        # ── Worker cycle close ──
+        # Atomic: WHERE worker_open=1 lets exactly one concurrent caller
+        # take the close, and increments worker_close_seq for a stable
+        # event_id. Loser callers see ``close_seq is None`` → skip emit.
+        worker_close_seq: int | None = None
         if prev["worker_open"] and not worker_open:
-            self._emit_worker_cycle_closed(
-                session_id, team_name, members, orch, workers,
+            worker_close_seq = self._try_close_worker_cycle(
+                session_id, worker_open, team_open, orch_running,
             )
-
-        if prev["team_open"] and not team_open:
-            # Meeting-aware: if a member is still mid-meeting, the team
-            # is NOT truly idle — defer the close. Meeting end events
-            # will re-trigger the handler and the next pass will fire.
-            member_names = {m.get("agent_name", "") for m in spawned}
-            if not self._active_meetings_with_members(member_names):
-                self._emit_full_cycle_closed(
-                    session_id, team_name, members, orch,
+            if worker_close_seq is not None:
+                self._emit_worker_cycle_closed(
+                    session_id, team_name, members, orch, workers,
+                    close_seq=worker_close_seq,
                 )
 
-        self._save_cycle_state(session_id, worker_open, team_open)
+        # ── Full cycle close ──
+        # Gate on the orchestrator's own transition, NOT on
+        # ``team_open``. See docstring incident 2026-05-19.
+        team_close_seq: int | None = None
+        if prev["orch_running"] and not orch_running and not worker_open:
+            # Meeting-aware: if any member is still mid-meeting, the
+            # team is NOT truly idle — defer the close. Meeting end
+            # events will re-trigger the handler and the next pass will
+            # fire.
+            member_names = {m.get("agent_name", "") for m in spawned}
+            if not self._active_meetings_with_members(member_names):
+                team_close_seq = self._try_close_team_cycle(
+                    session_id, worker_open, team_open, orch_running,
+                )
+                if team_close_seq is not None:
+                    self._emit_full_cycle_closed(
+                        session_id, team_name, members, orch,
+                        close_seq=team_close_seq,
+                    )
+
+        # ── Non-close path: persist new snapshot ──
+        # Atomic close helpers already updated the row on the close
+        # path; only run the upsert when neither close fired. Keeps the
+        # "one writer per event" invariant tight.
+        if worker_close_seq is None and team_close_seq is None:
+            self._save_cycle_state(
+                session_id, worker_open, team_open, orch_running,
+            )
 
     def _emit_worker_cycle_closed(
         self, session_id: str, team_name: str,
         members: list[dict], orch: dict | None, workers: list[dict],
+        *, close_seq: int,
     ) -> None:
-        """PM-facing event: ALL non-orch members have stopped running.
+        """Orchestrator-facing event: ALL non-orchestrator members have
+        stopped running.
 
-        Sends the consolidated worker status to PM's inbox so PM can
-        decide the next round. If PM itself is currently idle, also
-        triggers ``resume_with_inject`` so PM wakes to process it.
+        Sends the consolidated worker status to the orchestrator's
+        inbox so it can decide the next round. If the orchestrator is
+        currently idle, also triggers ``resume_with_inject`` so it
+        wakes to process it.
+
+        ``close_seq`` is the canonical worker-close sequence number
+        (incremented atomically by :py:meth:`_try_close_worker_cycle`).
+        It is embedded into the event_id PK so concurrent callers
+        observing the same close cannot generate distinct event_ids
+        (the old uuid-based key silently defeated PK conflict dedupe —
+        incident 2026-05-19).
         """
         if not orch:
             return
-        event_id = f"{session_id}:worker_cycle_closed:{uuid.uuid4().hex[:12]}"
+        event_id = f"{session_id}:worker_cycle_closed:{close_seq}"
         if not self._insert_event(
             event_id, "worker_cycle_closed", session_id, team_name,
             {"workers": [
@@ -1389,7 +1721,7 @@ class SpawnProgressBridge:
                  "run_id": w.get("run_id")} for w in workers
             ]},
         ):
-            return  # Conflict — already emitted (defensive; shouldn't happen with uuid)
+            return  # Conflict — another caller already emitted this close.
 
         orch_name = orch.get("agent_name", "")
         report = self._format_worker_status_report(workers, orch_name)
@@ -1418,7 +1750,12 @@ class SpawnProgressBridge:
             logger.warning("[CYCLE] worker_cycle_closed send failed: %s", e, exc_info=True)
             return
 
-        # If PM is idle, resume so the inbox notification is consumed.
+        # If the orchestrator is idle, resume so the inbox notification
+        # is consumed. This is the contract the team flow expects: a
+        # worker_cycle close MUST give the orchestrator a turn — that
+        # turn is what later transitions ``orch_running`` False→True
+        # then True→False, which is the canonical full_cycle_closed
+        # trigger.
         if orch.get("status") in ("idle", "completed", "error", "timeout", "cancelled"):
             try:
                 loop = asyncio.get_event_loop()
@@ -1432,13 +1769,19 @@ class SpawnProgressBridge:
     def _emit_full_cycle_closed(
         self, session_id: str, team_name: str,
         members: list[dict], orch: dict | None,
+        *, close_seq: int,
     ) -> None:
-        """User-facing event: the ENTIRE team (incl. orchestrator) is
-        non-running and no active meeting is blocking. Creates a UI
-        notification via the existing ``_create_team_notification``
-        helper (which preserves meeting-aware framing and SSE broadcast).
+        """User-facing event: the orchestrator has just finished its
+        post-worker turn and the team has nothing pending. Creates a
+        UI notification via the existing ``_create_team_notification``
+        helper (which preserves meeting-aware framing and SSE
+        broadcast).
+
+        ``close_seq`` is the canonical team-close sequence number
+        (incremented atomically by :py:meth:`_try_close_team_cycle`).
+        Embedded into the event_id PK to make concurrent emits idempotent.
         """
-        event_id = f"{session_id}:full_cycle_closed:{uuid.uuid4().hex[:12]}"
+        event_id = f"{session_id}:full_cycle_closed:{close_seq}"
         if not self._insert_event(
             event_id, "full_cycle_closed", session_id, team_name,
             {"members": [
@@ -1467,7 +1810,7 @@ class SpawnProgressBridge:
     def _format_worker_status_report(
         self, workers: list[dict], orch_name: str,
     ) -> str:
-        """Build the markdown status report sent to PM's inbox on
+        """Build the markdown status report sent to the orchestrator's inbox on
         ``worker_cycle_closed``. Preserves the meeting-aware framing
         from the prior implementation (b61af7db incident) — if a member
         is still mid-meeting the header reframes to "NOT done".

--- a/backend/services/spawn_progress_bridge.py
+++ b/backend/services/spawn_progress_bridge.py
@@ -16,9 +16,11 @@ Architecture:
 Also logs all events to the spawn_activity logger for ops/debugging.
 """
 
+import asyncio
 import json
 import logging
 import os
+import uuid
 from typing import Any, Protocol
 
 logger = logging.getLogger("spawn_activity")
@@ -143,7 +145,10 @@ class SpawnProgressBridge:
         self._request_id: str | None = None
         self._registry_db = registry_db
         self._token_accumulators: dict[str, dict] = {}  # key → last-seen cumulative values
-        self._orch_notify_hash: dict[str, str] = {}  # team_name → status hash (dedup)
+        # Event-stream tables for team cycle notifications. Lazy-create
+        # via raw SQL (matches pattern in core/agent_registry_db.py) — kept
+        # local to this module since the bridge is the only consumer.
+        self._ensure_event_tables()
 
     def set_request_id(self, request_id: str | None) -> None:
         """Set the active chat request ID for SSE routing."""
@@ -222,13 +227,16 @@ class SpawnProgressBridge:
                     agent_name, _exc,
                 )
 
-        # 4a. Check team completion — notify when ALL team agents are done
-        if event_type_str in ("result", "idle", "agent_completed"):
-            self._check_team_completion(agent_name, event_data)
-
-        # 4b. Consolidated orchestrator notification — all workers idle
-        if event_type_str in ("result", "idle", "agent_completed"):
-            self._notify_orchestrator_on_members_idle(agent_name, event_data)
+        # 4a+b. Cycle-event dispatch — single entry point that emits
+        # ``team.worker_cycle_closed`` (PM inbox) when workers all stop
+        # running, and ``team.full_cycle_closed`` (user UI) when the
+        # whole team stops running. Idempotent via DB event_id PK.
+        # See _on_member_state_event docstring for the state machine.
+        if run_id and event_type_str in {
+            "started", "result", "idle", "agent_completed",
+            "error", "timeout", "cancelled", "killed",
+        }:
+            self._on_member_state_event(run_id)
 
         # 4c. Handle removal events — clean DB records
         if event_type_str == "removed":
@@ -943,71 +951,6 @@ class SpawnProgressBridge:
         )
         return "\n".join(lines)
 
-    # ── Team Completion Notification ──
-
-    def _check_team_completion(self, trigger_agent: str, raw: dict) -> None:
-        """Check if all team agents are done → create notification if so.
-
-        Uses spawn_registry DB as single source of truth.
-        """
-        if not self._registry_db:
-            return
-
-        # Resolve team_name from registry for this agent
-        run_id = raw.get("run_id") or raw.get("data", {}).get("run_id")
-        if not run_id:
-            return
-
-        record = self._registry_db.get_record(run_id)
-        if not record:
-            return
-
-        team_name = record.get("team_name", "")
-        if not team_name:
-            return  # Solo agent, not part of a team
-
-        # Restrict to members of THIS session — team_name is reused across
-        # spawns ("toolset-self-audit" may be re-run daily), so filtering
-        # by team_name alone would mix yesterday's idle agents into
-        # today's completion check and dedupe against an unrelated past
-        # notification. The session_id is the unique handle.
-        session_id = record.get("session_id", "")
-        if not session_id:
-            return  # Pre-session agents (very old rows) — skip safely
-
-        members = [
-            m for m in self._registry_db.find_by_team_name(team_name)
-            if m.get("session_id") == session_id
-        ]
-        if not members:
-            return
-
-        # Only consider spawned agents (exclude "available" = not yet spawned)
-        _terminal = {"completed", "idle", "error", "timeout", "cancelled"}
-        spawned = [m for m in members if m.get("status") not in ("available", None)]
-        if not spawned:
-            return
-
-        all_done = all(m.get("status") in _terminal for m in spawned)
-        if not all_done:
-            return
-
-        # Dedupe per-session, not per-team-name: a re-spawn of the same
-        # named team is a brand new completion event and deserves its
-        # own notification.
-        if self._has_team_notification(session_id):
-            return
-
-        # Find orchestrator result
-        orchestrator = self._find_orchestrator(spawned)
-        result_text = orchestrator.get("result", "") if orchestrator else ""
-        orch_name = orchestrator.get("agent_name", team_name) if orchestrator else team_name
-
-        self._create_team_notification(
-            team_name, orch_name, result_text, spawned,
-            session_id=session_id,
-        )
-
     def _find_orchestrator(self, members: list[dict]) -> dict | None:
         """Find the orchestrator agent from team members.
 
@@ -1072,35 +1015,6 @@ class SpawnProgressBridge:
             f"to recover the response manually."
         )
         return preview, content
-
-    def _has_team_notification(self, session_id: str) -> bool:
-        """Dedupe: check if a team_completion notification already
-        exists FOR THIS SESSION.
-
-        Keyed by ``session_id`` (not ``team_name``): a reusable team
-        name ("toolset-self-audit") spawned twice on different days
-        produces two distinct completion events — each deserves its
-        own notification. Pre-2026-05-14 this dedupe was per
-        ``team_name`` and silently swallowed the second day's
-        notification.
-        """
-        if not session_id:
-            return False
-        try:
-            from core.database import NotificationModel, get_db_session
-
-            db = get_db_session()
-            try:
-                existing = db.query(NotificationModel).filter(
-                    NotificationModel.metadata_json.contains(f'"session_id": "{session_id}"'),
-                    NotificationModel.metadata_json.contains('"source": "team_completion"'),
-                ).first()
-                return existing is not None
-            finally:
-                db.close()
-        except Exception as e:
-            logger.warning("Failed to check team notification dedupe: %s", e)
-            return False
 
     def _create_team_notification(
         self, team_name: str, agent_name: str, result: str, members: list[dict],
@@ -1210,160 +1124,6 @@ class SpawnProgressBridge:
         except Exception as e:
             logger.warning("Failed to create team notification: %s", e, exc_info=True)
 
-    # ── Consolidated Orchestrator Notification ──
-
-    def _notify_orchestrator_on_members_idle(
-        self, trigger_agent: str, raw: dict,
-    ) -> None:
-        """Send consolidated status report when ALL non-orch members stop running.
-
-        Trigger: agent_completed / result / idle events.
-        Delivery: MessageBus → orchestrator inbox.
-        If orchestrator is idle → explicitly triggers resume.
-        Dedup: status hash prevents duplicate notifications for same state.
-        """
-        if not self._registry_db:
-            return
-
-        # 1. Resolve team from trigger agent
-        run_id = raw.get("run_id") or raw.get("data", {}).get("run_id")
-        if not run_id:
-            return
-        record = self._registry_db.get_record(run_id)
-        if not record:
-            return
-        team_name = record.get("team_name", "")
-        if not team_name:
-            return  # Solo agent
-
-        # 2. Get all team members
-        members = self._registry_db.find_by_team_name(team_name)
-        if not members:
-            return
-
-        # 3. Separate orchestrator vs workers
-        orchestrator = self._find_orchestrator(members)
-        if not orchestrator:
-            return
-        orch_name = orchestrator.get("agent_name", "")
-
-        # Skip when the trigger IS the orchestrator. The notification is for
-        # "workers finished delegated work — PM should review". PM going idle
-        # itself (e.g. after replying to a user inject, or after processing
-        # a previous notify-resume) shouldn't re-fire the notification:
-        # PM doesn't need to be told to check its own inbox right after it
-        # just acted. Without this guard, every user inject triggered one
-        # extra round-trip (User → PM responds → idle → bridge sends
-        # "Check inbox" → PM wakes → no-op → idle → dedup hash catches),
-        # which appeared to the user as "agent gets an inbox after every
-        # inject". Production trace 2026-05-16 10:18 ICT.
-        if trigger_agent == orch_name:
-            return
-
-        _non_running = {"idle", "completed", "error", "timeout", "cancelled"}
-        workers = [
-            m for m in members
-            if m.get("agent_name") != orch_name
-            and m.get("status") not in ("available", None)
-        ]
-        if not workers:
-            return
-
-        # 4. ALL workers must be non-running
-        if not all(m.get("status") in _non_running for m in workers):
-            return
-
-        # 5. Dedup via status hash
-        status_parts = sorted(
-            f"{m.get('run_id', '')}:{m.get('status', '')}" for m in workers
-        )
-        status_hash = "|".join(status_parts)
-        if self._orch_notify_hash.get(team_name) == status_hash:
-            return  # Already notified for this exact state
-        self._orch_notify_hash[team_name] = status_hash
-
-        # 6. Build status report — framing depends on whether the team is
-        # idled mid-meeting (b61af7db incident: "All finished | No output"
-        # was misleading because the team had stalled inside a meeting).
-        status_icons = {
-            "idle": "✅", "completed": "✅",
-            "error": "❌", "timeout": "⏰", "cancelled": "🚫",
-        }
-
-        member_names = {m.get("agent_name", "") for m in workers if m.get("agent_name")}
-        member_names.add(orch_name)
-        active_meetings = self._active_meetings_with_members(member_names)
-
-        if active_meetings:
-            header = (
-                f"⏳ **Team Status Update** — members are idle but {len(active_meetings)} "
-                f"meeting(s) still open. Team is NOT done."
-            )
-        else:
-            header = "📋 **Team Status Update** — All members have finished."
-        lines = [header, ""]
-        lines.append("| Member | Status | Summary |")
-        lines.append("|--------|--------|---------|")
-        for m in workers:
-            name = m.get("agent_name", "?")
-            status = m.get("status", "?")
-            icon = status_icons.get(status, "❓")
-            if status == "error":
-                summary = (m.get("error", "") or "Unknown error")[:80]
-            else:
-                summary = (m.get("result", "") or "No output")[:80]
-            summary = summary.replace("\n", " ").replace("|", "/").strip()
-            lines.append(f"| {name} | {icon} {status} | {summary} |")
-
-        if active_meetings:
-            lines.append(self._format_active_meetings_warning(active_meetings))
-        else:
-            lines.append("\nReview outputs and decide next actions.")
-        report = "\n".join(lines)
-
-        # 7. Resolve messages_dir and send via MessageBus
-        messages_dir = self._resolve_messages_dir(members)
-        if not messages_dir:
-            logger.warning(
-                "[TEAM_NOTIFY] Cannot resolve messages_dir for team %s",
-                team_name,
-            )
-            return
-
-        try:
-            from fast_agent.spawn.message_bus import MessageBus
-
-            bus = MessageBus(messages_dir=messages_dir)
-            bus.send(
-                from_name="System",
-                to_name=orch_name,
-                content=report,
-                message_type="notification",
-                priority="high",
-            )
-            logger.info(
-                "[TEAM_NOTIFY] Sent consolidated status to %s (%d workers, team=%s)",
-                orch_name, len(workers), team_name,
-            )
-        except Exception as e:
-            logger.warning("[TEAM_NOTIFY] Failed to send via MessageBus: %s", e, exc_info=True)
-            return
-
-        # 8. If orchestrator is idle, trigger resume so it processes the report
-        orch_status = orchestrator.get("status", "")
-        if orch_status in _non_running:
-            import asyncio
-            try:
-                loop = asyncio.get_event_loop()
-                loop.create_task(
-                    self._trigger_orchestrator_resume(orchestrator, team_name)
-                )
-            except RuntimeError:
-                logger.warning(
-                    "[TEAM_NOTIFY] No event loop — cannot resume idle orchestrator %s",
-                    orch_name,
-                )
-
     def _resolve_messages_dir(self, members: list[dict]) -> str:
         """Resolve TEAM_MESSAGES_DIR from any team member's original_config."""
         from pathlib import Path
@@ -1407,4 +1167,340 @@ class SpawnProgressBridge:
                 "[TEAM_NOTIFY] Failed to resume orchestrator %s: %s",
                 orch_name, e, exc_info=True,
             )
+
+    # ── Event-stream cycle handler ────────────────────────────────────
+    #
+    # Replaces the previous dedup-based notification pair
+    # (``_check_team_completion`` + ``_notify_orchestrator_on_members_idle``)
+    # with a transition-based event stream. The previous design tried to
+    # silence duplicate notifications via in-memory hash or DB content
+    # filter, but the dedup keys were too coarse — once a session had
+    # ever notified, every subsequent "all idle" cycle was silently
+    # dropped (production 2026-05-16: session ``be885ae8`` only ever got
+    # 1 user notification despite N work cycles).
+    #
+    # New model:
+    #
+    #   * Two named cycles per session: ``worker_cycle`` (PM-facing) and
+    #     ``team_cycle`` (user-facing). Open when at least one relevant
+    #     agent is ``running``; close when all are non-running.
+    #   * On every member state-change event, recompute both cycles
+    #     from the registry (single source of truth) and compare to the
+    #     last persisted state. Emit close events on the open→closed
+    #     transition only.
+    #   * Idempotency lives at the DB layer via ``team_events.event_id``
+    #     PRIMARY KEY + ``INSERT ... ON CONFLICT DO NOTHING``. No
+    #     application-level dedup; no in-memory hash.
+    #   * Cycle state persists in ``team_cycle_state`` so backend
+    #     restarts resume the correct transition view (no false fire,
+    #     no missed close).
+
+    def _ensure_event_tables(self) -> None:
+        """Create event-stream tables on first use. Mirrors the lazy
+        ``CREATE TABLE IF NOT EXISTS`` pattern from
+        ``core.agent_registry_db._ensure_team_sessions_table``.
+        """
+        try:
+            from core.agent_registry_db import _connect
+
+            with _connect() as conn:
+                conn.execute(
+                    """CREATE TABLE IF NOT EXISTS team_events (
+                        event_id    TEXT PRIMARY KEY,
+                        event_type  TEXT NOT NULL,
+                        session_id  TEXT NOT NULL,
+                        team_name   TEXT NOT NULL,
+                        payload_json TEXT NOT NULL,
+                        created_at  REAL NOT NULL
+                    )"""
+                )
+                conn.execute(
+                    """CREATE INDEX IF NOT EXISTS ix_team_events_session
+                       ON team_events(session_id, created_at)"""
+                )
+                conn.execute(
+                    """CREATE TABLE IF NOT EXISTS team_cycle_state (
+                        session_id    TEXT PRIMARY KEY,
+                        worker_open   INTEGER NOT NULL DEFAULT 0,
+                        team_open     INTEGER NOT NULL DEFAULT 0,
+                        updated_at    REAL NOT NULL
+                    )"""
+                )
+        except Exception as e:
+            logger.warning("[CYCLE] _ensure_event_tables failed: %s", e, exc_info=True)
+
+    def _load_cycle_state(self, session_id: str) -> dict:
+        """Return ``{worker_open, team_open}`` for the session. Defaults
+        to both-closed when no row exists — first event after spawn will
+        update to open and persist."""
+        try:
+            from core.agent_registry_db import _connect
+
+            with _connect() as conn:
+                row = conn.execute(
+                    "SELECT worker_open, team_open FROM team_cycle_state "
+                    "WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+                if row is None:
+                    return {"worker_open": False, "team_open": False}
+                return {
+                    "worker_open": bool(row["worker_open"]),
+                    "team_open": bool(row["team_open"]),
+                }
+        except Exception as e:
+            logger.warning("[CYCLE] _load_cycle_state(%s) failed: %s", session_id, e)
+            return {"worker_open": False, "team_open": False}
+
+    def _save_cycle_state(
+        self, session_id: str, worker_open: bool, team_open: bool,
+    ) -> None:
+        try:
+            import time
+            from core.agent_registry_db import _connect
+
+            with _connect() as conn:
+                conn.execute(
+                    """INSERT INTO team_cycle_state(session_id, worker_open, team_open, updated_at)
+                       VALUES(?, ?, ?, ?)
+                       ON CONFLICT(session_id) DO UPDATE SET
+                         worker_open = excluded.worker_open,
+                         team_open   = excluded.team_open,
+                         updated_at  = excluded.updated_at""",
+                    (session_id, int(worker_open), int(team_open), time.time()),
+                )
+        except Exception as e:
+            logger.warning("[CYCLE] _save_cycle_state(%s) failed: %s", session_id, e)
+
+    def _insert_event(
+        self, event_id: str, event_type: str,
+        session_id: str, team_name: str, payload: dict,
+    ) -> bool:
+        """INSERT … ON CONFLICT DO NOTHING. Returns True iff the row was
+        newly inserted (i.e. caller should run side effects). False on
+        conflict or error — caller must skip downstream notifications.
+        """
+        try:
+            import time
+            from core.agent_registry_db import _connect
+
+            with _connect() as conn:
+                cur = conn.execute(
+                    """INSERT INTO team_events(event_id, event_type, session_id, team_name, payload_json, created_at)
+                       VALUES(?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(event_id) DO NOTHING""",
+                    (event_id, event_type, session_id, team_name,
+                     json.dumps(payload), time.time()),
+                )
+                return cur.rowcount > 0
+        except Exception as e:
+            logger.warning(
+                "[CYCLE] _insert_event(%s) failed: %s", event_id, e, exc_info=True,
+            )
+            return False
+
+    def _on_member_state_event(self, run_id: str) -> None:
+        """Single entry point for status-changing events.
+
+        Pure transition detector:
+
+          1. Load registry record for ``run_id`` → resolve ``session_id``
+             and ``team_name`` (skip for solo agents).
+          2. Snapshot current cycle state from the registry: workers
+             open iff any non-orch member is ``running``; team open iff
+             any team agent is ``running``.
+          3. Compare against the last persisted cycle state. On
+             ``open → closed`` transitions, emit the matching cycle
+             event (idempotent via DB PK).
+          4. Persist the new cycle state.
+
+        See module-level docstring for the full state machine and the
+        14-case edge-case table.
+        """
+        if not self._registry_db:
+            return
+
+        record = self._registry_db.get_record(run_id)
+        if not record:
+            return
+        session_id = record.get("session_id", "")
+        team_name = record.get("team_name", "")
+        if not session_id or not team_name:
+            return  # Solo agent or pre-session record — not in scope
+
+        members = [
+            m for m in self._registry_db.find_by_team_name(team_name)
+            if m.get("session_id") == session_id
+        ]
+        if not members:
+            return
+
+        orch = self._find_orchestrator(members)
+        orch_name = orch.get("agent_name", "") if orch else ""
+        # ``available`` = registered but not spawned yet; ``None`` = legacy
+        # rows. Exclude both from cycle calculations — they are not
+        # transitionable states.
+        spawned = [
+            m for m in members
+            if m.get("status") not in ("available", None)
+        ]
+        workers = [m for m in spawned if m.get("agent_name") != orch_name]
+
+        worker_open = any(m.get("status") == "running" for m in workers)
+        team_open = any(m.get("status") == "running" for m in spawned)
+
+        prev = self._load_cycle_state(session_id)
+
+        if prev["worker_open"] and not worker_open:
+            self._emit_worker_cycle_closed(
+                session_id, team_name, members, orch, workers,
+            )
+
+        if prev["team_open"] and not team_open:
+            # Meeting-aware: if a member is still mid-meeting, the team
+            # is NOT truly idle — defer the close. Meeting end events
+            # will re-trigger the handler and the next pass will fire.
+            member_names = {m.get("agent_name", "") for m in spawned}
+            if not self._active_meetings_with_members(member_names):
+                self._emit_full_cycle_closed(
+                    session_id, team_name, members, orch,
+                )
+
+        self._save_cycle_state(session_id, worker_open, team_open)
+
+    def _emit_worker_cycle_closed(
+        self, session_id: str, team_name: str,
+        members: list[dict], orch: dict | None, workers: list[dict],
+    ) -> None:
+        """PM-facing event: ALL non-orch members have stopped running.
+
+        Sends the consolidated worker status to PM's inbox so PM can
+        decide the next round. If PM itself is currently idle, also
+        triggers ``resume_with_inject`` so PM wakes to process it.
+        """
+        if not orch:
+            return
+        event_id = f"{session_id}:worker_cycle_closed:{uuid.uuid4().hex[:12]}"
+        if not self._insert_event(
+            event_id, "worker_cycle_closed", session_id, team_name,
+            {"workers": [
+                {"agent_name": w.get("agent_name"),
+                 "status": w.get("status"),
+                 "run_id": w.get("run_id")} for w in workers
+            ]},
+        ):
+            return  # Conflict — already emitted (defensive; shouldn't happen with uuid)
+
+        orch_name = orch.get("agent_name", "")
+        report = self._format_worker_status_report(workers, orch_name)
+        messages_dir = self._resolve_messages_dir(members)
+        if not messages_dir:
+            logger.warning(
+                "[CYCLE] worker_cycle_closed for %s: no messages_dir resolvable",
+                team_name,
+            )
+            return
+        try:
+            from fast_agent.spawn.message_bus import MessageBus
+
+            MessageBus(messages_dir=messages_dir).send(
+                from_name="System",
+                to_name=orch_name,
+                content=report,
+                message_type="notification",
+                priority="high",
+            )
+            logger.info(
+                "[CYCLE] worker_cycle_closed → %s (%d workers, team=%s, event=%s)",
+                orch_name, len(workers), team_name, event_id,
+            )
+        except Exception as e:
+            logger.warning("[CYCLE] worker_cycle_closed send failed: %s", e, exc_info=True)
+            return
+
+        # If PM is idle, resume so the inbox notification is consumed.
+        if orch.get("status") in ("idle", "completed", "error", "timeout", "cancelled"):
+            try:
+                loop = asyncio.get_event_loop()
+                loop.create_task(self._trigger_orchestrator_resume(orch, team_name))
+            except RuntimeError:
+                logger.warning(
+                    "[CYCLE] No event loop — cannot resume idle orchestrator %s",
+                    orch_name,
+                )
+
+    def _emit_full_cycle_closed(
+        self, session_id: str, team_name: str,
+        members: list[dict], orch: dict | None,
+    ) -> None:
+        """User-facing event: the ENTIRE team (incl. orchestrator) is
+        non-running and no active meeting is blocking. Creates a UI
+        notification via the existing ``_create_team_notification``
+        helper (which preserves meeting-aware framing and SSE broadcast).
+        """
+        event_id = f"{session_id}:full_cycle_closed:{uuid.uuid4().hex[:12]}"
+        if not self._insert_event(
+            event_id, "full_cycle_closed", session_id, team_name,
+            {"members": [
+                {"agent_name": m.get("agent_name"),
+                 "status": m.get("status"),
+                 "run_id": m.get("run_id")} for m in members
+            ]},
+        ):
+            return
+
+        result_text = orch.get("result", "") if orch else ""
+        orch_name = orch.get("agent_name", team_name) if orch else team_name
+        spawned = [
+            m for m in members
+            if m.get("status") not in ("available", None)
+        ]
+        self._create_team_notification(
+            team_name, orch_name, result_text, spawned,
+            session_id=session_id,
+        )
+        logger.info(
+            "[CYCLE] full_cycle_closed → user notify (team=%s, event=%s)",
+            team_name, event_id,
+        )
+
+    def _format_worker_status_report(
+        self, workers: list[dict], orch_name: str,
+    ) -> str:
+        """Build the markdown status report sent to PM's inbox on
+        ``worker_cycle_closed``. Preserves the meeting-aware framing
+        from the prior implementation (b61af7db incident) — if a member
+        is still mid-meeting the header reframes to "NOT done".
+        """
+        status_icons = {
+            "idle": "✅", "completed": "✅",
+            "error": "❌", "timeout": "⏰", "cancelled": "🚫",
+        }
+        member_names = {w.get("agent_name", "") for w in workers if w.get("agent_name")}
+        member_names.add(orch_name)
+        active_meetings = self._active_meetings_with_members(member_names)
+
+        if active_meetings:
+            header = (
+                f"⏳ **Team Status Update** — members are idle but "
+                f"{len(active_meetings)} meeting(s) still open. Team is NOT done."
+            )
+        else:
+            header = "📋 **Team Status Update** — All members have finished."
+        lines = [header, "", "| Member | Status | Summary |", "|--------|--------|---------|"]
+        for w in workers:
+            name = w.get("agent_name", "?")
+            status = w.get("status", "?")
+            icon = status_icons.get(status, "❓")
+            if status == "error":
+                summary = (w.get("error", "") or "Unknown error")[:80]
+            else:
+                summary = (w.get("result", "") or "No output")[:80]
+            summary = summary.replace("\n", " ").replace("|", "/").strip()
+            lines.append(f"| {name} | {icon} {status} | {summary} |")
+        if active_meetings:
+            lines.append(self._format_active_meetings_warning(active_meetings))
+        else:
+            lines.append("\nReview outputs and decide next actions.")
+        return "\n".join(lines)
 

--- a/backend/services/team_reload.py
+++ b/backend/services/team_reload.py
@@ -1,0 +1,272 @@
+"""Force-kill + respawn agents in a team after a template change.
+
+The destructive half of the template edit flow. ``team_template_service``
+mutates DB SSoT; this module brings live processes into alignment.
+
+Semantics (per user decision 2026-05-17):
+  - No "wait for idle". Kill immediately on user confirmation.
+  - Respawn via the existing inject_resume path so context + history are
+    preserved through the restart.
+  - Per-role scope: reload only the roles the user named.
+
+Re-uses the same SSoT chain everyone else does:
+  1. spawn_record (latest by agent_name) → kill its PID tree
+  2. resume_with_inject() → reads fresh team_sessions.template from DB
+     (no caching) → spawns with new config
+
+The inject message is a sentinel agents are told to acknowledge silently;
+they don't have to react beyond reading their inbox.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Sentinel sent to the agent when reload is triggered. Kept short so it
+# doesn't clutter the context window if the agent decides to log it.
+_RELOAD_SENTINEL = (
+    "[SYSTEM] Your team template was updated by an administrator and your "
+    "process was restarted. Tools / skills / instructions may have changed. "
+    "Continue with your previous task; if uncertain, re-read your skills."
+)
+
+# Inject statuses (mirrors routes/inject.py). Keep in sync if those change.
+_PROCESS_ALIVE_STATUSES = {"running", "pending", "paused"}
+
+
+def _kill_process_tree(pid: int, *, sigkill_after: float = 2.0) -> bool:
+    """SIGTERM then SIGKILL after grace. Returns True if PID is gone."""
+    if pid <= 0:
+        return True
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True  # already dead
+    except PermissionError:
+        logger.warning("[RELOAD] kill SIGTERM permission denied for pid=%d", pid)
+        return False
+
+    # Wait briefly for graceful exit
+    deadline = time.time() + sigkill_after
+    while time.time() < deadline:
+        try:
+            os.kill(pid, 0)  # signal 0 = liveness probe
+        except ProcessLookupError:
+            return True
+        time.sleep(0.1)
+
+    # Still alive — escalate
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        logger.warning("[RELOAD] kill SIGKILL permission denied for pid=%d", pid)
+        return False
+
+    # Final liveness check
+    time.sleep(0.2)
+    try:
+        os.kill(pid, 0)
+        logger.warning("[RELOAD] pid=%d still alive after SIGKILL", pid)
+        return False
+    except ProcessLookupError:
+        return True
+
+
+def _list_agents_for_role(session: Any, role: str) -> list[tuple[str, dict[str, Any]]]:
+    """Return ``[(agent_name, agent_info_dict), ...]`` for agents in this session
+    matching the role. ``agent_info_dict`` is the value of
+    ``session.agents[name]`` (has run_id, role, status, ...).
+    """
+    out: list[tuple[str, dict[str, Any]]] = []
+    for name, info in (session.agents or {}).items():
+        if (info or {}).get("role") == role:
+            out.append((name, info))
+    return out
+
+
+async def reload_roles(
+    session_id: str,
+    roles: list[str],
+    *,
+    edited_by: str = "system",
+    inject_message: str | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Kill + respawn every agent in ``roles`` for the given session.
+
+    Returns ``{role: [{agent_name, old_run_id, old_pid, new_run_id, killed,
+    resumed}]}``. Per-agent errors are caught and reported in-band so a
+    single failure doesn't break the whole reload.
+
+    The respawn flow goes through ``services.inject_resume.resume_with_inject``.
+    That function now re-reads ``team_sessions.template.roles[role]`` at
+    resume time and overrides the spawn registry's frozen snapshot for
+    template-driven fields (servers / server_overrides / instruction /
+    skills / model). Before 2026-05-18 it silently read the snapshot, so
+    a template edit landed in DB but never reached the next resume —
+    incident: `playwright` added to QE servers list, every resume kept
+    using the stale 7-server snapshot, agent fell back to scrapling-server.
+    """
+    from fast_agent.spawn.team_spawner import get_team_session
+    from services import shared_state
+    from services.inject_resume import resume_with_inject
+
+    session = get_team_session(session_id)
+    if session is None:
+        raise LookupError(f"team session '{session_id}' not found")
+
+    msg = inject_message or _RELOAD_SENTINEL
+    results: dict[str, list[dict[str, Any]]] = {}
+
+    for role in roles:
+        results[role] = []
+        targets = _list_agents_for_role(session, role)
+        if not targets:
+            logger.warning(
+                "[RELOAD] role=%s in session=%s has no agents — skipping",
+                role, session_id,
+            )
+            continue
+
+        for agent_name, info in targets:
+            entry: dict[str, Any] = {
+                "agent_name": agent_name,
+                "old_run_id": info.get("run_id"),
+                "old_pid": None,
+                "new_run_id": None,
+                "killed": False,
+                "resumed": False,
+                "error": None,
+            }
+            try:
+                # 1. Find latest spawn record + its PID
+                if not shared_state.registry_db:
+                    raise RuntimeError("registry_db not initialised")
+                records = shared_state.registry_db.find_by_name(agent_name)
+                latest = records[0] if records else None
+                if not latest:
+                    raise LookupError(
+                        f"no spawn record for agent '{agent_name}'"
+                    )
+
+                pid = latest.get("pid")
+                entry["old_pid"] = pid
+
+                # 2. Kill if alive
+                if latest.get("status") in _PROCESS_ALIVE_STATUSES and pid:
+                    entry["killed"] = _kill_process_tree(int(pid))
+                    if not entry["killed"]:
+                        # Continue anyway — respawn will create a fresh run
+                        # under a new pid; the old will eventually exit or be
+                        # cleaned by the reaper.
+                        logger.warning(
+                            "[RELOAD] could not confirm kill of pid=%s for %s",
+                            pid, agent_name,
+                        )
+
+                # 3. Respawn via inject_resume — picks up fresh DB template
+                resume_result = await resume_with_inject(
+                    agent_name=agent_name,
+                    inject_message=msg,
+                    spawn_record=latest,
+                    bridge=None,
+                )
+                entry["new_run_id"] = resume_result.get("run_id")
+                entry["resumed"] = resume_result.get("status") == "resumed"
+
+            except Exception as exc:
+                entry["error"] = f"{type(exc).__name__}: {exc}"
+                logger.error(
+                    "[RELOAD] failed for session=%s role=%s agent=%s: %s",
+                    session_id, role, agent_name, exc, exc_info=True,
+                )
+
+            results[role].append(entry)
+
+            # Brief gap between agents so spawn events don't pile up — also
+            # gives the spawned subprocess a head-start to claim the run_id.
+            await asyncio.sleep(0.1)
+
+        logger.info(
+            "[RELOAD] session=%s role=%s reloaded %d agent(s) by %s",
+            session_id, role, len(results[role]), edited_by,
+        )
+
+    return results
+
+
+def find_sessions_using_skill(skill_name: str) -> list[dict[str, Any]]:
+    """Scan every team_sessions row for roles that reference ``skill_name``.
+
+    Returns ``[{session_id, team_name, roles: [role_keys...]}]`` — one entry
+    per affected session, only roles whose ``skills`` list contains the skill.
+    Used by the skill-reload endpoint to compute blast radius before showing
+    the confirm dialog.
+    """
+    from fast_agent.spawn.team_spawner import list_team_sessions
+
+    matches: list[dict[str, Any]] = []
+    for sess in list_team_sessions():
+        roles = (sess.get("template") or {}).get("roles") or {}
+        affected_roles = [
+            rk for rk, rcfg in roles.items()
+            if skill_name in ((rcfg or {}).get("skills") or [])
+        ]
+        if affected_roles:
+            matches.append({
+                "session_id": sess.get("session_id"),
+                "team_name": sess.get("team_name", ""),
+                "roles": affected_roles,
+            })
+    return matches
+
+
+async def reload_by_skill(
+    skill_name: str,
+    *,
+    edited_by: str = "system",
+    inject_message: str | None = None,
+) -> dict[str, Any]:
+    """Force-kill + respawn every agent across every team that uses ``skill_name``.
+
+    Returns ``{skill: name, sessions: [{session_id, results}]}`` where
+    ``results`` is exactly the per-role dict returned by ``reload_roles``.
+    Cross-team operation — a single skill is typically used by many roles in
+    many teams (e.g. ``team-communication``, ``self-audit-tools``).
+    """
+    sentinel = inject_message or (
+        f"[SYSTEM] The skill '{skill_name}' was updated by an administrator "
+        f"and your process was restarted. Re-read the skill before continuing "
+        f"your previous task."
+    )
+    affected = find_sessions_using_skill(skill_name)
+    out: dict[str, Any] = {"skill": skill_name, "sessions": []}
+    for entry in affected:
+        sid = entry["session_id"]
+        try:
+            results = await reload_roles(
+                session_id=sid,
+                roles=entry["roles"],
+                edited_by=edited_by,
+                inject_message=sentinel,
+            )
+        except Exception as exc:
+            logger.error(
+                "[RELOAD/skill=%s] session=%s failed: %s",
+                skill_name, sid, exc, exc_info=True,
+            )
+            results = {"_error": [{"error": f"{type(exc).__name__}: {exc}"}]}
+        out["sessions"].append({
+            "session_id": sid,
+            "team_name": entry["team_name"],
+            "roles": entry["roles"],
+            "results": results,
+        })
+    return out

--- a/backend/services/team_template_service.py
+++ b/backend/services/team_template_service.py
@@ -1,0 +1,440 @@
+"""Team template edit / diff / audit / rollback — pure service layer.
+
+Mounted as REST in ``routes/team_template.py``. Keep this module free of HTTP
+concerns so callers (cron jobs, CLI scripts, future MCP tools) can reuse it.
+
+Concepts:
+  - Template = ``team_sessions.data_json.template`` (per-team config snapshot).
+    SSoT for the RUNNING team. ``team_templates/*.yaml`` is the factory
+    default used only at team creation.
+  - History = ``team_template_history`` (audit log, append-only). Every
+    edit / rollback writes a row.
+  - Reload = separate concern, see ``services.team_reload``.
+
+Field-level edits (``patch`` argument) are diffed against current value and
+recorded with structural granularity (``field`` column = "servers" /
+"instruction" / "skills" / "server_overrides" / "model"). One PATCH call ⇒
+one or more history rows (one per changed field).
+"""
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from core.database import TeamTemplateHistory
+
+logger = logging.getLogger(__name__)
+
+
+# Fields of ``template.roles[role]`` we allow editing via this API. Edits to
+# unknown fields are rejected — keeps the surface area tight and prevents
+# accidental injection of unsafe keys (e.g. raw "cwd", "env" overrides).
+ALLOWED_ROLE_FIELDS: frozenset[str] = frozenset({
+    "instruction",
+    "servers",
+    "skills",
+    "server_overrides",
+    "model",
+    "role_display",
+})
+
+
+class ValidationError(ValueError):
+    """Raised when a patch fails schema or path-existence checks."""
+
+
+class NotFoundError(LookupError):
+    """Raised when session_id / role / history_id doesn't exist."""
+
+
+class ConflictError(RuntimeError):
+    """Raised on a no-op patch (everything already matches desired state)."""
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Read helpers — always fresh from DB (no caching). The team_sessions row IS
+# the single source of truth for the running team's template. Any caller that
+# holds an old reference must re-fetch before computing diffs.
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _get_team_session_dict(session_id: str) -> dict[str, Any]:
+    """Fetch a team_sessions row as dict. Raises NotFoundError if missing."""
+    # Lazy import — fast-agent package isn't part of the test harness for
+    # service-level unit tests. The function is mocked in those tests.
+    from fast_agent.spawn.team_spawner import get_team_session
+
+    sess = get_team_session(session_id)
+    if sess is None:
+        raise NotFoundError(f"team session '{session_id}' not found")
+    return sess.to_dict()
+
+
+def _put_team_session_dict(session_id: str, data: dict[str, Any]) -> None:
+    """Persist mutated team_sessions row back to SQLite."""
+    from fast_agent.spawn.team_spawner import _get_store  # noqa: PLC2701
+
+    _get_store().upsert(session_id, data)
+
+
+def get_template(session_id: str) -> dict[str, Any]:
+    """Return the current template dict for a session.
+
+    Always re-reads from DB — no in-memory cache. Callers that need the live
+    state (UI render, diff target, reload trigger) must call this each time.
+    """
+    return _get_team_session_dict(session_id).get("template", {})
+
+
+def get_role_config(session_id: str, role: str) -> dict[str, Any]:
+    """Return one role's config dict. Raises NotFoundError if role missing."""
+    roles = get_template(session_id).get("roles", {})
+    if role not in roles:
+        raise NotFoundError(f"role '{role}' not in template (have: {sorted(roles)})")
+    return roles[role]
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Diff
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def compute_role_diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, dict]:
+    """Return ``{field: {"before": <v>, "after": <v>}}`` for changed fields.
+
+    Order-insensitive for list-of-strings fields (``servers``, ``skills``)
+    so that re-ordering doesn't count as a change. Deep-equal for dicts.
+    """
+    diff: dict[str, dict] = {}
+    keys = set(before) | set(after)
+    for k in keys:
+        b, a = before.get(k), after.get(k)
+        if _equal(k, b, a):
+            continue
+        diff[k] = {"before": b, "after": a}
+    return diff
+
+
+def _equal(field: str, b: Any, a: Any) -> bool:
+    """Field-aware equality. Lists of strings are compared as sets when the
+    field is a known list-of-server / skill name (order doesn't carry meaning).
+    """
+    if field in ("servers", "skills") and isinstance(b, list) and isinstance(a, list):
+        return sorted(b) == sorted(a)
+    return b == a
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Validation
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def validate_patch(role: str, patch: dict[str, Any], project_dir: Path | None = None) -> None:
+    """Reject patches with unknown fields or path-shaped args that won't exist.
+
+    Mirrors the regression test ``test_fastagent_config_defaults`` — any path
+    in ``server_overrides.{server}.args`` must resolve to an existing
+    directory (or be a template placeholder like ``{workspace_dir}``).
+    """
+    if not isinstance(patch, dict):
+        raise ValidationError("patch must be an object")
+
+    unknown = set(patch) - ALLOWED_ROLE_FIELDS
+    if unknown:
+        raise ValidationError(
+            f"unknown fields: {sorted(unknown)}. Allowed: {sorted(ALLOWED_ROLE_FIELDS)}"
+        )
+
+    if "servers" in patch:
+        s = patch["servers"]
+        if not isinstance(s, list) or not all(isinstance(x, str) and x for x in s):
+            raise ValidationError("'servers' must be a list of non-empty strings")
+
+    if "skills" in patch:
+        s = patch["skills"]
+        if not isinstance(s, list) or not all(isinstance(x, str) and x for x in s):
+            raise ValidationError("'skills' must be a list of non-empty strings")
+
+    if "instruction" in patch and not isinstance(patch["instruction"], str):
+        raise ValidationError("'instruction' must be a string")
+
+    if "model" in patch and not isinstance(patch["model"], str):
+        raise ValidationError("'model' must be a string")
+
+    if "server_overrides" in patch:
+        overrides = patch["server_overrides"]
+        if not isinstance(overrides, dict):
+            raise ValidationError("'server_overrides' must be an object")
+        for server_name, cfg in overrides.items():
+            if not isinstance(cfg, dict):
+                raise ValidationError(
+                    f"server_overrides['{server_name}'] must be an object"
+                )
+            args = cfg.get("args")
+            if args is not None:
+                if not isinstance(args, list):
+                    raise ValidationError(
+                        f"server_overrides['{server_name}'].args must be a list"
+                    )
+                for arg in args:
+                    if not isinstance(arg, str):
+                        raise ValidationError(
+                            f"server_overrides['{server_name}'].args items must be strings"
+                        )
+                    _check_path_arg(server_name, arg, project_dir)
+
+
+def _check_path_arg(server_name: str, arg: str, project_dir: Path | None) -> None:
+    """If ``arg`` looks like a real filesystem path (not a placeholder or flag),
+    verify it exists. Same heuristic as test_fastagent_config_defaults.
+    """
+    if not arg or arg.startswith("-"):
+        return
+    if "{" in arg and "}" in arg:  # template placeholder
+        return
+    if arg.startswith("@") and "/" in arg:  # npm package specifier
+        return
+    if not (arg.startswith((".", "/", "~")) or "/" in arg):
+        return  # bare module name
+
+    if arg.startswith("./"):
+        if project_dir is None:
+            return  # can't resolve relative without context
+        resolved = project_dir / arg[2:]
+    elif arg.startswith("~"):
+        resolved = Path(arg).expanduser()
+    else:
+        resolved = Path(arg)
+
+    if not resolved.exists():
+        raise ValidationError(
+            f"server_overrides['{server_name}'].args contains path '{arg}' "
+            f"that resolves to {resolved} — directory does not exist. Create "
+            f"it first or use a template placeholder like '{{workspace_dir}}'."
+        )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Apply (PATCH)
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def apply_role_patch(
+    db: Session,
+    session_id: str,
+    role: str,
+    patch: dict[str, Any],
+    *,
+    edited_by: str = "system",
+    source: str = "api",
+    comment: str = "",
+    project_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Apply a per-role patch, write audit rows, persist team_sessions.
+
+    Returns ``{audit_ids: [...], diff: {field: {before, after}}, after_role: {...}}``.
+
+    Atomic at the DB level — either all audit rows + the team_sessions update
+    commit together, or nothing changes. Multiple fields in one patch ⇒
+    multiple audit rows (one per field) but a single commit.
+
+    Raises:
+        ValidationError: invalid patch shape or missing path
+        NotFoundError: unknown session_id / role
+        ConflictError: patch is a no-op (everything already matches)
+    """
+    validate_patch(role, patch, project_dir=project_dir)
+
+    data = _get_team_session_dict(session_id)
+    roles = data.get("template", {}).get("roles", {})
+    if role not in roles:
+        raise NotFoundError(f"role '{role}' not in template")
+
+    before_role = copy.deepcopy(roles[role])
+    after_role = copy.deepcopy(before_role)
+    after_role.update(patch)
+
+    diff = compute_role_diff(before_role, after_role)
+    if not diff:
+        raise ConflictError(
+            f"no-op: role '{role}' already matches the requested state"
+        )
+
+    # Write audit rows (one per changed field). Source-of-truth update goes
+    # in the SAME transaction so partial state is impossible.
+    now = time.time()
+    audit_ids: list[int] = []
+    for field, change in diff.items():
+        row = TeamTemplateHistory(
+            session_id=session_id,
+            role=role,
+            field=field,
+            before_json=json.dumps(change["before"], ensure_ascii=False),
+            after_json=json.dumps(change["after"], ensure_ascii=False),
+            source=source,
+            edited_by=edited_by,
+            edited_at=now,
+            comment=comment or None,
+        )
+        db.add(row)
+        db.flush()  # populate row.id without committing
+        audit_ids.append(row.id)
+
+    # Persist template update. ``_put_team_session_dict`` writes to the
+    # team_sessions store, which uses its own connection — commit ``db``
+    # first so audit rows are durable before the dependent template update.
+    db.commit()
+
+    roles[role] = after_role
+    _put_team_session_dict(session_id, data)
+
+    logger.info(
+        "[TEMPLATE-PATCH] session=%s role=%s fields=%s audit_ids=%s source=%s edited_by=%s",
+        session_id, role, sorted(diff), audit_ids, source, edited_by,
+    )
+
+    return {
+        "audit_ids": audit_ids,
+        "diff": diff,
+        "after_role": after_role,
+        "edited_at": now,
+    }
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# History + rollback
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def get_history(
+    db: Session,
+    session_id: str,
+    role: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Return audit rows for a session, optionally filtered by role.
+
+    Sorted newest-first. Both ``before_json`` and ``after_json`` are
+    decoded back to native Python so callers don't need to re-parse.
+    """
+    q = db.query(TeamTemplateHistory).filter(
+        TeamTemplateHistory.session_id == session_id,
+    )
+    if role:
+        q = q.filter(TeamTemplateHistory.role == role)
+    rows = (
+        q.order_by(TeamTemplateHistory.edited_at.desc())
+        .limit(max(1, min(limit, 500)))
+        .all()
+    )
+    return [
+        {
+            "id": r.id,
+            "session_id": r.session_id,
+            "role": r.role,
+            "field": r.field,
+            "before": json.loads(r.before_json) if r.before_json else None,
+            "after": json.loads(r.after_json) if r.after_json else None,
+            "source": r.source,
+            "edited_by": r.edited_by,
+            "edited_at": r.edited_at,
+            "comment": r.comment,
+        }
+        for r in rows
+    ]
+
+
+def rollback_to(
+    db: Session,
+    session_id: str,
+    audit_id: int,
+    *,
+    edited_by: str = "system",
+    comment: str = "",
+) -> dict[str, Any]:
+    """Revert ``role.field`` to the ``before`` value of the given audit row.
+
+    Writes a NEW audit row (``source='rollback'``) referencing the original
+    in ``comment`` — we never delete history. If the field already matches
+    the target value, raises ConflictError.
+    """
+    row = db.query(TeamTemplateHistory).filter(
+        TeamTemplateHistory.id == audit_id,
+        TeamTemplateHistory.session_id == session_id,
+    ).first()
+    if row is None:
+        raise NotFoundError(f"audit row {audit_id} not found for session {session_id}")
+    if not row.role or not row.field:
+        raise ValidationError(
+            f"audit row {audit_id} has no role/field — cannot rollback"
+        )
+
+    target_value = json.loads(row.before_json) if row.before_json else None
+    patch = {row.field: target_value}
+    rollback_comment = (
+        f"rollback of audit_id={audit_id} ({row.field}). "
+        f"{comment}".strip()
+    )
+    return apply_role_patch(
+        db,
+        session_id,
+        row.role,
+        patch,
+        edited_by=edited_by,
+        source="rollback",
+        comment=rollback_comment,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Reset to yaml factory default
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def reset_role_to_yaml(
+    db: Session,
+    session_id: str,
+    role: str,
+    yaml_path: Path,
+    *,
+    edited_by: str = "system",
+    comment: str = "",
+) -> dict[str, Any]:
+    """Reset one role's config back to the yaml factory default.
+
+    Reads the yaml file, extracts ``team.roles[role]``, and applies it as a
+    patch (so every field reset is audited). The current team_sessions
+    template is NOT replaced wholesale — only the named role is reset.
+    Other roles' current state (including UI edits) is preserved.
+    """
+    import yaml as yaml_lib  # local import — yaml isn't always at top
+
+    if not yaml_path.exists():
+        raise NotFoundError(f"yaml template not found at {yaml_path}")
+
+    with yaml_path.open(encoding="utf-8") as f:
+        yaml_doc = yaml_lib.safe_load(f) or {}
+
+    yaml_roles = yaml_doc.get("team", {}).get("roles") or yaml_doc.get("roles") or {}
+    if role not in yaml_roles:
+        raise NotFoundError(f"role '{role}' not in yaml at {yaml_path}")
+
+    yaml_role = yaml_roles[role]
+    patch = {
+        k: yaml_role[k] for k in ALLOWED_ROLE_FIELDS if k in yaml_role
+    }
+    return apply_role_patch(
+        db,
+        session_id,
+        role,
+        patch,
+        edited_by=edited_by,
+        source="yaml-reset",
+        comment=comment or f"reset to yaml: {yaml_path.name}",
+    )

--- a/backend/team_templates/agile_team.yaml
+++ b/backend/team_templates/agile_team.yaml
@@ -301,6 +301,7 @@ roles:
         mcp-atlassian,
         scrapling-server,
         figma-ui-mcp,
+        playwright,
       ]
     server_overrides:
       filesystem:
@@ -408,6 +409,7 @@ roles:
         mcp-atlassian,
         scrapling-server,
         figma-ui-mcp,
+        playwright,
       ]
     server_overrides:
       filesystem:

--- a/backend/tests/test_meeting_room_transcript.py
+++ b/backend/tests/test_meeting_room_transcript.py
@@ -371,3 +371,103 @@ def test_get_transcript_not_available():
     """get_transcript should no longer be importable as a tool."""
     import fast_agent.spawn.servers.meeting_room_server as mod
     assert not hasattr(mod, "get_transcript") or not callable(getattr(mod, "get_transcript", None))
+
+
+# ── Impersonation refusal in speak() / skip_turn() ──
+#
+# Production incident 2026-05-20 (agile-team_ccd1adb9): Taylor [PM]
+# force-skipped 6 teammates in a single round by calling
+# ``skip_turn(agent_name="<teammate>", reason="PM force-advancing...")``
+# six times. The MCP server only validated "is agent_name the current
+# speaker?" — not "is the caller actually that agent". The transcript
+# falsely attributed identical placeholder responses to BA / SA / Dev /
+# Designer / QE / DSO, breaking the audit value of the meeting record.
+#
+# Fix: _assert_self_identity() pins ``agent_name`` to the caller's
+# spawn-time TEAM_MY_NAME (read via _get_my_name). A mismatch returns
+# an error JSON instead of writing to the transcript.
+
+
+def _identity_check(caller_env_name: str, param_agent_name: str):
+    """Drive _assert_self_identity directly with the env name patched in."""
+    with patch(
+        "fast_agent.spawn.servers.meeting_room_server._get_my_name",
+        return_value=caller_env_name,
+    ):
+        from fast_agent.spawn.servers.meeting_room_server import _assert_self_identity
+        return _assert_self_identity(param_agent_name)
+
+
+def test_speak_refuses_impersonation_via_self_identity_check():
+    """Caller env=Taylor [PM] passes agent_name=Sawyer [BA] → REJECT."""
+    resolved, err = _identity_check("Taylor [PM]", "Sawyer [BA]")
+    assert resolved == ""
+    assert err is not None
+    err_data = json.loads(err)
+    assert "Impersonation refused" in err_data["error"]
+    assert err_data["caller"] == "Taylor [PM]"
+    assert err_data["claimed_agent_name"] == "Sawyer [BA]"
+
+
+def test_skip_turn_refuses_impersonation_via_self_identity_check():
+    """Same contract for skip_turn — both share _assert_self_identity."""
+    resolved, err = _identity_check("Taylor [PM]", "Reagan [SA]")
+    assert resolved == ""
+    assert err is not None
+    assert json.loads(err)["error"].startswith("Impersonation refused")
+
+
+def test_identity_check_allows_self_call_with_matching_agent_name():
+    """Passing your own name explicitly is fine (no impersonation)."""
+    resolved, err = _identity_check("Taylor [PM]", "Taylor [PM]")
+    assert err is None
+    assert resolved == "Taylor [PM]"
+
+
+def test_identity_check_is_case_insensitive_and_strips_whitespace():
+    """Match is case-insensitive and trims surrounding whitespace —
+    the LLM occasionally lowercases or pads role tags."""
+    resolved, err = _identity_check("Taylor [PM]", "  taylor [pm]  ")
+    assert err is None
+    assert resolved == "  taylor [pm]  "  # caller's spelling preserved, just normalized for comparison
+
+
+def test_identity_check_auto_detects_when_param_empty():
+    """Empty agent_name param → falls back to caller's TEAM_MY_NAME.
+    Preserves the legacy convenience contract."""
+    resolved, err = _identity_check("Taylor [PM]", "")
+    assert err is None
+    assert resolved == "Taylor [PM]"
+
+
+def test_identity_check_treats_agent_sentinel_as_no_identity():
+    """When TEAM_MY_NAME/TEAM_MY_ROLE both unset, _get_my_name returns
+    the literal ``"agent"`` sentinel — that's not a real identity, so
+    we don't have anything to compare against. Allow the param-supplied
+    name through (no impersonation possible without a real caller)."""
+    resolved, err = _identity_check("agent", "Sawyer [BA]")
+    assert err is None
+    assert resolved == "Sawyer [BA]"
+
+
+def test_identity_check_pm_force_skip_pattern_all_six_blocked():
+    """End-to-end replay of the 2026-05-20 incident: PM tries to skip
+    all 6 teammates' turns. Every one must be refused."""
+    pm_env = "Taylor [PM]"
+    teammates = [
+        "Sawyer [BA]",
+        "Reagan [SA]",
+        "Eden [Dev]",
+        "Devon [Designer]",
+        "Kai [QE]",
+        "Kai [DSO]",
+    ]
+    blocked = 0
+    for mate in teammates:
+        _, err = _identity_check(pm_env, mate)
+        if err and "Impersonation refused" in json.loads(err)["error"]:
+            blocked += 1
+    assert blocked == len(teammates), (
+        f"Expected all {len(teammates)} impersonation attempts to be "
+        f"blocked; only {blocked} were."
+    )

--- a/backend/tests/test_meeting_room_transcript.py
+++ b/backend/tests/test_meeting_room_transcript.py
@@ -4,6 +4,7 @@ Verifies that _notify_turn_agent embeds unread transcript and
 advances read cursors, and that auto-join works correctly.
 """
 import json
+import os
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -389,13 +390,34 @@ def test_get_transcript_not_available():
 
 
 def _identity_check(caller_env_name: str, param_agent_name: str):
-    """Drive _assert_self_identity directly with the env name patched in."""
-    with patch(
-        "fast_agent.spawn.servers.meeting_room_server._get_my_name",
-        return_value=caller_env_name,
+    """Drive _assert_self_identity directly with the env name set.
+
+    The helper reads ``TEAM_MY_NAME`` from ``os.environ`` directly (NOT
+    via ``_get_my_name()``) — only that env var proves the process was
+    spawned as a specific team member. We set it via ``patch.dict`` so
+    the value is restored after the test. Empty string means "env var
+    unset" (the test for the permissive non-team contract).
+    """
+    env_patch = {"TEAM_MY_NAME": caller_env_name} if caller_env_name else {}
+    with patch.dict(
+        "os.environ",
+        env_patch,
+        clear=False if caller_env_name else False,
     ):
-        from fast_agent.spawn.servers.meeting_room_server import _assert_self_identity
-        return _assert_self_identity(param_agent_name)
+        # When caller_env_name is empty, remove TEAM_MY_NAME so the
+        # "unset env" branch is exercised. patch.dict's clear=False
+        # leaves untouched keys alone, so we drop the key explicitly.
+        if not caller_env_name:
+            os.environ.pop("TEAM_MY_NAME", None)
+        # ``_get_my_name`` is still consulted ONLY when ``param_agent_name``
+        # is empty (auto-detect). Patch it too so that branch produces
+        # the env name verbatim instead of falling back to TEAM_MY_ROLE.
+        with patch(
+            "fast_agent.spawn.servers.meeting_room_server._get_my_name",
+            return_value=caller_env_name or "agent",
+        ):
+            from fast_agent.spawn.servers.meeting_room_server import _assert_self_identity
+            return _assert_self_identity(param_agent_name)
 
 
 def test_speak_refuses_impersonation_via_self_identity_check():
@@ -440,12 +462,13 @@ def test_identity_check_auto_detects_when_param_empty():
     assert resolved == "Taylor [PM]"
 
 
-def test_identity_check_treats_agent_sentinel_as_no_identity():
-    """When TEAM_MY_NAME/TEAM_MY_ROLE both unset, _get_my_name returns
-    the literal ``"agent"`` sentinel — that's not a real identity, so
-    we don't have anything to compare against. Allow the param-supplied
-    name through (no impersonation possible without a real caller)."""
-    resolved, err = _identity_check("agent", "Sawyer [BA]")
+def test_identity_check_allows_any_name_when_env_unset():
+    """When TEAM_MY_NAME is unset, the process is NOT a team-spawned
+    agent (CLI tests, dashboard direct calls, library callers). There
+    is no real identity to compare against, so the caller-supplied
+    ``agent_name`` is accepted as-is — preserves the legacy permissive
+    contract for non-team contexts."""
+    resolved, err = _identity_check("", "Sawyer [BA]")
     assert err is None
     assert resolved == "Sawyer [BA]"
 

--- a/backend/tests/test_routes/test_skills.py
+++ b/backend/tests/test_routes/test_skills.py
@@ -838,3 +838,71 @@ class TestTemplate:
         fm, _ = svc.parse_frontmatter(content)
         assert "name" in fm
         assert "description" in fm
+
+
+# ============================================================
+# L. Skill reload (preview + force-kill respawn across teams)
+#
+# Pins the dynamic-skill-update flow from 2026-05-17:
+#   1. Editing a skill .md doesn't auto-restart agents (they cached at spawn)
+#   2. /reload-preview shows blast radius without side-effects
+#   3. /reload requires explicit confirm: true (else 400)
+#   4. /reload calls team_reload.reload_by_skill with the skill name
+# ============================================================
+
+
+class TestSkillReload:
+    def test_preview_returns_zero_when_unused(self, client, monkeypatch):
+        from services import team_reload as tr
+
+        monkeypatch.setattr(tr, "find_sessions_using_skill", lambda name: [])
+        resp = client.get("/api/skills/some-skill/reload-preview", headers=AUTH)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["skill"] == "some-skill"
+        assert body["session_count"] == 0
+        assert body["approx_agent_count"] == 0
+        assert "no-op" in body["warning"].lower()
+
+    def test_preview_returns_blast_radius(self, client, monkeypatch):
+        from services import team_reload as tr
+
+        fake = [
+            {"session_id": "s1", "team_name": "alpha", "roles": ["qe", "dev"]},
+            {"session_id": "s2", "team_name": "beta", "roles": ["ba"]},
+        ]
+        monkeypatch.setattr(tr, "find_sessions_using_skill", lambda name: fake)
+        resp = client.get("/api/skills/team-comm/reload-preview", headers=AUTH)
+        body = resp.json()
+        assert body["session_count"] == 2
+        assert body["approx_agent_count"] == 3  # 2 roles + 1 role
+        assert "SIGKILL" in body["warning"]
+
+    def test_reload_requires_confirm(self, client):
+        resp = client.post(
+            "/api/skills/team-comm/reload", json={"confirm": False}, headers=AUTH,
+        )
+        assert resp.status_code == 400
+        assert "confirm" in resp.json()["detail"]
+
+    def test_reload_calls_helper_with_skill_name(self, client, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from services import team_reload as tr
+
+        fake_result = {"skill": "team-comm", "sessions": [{"session_id": "s1", "results": {}}]}
+        mock_reload = AsyncMock(return_value=fake_result)
+        monkeypatch.setattr(tr, "reload_by_skill", mock_reload)
+
+        resp = client.post(
+            "/api/skills/team-comm/reload",
+            json={"confirm": True, "inject_message": "custom msg"},
+            headers=AUTH,
+        )
+        assert resp.status_code == 200
+        assert resp.json() == fake_result
+        mock_reload.assert_called_once()
+        # Positional skill name + keyword inject_message
+        args, kwargs = mock_reload.call_args
+        assert args == ("team-comm",) or kwargs.get("skill_name") == "team-comm"
+        assert kwargs.get("inject_message") == "custom msg"

--- a/backend/tests/test_routes/test_team_template_routes.py
+++ b/backend/tests/test_routes/test_team_template_routes.py
@@ -1,0 +1,406 @@
+"""Tests for routes/team_template.py — REST surface for template edits.
+
+End-to-end pipeline tests: HTTP → router → service → audit table. Mocks
+the team_sessions store + team_reload module so we don't need a real
+backend / fast-agent runtime. Pins the contract every UI / curl caller
+will rely on.
+"""
+from __future__ import annotations
+
+import copy
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core import auth as core_auth
+from core.database import Base
+
+
+_API_KEY = "unit-test-master-key-team-template"
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    monkeypatch.setenv("JARVIS_API_KEY", _API_KEY)
+    monkeypatch.setattr(core_auth, "JARVIS_API_KEY", _API_KEY)
+
+
+@pytest.fixture()
+def db_factory(tmp_path, monkeypatch):
+    db_file = tmp_path / "team_template_test.db"
+    engine = create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    import core.database as core_db
+    monkeypatch.setattr(core_db, "SessionLocal", SessionFactory)
+    yield SessionFactory
+    engine.dispose()
+
+
+@pytest.fixture()
+def fake_store(monkeypatch):
+    """In-memory replacement for the team_sessions store + get_team_session."""
+    store_state = {
+        "ses-1": {
+            "session_id": "ses-1",
+            "team_name": "test-team",
+            "workspace": "/tmp/ws",
+            "project_brief": "x",
+            "parent_session_id": "",
+            "conversation_id": "",
+            "agents": {
+                "QE-1": {"run_id": "run-old-qe", "role": "qe", "status": "idle"},
+            },
+            "sprint_status": "running",
+            "template": {
+                "name": "agile-team",
+                "orchestrator": "pm",
+                "roles": {
+                    "qe": {
+                        "role_display": "QE",
+                        "instruction": "you are QE",
+                        "servers": ["filesystem", "scrapling-server"],
+                        "skills": ["qe-workflow"],
+                        "model": "",
+                        "server_overrides": {},
+                    },
+                    "dev": {
+                        "role_display": "Dev",
+                        "instruction": "you are dev",
+                        "servers": ["filesystem", "git"],
+                        "skills": ["dev-workflow"],
+                        "model": "",
+                        "server_overrides": {},
+                    },
+                },
+            },
+        },
+    }
+
+    from services import team_template_service as svc_mod
+
+    def fake_get(sid):
+        if sid not in store_state:
+            raise svc_mod.NotFoundError(f"team session '{sid}' not found")
+        return copy.deepcopy(store_state[sid])
+
+    def fake_put(sid, data):
+        store_state[sid] = copy.deepcopy(data)
+
+    monkeypatch.setattr(svc_mod, "_get_team_session_dict", fake_get)
+    monkeypatch.setattr(svc_mod, "_put_team_session_dict", fake_put)
+    return store_state
+
+
+@pytest.fixture()
+def client(db_factory, fake_store):
+    from routes.team_template import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _h() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_API_KEY}"}
+
+
+# ── Auth gate ──────────────────────────────────────────────────────────────
+
+
+class TestAuth:
+    def test_get_requires_bearer(self, client):
+        assert client.get("/api/team-sessions/ses-1/template").status_code == 401
+
+    def test_patch_requires_bearer(self, client):
+        r = client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={"patch": {"servers": ["filesystem"]}},
+        )
+        assert r.status_code == 401
+
+
+# ── GET template ───────────────────────────────────────────────────────────
+
+
+class TestGetTemplate:
+    def test_returns_current_state(self, client, fake_store):
+        r = client.get("/api/team-sessions/ses-1/template", headers=_h())
+        assert r.status_code == 200
+        body = r.json()
+        assert body["session_id"] == "ses-1"
+        assert "qe" in body["template"]["roles"]
+        assert body["template"]["roles"]["qe"]["servers"] == [
+            "filesystem", "scrapling-server",
+        ]
+
+    def test_unknown_session_404(self, client):
+        r = client.get("/api/team-sessions/nope/template", headers=_h())
+        assert r.status_code == 404
+
+
+# ── PATCH role ─────────────────────────────────────────────────────────────
+
+
+class TestPatchRole:
+    def test_add_server_writes_audit_and_persists(self, client, fake_store):
+        r = client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={
+                "patch": {"servers": ["filesystem", "scrapling-server", "playwright"]},
+                "comment": "add playwright for E2E",
+            },
+            headers=_h(),
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert "audit_ids" in body and len(body["audit_ids"]) == 1
+        assert "warning" in body  # yaml-not-auto-synced warning
+        assert "servers" in body["diff"]
+        # State persisted
+        assert "playwright" in fake_store["ses-1"]["template"]["roles"]["qe"]["servers"]
+
+    def test_unknown_role_404(self, client):
+        r = client.patch(
+            "/api/team-sessions/ses-1/template/roles/unknown",
+            json={"patch": {"servers": ["a"]}},
+            headers=_h(),
+        )
+        assert r.status_code == 404
+
+    def test_invalid_patch_400(self, client):
+        r = client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={"patch": {"cwd": "/etc"}},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+
+    def test_noop_409(self, client):
+        r = client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={"patch": {"servers": ["scrapling-server", "filesystem"]}},
+            headers=_h(),
+        )
+        assert r.status_code == 409
+
+
+# ── History + rollback ─────────────────────────────────────────────────────
+
+
+class TestHistoryAndRollback:
+    def test_history_newest_first(self, client, fake_store):
+        client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={"patch": {"servers": ["a"]}}, headers=_h(),
+        )
+        client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={"patch": {"servers": ["a", "b"]}}, headers=_h(),
+        )
+        r = client.get("/api/team-sessions/ses-1/template/history", headers=_h())
+        body = r.json()
+        assert body["count"] == 2
+        assert body["rows"][0]["edited_at"] >= body["rows"][1]["edited_at"]
+
+    def test_history_filter_role(self, client, fake_store):
+        client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={"patch": {"servers": ["a"]}}, headers=_h(),
+        )
+        client.patch(
+            "/api/team-sessions/ses-1/template/roles/dev",
+            json={"patch": {"servers": ["b"]}}, headers=_h(),
+        )
+        r = client.get(
+            "/api/team-sessions/ses-1/template/history?role=dev", headers=_h(),
+        )
+        assert r.json()["count"] == 1
+
+    def test_rollback_reverts_state(self, client, fake_store):
+        # PATCH adds playwright
+        r1 = client.patch(
+            "/api/team-sessions/ses-1/template/roles/qe",
+            json={"patch": {"servers": ["filesystem", "scrapling-server", "playwright"]}},
+            headers=_h(),
+        )
+        audit_id = r1.json()["audit_ids"][0]
+        # Rollback
+        r2 = client.post(
+            f"/api/team-sessions/ses-1/template/rollback/{audit_id}",
+            json={"comment": "regret"}, headers=_h(),
+        )
+        assert r2.status_code == 200
+        # playwright gone
+        assert "playwright" not in (
+            fake_store["ses-1"]["template"]["roles"]["qe"]["servers"]
+        )
+
+    def test_rollback_unknown_audit_404(self, client, fake_store):
+        r = client.post(
+            "/api/team-sessions/ses-1/template/rollback/9999",
+            json={"comment": ""}, headers=_h(),
+        )
+        assert r.status_code == 404
+
+
+# ── Reload ─────────────────────────────────────────────────────────────────
+
+
+class TestReload:
+    def test_reload_requires_confirm(self, client):
+        r = client.post(
+            "/api/team-sessions/ses-1/reload",
+            json={"roles": ["qe"], "confirm": False},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+        assert "confirm" in r.json()["detail"]
+
+    def test_reload_requires_roles(self, client):
+        r = client.post(
+            "/api/team-sessions/ses-1/reload",
+            json={"roles": [], "confirm": True},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+
+    def test_reload_calls_orchestrator_with_correct_args(self, client):
+        from routes import team_template as routes_mod
+
+        fake_result = {"qe": [{"agent_name": "QE-1", "killed": True, "resumed": True}]}
+        with patch.object(
+            routes_mod, "reload_roles", new=AsyncMock(return_value=fake_result),
+        ) as mocked:
+            r = client.post(
+                "/api/team-sessions/ses-1/reload",
+                json={"roles": ["qe"], "confirm": True},
+                headers=_h(),
+            )
+        assert r.status_code == 200
+        assert r.json()["results"] == fake_result
+        mocked.assert_called_once()
+        call_kwargs = mocked.call_args.kwargs
+        assert call_kwargs["session_id"] == "ses-1"
+        assert call_kwargs["roles"] == ["qe"]
+        assert call_kwargs["edited_by"] == "system"
+
+
+# ── Reset to yaml ──────────────────────────────────────────────────────────
+
+
+class TestYamlDiff:
+    def test_in_sync_returns_empty_diverged(self, client, fake_store, tmp_path, monkeypatch):
+        from routes import team_template as routes_mod
+
+        yaml_path = tmp_path / "agile_team.yaml"
+        # Write yaml that exactly matches the fake_store qe + dev config
+        yaml_path.write_text(
+            "team:\n"
+            "  name: agile-team\n"
+            "  roles:\n"
+            "    qe:\n"
+            "      role_display: QE\n"
+            "      instruction: 'you are QE'\n"
+            "      servers: [filesystem, scrapling-server]\n"
+            "      skills: [qe-workflow]\n"
+            "      model: ''\n"
+            "      server_overrides: {}\n"
+            "    dev:\n"
+            "      role_display: Dev\n"
+            "      instruction: 'you are dev'\n"
+            "      servers: [filesystem, git]\n"
+            "      skills: [dev-workflow]\n"
+            "      model: ''\n"
+            "      server_overrides: {}\n"
+        )
+        monkeypatch.setattr(routes_mod, "_resolve_yaml_for_session", lambda sid: yaml_path)
+        r = client.get(
+            "/api/team-sessions/ses-1/template/yaml-diff", headers=_h(),
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["in_sync"] is True
+        assert body["diverged_count"] == 0
+        assert all(v["status"] == "in_sync" for v in body["per_role"].values())
+
+    def test_diverged_shows_per_field_diff(self, client, fake_store, tmp_path, monkeypatch):
+        from routes import team_template as routes_mod
+
+        # Yaml has playwright; DB doesn't
+        yaml_path = tmp_path / "agile_team.yaml"
+        yaml_path.write_text(
+            "team:\n"
+            "  name: agile-team\n"
+            "  roles:\n"
+            "    qe:\n"
+            "      role_display: QE\n"
+            "      instruction: 'you are QE'\n"
+            "      servers: [filesystem, scrapling-server, playwright]\n"
+            "      skills: [qe-workflow]\n"
+            "      model: ''\n"
+            "      server_overrides: {}\n"
+        )
+        monkeypatch.setattr(routes_mod, "_resolve_yaml_for_session", lambda sid: yaml_path)
+        r = client.get(
+            "/api/team-sessions/ses-1/template/yaml-diff", headers=_h(),
+        )
+        body = r.json()
+        assert body["in_sync"] is False
+        # qe diverged on servers (yaml has playwright that DB doesn't)
+        assert body["per_role"]["qe"]["status"] == "diverged"
+        assert "servers" in body["per_role"]["qe"]["fields"]
+        # dev not in yaml → status added_in_db
+        assert body["per_role"]["dev"]["status"] == "added_in_db"
+
+    def test_yaml_missing_404(self, client, fake_store, tmp_path, monkeypatch):
+        from routes import team_template as routes_mod
+
+        monkeypatch.setattr(
+            routes_mod, "_resolve_yaml_for_session",
+            lambda sid: tmp_path / "non_existent.yaml",
+        )
+        r = client.get(
+            "/api/team-sessions/ses-1/template/yaml-diff", headers=_h(),
+        )
+        assert r.status_code == 404
+
+
+class TestResetRole:
+    def test_reset_writes_audit_and_replaces_role(self, client, fake_store, tmp_path, monkeypatch):
+        # Compose a yaml the route can load via _resolve_yaml_for_session
+        from routes import team_template as routes_mod
+
+        yaml_path = tmp_path / "agile_team.yaml"
+        yaml_path.write_text(
+            "team:\n"
+            "  roles:\n"
+            "    qe:\n"
+            "      role_display: QE\n"
+            "      instruction: factory qe\n"
+            "      servers: [filesystem, scrapling-server, playwright]\n"
+            "      skills: [qe-workflow]\n"
+            "      model: ''\n"
+        )
+        monkeypatch.setattr(
+            routes_mod, "_resolve_yaml_for_session", lambda sid: yaml_path,
+        )
+        r = client.post(
+            "/api/team-sessions/ses-1/template/reset/qe",
+            json={"comment": "back to factory"}, headers=_h(),
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert "playwright" in fake_store["ses-1"]["template"]["roles"]["qe"]["servers"]
+        # at least one audit row tagged yaml-reset
+        rows = client.get(
+            "/api/team-sessions/ses-1/template/history?role=qe", headers=_h(),
+        ).json()["rows"]
+        assert any(row["source"] == "yaml-reset" for row in rows)

--- a/backend/tests/test_services/test_cycle_orchestrator_gating.py
+++ b/backend/tests/test_services/test_cycle_orchestrator_gating.py
@@ -1,0 +1,564 @@
+"""Regression tests for the orchestrator-gated cycle close semantics.
+
+This file pins the 2026-05-19 fix for the duplicate-notify incident.
+
+## The incident (one-paragraph history)
+
+User session ``be885ae8`` produced 2 ``team_completion`` notifications
+32 seconds apart:
+
+* ``notif #39`` at 16:41:40 — fired the instant the last worker idled,
+  even though the orchestrator (Robin [PM]) had not yet had its turn.
+  ``team_open = any(spawned running)`` transitioned True→False because
+  the orchestrator was *already* idle (waiting). This was a false
+  close — the system pushed a worker-status report into the orch's
+  inbox and was about to wake it up.
+
+* ``notif #40`` at 16:42:12 — the *real* close, fired after the orch
+  was woken, read the worker report, produced its own outcome, and
+  idled again.
+
+The user saw 2 nearly-identical "team done" notifications and asked
+why. Root cause: ``team_open = any(running)`` is the wrong gating
+signal — it fires when *any* member finishes, not when the
+orchestrator finishes its turn. The fix is to gate ``full_cycle_closed``
+on the orchestrator's OWN transition ``orch_running: True → False``,
+treating worker-idle-with-orch-already-idle as a NO-OP for the
+user-facing notify.
+
+## What these tests pin
+
+1. ``orchestrator already idle + worker idles`` → MUST NOT emit
+   ``full_cycle_closed``. (the bogus notif #39 case)
+2. ``orchestrator running → idle (workers idle)`` → MUST emit exactly
+   one ``full_cycle_closed``. (the legitimate notif #40 case)
+3. Concurrent emit attempts within one cycle close MUST produce
+   exactly one DB row (atomic ``UPDATE … RETURNING WHERE orch_running=1``).
+4. reopen → close → reopen → close MUST produce 2 distinct
+   ``team_close_seq`` values and 2 distinct ``team_events`` rows.
+5. Schema migration is idempotent (multiple ``_ensure_event_tables``
+   calls don't crash on duplicate-column errors).
+6. ``_find_orchestrator`` honours ``template.orchestrator`` from
+   ``team_sessions`` — not substring matching on the role name.
+
+The tests use real SQLite (via ``SPAWN_REGISTRY_DB`` env var pointing
+at a temp file) so the atomic UPDATE…RETURNING semantics are exercised
+against the actual database engine — not a mock. This is the
+integration-vs-unit distinction from CLAUDE.md item 4: a mock-only
+test of "atomic update" is worse than no test.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    """Point ``SPAWN_REGISTRY_DB`` at a fresh temp file.
+
+    Returns the DB path. The bridge will auto-create ``team_events``
+    and ``team_cycle_state`` on first use via ``_ensure_event_tables``.
+    """
+    db_path = tmp_path / "jarvis.db"
+    monkeypatch.setenv("SPAWN_REGISTRY_DB", str(db_path))
+    return db_path
+
+
+@pytest.fixture
+def fake_registry():
+    """Build a ``registry_db`` MagicMock with controllable members.
+
+    The ``set_members`` method on the returned mock lets each test
+    swap in a new member list and recompute ``get_record`` /
+    ``find_by_team_name`` answers in one place.
+    """
+    reg = MagicMock()
+    state = {"members": []}
+
+    def set_members(members):
+        state["members"] = members
+        reg.find_by_team_name.side_effect = lambda name: [
+            m for m in state["members"] if m.get("team_name") == name
+        ]
+        reg.get_record.side_effect = lambda rid: next(
+            (m for m in state["members"] if m.get("run_id") == rid),
+            None,
+        )
+
+    reg.set_members = set_members  # type: ignore[attr-defined]
+    set_members([])
+    return reg
+
+
+@pytest.fixture
+def bridge(fake_registry, temp_db, monkeypatch):
+    """Construct a bridge wired to the fake registry + temp DB.
+
+    Stubs out:
+      * ``_active_meetings_with_members`` — returns [] (no meeting
+        gating in these tests; the meeting-aware path has its own
+        test file).
+      * ``_create_team_notification`` — replaced with a probe so we
+        can count user-facing notifies without hitting the SQLAlchemy
+        ``NotificationModel``.
+      * ``_resolve_messages_dir`` — returns a temp dir so the worker
+        report path doesn't blow up trying to write a real file.
+    """
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    b = SpawnProgressBridge(
+        progress_manager=MagicMock(),
+        registry_db=fake_registry,
+    )
+
+    monkeypatch.setattr(b, "_active_meetings_with_members", lambda names: [])
+
+    probes = {"team_notify": [], "worker_notify": []}
+
+    def _capture_team_notify(team_name, agent_name, result, members, *,
+                             session_id=""):
+        probes["team_notify"].append({
+            "team_name": team_name,
+            "agent_name": agent_name,
+            "session_id": session_id,
+            "member_count": len(members),
+        })
+
+    monkeypatch.setattr(b, "_create_team_notification", _capture_team_notify)
+
+    # The real worker notify path tries MessageBus + asyncio loop; for
+    # transition-counting tests we just want to know it was called.
+    real_emit_worker = b._emit_worker_cycle_closed
+
+    def _wrap_emit_worker(*args, **kwargs):
+        probes["worker_notify"].append({
+            "args": args,
+            "close_seq": kwargs.get("close_seq"),
+        })
+        # Don't delegate — the real impl does MessageBus IO. We just
+        # need to confirm it was called with the right seq.
+
+    monkeypatch.setattr(b, "_emit_worker_cycle_closed", _wrap_emit_worker)
+
+    b._probes = probes  # type: ignore[attr-defined]
+    return b
+
+
+def _member(
+    run_id: str,
+    *,
+    role: str,
+    status: str,
+    session_id: str,
+    team_name: str = "team-A",
+    agent_name: str | None = None,
+    started_at: float | None = None,
+    result: str = "",
+) -> dict:
+    """Build a registry-row shaped dict for the tests."""
+    return {
+        "run_id": run_id,
+        "agent_name": agent_name or f"{role}-{run_id}",
+        "role": role,
+        "status": status,
+        "session_id": session_id,
+        "team_name": team_name,
+        "started_at": started_at if started_at is not None else time.time(),
+        "result": result,
+    }
+
+
+def _seed_team_session(
+    db_path: Path,
+    session_id: str,
+    *,
+    team_name: str,
+    orchestrator_role: str,
+) -> None:
+    """Insert a minimal ``team_sessions`` row so the bridge's
+    ``_lookup_orchestrator_role`` returns the expected role.
+
+    The schema (``session_id TEXT PRIMARY KEY, data_json TEXT NOT NULL``)
+    mirrors the production table created by ``core.agent_registry_db``.
+    """
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS team_sessions (
+                session_id TEXT PRIMARY KEY,
+                data_json  TEXT NOT NULL
+            )"""
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO team_sessions(session_id, data_json) VALUES(?, ?)",
+            (
+                session_id,
+                json.dumps({
+                    "session_id": session_id,
+                    "team_name": team_name,
+                    "template": {
+                        "name": team_name,
+                        "orchestrator": orchestrator_role,
+                        "roles": {orchestrator_role: {}, "dev": {}},
+                    },
+                    "agents": {},
+                }),
+            ),
+        )
+        conn.commit()
+
+
+# ─── 1. Bogus notify #39 — orchestrator already idle + worker idles ───
+
+
+def test_full_cycle_NOT_fired_when_orchestrator_already_idle(
+    bridge, fake_registry, temp_db,
+):
+    """The 2026-05-19 incident replay.
+
+    Setup: orchestrator is idle, last worker transitions running →
+    idle. Old code observed ``team_open = any(running)`` flip True→False
+    and fired ``full_cycle_closed`` even though the orchestrator was
+    asleep waiting for the worker report it had just been pushed.
+    Expected new behaviour: NO ``full_cycle_closed`` emitted.
+
+    A ``worker_cycle_closed`` IS expected (workers stopped) — that's
+    the path that wakes the orchestrator.
+    """
+    _seed_team_session(
+        temp_db, "sess-incident", team_name="team-A", orchestrator_role="pm",
+    )
+    pm = _member("pm-1", role="pm", status="idle", session_id="sess-incident")
+    wkr_running = _member(
+        "wkr-1", role="dev", status="running", session_id="sess-incident",
+    )
+    fake_registry.set_members([pm, wkr_running])
+
+    # First event opens the worker cycle.
+    bridge._on_member_state_event("wkr-1")
+    state = bridge._load_cycle_state("sess-incident")
+    assert state["worker_open"] is True
+    assert state["orch_running"] is False, (
+        "Orchestrator is idle from the start — must NOT be flagged as running"
+    )
+
+    # Worker idles.
+    wkr_running["status"] = "idle"
+    bridge._on_member_state_event("wkr-1")
+
+    # Worker-close fires (orch needs to be woken).
+    assert len(bridge._probes["worker_notify"]) == 1, (
+        f"worker_cycle_closed should fire exactly once; got "
+        f"{len(bridge._probes['worker_notify'])}"
+    )
+    # Full-close MUST NOT fire — orchestrator hasn't had its turn yet.
+    assert bridge._probes["team_notify"] == [], (
+        "REGRESSION: full_cycle_closed fired even though the "
+        "orchestrator was already idle and never transitioned "
+        "running→idle. This is the 2026-05-19 notify #39 bug."
+    )
+
+
+# ─── 2. Legitimate notify — orchestrator running → idle ──────────────
+
+
+def test_full_cycle_fires_when_orchestrator_transitions_to_idle(
+    bridge, fake_registry, temp_db,
+):
+    """The notif #40 case — orchestrator finishes its turn after
+    workers, and we want exactly one user-facing notify.
+    """
+    _seed_team_session(
+        temp_db, "sess-ok", team_name="team-A", orchestrator_role="pm",
+    )
+    pm = _member(
+        "pm-1", role="pm", status="running", session_id="sess-ok",
+        result="rollup body",
+    )
+    wkr = _member(
+        "wkr-1", role="dev", status="idle", session_id="sess-ok",
+    )
+    fake_registry.set_members([pm, wkr])
+
+    # Open: orch_running=True snapshot is persisted.
+    bridge._on_member_state_event("pm-1")
+    assert bridge._load_cycle_state("sess-ok")["orch_running"] is True
+
+    # Orchestrator idles.
+    pm["status"] = "idle"
+    bridge._on_member_state_event("pm-1")
+
+    assert len(bridge._probes["team_notify"]) == 1, (
+        f"Expected exactly 1 full_cycle_closed notify; got "
+        f"{len(bridge._probes['team_notify'])}"
+    )
+    assert bridge._probes["team_notify"][0]["session_id"] == "sess-ok"
+
+
+# ─── 3. Atomic close — concurrent callers, single notify ─────────────
+
+
+def test_concurrent_close_attempts_emit_exactly_once(
+    bridge, fake_registry, temp_db,
+):
+    """Two ``_on_member_state_event`` invocations observing the same
+    transition MUST produce exactly one ``full_cycle_closed`` emit.
+
+    Atomic-UPDATE…RETURNING ``WHERE orch_running = 1`` is the gating
+    primitive: only the first caller's UPDATE matches the WHERE, so
+    only one caller returns a non-None close_seq → only one emit.
+
+    The earlier implementation embedded ``uuid.uuid4()`` in
+    ``event_id``, so the DB-PK conflict dedupe in ``_insert_event``
+    never engaged: 2 concurrent callers minted 2 different event_ids
+    → 2 emits → 2 user notifications.
+    """
+    _seed_team_session(
+        temp_db, "sess-race", team_name="team-A", orchestrator_role="pm",
+    )
+    pm = _member(
+        "pm-1", role="pm", status="running", session_id="sess-race",
+        result="x",
+    )
+    fake_registry.set_members([pm])
+
+    # Prime ``orch_running=True``.
+    bridge._on_member_state_event("pm-1")
+    pm["status"] = "idle"
+
+    # Two callers race. We simulate by invoking the handler twice
+    # back-to-back. The second call will see ``orch_running=0`` in
+    # team_cycle_state (the first call's UPDATE already flipped it),
+    # so its ``WHERE orch_running=1`` predicate misses → no close.
+    bridge._on_member_state_event("pm-1")
+    bridge._on_member_state_event("pm-1")
+
+    assert len(bridge._probes["team_notify"]) == 1, (
+        f"Atomic close failed — got {len(bridge._probes['team_notify'])} "
+        f"notifies for one logical cycle close. The WHERE orch_running=1 "
+        f"predicate must serialise concurrent callers."
+    )
+
+    # Verify the DB row has team_close_seq incremented exactly once.
+    with sqlite3.connect(str(temp_db)) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT team_close_seq FROM team_cycle_state WHERE session_id=?",
+            ("sess-race",),
+        ).fetchone()
+    assert row is not None
+    assert row["team_close_seq"] == 1, (
+        f"team_close_seq={row['team_close_seq']} — should be 1 after "
+        f"one logical close. >1 means the atomic guard let a second "
+        f"caller through; 0 means the close never fired."
+    )
+
+
+# ─── 4. Multi-cycle: reopen→close→reopen→close → 2 distinct seqs ─────
+
+
+def test_reopen_close_produces_distinct_close_seqs(
+    bridge, fake_registry, temp_db,
+):
+    """Two legitimate close cycles (orchestrator running→idle, then
+    running→idle again after a reopen) MUST get distinct
+    ``team_close_seq`` values AND distinct ``team_events`` rows.
+
+    This is the case the user explicitly approved: if the
+    orchestrator wakes after a close (e.g. an inbox message) and
+    idles again, that IS a new cycle and DOES deserve a new notify.
+    """
+    _seed_team_session(
+        temp_db, "sess-multi", team_name="team-A", orchestrator_role="pm",
+    )
+    pm = _member(
+        "pm-1", role="pm", status="running", session_id="sess-multi",
+        result="cycle 1",
+    )
+    fake_registry.set_members([pm])
+
+    bridge._on_member_state_event("pm-1")  # open
+    pm["status"] = "idle"
+    bridge._on_member_state_event("pm-1")  # close 1
+
+    pm["status"] = "running"
+    bridge._on_member_state_event("pm-1")  # reopen
+    pm["status"] = "idle"
+    bridge._on_member_state_event("pm-1")  # close 2
+
+    assert len(bridge._probes["team_notify"]) == 2, (
+        f"Expected 2 notifies across 2 cycles; got "
+        f"{len(bridge._probes['team_notify'])}"
+    )
+
+    # team_events should hold 2 distinct full_cycle_closed rows.
+    with sqlite3.connect(str(temp_db)) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """SELECT event_id FROM team_events
+               WHERE session_id=? AND event_type='full_cycle_closed'
+               ORDER BY created_at""",
+            ("sess-multi",),
+        ).fetchall()
+    assert [r["event_id"] for r in rows] == [
+        "sess-multi:full_cycle_closed:1",
+        "sess-multi:full_cycle_closed:2",
+    ], (
+        f"event_ids should be stable seq-based (not uuid-based): {rows}"
+    )
+
+
+# ─── 5. Schema migration idempotency ─────────────────────────────────
+
+
+def test_ensure_event_tables_is_idempotent(bridge, temp_db):
+    """Calling ``_ensure_event_tables`` multiple times must NOT crash
+    on duplicate-column errors. The bridge calls it on every event,
+    so any per-event failure would manifest as a flood of warning
+    logs in production.
+    """
+    # First call already happened during __init__. Call 5 more times.
+    for _ in range(5):
+        bridge._ensure_event_tables()
+
+    # Verify the migration columns are present exactly once.
+    with sqlite3.connect(str(temp_db)) as conn:
+        conn.row_factory = sqlite3.Row
+        cols = [r["name"] for r in conn.execute(
+            "PRAGMA table_info(team_cycle_state)"
+        ).fetchall()]
+    assert cols.count("orch_running") == 1
+    assert cols.count("team_close_seq") == 1
+    assert cols.count("worker_close_seq") == 1
+
+
+# ─── 6. _find_orchestrator honours template.orchestrator ─────────────
+
+
+def test_find_orchestrator_uses_template_field_not_substring(
+    bridge, temp_db, fake_registry,
+):
+    """Templates whose orchestrator role is NOT named "pm" still work.
+
+    The old code matched substring ``"pm" in role.lower()``, which
+    silently failed for any template that named its orchestrator
+    "lead", "ba", "coordinator", etc. With the audit 2026-05-19 fix,
+    the bridge reads ``team_sessions.template.orchestrator`` and
+    matches the role by exact (case-insensitive) equality.
+    """
+    _seed_team_session(
+        temp_db, "sess-custom-orch",
+        team_name="team-custom", orchestrator_role="lead",
+    )
+    lead = _member(
+        "lead-1", role="lead", status="running",
+        session_id="sess-custom-orch", team_name="team-custom",
+    )
+    dev = _member(
+        "dev-1", role="dev", status="idle",
+        session_id="sess-custom-orch", team_name="team-custom",
+    )
+    fake_registry.set_members([lead, dev])
+
+    found = bridge._find_orchestrator(
+        [lead, dev], session_id="sess-custom-orch",
+    )
+    assert found is lead, (
+        f"_find_orchestrator picked {found.get('role')} but the "
+        f"template declares 'lead' as orchestrator. Substring 'pm' "
+        f"match is gone — template.orchestrator is the single source "
+        f"of truth."
+    )
+
+
+def test_find_orchestrator_falls_back_to_first_spawned_without_session(
+    bridge, fake_registry,
+):
+    """Ad-hoc / legacy callers without a ``session_id`` fall back to
+    ``first spawned`` — the orchestrator spawns first by construction.
+    Preserves backward compatibility for the rare callers that don't
+    have a session_id.
+    """
+    earliest = _member(
+        "a-1", role="any", status="idle", session_id="",
+        started_at=100.0,
+    )
+    later = _member(
+        "b-1", role="any", status="idle", session_id="",
+        started_at=200.0,
+    )
+    found = bridge._find_orchestrator([later, earliest])
+    assert found is earliest
+
+
+# ─── 7. The 2026-05-19 sequence reconstructed end-to-end ─────────────
+
+
+def test_2026_05_19_incident_sequence_emits_exactly_one_notify(
+    bridge, fake_registry, temp_db,
+):
+    """Replay the exact incident sequence (log timestamps in module
+    docstring) and assert the new state machine produces 1 notify,
+    not 2.
+
+    Steps from the log:
+      A. 16:41:30 — worker QE is running (cycle is open).
+      B. 16:41:40 — worker QE idles. Worker cycle closes. Bridge
+         wakes the orchestrator (which was already idle).
+      C. 16:41:40 — orchestrator wakes (running), processes report.
+      D. 16:42:12 — orchestrator idles after producing its outcome.
+
+    Old code produced notifies at (B) and (D) → 2 notifications.
+    New code produces a notify ONLY at (D).
+    """
+    _seed_team_session(
+        temp_db, "be885ae8",
+        team_name="agile-team", orchestrator_role="pm",
+    )
+    pm = _member(
+        "pm-resume-1", role="pm", status="idle",
+        session_id="be885ae8", team_name="agile-team",
+    )
+    qe = _member(
+        "qe-1", role="qe", status="running",
+        session_id="be885ae8", team_name="agile-team",
+    )
+    fake_registry.set_members([pm, qe])
+
+    # A. Worker is running → opens worker cycle.
+    bridge._on_member_state_event("qe-1")
+
+    # B. QE goes idle. orch was already idle → no full close.
+    qe["status"] = "idle"
+    bridge._on_member_state_event("qe-1")
+
+    # Verify no premature notify.
+    assert bridge._probes["team_notify"] == [], (
+        "Step B fired full_cycle_closed prematurely — the 2026-05-19 "
+        "notif #39 bug has regressed."
+    )
+
+    # C. Orchestrator is woken (production: _trigger_orchestrator_resume).
+    pm["status"] = "running"
+    pm["result"] = "Final consolidated status: BLOCKED"
+    bridge._on_member_state_event("pm-resume-1")
+
+    # D. Orchestrator finishes its turn and idles.
+    pm["status"] = "idle"
+    bridge._on_member_state_event("pm-resume-1")
+
+    assert len(bridge._probes["team_notify"]) == 1, (
+        f"Expected exactly 1 notify across the incident sequence; "
+        f"got {len(bridge._probes['team_notify'])}. The new state "
+        f"machine must gate on orch_running transition, not "
+        f"team_open."
+    )

--- a/backend/tests/test_services/test_effective_status.py
+++ b/backend/tests/test_services/test_effective_status.py
@@ -86,9 +86,30 @@ def test_terminal_status_passes_through(terminal):
     """Once an agent is in a terminal/overlay state, the helper must
     NOT second-guess it. Bridge / cleanup / PauseManager are
     authoritative for these.
+
+    Note: the ``completed`` + non-oneshot lifecycle case is exempted —
+    see ``test_completed_resumable_record_overrides_to_idle``.
     """
     record = {"agent_name": "X", "status": terminal}
     assert _compute_effective_status(record) == terminal
+
+
+def test_completed_resumable_record_overrides_to_idle():
+    """Post-2026-05-20 lifecycle merge: legacy DB rows had
+    ``status="completed"`` written by the old spawner for what is now a
+    ``resumable`` agent. The canonical state for a non-oneshot agent
+    after task completion is ``idle`` (waiting for follow-up). Override
+    at the API layer so UI doesn't render a misleading "Completed" badge
+    while the same agent is still resumable from inbox or resume_spawn.
+    """
+    record = {"agent_name": "X", "status": "completed", "lifecycle": "resumable"}
+    assert _compute_effective_status(record) == "idle"
+
+
+def test_completed_oneshot_record_stays_completed():
+    """Oneshot agents really ARE done — the override must not touch them."""
+    record = {"agent_name": "X", "status": "completed", "lifecycle": "oneshot"}
+    assert _compute_effective_status(record) == "completed"
 
 
 def test_unrecognized_status_passes_through():

--- a/backend/tests/test_services/test_fastagent_config_defaults.py
+++ b/backend/tests/test_services/test_fastagent_config_defaults.py
@@ -1,0 +1,128 @@
+"""Regression tests for fastagent.config.yaml MCP server defaults.
+
+Incident 2026-05-17 (Designer "không thấy filesystem MCP"):
+
+  ``fastagent.config.yaml`` declared the ``filesystem`` MCP server with
+  default args ``["-y", "@modelcontextprotocol/server-filesystem", "./data",
+  "./jarvis_workspace"]``. The second path was never created on disk →
+  ``@modelcontextprotocol/server-filesystem`` validates every allowed-roots
+  arg at startup and refuses to launch if any is missing → the MCP
+  subprocess exited before completing the handshake → fast-agent silently
+  dropped the server from the agent's tool list.
+
+  This bit only after the auto-resume cascade (Bug B/D) dropped per-role
+  ``server_overrides``, causing the agent to fall back to these base
+  defaults instead of the team workspace path.
+
+This test pins the contract: every path-shaped arg in a server's default
+args MUST resolve to a directory that exists on disk. If a future edit
+re-introduces a phantom path, this test fails BEFORE it lands in prod.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+CONFIG_FILE = BACKEND_DIR / "fastagent.config.yaml"
+
+
+def _looks_like_path(arg: str) -> bool:
+    """Heuristic: is this CLI arg a path we should validate?
+
+    Skips:
+      - flags (``-y``, ``--whatever``)
+      - npm/pypi package specifiers (``@scope/name``, ``name@version``)
+      - placeholders that fast-agent substitutes at spawn time
+        (``{workspace_dir}``, ``{project_dir}/...``)
+      - bare module/command names (no slash, no leading dot)
+    """
+    if not isinstance(arg, str) or not arg:
+        return False
+    if arg.startswith("-"):
+        return False
+    if arg.startswith("@") and "/" in arg:  # @modelcontextprotocol/server-filesystem
+        return False
+    if "{" in arg and "}" in arg:  # contains template placeholder
+        return False
+    # Treat as path if it starts with ".", "/", or "~" or contains a slash
+    return arg.startswith((".", "/", "~")) or "/" in arg
+
+
+@pytest.fixture(scope="module")
+def config() -> dict:
+    with CONFIG_FILE.open(encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+@pytest.mark.parametrize("server_name", [
+    "filesystem",
+    "time-service",
+    "gmail",
+    "calendar",
+    "media-server",
+    "story-server",
+    "library-server",
+    "iot-control",
+    "cron-server",
+    "approval-server",
+    "skill_server",
+    "mcp_admin",
+])
+def test_default_server_args_all_paths_exist(config, server_name):
+    """Every relative/absolute path in a server's default args must exist.
+
+    Per-role ``server_overrides`` (e.g. agile_team.yaml's filesystem
+    override) can REPLACE these args, but only if the override actually
+    propagates. When the cascade drops ``server_overrides`` (Bug B/D),
+    these defaults are what the MCP subprocess sees — so they MUST be
+    valid out of the box.
+    """
+    servers = config.get("mcp", {}).get("servers", {})
+    server = servers.get(server_name)
+    if not server:
+        pytest.skip(f"server '{server_name}' not declared in this config")
+
+    args = server.get("args") or []
+    path_args = [a for a in args if _looks_like_path(a)]
+
+    for path_arg in path_args:
+        # Resolve relative to backend dir (the cwd fast-agent runs from)
+        if path_arg.startswith("./"):
+            resolved = BACKEND_DIR / path_arg[2:]
+        elif path_arg.startswith("/"):
+            resolved = Path(path_arg)
+        elif path_arg.startswith("~"):
+            resolved = Path(path_arg).expanduser()
+        else:
+            resolved = BACKEND_DIR / path_arg
+
+        assert resolved.exists(), (
+            f"fastagent.config.yaml server '{server_name}' has default arg "
+            f"'{path_arg}' resolving to {resolved} which does NOT exist. "
+            f"When a spawn falls back to these defaults (e.g. cascade drops "
+            f"server_overrides), the MCP subprocess will fail to start and "
+            f"the agent will silently lose the tool. Either remove the arg, "
+            f"point it at an existing directory, or create the directory at "
+            f"backend boot."
+        )
+
+
+def test_filesystem_default_does_not_include_broken_jarvis_workspace(config):
+    """Specific regression: the 2026-05-17 Designer incident root cause.
+
+    Pin the exact filesystem default to NOT include the phantom
+    ``./jarvis_workspace`` path. If someone re-adds it (for whatever
+    well-intentioned reason), this test catches it before deploy.
+    """
+    fs = config.get("mcp", {}).get("servers", {}).get("filesystem", {})
+    args = fs.get("args") or []
+    assert "./jarvis_workspace" not in args, (
+        "filesystem default args MUST NOT include './jarvis_workspace' — "
+        "the directory is never created and breaks MCP startup. Use a "
+        "per-role server_overrides in team_templates/agile_team.yaml to "
+        "point filesystem at the actual team workspace at spawn time."
+    )

--- a/backend/tests/test_services/test_inject_resume.py
+++ b/backend/tests/test_services/test_inject_resume.py
@@ -12,11 +12,22 @@ The class had been renamed to ``SpawnDisplayManager`` but
 was swallowed by ``_trigger_orchestrator_resume``'s try/except, surviving
 only as a WARNING in ``spawn_activity.log`` — meanwhile the orchestrator
 was never woken to read the team-status notification sitting in its inbox.
+
+Also guards the ``server_overrides`` forwarding path (2026-05-17 incident):
+``resume_with_inject`` is the dashboard "Send message to agent" code path.
+Earlier work fixed ``_check_and_resume_on_inbox`` / ``restart_spawn`` /
+``resume_spawn`` to forward ``server_overrides``, but ``inject_resume.py``
+was missed → every dashboard inject silently fell back to the base
+``fastagent.config.yaml`` filesystem args (``./data`` only) and the agent
+lost workspace + skills access. Pin the forward here so the next refactor
+catches it.
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def test_create_bridge_display_imports_correct_class():
@@ -71,3 +82,442 @@ def test_create_bridge_display_forwards_events_to_bridge():
     assert payload["event_type"] == "agent_ready"
     assert payload["run_id"] == "abc12345"
     assert payload["data"] == {"foo": "bar"}
+
+
+# ─── server_overrides forwarding (2026-05-17 incident) ────────────────────────
+#
+# These tests pin the dashboard inject code path. The bug was a single missing
+# kwarg on the ``run_isolated_agent_background`` call inside
+# ``resume_with_inject`` — without the test, a future refactor that touches
+# the call signature could silently drop ``server_overrides`` again and every
+# subsequent inject would point filesystem MCP at the wrong directory.
+
+
+@pytest.fixture
+def _baseline_original_config():
+    """Original config a team-spawned agent would have in its spawn_record.
+
+    Mirrors what ``isolated_spawner._register_spawn`` persists into
+    ``original_config_json`` for a team agent. The presence of
+    ``server_overrides`` here is what we want forwarded.
+    """
+    return {
+        "task": "previous task",
+        "instruction": "You are a designer.",
+        "context": "",
+        "servers": ["filesystem", "meeting_room", "email"],
+        "skills": ["figma-designer"],
+        "model": "",
+        "timeout_seconds": 0,
+        "role": "designer",
+        "agent_name": "Jesse [Designer]",
+        "team_name": "team-alpha",
+        "workspace_dir": "/ws/team-alpha",
+        "env_vars": {"TEAM_SESSION_ID": "sess-1", "TEAM_MY_NAME": "Jesse [Designer]"},
+        "project_dir": "/proj",
+        "server_overrides": {
+            "filesystem": {
+                "args": [
+                    "-y",
+                    "@modelcontextprotocol/server-filesystem",
+                    "/ws/team-alpha",
+                    "/proj/.fast-agent/skills",
+                ],
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_inject_resume_forwards_server_overrides(_baseline_original_config):
+    """resume_with_inject must pass server_overrides from original_config.
+
+    Without this forward, the dashboard "Send message" path falls back to
+    base config defaults → agent loses per-role filesystem args. Pin by
+    asserting the exact dict propagates to run_isolated_agent_background.
+    """
+    from services import inject_resume
+
+    spawn_record = {
+        "agent_name": "Jesse [Designer]",
+        "team_name": "team-alpha",
+        "original_config": _baseline_original_config,
+    }
+
+    captured_kwargs: dict = {}
+
+    async def fake_run_isolated(**kwargs):
+        captured_kwargs.update(kwargs)
+        return "run_new_123"
+
+    with patch.object(inject_resume, "_load_context_from_db", return_value=None), \
+         patch.object(inject_resume, "_create_registry", return_value=MagicMock()), \
+         patch.object(inject_resume, "_reinject_team_context", side_effect=lambda m, *a, **k: m), \
+         patch(
+             "fast_agent.spawn.isolated_spawner.run_isolated_agent_background",
+             new=AsyncMock(side_effect=fake_run_isolated),
+         ):
+        result = await inject_resume.resume_with_inject(
+            agent_name="Jesse [Designer]",
+            inject_message="export the figma to png and attach to Jira",
+            spawn_record=spawn_record,
+            bridge=None,
+        )
+
+    assert result["status"] == "resumed"
+    assert result["run_id"] == "run_new_123"
+
+    # The pin: server_overrides must be present AND equal to original_config's.
+    assert "server_overrides" in captured_kwargs, (
+        "resume_with_inject dropped server_overrides — every dashboard inject "
+        "will spawn the agent with base fastagent.config.yaml filesystem args "
+        "(./data only) and lose workspace + skills access."
+    )
+    assert captured_kwargs["server_overrides"] == _baseline_original_config["server_overrides"]
+    # Sanity: workspace_dir + agent identity also still forwarded.
+    assert captured_kwargs["workspace_dir"] == "/ws/team-alpha"
+    assert captured_kwargs["agent_name"] == "Jesse [Designer]"
+    assert captured_kwargs["team_name"] == "team-alpha"
+
+
+@pytest.mark.asyncio
+async def test_inject_resume_passes_none_when_no_overrides(_baseline_original_config):
+    """Non-team / ad-hoc spawn → no server_overrides in original_config.
+
+    The forward must not invent a value; it must pass None so
+    run_isolated_agent_background falls through to base defaults (the
+    correct behaviour when the agent never had role-specific overrides).
+    """
+    from services import inject_resume
+
+    cfg = dict(_baseline_original_config)
+    cfg.pop("server_overrides")
+
+    spawn_record = {
+        "agent_name": "ad-hoc-agent",
+        "team_name": "",
+        "original_config": cfg,
+    }
+
+    captured_kwargs: dict = {}
+
+    async def fake_run_isolated(**kwargs):
+        captured_kwargs.update(kwargs)
+        return "run_new_456"
+
+    with patch.object(inject_resume, "_load_context_from_db", return_value=None), \
+         patch.object(inject_resume, "_create_registry", return_value=MagicMock()), \
+         patch.object(inject_resume, "_reinject_team_context", side_effect=lambda m, *a, **k: m), \
+         patch(
+             "fast_agent.spawn.isolated_spawner.run_isolated_agent_background",
+             new=AsyncMock(side_effect=fake_run_isolated),
+         ):
+        await inject_resume.resume_with_inject(
+            agent_name="ad-hoc-agent",
+            inject_message="continue",
+            spawn_record=spawn_record,
+            bridge=None,
+        )
+
+    # Pin the explicit-None behaviour — empty dict or omission would also
+    # confuse isolated_spawner; ``None`` is the documented sentinel for "no
+    # override, use base config".
+    assert captured_kwargs.get("server_overrides") is None
+
+
+@pytest.mark.asyncio
+async def test_inject_resume_explicit_none_in_config_forwarded_as_none(_baseline_original_config):
+    """Defence-in-depth: an explicit None (vs missing key) must also forward as None.
+
+    Some upstream paths may write ``server_overrides: null`` instead of
+    omitting the key entirely. The ``or None`` coalesce in inject_resume
+    must collapse both to the same forward value.
+    """
+    from services import inject_resume
+
+    cfg = dict(_baseline_original_config)
+    cfg["server_overrides"] = None
+
+    captured_kwargs: dict = {}
+
+    async def fake_run_isolated(**kwargs):
+        captured_kwargs.update(kwargs)
+        return "run_new_789"
+
+    with patch.object(inject_resume, "_load_context_from_db", return_value=None), \
+         patch.object(inject_resume, "_create_registry", return_value=MagicMock()), \
+         patch.object(inject_resume, "_reinject_team_context", side_effect=lambda m, *a, **k: m), \
+         patch(
+             "fast_agent.spawn.isolated_spawner.run_isolated_agent_background",
+             new=AsyncMock(side_effect=fake_run_isolated),
+         ):
+        await inject_resume.resume_with_inject(
+            agent_name="Jesse [Designer]",
+            inject_message="continue",
+            spawn_record={"agent_name": "Jesse [Designer]", "original_config": cfg},
+            bridge=None,
+        )
+
+    assert captured_kwargs.get("server_overrides") is None
+
+
+# ─── template-driven resume (2026-05-18 incident) ─────────────────────────────
+#
+# After incident 2026-05-18: the patch script + /reload endpoint correctly
+# updated ``team_sessions.template.roles.qe.servers`` to add ``playwright``,
+# but every subsequent QE resume still passed the stale 7-server list to
+# ``run_isolated_agent_background`` because ``resume_with_inject`` was
+# reading from the FROZEN ``original_config.servers`` snapshot rather than
+# the live template. Result: agent had no playwright tools and silently
+# fell back to scrapling-server.
+#
+# Root cause was an SSoT violation — two truths for "what servers does QE
+# have", the writer/patch updated one, the reader/resume read the other.
+# These tests pin the fix: when the live template diverges from the
+# snapshot, resume MUST use the template values.
+
+
+@pytest.fixture
+def _team_config_with_playwright():
+    """Original config snapshot taken BEFORE playwright was added.
+
+    Represents the production state on 2026-05-18: agent first spawned
+    when the template had 7 servers, then the operator patched the
+    template to add playwright. The snapshot is still 7 — that's the
+    point. The reader must NOT trust this anymore for team agents.
+    """
+    return {
+        "task": "test",
+        "instruction": "OLD instruction",
+        "context": "",
+        "servers": ["filesystem", "meeting_room", "email", "scrapling-server"],
+        "skills": [],
+        "model": "",
+        "timeout_seconds": 0,
+        "role": "qe",
+        "agent_name": "Eden [QE]",
+        "team_name": "agile-team",
+        "workspace_dir": "/ws/agile-team",
+        "env_vars": {"TEAM_SESSION_ID": "sess-be885ae8", "TEAM_MY_NAME": "Eden [QE]"},
+        "project_dir": "/proj",
+        "server_overrides": {"filesystem": {"args": ["-y", "x", "/ws"]}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_resume_prefers_live_template_servers_over_snapshot(
+    _team_config_with_playwright,
+):
+    """Pin the 2026-05-18 fix: when team_session_id resolves a live template,
+    spawn passes the TEMPLATE's servers list — not the original_config snapshot.
+
+    Without this, the dashboard /reload flow is broken: user edits the
+    template to add a server, reload kills + resumes the agent, but the
+    new agent still has the old server list. The bug was visible to the
+    user as "QE doesn't see playwright tools even though the template says
+    so" and required tail-following two SQL rows to diagnose.
+    """
+    from services import inject_resume
+
+    fake_session = MagicMock()
+    fake_session.template = {
+        "roles": {
+            "qe": {
+                "servers": [
+                    "filesystem", "meeting_room", "email",
+                    "scrapling-server", "playwright",  # ← new
+                ],
+                "server_overrides": {"filesystem": {"args": ["-y", "x", "/ws"]}},
+                "instruction": "NEW instruction",
+                "skills": ["browser-testing"],
+                "model": "",
+            },
+        },
+    }
+
+    captured: dict = {}
+
+    async def fake_run_isolated(**kwargs):
+        captured.update(kwargs)
+        return "run_new_001"
+
+    with patch.object(inject_resume, "_load_context_from_db", return_value=None), \
+         patch.object(inject_resume, "_create_registry", return_value=MagicMock()), \
+         patch.object(inject_resume, "_reinject_team_context", side_effect=lambda m, *a, **k: m), \
+         patch("fast_agent.spawn.team_spawner.get_team_session", return_value=fake_session), \
+         patch(
+             "fast_agent.spawn.isolated_spawner.run_isolated_agent_background",
+             new=AsyncMock(side_effect=fake_run_isolated),
+         ):
+        await inject_resume.resume_with_inject(
+            agent_name="Eden [QE]",
+            inject_message="test",
+            spawn_record={
+                "agent_name": "Eden [QE]",
+                "team_name": "agile-team",
+                "original_config": _team_config_with_playwright,
+            },
+            bridge=None,
+        )
+
+    assert "playwright" in captured["servers"], (
+        f"resume_with_inject passed servers={captured['servers']!r} — the live "
+        f"team template added 'playwright' but resume still read the stale "
+        f"original_config snapshot. SSoT violation reintroduced."
+    )
+    assert captured["instruction"] == "NEW instruction", (
+        "Instruction edits in the template must reach the next resume."
+    )
+    assert captured["skills"] == ["browser-testing"], (
+        "Skill edits in the template must reach the next resume."
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_falls_back_to_snapshot_when_template_missing(
+    _team_config_with_playwright,
+):
+    """If the team session was deleted (or the role was removed from the
+    template after the agent spawned), resume MUST fall back to the snapshot
+    rather than crash. This preserves the ability to inspect / wind down
+    legacy agents whose template no longer exists.
+    """
+    from services import inject_resume
+
+    captured: dict = {}
+
+    async def fake_run_isolated(**kwargs):
+        captured.update(kwargs)
+        return "run_new_002"
+
+    with patch.object(inject_resume, "_load_context_from_db", return_value=None), \
+         patch.object(inject_resume, "_create_registry", return_value=MagicMock()), \
+         patch.object(inject_resume, "_reinject_team_context", side_effect=lambda m, *a, **k: m), \
+         patch("fast_agent.spawn.team_spawner.get_team_session", return_value=None), \
+         patch(
+             "fast_agent.spawn.isolated_spawner.run_isolated_agent_background",
+             new=AsyncMock(side_effect=fake_run_isolated),
+         ):
+        await inject_resume.resume_with_inject(
+            agent_name="Eden [QE]",
+            inject_message="test",
+            spawn_record={
+                "agent_name": "Eden [QE]",
+                "team_name": "agile-team",
+                "original_config": _team_config_with_playwright,
+            },
+            bridge=None,
+        )
+
+    assert captured["servers"] == _team_config_with_playwright["servers"]
+    assert captured["instruction"] == "OLD instruction"
+
+
+@pytest.mark.asyncio
+async def test_resume_for_ad_hoc_agent_does_not_lookup_template(
+    _team_config_with_playwright,
+):
+    """Ad-hoc spawns (no TEAM_SESSION_ID in env_vars) MUST NOT trigger the
+    template lookup — they don't belong to any team. Pin this so the
+    template-load helper doesn't sneak its way into the ad-hoc path and
+    add a needless DB read per resume.
+    """
+    from services import inject_resume
+
+    cfg = dict(_team_config_with_playwright)
+    cfg["env_vars"] = {}  # ad-hoc — no team session
+    cfg["team_name"] = ""
+
+    captured: dict = {}
+    template_lookups = MagicMock()
+
+    async def fake_run_isolated(**kwargs):
+        captured.update(kwargs)
+        return "run_new_003"
+
+    with patch.object(inject_resume, "_load_context_from_db", return_value=None), \
+         patch.object(inject_resume, "_create_registry", return_value=MagicMock()), \
+         patch.object(inject_resume, "_reinject_team_context", side_effect=lambda m, *a, **k: m), \
+         patch("fast_agent.spawn.team_spawner.get_team_session", new=template_lookups), \
+         patch(
+             "fast_agent.spawn.isolated_spawner.run_isolated_agent_background",
+             new=AsyncMock(side_effect=fake_run_isolated),
+         ):
+        await inject_resume.resume_with_inject(
+            agent_name="ad-hoc",
+            inject_message="test",
+            spawn_record={"agent_name": "ad-hoc", "original_config": cfg},
+            bridge=None,
+        )
+
+    template_lookups.assert_not_called()
+    # Snapshot values survive — ad-hoc agents have no template.
+    assert captured["servers"] == cfg["servers"]
+
+
+def test_audit_all_run_isolated_agent_background_callers_forward_overrides():
+    """Static audit: every caller of run_isolated_agent_background that
+    handles a TEAM-managed agent must forward server_overrides.
+
+    This guard catches NEW call sites added in future refactors. Without it
+    the bug-class repeats: 5 of 6 paths fixed, 1 silent miss. We hard-code
+    the known team-aware call sites — if a new one is added without
+    forwarding overrides, the assertion message tells the author exactly
+    which test fixture to update and which kwarg they forgot.
+    """
+    import re
+    from pathlib import Path
+
+    # Paths that legitimately do NOT need server_overrides (generic ad-hoc
+    # spawn tools that never had role-specific config). Keep this list tight.
+    EXEMPT_FILES = {
+        "fast_agent/spawn/servers/agent_spawner_server.py",  # _spawn_agent_background MCP tool
+    }
+
+    # All files we expect to forward overrides when they call the spawner.
+    REQUIRED_FILES = [
+        "backend/services/inject_resume.py",
+        "backend/fast-agent/src/fast_agent/spawn/team_spawner.py",
+        "backend/fast-agent/src/fast_agent/spawn/isolated_spawner.py",
+    ]
+
+    project_root = Path(__file__).resolve().parents[3]
+    misses = []
+    for rel in REQUIRED_FILES:
+        f = project_root / rel
+        if not f.exists():
+            continue
+        src = f.read_text()
+        # Find each call to run_isolated_agent_background(...) and check the
+        # subsequent block contains "server_overrides=".
+        for m in re.finditer(r"run_isolated_agent_background\s*\(", src):
+            start = m.start()
+            # Find the matching close paren (simple balance counter — these
+            # calls don't contain string literals with stray parens).
+            depth = 0
+            i = m.end() - 1  # position of '('
+            end = None
+            for j in range(i, len(src)):
+                ch = src[j]
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                    if depth == 0:
+                        end = j + 1
+                        break
+            if end is None:
+                continue
+            call_text = src[start:end]
+            line_no = src[:start].count("\n") + 1
+            if "server_overrides" not in call_text:
+                misses.append(f"{rel}:{line_no}")
+
+    assert not misses, (
+        "run_isolated_agent_background callers that DO NOT forward "
+        "server_overrides:\n  " + "\n  ".join(misses) + "\n\n"
+        "Each missing call will silently drop per-role MCP arg overrides "
+        "(filesystem allowed roots, git repo path, etc.) on the next spawn. "
+        "Either add `server_overrides=<source>.get('server_overrides') or None` "
+        "to the call, or add the file to EXEMPT_FILES with a justification."
+    )

--- a/backend/tests/test_services/test_spawn_caller_audit.py
+++ b/backend/tests/test_services/test_spawn_caller_audit.py
@@ -1,0 +1,185 @@
+"""Static audit: callers of ``run_isolated_agent_background`` must pass a
+team-distinct ``agent_name`` whenever they also pass a non-empty
+``team_name``.
+
+This is belt-and-suspenders with the runtime validator in
+``SpawnRegistry.register`` (see ``test_spawn_registry_validation.py``).
+The runtime validator catches the bug at write time; this static test
+catches new call sites at CI time so the bug is rejected in PR review
+BEFORE it ships.
+
+Scope: parses every ``run_isolated_agent_background(...)`` invocation in
+backend code (NOT in tests), then asserts the per-call pattern. If a call
+site adds ``team_name=`` it MUST also add ``agent_name=``, AND the
+``agent_name=`` value must not be the literal string ``"role"`` (which
+would mean it's just echoing the role variable as identity — the exact
+mistake that produced the 2026-05-17 incident).
+
+Refer to incident notes in ``isolated_spawner.py`` and the SpawnRegistry
+validator for full context.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+# Source trees to scan. Don't include /tests or generated /__pycache__.
+_SOURCE_TREES = [
+    _PROJECT_ROOT / "backend" / "services",
+    _PROJECT_ROOT / "backend" / "routes",
+    _PROJECT_ROOT / "backend" / "fast-agent" / "src" / "fast_agent" / "spawn",
+]
+
+_TARGET = "run_isolated_agent_background"
+
+
+def _iter_python_files(root: Path):
+    for p in root.rglob("*.py"):
+        # Skip generated copies of the source tree inside agent workspaces
+        if ".runtime" in p.parts or "node_modules" in p.parts:
+            continue
+        yield p
+
+
+def _is_target_call(node: ast.AST) -> bool:
+    """True if this AST node is a Call to ``run_isolated_agent_background``.
+
+    Matches both bare-name and attribute calls. We don't try to resolve
+    imports — assume the function name is unique enough in this codebase
+    (it is — grep confirms one definition).
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == _TARGET:
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == _TARGET:
+        return True
+    return False
+
+
+def _kw_value(call: ast.Call, name: str) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _is_definitely_non_empty(node: ast.AST | None) -> bool:
+    """Best-effort: does this expression have a non-empty value at all
+    paths? We only enforce the EASY cases (literal strings, simple ``Name``s)
+    — anything fancy is treated as "trust the caller" with a permissive
+    return. The runtime validator catches what we miss.
+    """
+    if node is None:
+        return False
+    # Literal: must be a non-empty string. Empty string or None → fail.
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, str) and bool(node.value)
+    # Subscript like cfg["agent_name"] / spawn_record["agent_name"] / dict.get(...).
+    # We can't statically prove non-emptiness; allow with hope the runtime
+    # validator catches surprises.
+    return True
+
+
+def _looks_like_bare_role_variable(node: ast.AST | None) -> bool:
+    """The exact mistake at agent_spawner_server.py:445 was
+    ``agent_name=role`` — using the role *variable* as the identity. For
+    ad-hoc spawns this is OK (no team_name) but for team-managed spawns
+    it's the silent-fail pattern we want to forbid.
+    """
+    return isinstance(node, ast.Name) and node.id == "role"
+
+
+def test_every_team_spawn_caller_passes_distinct_agent_name():
+    """For each ``run_isolated_agent_background(...)`` call: if it passes
+    ``team_name=<truthy expression>`` it MUST also pass ``agent_name=`` with
+    a value that is NOT the bare ``role`` variable.
+
+    The runtime validator in ``SpawnRegistry.register`` already enforces
+    this at WRITE time. This static test exists to catch new offenders
+    *during code review*, before the runtime validator fires in
+    production. Failing here means: a caller you added would crash on its
+    first execution. Fix the call before merging.
+    """
+    offenders: list[str] = []
+
+    for tree in _SOURCE_TREES:
+        if not tree.exists():
+            continue
+        for src_file in _iter_python_files(tree):
+            try:
+                source = src_file.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            if _TARGET not in source:
+                continue
+            try:
+                module = ast.parse(source, filename=str(src_file))
+            except SyntaxError:
+                # If the file doesn't parse the broader test suite will
+                # explode anyway; skip silently here.
+                continue
+
+            for node in ast.walk(module):
+                if not _is_target_call(node):
+                    continue
+                team_kw = _kw_value(node, "team_name")
+                # No team_name → ad-hoc spawn → out of scope.
+                if team_kw is None:
+                    continue
+                # team_name explicitly empty string → also ad-hoc, skip.
+                if isinstance(team_kw, ast.Constant) and team_kw.value in ("", None):
+                    continue
+
+                agent_kw = _kw_value(node, "agent_name")
+                rel = src_file.relative_to(_PROJECT_ROOT)
+                location = f"{rel}:{node.lineno}"
+
+                if not _is_definitely_non_empty(agent_kw):
+                    offenders.append(
+                        f"{location}: team_name passed but agent_name is missing "
+                        f"or definitely-empty — would crash SpawnRegistry validator."
+                    )
+                    continue
+                if _looks_like_bare_role_variable(agent_kw):
+                    offenders.append(
+                        f"{location}: team_name passed AND agent_name=role — "
+                        f"this is the exact silent-fail pattern from the "
+                        f"2026-05-17 incident. Pass the team-managed identity "
+                        f"(e.g. cfg['agent_name']) instead of the bare role."
+                    )
+
+    assert not offenders, (
+        "run_isolated_agent_background callers violate team-distinct-name "
+        "invariant:\n  - " + "\n  - ".join(offenders) + "\n\n"
+        "Each offender will crash at registry.register() time. Fix the "
+        "call site, or — if this is intentionally an ad-hoc spawn — drop "
+        "the ``team_name=`` kwarg so the validator doesn't apply."
+    )
+
+
+def test_target_function_actually_referenced():
+    """Smoke test: prove our scan isn't a no-op. If someone renames
+    ``run_isolated_agent_background`` and forgets to update this test,
+    the audit would silently pass on zero call sites — a false-green.
+    """
+    total_hits = 0
+    for tree in _SOURCE_TREES:
+        if not tree.exists():
+            continue
+        for src_file in _iter_python_files(tree):
+            try:
+                if _TARGET in src_file.read_text(encoding="utf-8"):
+                    total_hits += 1
+            except OSError:
+                pass
+    assert total_hits >= 3, (
+        f"Static audit found only {total_hits} file(s) mentioning "
+        f"{_TARGET!r}. Either the function was renamed (update _TARGET) "
+        f"or the _SOURCE_TREES list is wrong."
+    )

--- a/backend/tests/test_services/test_team_completion_meeting_aware.py
+++ b/backend/tests/test_services/test_team_completion_meeting_aware.py
@@ -483,3 +483,136 @@ def test_create_team_notification_keeps_full_result_when_present(env_db):
     assert captured_notif["content"] == rollup
     assert "BUG" not in captured_notif["preview"]
     assert "Verdict" in captured_notif["preview"]  # truncated preview shows real text
+
+
+def test_notify_orchestrator_skips_when_trigger_is_orchestrator(env_db, monkeypatch):
+    """REGRESSION: ``_notify_orchestrator_on_members_idle`` MUST skip
+    when the trigger agent IS the orchestrator itself.
+
+    Production incident 2026-05-16 10:18 ICT: every user inject to PM
+    resulted in PM receiving an "inbox" message right after responding:
+      Inject: "..." → PM responds → PM idle → bridge fires
+      _notify_orchestrator_on_members_idle(trigger_agent=PM) →
+      all workers idle (from before) → status_hash empty (post-restart
+      dedupe) → resume PM with "Check your inbox for team status updates"
+
+    The notification's intent is "workers finished delegated work →
+    tell PM to review". PM going idle after replying to a user inject
+    is NOT a worker-completion event; firing the notify wakes PM
+    unnecessarily and confuses the user about why agents got an inbox
+    after every inject.
+
+    Fix: skip when trigger_agent == orch_name. Worker idle still
+    triggers notify normally.
+    """
+    from unittest.mock import MagicMock
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    fake_registry = MagicMock()
+    fake_registry.get_record.return_value = {
+        "run_id": "run-pm-1", "team_name": "agile-team",
+        "session_id": "be885ae8",
+    }
+    fake_registry.find_by_team_name.return_value = [
+        {"run_id": "run-pm-1", "agent_name": "Robin [PM]", "role": "pm",
+         "status": "idle", "session_id": "be885ae8"},
+        {"run_id": "run-toby", "agent_name": "Toby [BA]", "role": "ba",
+         "status": "idle", "session_id": "be885ae8",
+         "original_config": {"env_vars": {"TEAM_MESSAGES_DIR": "/tmp/x"}}},
+    ]
+
+    bridge = SpawnProgressBridge(
+        progress_manager=MagicMock(), registry_db=fake_registry,
+    )
+
+    # Stub _find_orchestrator so the bridge identifies PM as orch.
+    monkeypatch.setattr(
+        bridge, "_find_orchestrator",
+        lambda members: next(
+            (m for m in members if m.get("role") == "pm"), None,
+        ),
+    )
+
+    # Capture whether the resume path is reached (it shouldn't be).
+    resume_called = {"flag": False}
+    async def _fake_resume(*args, **kwargs):
+        resume_called["flag"] = True
+
+    monkeypatch.setattr(bridge, "_trigger_orchestrator_resume", _fake_resume)
+
+    # Trigger from PM itself (the buggy path).
+    bridge._notify_orchestrator_on_members_idle(
+        trigger_agent="Robin [PM]",
+        raw={"run_id": "run-pm-1"},
+    )
+
+    assert resume_called["flag"] is False, (
+        "Bridge fired orchestrator-resume even though the trigger was the "
+        "orchestrator itself. This is the 2026-05-16 'inbox after every inject' "
+        "loop — PM doesn't need to be re-woken after it just responded."
+    )
+
+
+def test_notify_orchestrator_fires_when_worker_triggers(env_db, monkeypatch):
+    """Inverse of the regression test: when a WORKER triggers the event
+    (the legitimate use case), the orchestrator-notify MUST proceed.
+
+    This guards against an overcorrection that would silence the
+    legitimate "workers finished → tell PM to review" notification.
+    """
+    from unittest.mock import MagicMock
+
+    from services.spawn_progress_bridge import SpawnProgressBridge
+
+    fake_registry = MagicMock()
+    fake_registry.get_record.return_value = {
+        "run_id": "run-toby", "team_name": "agile-team",
+        "session_id": "be885ae8",
+    }
+    fake_registry.find_by_team_name.return_value = [
+        {"run_id": "run-pm-1", "agent_name": "Robin [PM]", "role": "pm",
+         "status": "idle", "session_id": "be885ae8",
+         "original_config": {"env_vars": {"TEAM_MESSAGES_DIR": "/tmp/x"}}},
+        {"run_id": "run-toby", "agent_name": "Toby [BA]", "role": "ba",
+         "status": "idle", "session_id": "be885ae8",
+         "original_config": {"env_vars": {"TEAM_MESSAGES_DIR": "/tmp/x"}}},
+    ]
+
+    bridge = SpawnProgressBridge(
+        progress_manager=MagicMock(), registry_db=fake_registry,
+    )
+    monkeypatch.setattr(
+        bridge, "_find_orchestrator",
+        lambda members: next(
+            (m for m in members if m.get("role") == "pm"), None,
+        ),
+    )
+    # Stub bus-send + meeting-check + resume so the function reaches
+    # the resume call without IO.
+    monkeypatch.setattr(
+        bridge, "_active_meetings_with_members", lambda names: [],
+    )
+    monkeypatch.setattr(
+        bridge, "_resolve_messages_dir", lambda members: "/tmp/x",
+    )
+
+    bus_send_called = {"flag": False}
+    class _FakeBus:
+        def __init__(self, *a, **kw): pass
+        def send(self, *a, **kw):
+            bus_send_called["flag"] = True
+
+    monkeypatch.setattr(
+        "fast_agent.spawn.message_bus.MessageBus", _FakeBus,
+    )
+
+    bridge._notify_orchestrator_on_members_idle(
+        trigger_agent="Toby [BA]",  # worker, not orchestrator
+        raw={"run_id": "run-toby"},
+    )
+
+    assert bus_send_called["flag"] is True, (
+        "Worker-triggered notify must still fire — guard should NOT silence "
+        "legitimate worker-completion events."
+    )

--- a/backend/tests/test_services/test_team_completion_meeting_aware.py
+++ b/backend/tests/test_services/test_team_completion_meeting_aware.py
@@ -385,17 +385,16 @@ def test_create_team_notification_writes_session_id_into_metadata(env_db):
 
 
 def test_check_team_completion_filters_members_by_session_id(env_db, monkeypatch):
-    """REGRESSION: ``_check_team_completion`` MUST scope the member
-    sweep to the session_id of the triggering agent. The team_name
-    is reused across spawns ("toolset-self-audit" yesterday and
-    today both produce rows with that ``team_name``), so a raw
-    ``find_by_team_name`` join mixes the old idle agents into the
-    new completion check.
+    """REGRESSION: cycle handler MUST scope the member sweep to the
+    session_id of the triggering agent. ``team_name`` is reused across
+    spawns ("toolset-self-audit" yesterday and today produce rows with
+    the same name); without session filtering, old idle members from
+    yesterday would contaminate today's cycle calculation.
 
-    Pre-2026-05-14 the bridge looked at all members of the team
-    name regardless of session and dedupe-skipped today's run
-    because yesterday's notification already existed under that
-    name. The fix: filter members + dedupe by session_id.
+    Pre-event-stream (2026-05-14 era) the bridge looked at all members
+    of the team name regardless of session and dedupe-skipped today's
+    run. Post-event-stream the handler still must filter by session;
+    this test pins that contract.
     """
     from unittest.mock import MagicMock, patch
 
@@ -406,47 +405,58 @@ def test_check_team_completion_filters_members_by_session_id(env_db, monkeypatch
         "run_id": "run-pm-new", "team_name": "toolset-self-audit",
         "session_id": "newsess",
     }
-    # The registry returns BOTH sessions' members under the name.
-    # The fix filters them down to newsess before the all-done check.
     fake_registry.find_by_team_name.return_value = [
-        # Today's
+        # Today's spawn — also includes 1 running worker so the worker
+        # cycle is OPEN at the moment of the test snapshot. The handler
+        # should NOT fire the cycle-close event because worker is still
+        # running (so dedupe across sessions never gets a chance to
+        # silence anything — we only need to assert session scoping).
         {"run_id": "run-pm-new", "agent_name": "Bailey [PM]", "role": "pm",
          "status": "idle", "session_id": "newsess",
          "result": "# Roll-up — Verdict: PARTIAL"},
-        # Yesterday's — must be excluded
+        {"run_id": "run-toby-new", "agent_name": "Toby [BA]", "role": "ba",
+         "status": "running", "session_id": "newsess"},
+        # Yesterday's idle members — must NOT be counted in today's
+        # session's snapshot. If they leak in, the cycle handler would
+        # see "all idle" because yesterday's workers are stale-idle,
+        # and emit an incorrect close event.
         {"run_id": "run-pm-old", "agent_name": "Morgan [PM]", "role": "pm",
          "status": "idle", "session_id": "oldsess", "result": ""},
+        {"run_id": "run-toby-old", "agent_name": "Toby [BA]", "role": "ba",
+         "status": "idle", "session_id": "oldsess"},
     ]
 
     bridge = SpawnProgressBridge(
         progress_manager=MagicMock(), registry_db=fake_registry,
     )
-    # Force the dedupe to miss so we can observe the creation path.
-    monkeypatch.setattr(bridge, "_has_team_notification", lambda sid: False)
+    monkeypatch.setattr(
+        bridge, "_find_orchestrator",
+        lambda members: next(
+            (m for m in members if m.get("role") == "pm"), None,
+        ),
+    )
+    # Stub side-effect helpers so we can probe cycle state save.
+    saved = {}
+    monkeypatch.setattr(
+        bridge, "_save_cycle_state",
+        lambda sid, w, t: saved.update({"sid": sid, "w": w, "t": t}),
+    )
+    monkeypatch.setattr(
+        bridge, "_load_cycle_state",
+        lambda sid: {"worker_open": False, "team_open": False},
+    )
 
-    captured: dict = {}
+    bridge._on_member_state_event("run-pm-new")
 
-    class _Notif:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-            self.id = 201
-
-    with patch("core.database.NotificationModel", _Notif), \
-            patch("core.database.get_db_session", return_value=MagicMock()), \
-            patch("services.cron_scheduler.scheduler_stream_manager", MagicMock()):
-        bridge._check_team_completion(
-            trigger_agent="Bailey [PM]",
-            raw={"run_id": "run-pm-new"},
-        )
-
-    # Notification must surface TODAY's roll-up, not yesterday's empty.
-    assert captured, "completion check skipped — likely picked the wrong session"
-    assert "Roll-up" in captured["content"]
-    assert "Verdict" in captured["content"]
-    # Metadata carries today's session_id so future dedupe matches it.
-    meta = json.loads(captured["metadata_json"])
-    assert meta["session_id"] == "newsess"
-    assert meta["agent"] == "Bailey [PM]"
+    # Saved state reflects ONLY today's session (newsess), with worker
+    # cycle still OPEN (Toby [BA] running). If yesterday's members had
+    # leaked in, worker_open would still be False (their stale "idle")
+    # — but worker_open=True confirms today's running member was seen.
+    assert saved["sid"] == "newsess"
+    assert saved["w"] is True, (
+        "Session scoping broken: worker_open=False suggests yesterday's "
+        "all-idle members were counted instead of today's running worker."
+    )
 
 
 def test_create_team_notification_keeps_full_result_when_present(env_db):
@@ -485,134 +495,321 @@ def test_create_team_notification_keeps_full_result_when_present(env_db):
     assert "Verdict" in captured_notif["preview"]  # truncated preview shows real text
 
 
-def test_notify_orchestrator_skips_when_trigger_is_orchestrator(env_db, monkeypatch):
-    """REGRESSION: ``_notify_orchestrator_on_members_idle`` MUST skip
-    when the trigger agent IS the orchestrator itself.
+# ─── Event-stream cycle handler regression tests ────────────────────
+#
+# These tests replace the previous dedup-based pair
+# (_check_team_completion + _notify_orchestrator_on_members_idle) which
+# silently silenced repeat notifications via in-memory hash / DB content
+# filter. Production incident 2026-05-16: session ``be885ae8`` got 1
+# user notification on May 15 and zero thereafter despite 7+ work cycles.
+#
+# The 14 edge-case rows from the design table are covered by the tests
+# below (E1, E2, E5, E9, E12, E13, E14 directly tested; E3/E4/E8/E10/E11
+# implicit in the state-derivation logic; E7 documented out-of-scope).
 
-    Production incident 2026-05-16 10:18 ICT: every user inject to PM
-    resulted in PM receiving an "inbox" message right after responding:
-      Inject: "..." → PM responds → PM idle → bridge fires
-      _notify_orchestrator_on_members_idle(trigger_agent=PM) →
-      all workers idle (from before) → status_hash empty (post-restart
-      dedupe) → resume PM with "Check your inbox for team status updates"
 
-    The notification's intent is "workers finished delegated work →
-    tell PM to review". PM going idle after replying to a user inject
-    is NOT a worker-completion event; firing the notify wakes PM
-    unnecessarily and confuses the user about why agents got an inbox
-    after every inject.
+def _make_bridge_with_registry(members, monkeypatch, env_db, team_name="agile"):
+    """Test helper: build a bridge whose registry returns ``members``
+    and whose cycle-state tables point at a fresh temp SQLite.
 
-    Fix: skip when trigger_agent == orch_name. Worker idle still
-    triggers notify normally.
+    Each member dict is auto-tagged with ``team_name`` so the handler's
+    "is part of a team?" guard passes.
     """
     from unittest.mock import MagicMock
 
     from services.spawn_progress_bridge import SpawnProgressBridge
 
+    for m in members:
+        m.setdefault("team_name", team_name)
+
     fake_registry = MagicMock()
-    fake_registry.get_record.return_value = {
-        "run_id": "run-pm-1", "team_name": "agile-team",
-        "session_id": "be885ae8",
-    }
-    fake_registry.find_by_team_name.return_value = [
-        {"run_id": "run-pm-1", "agent_name": "Robin [PM]", "role": "pm",
-         "status": "idle", "session_id": "be885ae8"},
-        {"run_id": "run-toby", "agent_name": "Toby [BA]", "role": "ba",
-         "status": "idle", "session_id": "be885ae8",
-         "original_config": {"env_vars": {"TEAM_MESSAGES_DIR": "/tmp/x"}}},
-    ]
+    fake_registry.find_by_team_name.return_value = members
+    fake_registry.get_record.side_effect = lambda rid: next(
+        (m for m in members if m.get("run_id") == rid), None,
+    )
 
     bridge = SpawnProgressBridge(
         progress_manager=MagicMock(), registry_db=fake_registry,
     )
-
-    # Stub _find_orchestrator so the bridge identifies PM as orch.
+    # Default _find_orchestrator to role-based pick.
     monkeypatch.setattr(
         bridge, "_find_orchestrator",
-        lambda members: next(
-            (m for m in members if m.get("role") == "pm"), None,
+        lambda mems: next(
+            (m for m in mems if m.get("role") == "pm"), None,
         ),
     )
-
-    # Capture whether the resume path is reached (it shouldn't be).
-    resume_called = {"flag": False}
-    async def _fake_resume(*args, **kwargs):
-        resume_called["flag"] = True
-
-    monkeypatch.setattr(bridge, "_trigger_orchestrator_resume", _fake_resume)
-
-    # Trigger from PM itself (the buggy path).
-    bridge._notify_orchestrator_on_members_idle(
-        trigger_agent="Robin [PM]",
-        raw={"run_id": "run-pm-1"},
-    )
-
-    assert resume_called["flag"] is False, (
-        "Bridge fired orchestrator-resume even though the trigger was the "
-        "orchestrator itself. This is the 2026-05-16 'inbox after every inject' "
-        "loop — PM doesn't need to be re-woken after it just responded."
-    )
+    return bridge
 
 
-def test_notify_orchestrator_fires_when_worker_triggers(env_db, monkeypatch):
-    """Inverse of the regression test: when a WORKER triggers the event
-    (the legitimate use case), the orchestrator-notify MUST proceed.
+def test_cycle_worker_closed_fires_on_workers_idle_transition(env_db, monkeypatch):
+    """**Case 1** — Worker cycle closes when all workers stop running.
 
-    This guards against an overcorrection that would silence the
-    legitimate "workers finished → tell PM to review" notification.
+    PM is still running (delegating). One worker was running, now idle.
+    Worker cycle transitions open→closed → emit worker_cycle_closed.
+    PM receives inbox notification.
     """
-    from unittest.mock import MagicMock
-
-    from services.spawn_progress_bridge import SpawnProgressBridge
-
-    fake_registry = MagicMock()
-    fake_registry.get_record.return_value = {
-        "run_id": "run-toby", "team_name": "agile-team",
-        "session_id": "be885ae8",
-    }
-    fake_registry.find_by_team_name.return_value = [
-        {"run_id": "run-pm-1", "agent_name": "Robin [PM]", "role": "pm",
-         "status": "idle", "session_id": "be885ae8",
+    members_running = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sX",
          "original_config": {"env_vars": {"TEAM_MESSAGES_DIR": "/tmp/x"}}},
-        {"run_id": "run-toby", "agent_name": "Toby [BA]", "role": "ba",
-         "status": "idle", "session_id": "be885ae8",
+        {"run_id": "w1", "agent_name": "Wkr", "role": "dev",
+         "status": "running", "session_id": "sX",
          "original_config": {"env_vars": {"TEAM_MESSAGES_DIR": "/tmp/x"}}},
     ]
+    bridge = _make_bridge_with_registry(members_running, monkeypatch, env_db)
+    bridge._registry_db.get_record.return_value = {
+        "run_id": "w1", "team_name": "agile", "session_id": "sX",
+    }
 
-    bridge = SpawnProgressBridge(
-        progress_manager=MagicMock(), registry_db=fake_registry,
+    # First event: worker running → opens worker cycle (and team cycle)
+    bridge._on_member_state_event("w1")
+    state = bridge._load_cycle_state("sX")
+    assert state == {"worker_open": True, "team_open": True}
+
+    # Now worker idle → workers all non-running → close fires
+    members_running[1]["status"] = "idle"
+    bridge._registry_db.get_record.return_value = members_running[1]
+
+    emit_called = {"worker": False, "full": False}
+    monkeypatch.setattr(
+        bridge, "_emit_worker_cycle_closed",
+        lambda *a, **kw: emit_called.update({"worker": True}),
     )
     monkeypatch.setattr(
-        bridge, "_find_orchestrator",
-        lambda members: next(
-            (m for m in members if m.get("role") == "pm"), None,
-        ),
+        bridge, "_emit_full_cycle_closed",
+        lambda *a, **kw: emit_called.update({"full": True}),
     )
-    # Stub bus-send + meeting-check + resume so the function reaches
-    # the resume call without IO.
+
+    bridge._on_member_state_event("w1")
+    assert emit_called["worker"] is True, "Worker cycle close MUST fire"
+    assert emit_called["full"] is False, "Team cycle still open (PM running) — must NOT fire full"
+
+
+def test_cycle_full_closed_fires_when_team_idle_no_meeting(env_db, monkeypatch):
+    """**Case 2** — Team cycle closes when ALL agents (incl PM) stop
+    running and no active meeting blocks. User UI notification fires.
+    """
+    members = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sY"},
+        {"run_id": "w1", "agent_name": "Wkr", "role": "dev",
+         "status": "idle", "session_id": "sY"},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    monkeypatch.setattr(bridge, "_active_meetings_with_members", lambda names: [])
+
+    # Open team cycle (PM running)
+    bridge._registry_db.get_record.return_value = members[0]
+    bridge._on_member_state_event("pm1")
+    assert bridge._load_cycle_state("sY")["team_open"] is True
+
+    # PM goes idle → team all non-running → full cycle closes
+    members[0]["status"] = "idle"
+    bridge._registry_db.get_record.return_value = members[0]
+
+    full_emitted = {"flag": False}
     monkeypatch.setattr(
-        bridge, "_active_meetings_with_members", lambda names: [],
+        bridge, "_emit_full_cycle_closed",
+        lambda *a, **kw: full_emitted.update({"flag": True}),
+    )
+    monkeypatch.setattr(bridge, "_emit_worker_cycle_closed", lambda *a, **kw: None)
+
+    bridge._on_member_state_event("pm1")
+    assert full_emitted["flag"] is True
+
+
+def test_cycle_full_blocked_by_active_meeting(env_db, monkeypatch):
+    """**E5** — When all agents idle BUT an active meeting exists, full
+    cycle close MUST be deferred. Meeting end event will re-trigger.
+    Prevents the b61af7db "All finished | No output" false-positive.
+    """
+    members = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sM"},
+        {"run_id": "w1", "agent_name": "Wkr", "role": "dev",
+         "status": "idle", "session_id": "sM"},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    monkeypatch.setattr(
+        bridge, "_active_meetings_with_members",
+        lambda names: [{"meeting_id": "m1", "current_speaker": "Wkr"}],
+    )
+
+    bridge._registry_db.get_record.return_value = members[0]
+    bridge._on_member_state_event("pm1")
+
+    members[0]["status"] = "idle"
+    bridge._registry_db.get_record.return_value = members[0]
+
+    full_called = {"flag": False}
+    monkeypatch.setattr(
+        bridge, "_emit_full_cycle_closed",
+        lambda *a, **kw: full_called.update({"flag": True}),
+    )
+    monkeypatch.setattr(bridge, "_emit_worker_cycle_closed", lambda *a, **kw: None)
+
+    bridge._on_member_state_event("pm1")
+    assert full_called["flag"] is False, (
+        "Active meeting should defer full_cycle_closed — team is NOT done"
+    )
+
+
+def test_cycle_state_persists_across_handler_invocations(env_db, monkeypatch):
+    """**E13** — Cycle state is DB-persisted so backend restart does not
+    cause spurious fires or missed closes.
+    """
+    members = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sP"},
+        {"run_id": "w1", "agent_name": "Wkr", "role": "dev",
+         "status": "running", "session_id": "sP"},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    bridge._registry_db.get_record.return_value = members[1]
+
+    bridge._on_member_state_event("w1")
+    state_after_open = bridge._load_cycle_state("sP")
+    assert state_after_open == {"worker_open": True, "team_open": True}
+
+    # Simulate "restart" — recreate bridge with same registry
+    from unittest.mock import MagicMock
+    from services.spawn_progress_bridge import SpawnProgressBridge
+    fresh_bridge = SpawnProgressBridge(
+        progress_manager=MagicMock(), registry_db=bridge._registry_db,
+    )
+    # State must be loaded from DB, not from in-memory reset
+    fresh_state = fresh_bridge._load_cycle_state("sP")
+    assert fresh_state == {"worker_open": True, "team_open": True}, (
+        "Cycle state lost across restart — restart-safety contract broken"
+    )
+
+
+def test_cycle_event_idempotent_via_db_primary_key(env_db, monkeypatch):
+    """**E12** — Same event_id inserted twice MUST be a no-op the second
+    time (DB ON CONFLICT). Caller must NOT run side effects on conflict.
+    """
+    members = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "idle", "session_id": "sI"},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+
+    payload = {"foo": "bar"}
+    ok_first = bridge._insert_event(
+        "stable-id-1", "worker_cycle_closed", "sI", "team", payload,
+    )
+    ok_second = bridge._insert_event(
+        "stable-id-1", "worker_cycle_closed", "sI", "team", payload,
+    )
+    assert ok_first is True, "First insert should succeed"
+    assert ok_second is False, (
+        "Second insert with same event_id MUST conflict and return False — "
+        "caller relies on this to skip duplicate side effects"
+    )
+
+
+def test_cycle_multi_session_isolation(env_db, monkeypatch):
+    """**E14** — Cycle state is keyed by session_id. Two teams running
+    concurrently MUST NOT cross-contaminate.
+    """
+    members = [
+        {"run_id": "pm-A", "agent_name": "PM-A", "role": "pm",
+         "status": "running", "session_id": "sA"},
+        {"run_id": "pm-B", "agent_name": "PM-B", "role": "pm",
+         "status": "idle", "session_id": "sB"},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+
+    bridge._registry_db.find_by_team_name.side_effect = (
+        lambda name: [m for m in members if m.get("session_id") == (
+            "sA" if name == "team-A" else "sB"
+        )]
+    )
+    bridge._registry_db.get_record.side_effect = lambda rid: next(
+        (m | {"team_name": "team-A" if m["session_id"] == "sA" else "team-B"}
+         for m in members if m.get("run_id") == rid), None,
+    )
+
+    bridge._on_member_state_event("pm-A")
+    bridge._on_member_state_event("pm-B")
+    state_A = bridge._load_cycle_state("sA")
+    state_B = bridge._load_cycle_state("sB")
+    assert state_A == {"worker_open": False, "team_open": True}
+    assert state_B == {"worker_open": False, "team_open": False}, (
+        "Session B (PM idle) leaked Session A's running state"
+    )
+
+
+def test_cycle_solo_pm_no_workers(env_db, monkeypatch):
+    """**E1** — PM responds to a user inject solo (no workers spawned).
+    worker_cycle never opens. team_cycle open→close on PM idle fires
+    full notification; no worker notification fires.
+    """
+    members = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sSolo"},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    monkeypatch.setattr(bridge, "_active_meetings_with_members", lambda names: [])
+
+    bridge._registry_db.get_record.return_value = members[0]
+    bridge._on_member_state_event("pm1")
+    state = bridge._load_cycle_state("sSolo")
+    assert state == {"worker_open": False, "team_open": True}, (
+        "Solo PM running: workers absent → worker_open=False; PM running → team_open=True"
+    )
+
+    # PM idle → only full cycle fires, worker cycle never opened/closed
+    members[0]["status"] = "idle"
+    bridge._registry_db.get_record.return_value = members[0]
+
+    fires = {"worker": False, "full": False}
+    monkeypatch.setattr(
+        bridge, "_emit_worker_cycle_closed",
+        lambda *a, **kw: fires.update({"worker": True}),
     )
     monkeypatch.setattr(
-        bridge, "_resolve_messages_dir", lambda members: "/tmp/x",
+        bridge, "_emit_full_cycle_closed",
+        lambda *a, **kw: fires.update({"full": True}),
     )
+    bridge._on_member_state_event("pm1")
+    assert fires == {"worker": False, "full": True}
 
-    bus_send_called = {"flag": False}
-    class _FakeBus:
-        def __init__(self, *a, **kw): pass
-        def send(self, *a, **kw):
-            bus_send_called["flag"] = True
 
+def test_cycle_multiround_worker_closes_each_round(env_db, monkeypatch):
+    """**E2** — Multi-round delegation: PM delegates → workers idle →
+    PM delegates again → workers idle. Worker cycle MUST close on EACH
+    round (idempotency via unique event_id, not blocked by state-hash
+    matching across rounds).
+    """
+    members = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sR"},
+        {"run_id": "w1", "agent_name": "Wkr", "role": "dev",
+         "status": "running", "session_id": "sR"},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    bridge._registry_db.get_record.return_value = members[1]
+
+    fires = {"count": 0}
     monkeypatch.setattr(
-        "fast_agent.spawn.message_bus.MessageBus", _FakeBus,
+        bridge, "_emit_worker_cycle_closed",
+        lambda *a, **kw: fires.update({"count": fires["count"] + 1}),
     )
+    monkeypatch.setattr(bridge, "_emit_full_cycle_closed", lambda *a, **kw: None)
 
-    bridge._notify_orchestrator_on_members_idle(
-        trigger_agent="Toby [BA]",  # worker, not orchestrator
-        raw={"run_id": "run-toby"},
-    )
+    # Round 1: worker running → idle
+    bridge._on_member_state_event("w1")  # opens
+    members[1]["status"] = "idle"
+    bridge._on_member_state_event("w1")  # closes → fire 1
+    assert fires["count"] == 1
 
-    assert bus_send_called["flag"] is True, (
-        "Worker-triggered notify must still fire — guard should NOT silence "
-        "legitimate worker-completion events."
+    # Round 2: worker re-runs → idle again
+    members[1]["status"] = "running"
+    bridge._on_member_state_event("w1")  # re-opens
+    members[1]["status"] = "idle"
+    bridge._on_member_state_event("w1")  # closes → fire 2
+    assert fires["count"] == 2, (
+        "Worker cycle MUST fire each round. State-hash dedupe would "
+        "incorrectly silence round 2 because (run_id, status) is identical."
     )

--- a/backend/tests/test_services/test_team_completion_meeting_aware.py
+++ b/backend/tests/test_services/test_team_completion_meeting_aware.py
@@ -431,7 +431,7 @@ def test_check_team_completion_filters_members_by_session_id(env_db, monkeypatch
     )
     monkeypatch.setattr(
         bridge, "_find_orchestrator",
-        lambda members: next(
+        lambda members, session_id="": next(
             (m for m in members if m.get("role") == "pm"), None,
         ),
     )
@@ -439,11 +439,15 @@ def test_check_team_completion_filters_members_by_session_id(env_db, monkeypatch
     saved = {}
     monkeypatch.setattr(
         bridge, "_save_cycle_state",
-        lambda sid, w, t: saved.update({"sid": sid, "w": w, "t": t}),
+        lambda sid, w, t, orch: saved.update(
+            {"sid": sid, "w": w, "t": t, "orch": orch},
+        ),
     )
     monkeypatch.setattr(
         bridge, "_load_cycle_state",
-        lambda sid: {"worker_open": False, "team_open": False},
+        lambda sid: {
+            "worker_open": False, "team_open": False, "orch_running": False,
+        },
     )
 
     bridge._on_member_state_event("run-pm-new")
@@ -531,10 +535,13 @@ def _make_bridge_with_registry(members, monkeypatch, env_db, team_name="agile"):
     bridge = SpawnProgressBridge(
         progress_manager=MagicMock(), registry_db=fake_registry,
     )
-    # Default _find_orchestrator to role-based pick.
+    # Default _find_orchestrator to role-based pick. Accept the new
+    # ``session_id`` kwarg (2026-05-19 refactor — production lookup
+    # reads ``template.orchestrator`` from ``team_sessions``; in the
+    # bridge unit tests we pin the role directly).
     monkeypatch.setattr(
         bridge, "_find_orchestrator",
-        lambda mems: next(
+        lambda mems, session_id="": next(
             (m for m in mems if m.get("role") == "pm"), None,
         ),
     )
@@ -561,10 +568,13 @@ def test_cycle_worker_closed_fires_on_workers_idle_transition(env_db, monkeypatc
         "run_id": "w1", "team_name": "agile", "session_id": "sX",
     }
 
-    # First event: worker running → opens worker cycle (and team cycle)
+    # First event: worker running → opens worker cycle (and team cycle);
+    # the orchestrator (PM) is also running → orch_running=True.
     bridge._on_member_state_event("w1")
     state = bridge._load_cycle_state("sX")
-    assert state == {"worker_open": True, "team_open": True}
+    assert state == {
+        "worker_open": True, "team_open": True, "orch_running": True,
+    }
 
     # Now worker idle → workers all non-running → close fires
     members_running[1]["status"] = "idle"
@@ -598,12 +608,16 @@ def test_cycle_full_closed_fires_when_team_idle_no_meeting(env_db, monkeypatch):
     bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
     monkeypatch.setattr(bridge, "_active_meetings_with_members", lambda names: [])
 
-    # Open team cycle (PM running)
+    # Open team cycle (orchestrator running). orch_running=True is the
+    # transition we now gate on (2026-05-19 refactor).
     bridge._registry_db.get_record.return_value = members[0]
     bridge._on_member_state_event("pm1")
-    assert bridge._load_cycle_state("sY")["team_open"] is True
+    state = bridge._load_cycle_state("sY")
+    assert state["orch_running"] is True
+    assert state["team_open"] is True
 
-    # PM goes idle → team all non-running → full cycle closes
+    # PM goes idle → orch_running flips True→False, no workers running →
+    # full cycle closes.
     members[0]["status"] = "idle"
     bridge._registry_db.get_record.return_value = members[0]
 
@@ -669,7 +683,9 @@ def test_cycle_state_persists_across_handler_invocations(env_db, monkeypatch):
 
     bridge._on_member_state_event("w1")
     state_after_open = bridge._load_cycle_state("sP")
-    assert state_after_open == {"worker_open": True, "team_open": True}
+    assert state_after_open == {
+        "worker_open": True, "team_open": True, "orch_running": True,
+    }
 
     # Simulate "restart" — recreate bridge with same registry
     from unittest.mock import MagicMock
@@ -679,7 +695,9 @@ def test_cycle_state_persists_across_handler_invocations(env_db, monkeypatch):
     )
     # State must be loaded from DB, not from in-memory reset
     fresh_state = fresh_bridge._load_cycle_state("sP")
-    assert fresh_state == {"worker_open": True, "team_open": True}, (
+    assert fresh_state == {
+        "worker_open": True, "team_open": True, "orch_running": True,
+    }, (
         "Cycle state lost across restart — restart-safety contract broken"
     )
 
@@ -734,10 +752,12 @@ def test_cycle_multi_session_isolation(env_db, monkeypatch):
     bridge._on_member_state_event("pm-B")
     state_A = bridge._load_cycle_state("sA")
     state_B = bridge._load_cycle_state("sB")
-    assert state_A == {"worker_open": False, "team_open": True}
-    assert state_B == {"worker_open": False, "team_open": False}, (
-        "Session B (PM idle) leaked Session A's running state"
-    )
+    assert state_A == {
+        "worker_open": False, "team_open": True, "orch_running": True,
+    }
+    assert state_B == {
+        "worker_open": False, "team_open": False, "orch_running": False,
+    }, "Session B (orch idle) leaked Session A's running state"
 
 
 def test_cycle_solo_pm_no_workers(env_db, monkeypatch):
@@ -755,11 +775,15 @@ def test_cycle_solo_pm_no_workers(env_db, monkeypatch):
     bridge._registry_db.get_record.return_value = members[0]
     bridge._on_member_state_event("pm1")
     state = bridge._load_cycle_state("sSolo")
-    assert state == {"worker_open": False, "team_open": True}, (
-        "Solo PM running: workers absent → worker_open=False; PM running → team_open=True"
+    assert state == {
+        "worker_open": False, "team_open": True, "orch_running": True,
+    }, (
+        "Solo orchestrator running: no workers → worker_open=False; "
+        "orchestrator running → team_open=True, orch_running=True"
     )
 
-    # PM idle → only full cycle fires, worker cycle never opened/closed
+    # Orchestrator idle → only full cycle fires, worker cycle never
+    # opened/closed. New gating is on orch_running transition.
     members[0]["status"] = "idle"
     bridge._registry_db.get_record.return_value = members[0]
 
@@ -813,3 +837,127 @@ def test_cycle_multiround_worker_closes_each_round(env_db, monkeypatch):
         "Worker cycle MUST fire each round. State-hash dedupe would "
         "incorrectly silence round 2 because (run_id, status) is identical."
     )
+
+
+# ── Regression: dedupe by agent_name across stale run_ids ────────────
+#
+# Tracks the 2026-05-17 notif #28 incident: PM with 10 historical resume
+# rows + 6 stale worker rows produced "16 agents hoàn thành" and fired
+# while PM's latest run was still mid-turn. The bridge MUST collapse all
+# run_ids of the same agent_name down to the latest row.
+
+
+def test_cycle_dedupe_keeps_latest_run_per_agent(env_db, monkeypatch):
+    """When an agent has multiple registry rows (1 per resume), only the
+    LATEST row should be considered for cycle status + count.
+    """
+    members = [
+        # 3 historical PM rows — all idle, oldest first
+        {"run_id": "pm_old1", "agent_name": "PM", "role": "pm",
+         "status": "idle", "session_id": "sD", "started_at": 100.0},
+        {"run_id": "pm_old2", "agent_name": "PM", "role": "pm",
+         "status": "idle", "session_id": "sD", "started_at": 200.0},
+        # Latest PM — currently RUNNING (this is the truth)
+        {"run_id": "pm_latest", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sD", "started_at": 999.0},
+        # Worker — single row, idle
+        {"run_id": "w_old", "agent_name": "Wkr", "role": "dev",
+         "status": "idle", "session_id": "sD", "started_at": 150.0},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    bridge._registry_db.get_record.return_value = members[2]  # latest PM
+
+    fires = {"worker": False, "full": False}
+    monkeypatch.setattr(
+        bridge, "_emit_worker_cycle_closed",
+        lambda *a, **kw: fires.update({"worker": True}),
+    )
+    monkeypatch.setattr(
+        bridge, "_emit_full_cycle_closed",
+        lambda *a, **kw: fires.update({"full": True}),
+    )
+
+    # Open cycle first (so prev[orch_running] is True for the next
+    # call). New 4-arg signature includes orch_running.
+    bridge._save_cycle_state(
+        "sD", worker_open=False, team_open=True, orch_running=True,
+    )
+    bridge._on_member_state_event("pm_latest")
+
+    # Latest orchestrator is running → orch_running MUST stay True →
+    # no full fire. Stale idle rows must NOT dominate the latest row.
+    state = bridge._load_cycle_state("sD")
+    assert state["orch_running"] is True, (
+        "Latest orchestrator row is running — bridge MUST treat it as "
+        "running. Stale idle rows must NOT dominate the latest row's "
+        "status."
+    )
+    assert fires["full"] is False, (
+        "Premature full_cycle_closed would mean dedupe is missing — "
+        "the stale idle rows are masking the real running row."
+    )
+
+
+def test_cycle_dedupe_count_collapses_stale_rows(env_db, monkeypatch):
+    """``_emit_full_cycle_closed`` MUST receive a member list with N unique
+    agents, not N*resume_count rows. Otherwise notif title shows
+    "16 agents hoàn thành" instead of the real team size.
+    """
+    captured: dict = {}
+    members = [
+        # 3 stale PM rows (different run_ids, same agent) + 1 latest idle
+        {"run_id": "pm_a", "agent_name": "PM", "role": "pm",
+         "status": "idle", "session_id": "sE", "started_at": 100.0},
+        {"run_id": "pm_b", "agent_name": "PM", "role": "pm",
+         "status": "idle", "session_id": "sE", "started_at": 200.0},
+        {"run_id": "pm_c", "agent_name": "PM", "role": "pm",
+         "status": "idle", "session_id": "sE", "started_at": 300.0},
+        # Single worker, idle
+        {"run_id": "w1", "agent_name": "Wkr", "role": "dev",
+         "status": "idle", "session_id": "sE", "started_at": 250.0},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    bridge._registry_db.get_record.return_value = members[2]
+    monkeypatch.setattr(
+        bridge, "_active_meetings_with_members", lambda names: False,
+    )
+    monkeypatch.setattr(
+        bridge, "_emit_full_cycle_closed",
+        lambda sid, tname, members_list, orch, **kw: captured.setdefault(
+            "members", members_list,
+        ),
+    )
+
+    # Pretend orchestrator was running then idled. The new state
+    # machine requires orch_running=True in the prev snapshot so the
+    # transition T→F triggers a close.
+    bridge._save_cycle_state(
+        "sE", worker_open=False, team_open=True, orch_running=True,
+    )
+    bridge._on_member_state_event("pm_c")
+
+    captured_members = captured.get("members") or []
+    names = sorted(m.get("agent_name") for m in captured_members)
+    assert names == ["PM", "Wkr"], (
+        f"Expected 2 unique agents, got {len(captured_members)} rows: {names}. "
+        "Stale resume rows must be deduped before emitting."
+    )
+
+
+def test_cycle_dedupe_skips_rows_with_empty_agent_name(env_db, monkeypatch):
+    """Rows where ``agent_name`` is missing or empty must be filtered out,
+    not crash the dedupe (defensive against corrupted/legacy registry data).
+    """
+    members = [
+        {"run_id": "pm1", "agent_name": "PM", "role": "pm",
+         "status": "running", "session_id": "sF", "started_at": 100.0},
+        {"run_id": "ghost", "agent_name": "", "role": "",
+         "status": "idle", "session_id": "sF", "started_at": 50.0},
+    ]
+    bridge = _make_bridge_with_registry(members, monkeypatch, env_db)
+    bridge._registry_db.get_record.return_value = members[0]
+
+    # Must not crash, must treat as 1-member team.
+    bridge._on_member_state_event("pm1")
+    state = bridge._load_cycle_state("sF")
+    assert state["team_open"] is True

--- a/backend/tests/test_services/test_team_reload_skill.py
+++ b/backend/tests/test_services/test_team_reload_skill.py
@@ -1,0 +1,162 @@
+"""Tests for the skill-driven reload helpers in services.team_reload.
+
+Pin the contract: when a skill is updated, we must (a) compute who's
+affected without side-effects, and (b) only respawn agents whose role
+references that skill — not the whole team.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import team_reload
+
+
+def _fake_team(session_id: str, team_name: str, role_to_skills: dict[str, list[str]]):
+    """Build a team_sessions row matching the live shape."""
+    return {
+        "session_id": session_id,
+        "team_name": team_name,
+        "workspace": "/tmp/ws",
+        "project_brief": "x",
+        "parent_session_id": "",
+        "conversation_id": "",
+        "agents": {
+            f"{role}-1": {"run_id": f"run-{role}", "role": role, "status": "running"}
+            for role in role_to_skills
+        },
+        "sprint_status": "running",
+        "template": {
+            "name": "agile-team",
+            "orchestrator": "pm",
+            "roles": {
+                role: {"role_display": role.upper(), "instruction": "", "servers": [], "skills": skills, "model": ""}
+                for role, skills in role_to_skills.items()
+            },
+        },
+    }
+
+
+# ── find_sessions_using_skill ──────────────────────────────────────────────
+
+
+class TestFindSessionsUsingSkill:
+    def test_returns_only_roles_using_skill(self):
+        teams = [
+            _fake_team("ses-a", "A", {
+                "qe": ["qe-workflow", "team-communication"],
+                "dev": ["dev-workflow", "team-communication"],
+                "pm": ["project-management"],  # doesn't use team-communication
+            }),
+            _fake_team("ses-b", "B", {
+                "ba": ["ba-workflow", "team-communication"],
+            }),
+            _fake_team("ses-c", "C", {
+                "pm": ["project-management"],  # no match anywhere
+            }),
+        ]
+        with patch.object(team_reload, "list_team_sessions", create=True) if False else patch(
+            "fast_agent.spawn.team_spawner.list_team_sessions",
+            return_value=teams,
+        ):
+            result = team_reload.find_sessions_using_skill("team-communication")
+
+        assert len(result) == 2
+        by_sid = {r["session_id"]: r for r in result}
+        assert sorted(by_sid["ses-a"]["roles"]) == ["dev", "qe"]
+        assert by_sid["ses-b"]["roles"] == ["ba"]
+        assert "ses-c" not in by_sid  # zero matching roles → not included
+
+    def test_unused_skill_returns_empty(self):
+        with patch(
+            "fast_agent.spawn.team_spawner.list_team_sessions",
+            return_value=[_fake_team("ses-a", "A", {"pm": ["x"]})],
+        ):
+            assert team_reload.find_sessions_using_skill("non-existent") == []
+
+
+# ── reload_by_skill ────────────────────────────────────────────────────────
+
+
+class TestReloadBySkill:
+    @pytest.mark.asyncio
+    async def test_reloads_only_affected_roles(self):
+        teams = [
+            _fake_team("ses-a", "A", {
+                "qe": ["qe-workflow", "team-communication"],
+                "dev": ["dev-workflow"],  # not using team-communication
+            }),
+        ]
+        captured: dict[str, list[str]] = {}
+
+        async def fake_reload_roles(*, session_id, roles, edited_by, inject_message):
+            captured[session_id] = list(roles)
+            return {r: [{"agent_name": f"{r}-1", "killed": True, "resumed": True}] for r in roles}
+
+        with patch(
+            "fast_agent.spawn.team_spawner.list_team_sessions",
+            return_value=teams,
+        ), patch.object(team_reload, "reload_roles", new=AsyncMock(side_effect=fake_reload_roles)):
+            result = await team_reload.reload_by_skill("team-communication")
+
+        # qe is the ONLY role using the skill — dev untouched
+        assert captured == {"ses-a": ["qe"]}
+        assert result["skill"] == "team-communication"
+        assert len(result["sessions"]) == 1
+        assert result["sessions"][0]["roles"] == ["qe"]
+
+    @pytest.mark.asyncio
+    async def test_per_session_error_does_not_abort_others(self):
+        teams = [
+            _fake_team("ses-a", "A", {"qe": ["team-communication"]}),
+            _fake_team("ses-b", "B", {"qe": ["team-communication"]}),
+        ]
+        call_count = {"n": 0}
+
+        async def flaky(*, session_id, roles, edited_by, inject_message):
+            call_count["n"] += 1
+            if session_id == "ses-a":
+                raise RuntimeError("boom")
+            return {"qe": [{"agent_name": "qe-1", "resumed": True}]}
+
+        with patch(
+            "fast_agent.spawn.team_spawner.list_team_sessions",
+            return_value=teams,
+        ), patch.object(team_reload, "reload_roles", new=AsyncMock(side_effect=flaky)):
+            result = await team_reload.reload_by_skill("team-communication")
+
+        assert call_count["n"] == 2  # both sessions attempted
+        by_sid = {s["session_id"]: s for s in result["sessions"]}
+        assert "_error" in by_sid["ses-a"]["results"]
+        # ses-b still succeeded
+        assert "qe" in by_sid["ses-b"]["results"]
+        assert by_sid["ses-b"]["results"]["qe"][0]["resumed"]
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty_sessions(self):
+        with patch(
+            "fast_agent.spawn.team_spawner.list_team_sessions",
+            return_value=[_fake_team("ses-a", "A", {"pm": ["other"]})],
+        ):
+            result = await team_reload.reload_by_skill("nonexistent")
+        assert result == {"skill": "nonexistent", "sessions": []}
+
+    @pytest.mark.asyncio
+    async def test_custom_inject_message_propagates(self):
+        teams = [_fake_team("ses-a", "A", {"qe": ["team-communication"]})]
+        captured_msgs: list[str] = []
+
+        async def capture_msg(*, session_id, roles, edited_by, inject_message):
+            captured_msgs.append(inject_message)
+            return {}
+
+        with patch(
+            "fast_agent.spawn.team_spawner.list_team_sessions",
+            return_value=teams,
+        ), patch.object(team_reload, "reload_roles", new=AsyncMock(side_effect=capture_msg)):
+            await team_reload.reload_by_skill(
+                "team-communication",
+                inject_message="custom heads-up text",
+            )
+        assert captured_msgs == ["custom heads-up text"]

--- a/backend/tests/test_services/test_team_template_service.py
+++ b/backend/tests/test_services/test_team_template_service.py
@@ -1,0 +1,420 @@
+"""Unit tests for services.team_template_service.
+
+Pin the invariants users rely on every time they edit a template:
+  - diff is order-insensitive for servers/skills
+  - validate rejects unknown fields + phantom paths
+  - apply writes audit rows in the SAME transaction as the team_sessions update
+  - rollback writes a NEW history row, never deletes
+  - reset-from-yaml only touches the named role
+
+Uses an in-memory SQLite for the audit table; the team_sessions read/write
+path is mocked because that lives in the fast_agent submodule and we don't
+want to drag in the whole spawn stack for service-level unit tests.
+"""
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.database import Base, TeamTemplateHistory
+from services import team_template_service as svc
+
+
+# ── shared fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_session():
+    """Fresh in-memory SQLite + create_all so TeamTemplateHistory exists."""
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def fake_team_data():
+    """A minimal team_sessions row mirroring the real shape."""
+    return {
+        "session_id": "ses-1",
+        "team_name": "test-team",
+        "workspace": "/tmp/ws",
+        "project_brief": "x",
+        "parent_session_id": "",
+        "conversation_id": "",
+        "agents": {},
+        "sprint_status": "running",
+        "template": {
+            "name": "agile-team",
+            "orchestrator": "pm",
+            "roles": {
+                "qe": {
+                    "role_display": "QE",
+                    "instruction": "you are QE",
+                    "servers": ["filesystem", "scrapling-server"],
+                    "skills": ["qe-workflow"],
+                    "model": "",
+                    "server_overrides": {
+                        "filesystem": {
+                            "args": [
+                                "-y",
+                                "@modelcontextprotocol/server-filesystem",
+                                "{workspace_dir}",
+                            ],
+                        },
+                    },
+                },
+                "dev": {
+                    "role_display": "Dev",
+                    "instruction": "you are dev",
+                    "servers": ["filesystem", "git"],
+                    "skills": ["dev-workflow"],
+                    "model": "",
+                    "server_overrides": {},
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture
+def patched_store(fake_team_data, monkeypatch):
+    """Patch get_team_session + _get_store to use an in-memory dict."""
+    store_state = {"ses-1": copy.deepcopy(fake_team_data)}
+
+    class FakeStore:
+        def upsert(self, sid, data):
+            store_state[sid] = copy.deepcopy(data)
+
+        def get(self, sid):
+            return copy.deepcopy(store_state.get(sid))
+
+    class FakeSession:
+        def __init__(self, data):
+            self._data = data
+
+        def to_dict(self):
+            return copy.deepcopy(self._data)
+
+    def fake_get_team_session(sid):
+        data = store_state.get(sid)
+        if data is None:
+            return None
+        return FakeSession(data)
+
+    def fake_get_store():
+        return FakeStore()
+
+    with patch.object(
+        svc, "_get_team_session_dict",
+        side_effect=lambda sid: (
+            store_state[sid] if sid in store_state
+            else (_ for _ in ()).throw(svc.NotFoundError(f"team session '{sid}' not found"))
+        ),
+    ), patch.object(
+        svc, "_put_team_session_dict",
+        side_effect=lambda sid, data: store_state.__setitem__(sid, copy.deepcopy(data)),
+    ):
+        yield store_state
+
+
+# ── compute_role_diff ──────────────────────────────────────────────────────
+
+
+class TestComputeRoleDiff:
+    def test_identical_returns_empty(self):
+        b = {"servers": ["a", "b"], "instruction": "x"}
+        assert svc.compute_role_diff(b, dict(b)) == {}
+
+    def test_servers_reorder_is_not_a_change(self):
+        before = {"servers": ["a", "b", "c"]}
+        after = {"servers": ["c", "a", "b"]}
+        assert svc.compute_role_diff(before, after) == {}
+
+    def test_skills_reorder_is_not_a_change(self):
+        before = {"skills": ["one", "two"]}
+        after = {"skills": ["two", "one"]}
+        assert svc.compute_role_diff(before, after) == {}
+
+    def test_servers_added(self):
+        before = {"servers": ["a"]}
+        after = {"servers": ["a", "b"]}
+        diff = svc.compute_role_diff(before, after)
+        assert "servers" in diff
+        assert sorted(diff["servers"]["before"]) == ["a"]
+        assert sorted(diff["servers"]["after"]) == ["a", "b"]
+
+    def test_instruction_changed(self):
+        diff = svc.compute_role_diff({"instruction": "x"}, {"instruction": "y"})
+        assert diff == {"instruction": {"before": "x", "after": "y"}}
+
+    def test_nested_overrides_deep_equal(self):
+        b = {"server_overrides": {"fs": {"args": ["a", "b"]}}}
+        a = {"server_overrides": {"fs": {"args": ["a", "b"]}}}
+        assert svc.compute_role_diff(b, a) == {}
+
+    def test_nested_overrides_change(self):
+        b = {"server_overrides": {"fs": {"args": ["a"]}}}
+        a = {"server_overrides": {"fs": {"args": ["a", "b"]}}}
+        diff = svc.compute_role_diff(b, a)
+        assert "server_overrides" in diff
+
+
+# ── validate_patch ─────────────────────────────────────────────────────────
+
+
+class TestValidatePatch:
+    def test_accepts_known_fields(self):
+        svc.validate_patch("qe", {"servers": ["a"], "instruction": "x", "skills": ["s"]})
+        svc.validate_patch("qe", {"server_overrides": {"fs": {"args": ["{workspace_dir}"]}}})
+
+    def test_rejects_unknown_field(self):
+        with pytest.raises(svc.ValidationError, match="unknown fields"):
+            svc.validate_patch("qe", {"cwd": "/etc"})
+
+    def test_servers_must_be_list_of_strings(self):
+        with pytest.raises(svc.ValidationError, match="'servers' must be"):
+            svc.validate_patch("qe", {"servers": "filesystem"})
+        with pytest.raises(svc.ValidationError, match="'servers' must be"):
+            svc.validate_patch("qe", {"servers": ["", "filesystem"]})
+
+    def test_skills_must_be_list_of_strings(self):
+        with pytest.raises(svc.ValidationError, match="'skills' must be"):
+            svc.validate_patch("qe", {"skills": [123]})
+
+    def test_phantom_path_rejected(self, tmp_path):
+        patch_obj = {
+            "server_overrides": {
+                "fs": {
+                    "args": [
+                        "-y",
+                        "@modelcontextprotocol/server-filesystem",
+                        str(tmp_path / "does_not_exist_for_sure"),
+                    ],
+                },
+            },
+        }
+        with pytest.raises(svc.ValidationError, match="does not exist"):
+            svc.validate_patch("qe", patch_obj, project_dir=tmp_path)
+
+    def test_template_placeholder_accepted(self, tmp_path):
+        # {workspace_dir} is substituted at spawn — must NOT be path-checked
+        patch_obj = {
+            "server_overrides": {
+                "fs": {"args": ["-y", "@x/y", "{workspace_dir}", "{project_dir}/skills"]},
+            },
+        }
+        svc.validate_patch("qe", patch_obj, project_dir=tmp_path)  # no raise
+
+    def test_existing_path_accepted(self, tmp_path):
+        target = tmp_path / "real_dir"
+        target.mkdir()
+        patch_obj = {
+            "server_overrides": {"fs": {"args": [str(target)]}},
+        }
+        svc.validate_patch("qe", patch_obj, project_dir=tmp_path)  # no raise
+
+
+# ── apply_role_patch ───────────────────────────────────────────────────────
+
+
+class TestApplyRolePatch:
+    def test_one_field_writes_one_audit_row(self, db_session, patched_store):
+        result = svc.apply_role_patch(
+            db_session, "ses-1", "qe",
+            {"servers": ["filesystem", "scrapling-server", "playwright"]},
+            edited_by="alice", source="api", comment="add playwright",
+        )
+        assert len(result["audit_ids"]) == 1
+        assert "servers" in result["diff"]
+        # State persisted
+        assert "playwright" in patched_store["ses-1"]["template"]["roles"]["qe"]["servers"]
+        # Audit row exists
+        rows = db_session.query(TeamTemplateHistory).all()
+        assert len(rows) == 1
+        assert rows[0].role == "qe"
+        assert rows[0].field == "servers"
+        assert rows[0].edited_by == "alice"
+        assert rows[0].source == "api"
+
+    def test_multiple_fields_write_multiple_rows_one_commit(
+        self, db_session, patched_store,
+    ):
+        result = svc.apply_role_patch(
+            db_session, "ses-1", "qe",
+            {"servers": ["a"], "instruction": "new", "skills": ["s2"]},
+            edited_by="bob",
+        )
+        assert len(result["audit_ids"]) == 3
+        fields = {r.field for r in db_session.query(TeamTemplateHistory).all()}
+        assert fields == {"servers", "instruction", "skills"}
+
+    def test_noop_raises_conflict(self, db_session, patched_store):
+        # Same servers in different order = NOOP per order-insensitive diff
+        with pytest.raises(svc.ConflictError):
+            svc.apply_role_patch(
+                db_session, "ses-1", "qe",
+                {"servers": ["scrapling-server", "filesystem"]},
+            )
+        # No rows written
+        assert db_session.query(TeamTemplateHistory).count() == 0
+
+    def test_unknown_role_raises(self, db_session, patched_store):
+        with pytest.raises(svc.NotFoundError):
+            svc.apply_role_patch(db_session, "ses-1", "unknown", {"servers": ["a"]})
+
+    def test_invalid_patch_rejected_before_db_write(
+        self, db_session, patched_store,
+    ):
+        with pytest.raises(svc.ValidationError):
+            svc.apply_role_patch(db_session, "ses-1", "qe", {"unknown_field": 1})
+        assert db_session.query(TeamTemplateHistory).count() == 0
+
+
+# ── get_history ────────────────────────────────────────────────────────────
+
+
+class TestGetHistory:
+    def test_empty_history(self, db_session, patched_store):
+        assert svc.get_history(db_session, "ses-1") == []
+
+    def test_newest_first(self, db_session, patched_store):
+        svc.apply_role_patch(db_session, "ses-1", "qe", {"servers": ["a"]})
+        svc.apply_role_patch(db_session, "ses-1", "qe", {"servers": ["a", "b"]})
+        rows = svc.get_history(db_session, "ses-1")
+        assert len(rows) == 2
+        assert rows[0]["edited_at"] >= rows[1]["edited_at"]
+
+    def test_filter_by_role(self, db_session, patched_store):
+        svc.apply_role_patch(db_session, "ses-1", "qe", {"servers": ["x"]})
+        svc.apply_role_patch(db_session, "ses-1", "dev", {"servers": ["y"]})
+        rows = svc.get_history(db_session, "ses-1", role="dev")
+        assert len(rows) == 1
+        assert rows[0]["role"] == "dev"
+
+    def test_before_after_decoded(self, db_session, patched_store):
+        svc.apply_role_patch(
+            db_session, "ses-1", "qe",
+            {"servers": ["filesystem", "scrapling-server", "playwright"]},
+        )
+        rows = svc.get_history(db_session, "ses-1")
+        # The 'before' must equal what was originally in fake_team_data — list of 2
+        assert sorted(rows[0]["before"]) == ["filesystem", "scrapling-server"]
+        assert "playwright" in rows[0]["after"]
+
+
+# ── rollback_to ────────────────────────────────────────────────────────────
+
+
+class TestRollback:
+    def test_rollback_writes_new_row_does_not_delete(self, db_session, patched_store):
+        # Add playwright
+        r1 = svc.apply_role_patch(
+            db_session, "ses-1", "qe",
+            {"servers": ["filesystem", "scrapling-server", "playwright"]},
+        )
+        audit_id = r1["audit_ids"][0]
+        # Rollback
+        r2 = svc.rollback_to(
+            db_session, "ses-1", audit_id, edited_by="charlie", comment="oops",
+        )
+        # Two history rows total
+        all_rows = db_session.query(TeamTemplateHistory).all()
+        assert len(all_rows) == 2
+        # New row tagged 'rollback' with reference comment
+        latest = max(all_rows, key=lambda r: r.id)
+        assert latest.source == "rollback"
+        assert f"audit_id={audit_id}" in latest.comment
+        # State reverted
+        assert "playwright" not in patched_store["ses-1"]["template"]["roles"]["qe"]["servers"]
+
+    def test_rollback_to_unknown_audit_raises(self, db_session, patched_store):
+        with pytest.raises(svc.NotFoundError):
+            svc.rollback_to(db_session, "ses-1", 9999)
+
+    def test_rollback_noop_raises_conflict(self, db_session, patched_store):
+        r1 = svc.apply_role_patch(db_session, "ses-1", "qe", {"servers": ["a"]})
+        svc.rollback_to(db_session, "ses-1", r1["audit_ids"][0])
+        # Second rollback to same audit = NOOP (state already reverted)
+        with pytest.raises(svc.ConflictError):
+            svc.rollback_to(db_session, "ses-1", r1["audit_ids"][0])
+
+
+# ── reset_role_to_yaml ─────────────────────────────────────────────────────
+
+
+class TestResetToYaml:
+    def test_reset_one_role_does_not_touch_others(
+        self, db_session, patched_store, tmp_path,
+    ):
+        # Edit dev → diverge from yaml
+        svc.apply_role_patch(db_session, "ses-1", "dev", {"instruction": "edited"})
+        # Compose a yaml with only 'qe' definition
+        yaml_path = tmp_path / "agile_team.yaml"
+        yaml_path.write_text(
+            "team:\n"
+            "  roles:\n"
+            "    qe:\n"
+            "      role_display: QE\n"
+            "      instruction: factory qe\n"
+            "      servers: [filesystem, scrapling-server]\n"
+            "      skills: [qe-workflow]\n"
+            "      model: ''\n"
+        )
+        result = svc.reset_role_to_yaml(db_session, "ses-1", "qe", yaml_path)
+        # qe reset
+        assert patched_store["ses-1"]["template"]["roles"]["qe"]["instruction"] == "factory qe"
+        # dev untouched
+        assert patched_store["ses-1"]["template"]["roles"]["dev"]["instruction"] == "edited"
+        # Audit row tagged yaml-reset
+        rows = svc.get_history(db_session, "ses-1", role="qe")
+        assert any(r["source"] == "yaml-reset" for r in rows)
+
+    def test_reset_role_missing_in_yaml_raises(self, db_session, patched_store, tmp_path):
+        yaml_path = tmp_path / "x.yaml"
+        yaml_path.write_text("team:\n  roles: {}\n")
+        with pytest.raises(svc.NotFoundError):
+            svc.reset_role_to_yaml(db_session, "ses-1", "qe", yaml_path)
+
+
+# ── static audit: no caller of run_isolated_agent_background drops overrides ─
+
+
+def test_audit_inject_resume_still_forwards_server_overrides():
+    """Phase 1 must NOT regress the inject_resume fix from earlier today.
+
+    We already have a static audit test in test_inject_resume.py; this one
+    is a tighter pin: parse the call site directly, assert the kwarg is
+    forwarded to ``run_isolated_agent_background``. Belt-and-suspenders;
+    the two together catch refactors that rename the kwarg as well as
+    ones that drop it.
+
+    After the live-template SSoT refactor the value is resolved via the
+    local ``_resolve("server_overrides", None)`` helper rather than read
+    directly from ``original_config`` — but the call-site contract that
+    matters here is "the kwarg is present and is bound to a local of the
+    same name". Pin BOTH the resolver call AND the kwarg forward, so
+    either kind of regression fails loudly.
+    """
+    p = Path(__file__).resolve().parents[2] / "services" / "inject_resume.py"
+    src = p.read_text()
+    assert "_resolve(\"server_overrides\"" in src, (
+        "inject_resume.py:resume_with_inject must resolve server_overrides "
+        "through the SSoT-aware _resolve() helper (prefers live "
+        "team_sessions.template, falls back to original_config snapshot)."
+    )
+    assert "server_overrides=server_overrides" in src, (
+        "inject_resume.py:resume_with_inject must forward "
+        "server_overrides=server_overrides to run_isolated_agent_background — "
+        "without it, the dashboard inject path silently drops per-role MCP "
+        "arg customisations (incident 2026-05-17)."
+    )

--- a/backend/tests/test_subprocess_env_vars.py
+++ b/backend/tests/test_subprocess_env_vars.py
@@ -835,3 +835,144 @@ class TestFullEnvPipeline:
 
         # SPAWN_REGISTRY_DB must still be there
         assert subprocess_env["SPAWN_REGISTRY_DB"] == db_path
+
+
+# ═══════════════════════════════════════════════
+# 7. JARVIS_RUNTIME_RPC_SOCKET multi-hop propagation
+# ═══════════════════════════════════════════════
+
+
+class TestRuntimeRpcSocketMultiHop:
+    """Pin the multi-hop chain that broke approval-server + pause from
+    2026-05-09 onwards. When approval-server (or skill_server / mcp_admin)
+    is loaded by a spawned agent, the chain is:
+
+        backend (uvicorn)
+          → fast-agent stdio MCP: agent_spawner_server         [hop 1]
+          → subprocess.Popen({**os.environ, ...}): isolated_runner   [hop 2]
+          → fast-agent stdio MCP: approval-server              [hop 3]
+
+    JARVIS_RUNTIME_RPC_SOCKET must survive every hop. Hop 1 (the
+    fast-agent stdio env build) is where it previously dropped, because
+    ``_parent_extras`` only forwarded ``SPAWN_*`` + ``VIRTUAL_ENV``. The
+    fix added ``JARVIS_RUNTIME_RPC_SOCKET`` to that whitelist.
+    """
+
+    def _build_stdio_env(self, config_env: dict) -> dict:
+        """Replicate mcp_connection_manager.py lines 952-986 — the env
+        build for a stdio MCP child. Kept inline so the test fails
+        loudly if production drops the whitelist entry.
+        """
+        from mcp.client.stdio import get_default_environment
+        _parent_extras = {
+            k: v for k, v in os.environ.items()
+            if (
+                k.startswith("SPAWN_")
+                or k == "JARVIS_RUNTIME_RPC_SOCKET"
+                or k in ("VIRTUAL_ENV",)
+            )
+        }
+        _config_env = {
+            k: (os.path.expandvars(v) if isinstance(v, str) else v)
+            for k, v in config_env.items()
+        }
+        return {**get_default_environment(), **_parent_extras, **_config_env}
+
+    def test_hop1_backend_to_middleware_mcp(self, monkeypatch):
+        """Backend has JARVIS_RUNTIME_RPC_SOCKET → agent_spawner_server
+        (middleware MCP, YAML does NOT declare the var) inherits it via
+        the ``_parent_extras`` whitelist.
+        """
+        monkeypatch.setenv("JARVIS_RUNTIME_RPC_SOCKET", "/tmp/test-rpc.sock")
+
+        # agent_spawner's YAML env block — note: no JARVIS_RUNTIME_RPC_SOCKET
+        agent_spawner_yaml_env = {
+            "PYTHONUNBUFFERED": "1",
+            "JARVIS_API_KEY": "${JARVIS_API_KEY}",
+            "JARVIS_API_BASE": "${JARVIS_API_BASE}",
+        }
+        child_env = self._build_stdio_env(agent_spawner_yaml_env)
+
+        assert child_env.get("JARVIS_RUNTIME_RPC_SOCKET") == "/tmp/test-rpc.sock", (
+            "agent_spawner_server MUST inherit JARVIS_RUNTIME_RPC_SOCKET via "
+            "_parent_extras whitelist — without it, grandchild MCPs fail with "
+            "ENOENT on a literal ${JARVIS_RUNTIME_RPC_SOCKET} path."
+        )
+
+    def test_hop2_middleware_to_isolated_runner(self, monkeypatch):
+        """agent_spawner_server's os.environ → isolated_runner subprocess.
+        Replicates ``isolated_spawner._run_subprocess`` line 200-206.
+        """
+        monkeypatch.setenv("JARVIS_RUNTIME_RPC_SOCKET", "/tmp/test-rpc.sock")
+
+        # agent_spawner_server's os.environ at this point — inherited via hop 1
+        # Now it spawns isolated_runner via subprocess.Popen({**os.environ, ...})
+        subprocess_env = {
+            **os.environ,
+            "PYTHONPATH": "/project",
+        }
+        team_env = {"TEAM_MY_ROLE": "pm", "TEAM_SESSION_ID": "sess-1"}
+        subprocess_env.update(team_env)
+
+        assert subprocess_env["JARVIS_RUNTIME_RPC_SOCKET"] == "/tmp/test-rpc.sock"
+        assert subprocess_env["TEAM_MY_ROLE"] == "pm"
+
+    def test_hop3_isolated_runner_to_grandchild_mcp(self, monkeypatch):
+        """isolated_runner spawns approval-server (grandchild MCP) which
+        declares ``JARVIS_RUNTIME_RPC_SOCKET: "${JARVIS_RUNTIME_RPC_SOCKET}"``
+        in YAML. expandvars must resolve against isolated_runner's env.
+        """
+        monkeypatch.setenv("JARVIS_RUNTIME_RPC_SOCKET", "/tmp/test-rpc.sock")
+
+        approval_yaml_env = {
+            "PYTHONUNBUFFERED": "1",
+            "JARVIS_RUNTIME_RPC_SOCKET": "${JARVIS_RUNTIME_RPC_SOCKET}",
+        }
+        grandchild_env = self._build_stdio_env(approval_yaml_env)
+
+        assert grandchild_env["JARVIS_RUNTIME_RPC_SOCKET"] == "/tmp/test-rpc.sock", (
+            "approval-server received literal ${JARVIS_RUNTIME_RPC_SOCKET} — "
+            "this is the 2026-05-09 regression. The fix is in "
+            "mcp_connection_manager.py:_parent_extras."
+        )
+
+    def test_regression_break_when_whitelist_drops_var(self, monkeypatch):
+        """Inverse contract: explicitly demonstrate what BREAKS if the
+        whitelist forgets JARVIS_RUNTIME_RPC_SOCKET. This pins the
+        forward direction — if someone refactors _parent_extras and
+        drops the entry, hop 1 produces an empty env, hop 3 expandvars
+        leaks the literal placeholder, and approval-server hits ENOENT.
+        """
+        monkeypatch.setenv("JARVIS_RUNTIME_RPC_SOCKET", "/tmp/test-rpc.sock")
+
+        from mcp.client.stdio import get_default_environment
+
+        # Simulate the OLD (broken) whitelist — SPAWN_* + VIRTUAL_ENV only
+        broken_parent_extras = {
+            k: v for k, v in os.environ.items()
+            if k.startswith("SPAWN_") or k in ("VIRTUAL_ENV",)
+        }
+        agent_spawner_env = {
+            **get_default_environment(),
+            **broken_parent_extras,
+            **{"JARVIS_API_KEY": os.path.expandvars("${JARVIS_API_KEY}")},
+        }
+        # Hop 1 with broken whitelist: var is gone
+        assert "JARVIS_RUNTIME_RPC_SOCKET" not in agent_spawner_env
+
+        # Hop 2: subprocess inherits agent_spawner's (broken) env
+        # We restrict to agent_spawner_env to simulate the chain truthfully
+        runner_env = {**agent_spawner_env, "PYTHONPATH": "/project"}
+
+        # Hop 3: grandchild expandvars now resolves against an env WITHOUT
+        # the var. expandvars leaves the placeholder LITERAL.
+        approval_value_raw = "${JARVIS_RUNTIME_RPC_SOCKET}"
+        # Simulate what mcp_connection_manager does: os.path.expandvars
+        # uses os.environ of the CURRENT process. In production this is
+        # isolated_runner's os.environ which lacks the var. Force the
+        # scenario by temporarily clearing it from the test env.
+        monkeypatch.delenv("JARVIS_RUNTIME_RPC_SOCKET", raising=False)
+        leaked = os.path.expandvars(approval_value_raw)
+        # In a broken chain, expandvars returns the literal placeholder
+        # because the var is unset → approval-server gets ENOENT.
+        assert leaked == "${JARVIS_RUNTIME_RPC_SOCKET}"

--- a/dashboard/src/components/StatusBadge.vue
+++ b/dashboard/src/components/StatusBadge.vue
@@ -19,7 +19,6 @@ const statusConfig = {
   idle:      { label: 'Idle',      dotColor: '#64748b', textColor: '#64748b', bgColor: 'rgba(100,116,139,0.12)', pulse: false },
   blocked:   { label: 'Blocked',   dotColor: '#ef4444', textColor: '#ef4444', bgColor: 'rgba(239,68,68,0.15)', pulse: false },
   error:     { label: 'Error',     dotColor: '#ff4560', textColor: '#ff4560', bgColor: 'rgba(255,69,96,0.15)', pulse: false },
-  completed: { label: 'Completed', dotColor: '#00c896', textColor: '#00c896', bgColor: 'rgba(0,200,150,0.15)', pulse: false },
   spawning:  { label: 'Spawning',  dotColor: '#ffb547', textColor: '#ffb547', bgColor: 'rgba(255,181,71,0.15)', pulse: true },
 }
 </script>

--- a/dashboard/src/components/chat/ChatMessages.vue
+++ b/dashboard/src/components/chat/ChatMessages.vue
@@ -2,6 +2,7 @@
 import { ref, watch, nextTick, computed, reactive } from 'vue'
 import { useBreakpoint } from '../../composables/useBreakpoint'
 import { parseYoutubeTags, youtubeEmbedUrl } from '../../utils/youtubeTags'
+import { normalizeTs } from '../../utils/timeFormat.js'
 import MarkdownRenderer from '../MarkdownRenderer.vue'
 
 const props = defineProps({
@@ -49,8 +50,9 @@ const agentInitials = computed(() => {
 })
 
 function formatTime(ts) {
-  if (!ts) return ''
-  const d = new Date(ts)
+  const ms = normalizeTs(ts)
+  if (ms === null) return ''
+  const d = new Date(ms)
   const now = new Date()
   const diff = now - d
   if (diff < 60000) return 'just now'

--- a/dashboard/src/components/meetings/MeetingList.vue
+++ b/dashboard/src/components/meetings/MeetingList.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import { normalizeTs } from '../../utils/timeFormat.js'
 
 const props = defineProps({
   meetings: { type: Array, required: true },
@@ -32,9 +33,10 @@ function statusIcon(meeting) {
 }
 
 function formatTime(ts) {
-  if (!ts) return ''
+  const ms = normalizeTs(ts)
+  if (ms === null) return ''
   try {
-    const d = new Date(ts)
+    const d = new Date(ms)
     const now = new Date()
     const isToday = d.toDateString() === now.toDateString()
     if (isToday) {

--- a/dashboard/src/components/meetings/MeetingTranscript.vue
+++ b/dashboard/src/components/meetings/MeetingTranscript.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import MarkdownRenderer from '../MarkdownRenderer.vue'
+import { normalizeTs } from '../../utils/timeFormat.js'
 
 const props = defineProps({
   meeting: { type: Object, default: null },
@@ -134,9 +135,10 @@ function agentInitial(name) {
 }
 
 function formatTimestamp(ts) {
-  if (!ts) return ''
+  const ms = normalizeTs(ts)
+  if (ms === null) return ''
   try {
-    const d = new Date(ts)
+    const d = new Date(ms)
     return d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
   } catch {
     return ''

--- a/dashboard/src/components/monitor/AgentTerminal.vue
+++ b/dashboard/src/components/monitor/AgentTerminal.vue
@@ -81,11 +81,11 @@ onMounted(() => nextTick(() => scrollToBottom()))
 
 // ── Status helpers ──
 function statusColor(s) {
-  const m = { running: '#f59e0b', paused: '#8b5cf6', idle: '#10b981', error: '#ef4444', completed: '#3b82f6' }
+  const m = { running: '#f59e0b', paused: '#8b5cf6', idle: '#10b981', error: '#ef4444' }
   return m[s] || '#555872'
 }
 function statusLabel(s) {
-  const m = { running: 'Running', paused: 'Paused', idle: 'Idle', error: 'Error', completed: 'Completed' }
+  const m = { running: 'Running', paused: 'Paused', idle: 'Idle', error: 'Error' }
   return m[s] || 'Unknown'
 }
 

--- a/dashboard/src/composables/agentTurnsUtils.js
+++ b/dashboard/src/composables/agentTurnsUtils.js
@@ -6,39 +6,76 @@
  */
 
 /**
- * Insert a turn into a sorted-by-turn_idx array, deduplicating by turn_idx.
+ * Composite key used to dedupe turns. resume_spawn / restart_spawn / auto-
+ * resume all start the NEW subprocess at turn_idx=0 while the agent_name
+ * stays the same — so turn_idx alone is not unique across runs and would
+ * cause new turns to overwrite history. The (run_id, turn_idx) pair IS
+ * unique per logical message. Falls back to turn_idx when run_id missing
+ * (legacy events) so older buckets still dedupe correctly.
+ */
+function _turnKey(turn) {
+  return `${turn?.run_id || ''}::${turn?.turn_idx}`
+}
+
+/**
+ * Stable ordering: turns are sorted by (timestamp, run_id-appearance,
+ * turn_idx). Falling back to insertion order keeps runs grouped in the
+ * order they happened — buildRenderRows then inserts a "run X" separator
+ * whenever run_id changes, so the user sees runs stacked chronologically.
+ */
+function _compareTurns(a, b) {
+  // Prefer timestamp when both sides have it — survives clock skew across
+  // runs of the same agent better than run_id alphabetical compare.
+  if (a.ts && b.ts && a.ts !== b.ts) return a.ts - b.ts
+  // Same logical run (or BOTH legacy missing run_id) → sort by turn_idx.
+  // Cross-run without timestamps falls through to "equal" (keep insertion
+  // order) — buildRenderRows then groups by run_id appearance.
+  if ((a.run_id || '') === (b.run_id || '')) {
+    return (a.turn_idx ?? 0) - (b.turn_idx ?? 0)
+  }
+  return 0
+}
+
+/**
+ * Insert a turn into a bucket, deduplicating by (run_id, turn_idx).
  *
- * @param {Array<{turn_idx:number}>} arr — current bucket (caller's snapshot)
- * @param {{turn_idx:number}} turn
+ * @param {Array<{turn_idx:number, run_id?:string}>} arr — current bucket
+ * @param {{turn_idx:number, run_id?:string}} turn
  * @param {number} maxPerAgent — cap on returned size
  * @returns {Array} a new array (does not mutate the input)
  */
 export function insertTurn(arr, turn, maxPerAgent) {
   const next = arr.slice()
-  const existingIdx = next.findIndex(t => t.turn_idx === turn.turn_idx)
+  const key = _turnKey(turn)
+  const existingIdx = next.findIndex(t => _turnKey(t) === key)
   if (existingIdx >= 0) {
     next[existingIdx] = turn
   } else {
-    let i = next.length
-    while (i > 0 && next[i - 1].turn_idx > turn.turn_idx) i--
-    next.splice(i, 0, turn)
+    // Append, then sort stably so out-of-order arrival lands correctly.
+    next.push(turn)
+    next.sort(_compareTurns)
   }
   if (next.length > maxPerAgent) next.splice(0, next.length - maxPerAgent)
   return next
 }
 
 /**
- * Detect a "history was cleared" signal: a delta arriving at turn_idx 0
- * when the bucket already has higher turn_idx entries means the agent
- * started a new conversation; the old turns are stale.
+ * Detect a "history was cleared" signal.
+ *
+ * A delta at ``turn_idx=0`` only means the bucket should be wiped when
+ * the SAME run_id is restarting from scratch (a real reset). When the
+ * run_id differs from the latest one in the bucket, this is a fresh run
+ * (resume_spawn / restart_spawn / auto-resume) and the previous run's
+ * turns must be kept so the user can see the stacked history.
  */
 export function isResetSignal(arr, turn) {
-  return (
-    !!turn &&
-    turn.turn_idx === 0 &&
-    arr.length > 0 &&
-    arr[arr.length - 1].turn_idx > 0
-  )
+  if (!turn || turn.turn_idx !== 0 || arr.length === 0) return false
+  const last = arr[arr.length - 1]
+  if (last.turn_idx <= 0) return false
+  // Different run_id ⇒ new run of the same agent, NOT a reset of the
+  // current conversation. Keep prior turns.
+  if (turn.run_id && last.run_id && turn.run_id !== last.run_id) return false
+  return true
 }
 
 /**

--- a/dashboard/src/composables/agentTurnsUtils.test.js
+++ b/dashboard/src/composables/agentTurnsUtils.test.js
@@ -80,6 +80,52 @@ test('isResetSignal false: non-zero turn_idx delta', () => {
   assert.equal(isResetSignal(arr, { turn_idx: 2 }), false)
 })
 
+test('isResetSignal false: turn_idx=0 with new run_id (resume_spawn case)', () => {
+  // The previous run finished at turn_idx>=1. resume_spawn starts a new
+  // subprocess with run_id="r2" whose first turn is turn_idx=0. This is
+  // a fresh run of the same agent — old turns must be kept so the user
+  // sees the conversation stacked, not reset.
+  const arr = [
+    { turn_idx: 0, run_id: 'r1' },
+    { turn_idx: 1, run_id: 'r1' },
+  ]
+  assert.equal(isResetSignal(arr, { turn_idx: 0, run_id: 'r2' }), false)
+})
+
+test('isResetSignal true: turn_idx=0 with same run_id (real history reset)', () => {
+  // Same run_id restarting at turn_idx=0 is a real history clear — this
+  // is the legacy ``compact`` / ``new conversation`` signal.
+  const arr = [
+    { turn_idx: 0, run_id: 'r1' },
+    { turn_idx: 1, run_id: 'r1' },
+  ]
+  assert.equal(isResetSignal(arr, { turn_idx: 0, run_id: 'r1' }), true)
+})
+
+test('insertTurn dedups within same run, stacks across runs (resume case)', () => {
+  // r1 contributed turn_idx 0 and 1. r2 (resumed) starts a new turn_idx=0
+  // — must NOT replace r1's turn 0. Bucket should hold all 3 turns.
+  let arr = []
+  arr = insertTurn(arr, { turn_idx: 0, run_id: 'r1', ts: 100, role: 'user' }, 100)
+  arr = insertTurn(arr, { turn_idx: 1, run_id: 'r1', ts: 101, role: 'assistant' }, 100)
+  arr = insertTurn(arr, { turn_idx: 0, run_id: 'r2', ts: 200, role: 'user' }, 100)
+  assert.equal(arr.length, 3)
+  assert.deepEqual(arr.map(t => [t.run_id, t.turn_idx]), [
+    ['r1', 0], ['r1', 1], ['r2', 0],
+  ])
+})
+
+test('insertTurn still replaces an exact (run_id, turn_idx) duplicate', () => {
+  // SSE replay scenario: same run, same turn arrives twice with later
+  // payload (e.g. tool_result attached). Must replace, not duplicate.
+  let arr = [
+    { turn_idx: 0, run_id: 'r1', ts: 100, message: { content: [{ text: 'partial' }] } },
+  ]
+  arr = insertTurn(arr, { turn_idx: 0, run_id: 'r1', ts: 100, message: { content: [{ text: 'final' }] } }, 100)
+  assert.equal(arr.length, 1)
+  assert.equal(arr[0].message.content[0].text, 'final')
+})
+
 
 // ── lastAssistantText ───────────────────────────────────────────────
 

--- a/dashboard/src/composables/useActivityStream.js
+++ b/dashboard/src/composables/useActivityStream.js
@@ -28,18 +28,17 @@ export function useActivityStream(options = {}) {
   // Active filter: 'all' | 'active' | 'team:<name>'
   const filter = ref('all')
 
-  // Agent selection. Filled by a watcher once the store roster loads so
-  // the dropdown opens with every agent already ticked AND the bulk-
-  // delete count badge shows the full roster size. Without this, an
-  // empty Set rendered visually as "all checked" (filter convention)
-  // while bulk-delete saw zero selections — see the 2026-05-21 thread
-  // about that mismatch.
+  // Agent selection. Empty Set = implicit-all (default state): the filter
+  // below treats ``size === 0`` as "no filter applied" and the checkboxes
+  // render as ✓ via ``size === 0 || has(name)``. We do NOT eagerly fill
+  // this with the roster — the store populates agents one-by-one, so a
+  // watcher that latched on first non-zero length would lock the set to
+  // whatever agent arrived first and silently drop later arrivals
+  // (regression 2026-05-21 e2e: ``agent-monitor.spec.ts`` saw only
+  // alpha-agent while beta was already in the store). The bulk-delete
+  // count badge derives its number from ``store.agentsList`` whenever
+  // ``selectedAgents`` is empty — display layer, not state layer.
   const selectedAgents = ref(new Set())
-  // Flips to true the first time the user touches the selection
-  // (toggleAgent / selectAll / clearAll / toggleSortLock... any explicit
-  // intent). Once flipped, the "auto-select-all-on-first-roster-load"
-  // watcher stops mutating selectedAgents — the user's choice wins.
-  const userTouchedSelection = ref(false)
 
   // Sort lock: freeze grid order so agents stop jumping
   const sortLocked = ref(false)
@@ -210,7 +209,6 @@ export function useActivityStream(options = {}) {
   //   grid", which is filtered out of explicit name lists.
 
   function toggleAgent(name) {
-    userTouchedSelection.value = true
     let s = new Set(selectedAgents.value)
     if (s.size === 0) {
       // Expand implicit-all → explicit roster so we can subtract from it.
@@ -223,7 +221,6 @@ export function useActivityStream(options = {}) {
   }
 
   function selectAll() {
-    userTouchedSelection.value = true
     // Materialize the roster so consumers see real names, not the
     // implicit-all empty Set. Drops the `__none__` sentinel implicitly
     // by overwriting the value.
@@ -231,31 +228,9 @@ export function useActivityStream(options = {}) {
   }
 
   function clearAll() {
-    userTouchedSelection.value = true
     // Select none — show empty grid
     selectedAgents.value = new Set(['__none__'])
   }
-
-  // Auto-fill selection on first roster load. Watches store.agentsList:
-  // the moment it transitions from empty → non-empty (initial fetch
-  // completes), populate selectedAgents with every name so default state
-  // is "all selected" (visual ✓ + state ✓ + delete button enabled with
-  // full count, all in sync). Stops mutating once the user has made any
-  // explicit choice — even back to "everything" — to avoid stomping on
-  // intent (e.g. user clears, new agent arrives later, the watcher
-  // should NOT re-select-all).
-  const stopRosterAutoSelect = watch(
-    () => store.agentsList.length,
-    (n) => {
-      if (n === 0) return
-      if (userTouchedSelection.value) return
-      if (selectedAgents.value.size > 0) return  // already populated
-      selectedAgents.value = new Set(store.agentsList.map(a => a.name))
-    },
-    { immediate: true },
-  )
-
-  onUnmounted(() => stopRosterAutoSelect())
 
   function toggleSortLock() {
     if (!sortLocked.value) {

--- a/dashboard/src/composables/useActivityStream.js
+++ b/dashboard/src/composables/useActivityStream.js
@@ -1,5 +1,9 @@
 import { ref, shallowRef, triggerRef, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useAgentsStore } from '../stores/agents'
+import { normalizeTs, formatTimestamp } from '../utils/timeFormat.js'
+
+// Re-export for callers that still import these from here.
+export { normalizeTs, formatTimestamp }
 
 /**
  * Activity Stream composable for Team Monitor.
@@ -24,8 +28,18 @@ export function useActivityStream(options = {}) {
   // Active filter: 'all' | 'active' | 'team:<name>'
   const filter = ref('all')
 
-  // Agent selection filter (empty = show all)
+  // Agent selection. Filled by a watcher once the store roster loads so
+  // the dropdown opens with every agent already ticked AND the bulk-
+  // delete count badge shows the full roster size. Without this, an
+  // empty Set rendered visually as "all checked" (filter convention)
+  // while bulk-delete saw zero selections — see the 2026-05-21 thread
+  // about that mismatch.
   const selectedAgents = ref(new Set())
+  // Flips to true the first time the user touches the selection
+  // (toggleAgent / selectAll / clearAll / toggleSortLock... any explicit
+  // intent). Once flipped, the "auto-select-all-on-first-roster-load"
+  // watcher stops mutating selectedAgents — the user's choice wins.
+  const userTouchedSelection = ref(false)
 
   // Sort lock: freeze grid order so agents stop jumping
   const sortLocked = ref(false)
@@ -134,7 +148,14 @@ export function useActivityStream(options = {}) {
 
   // --- Computed: filtered agent panels ---
   const filteredAgents = computed(() => {
-    let agents = store.agentsList
+    // Team Monitor does NOT use status-priority sort (running/error first).
+    // Keep Jarvis (is_default) pinned at top, then alphabetical by name —
+    // stable layout so panels don't reshuffle as agents transition status.
+    let agents = [...store.agentsList].sort((a, b) => {
+      if (a.is_default && !b.is_default) return -1
+      if (!a.is_default && b.is_default) return 1
+      return a.name.localeCompare(b.name)
+    })
 
     // Apply status filter
     switch (filter.value) {
@@ -169,21 +190,72 @@ export function useActivityStream(options = {}) {
   })
 
   // Selection helpers
+  //
+  // Selection-state contract (post-2026-05-21):
+  // - Empty Set = "no explicit selection" (initial state). Visual:
+  //   all checkboxes render checked because the filter is inactive;
+  //   `dropdownLabel` says "All Agents". BUT downstream consumers that
+  //   need an explicit name list (e.g. bulk-delete) MUST treat this as
+  //   zero selection — never as "all". This guards destructive actions
+  //   from firing without user consent.
+  // - `selectAll()` PROMOTES the implicit-all state to an explicit Set
+  //   containing every name from the store, so the delete button (and
+  //   the count badge) match the visual.
+  // - Toggling an individual when starting from empty: the click means
+  //   "I want all EXCEPT this one" — expand the implicit-all into an
+  //   explicit Set, then remove the clicked name. Without this, the
+  //   first click flips from "all checked" to "only this one checked"
+  //   which is the opposite of what the checkbox visually promised.
+  // - `clearAll()` writes the `__none__` sentinel to signal "show empty
+  //   grid", which is filtered out of explicit name lists.
+
   function toggleAgent(name) {
-    const s = new Set(selectedAgents.value)
+    userTouchedSelection.value = true
+    let s = new Set(selectedAgents.value)
+    if (s.size === 0) {
+      // Expand implicit-all → explicit roster so we can subtract from it.
+      s = new Set(store.agentsList.map(a => a.name))
+    }
+    s.delete('__none__')
     if (s.has(name)) s.delete(name)
     else s.add(name)
     selectedAgents.value = s
   }
 
   function selectAll() {
-    selectedAgents.value = new Set() // empty = show all
+    userTouchedSelection.value = true
+    // Materialize the roster so consumers see real names, not the
+    // implicit-all empty Set. Drops the `__none__` sentinel implicitly
+    // by overwriting the value.
+    selectedAgents.value = new Set(store.agentsList.map(a => a.name))
   }
 
   function clearAll() {
+    userTouchedSelection.value = true
     // Select none — show empty grid
     selectedAgents.value = new Set(['__none__'])
   }
+
+  // Auto-fill selection on first roster load. Watches store.agentsList:
+  // the moment it transitions from empty → non-empty (initial fetch
+  // completes), populate selectedAgents with every name so default state
+  // is "all selected" (visual ✓ + state ✓ + delete button enabled with
+  // full count, all in sync). Stops mutating once the user has made any
+  // explicit choice — even back to "everything" — to avoid stomping on
+  // intent (e.g. user clears, new agent arrives later, the watcher
+  // should NOT re-select-all).
+  const stopRosterAutoSelect = watch(
+    () => store.agentsList.length,
+    (n) => {
+      if (n === 0) return
+      if (userTouchedSelection.value) return
+      if (selectedAgents.value.size > 0) return  // already populated
+      selectedAgents.value = new Set(store.agentsList.map(a => a.name))
+    },
+    { immediate: true },
+  )
+
+  onUnmounted(() => stopRosterAutoSelect())
 
   function toggleSortLock() {
     if (!sortLocked.value) {
@@ -240,71 +312,3 @@ export function useActivityStream(options = {}) {
   }
 }
 
-/**
- * Normalize any timestamp value to milliseconds.
- *
- * Handles:
- * - Unix seconds (float or int, e.g. 1775967073.51)
- * - Unix milliseconds (e.g. 1775967073000)
- * - ISO 8601 strings (e.g. "2026-04-12T12:30:00Z")
- * - null / undefined / 0 / NaN → returns null
- *
- * Heuristic: numeric values < 1e12 (~year 2001 in ms) are treated as seconds.
- */
-export function normalizeTs(ts) {
-  if (ts == null || ts === 0 || ts === '') return null
-
-  if (typeof ts === 'number') {
-    if (!Number.isFinite(ts)) return null
-    // seconds → ms (timestamps < 1e12 are definitely in seconds)
-    return ts < 1e12 ? Math.round(ts * 1000) : Math.round(ts)
-  }
-
-  if (typeof ts === 'string') {
-    // Try numeric string first (e.g. "1775967073.51")
-    const num = Number(ts)
-    if (Number.isFinite(num) && num > 0) {
-      return num < 1e12 ? Math.round(num * 1000) : Math.round(num)
-    }
-    // Try ISO / date string
-    const d = new Date(ts)
-    return Number.isFinite(d.getTime()) ? d.getTime() : null
-  }
-
-  return null
-}
-
-/**
- * Format a timestamp for display: 24h, dd/MM/YYYY.
- *
- * @param {number|string|null} ts - raw timestamp (seconds, ms, or ISO string)
- * @param {Object} opts
- * @param {boolean} [opts.dateOnly=false] - show only date without time
- * @param {boolean} [opts.timeOnly=false] - show only time without date
- * @returns {string} formatted string like "14:30:05 12/04/2026" or "" if invalid
- */
-export function formatTimestamp(ts, opts = {}) {
-  const ms = normalizeTs(ts)
-  if (ms === null) return ''
-
-  const d = new Date(ms)
-  if (!Number.isFinite(d.getTime())) return ''
-
-  const hh = String(d.getHours()).padStart(2, '0')
-  const mm = String(d.getMinutes()).padStart(2, '0')
-  const ss = String(d.getSeconds()).padStart(2, '0')
-  const dd = String(d.getDate()).padStart(2, '0')
-  const MM = String(d.getMonth() + 1).padStart(2, '0')
-  const yyyy = d.getFullYear()
-
-  if (opts.timeOnly) return `${hh}:${mm}:${ss}`
-  if (opts.dateOnly) return `${dd}/${MM}/${yyyy}`
-
-  // Same day → show time only to save space
-  const now = new Date()
-  if (d.getDate() === now.getDate() && d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear()) {
-    return `${hh}:${mm}:${ss}`
-  }
-
-  return `${hh}:${mm}:${ss} ${dd}/${MM}/${yyyy}`
-}

--- a/dashboard/src/stores/agents.js
+++ b/dashboard/src/stores/agents.js
@@ -11,8 +11,13 @@ export const useAgentsStore = defineStore('agents', () => {
   const tokenMetrics = ref(new Map()) // per-agent token accumulation from SSE
 
   // --- Computed ---
-  // Sort priority: running > error > default(Jarvis) > completed > idle
-  const STATUS_PRIORITY = { running: 0, paused: 1, error: 2, completed: 3, idle: 4 }
+  // Sort priority: running > error > default(Jarvis) > idle.
+  // After the 2026-05-20 lifecycle merge, only oneshot agents transit
+  // through ``completed`` and they're removed by the cleanup hook
+  // immediately — non-oneshot agents settle into ``idle``. No status
+  // badge for ``completed`` is rendered anywhere, so it's omitted from
+  // the priority table too.
+  const STATUS_PRIORITY = { running: 0, paused: 1, error: 2, idle: 3 }
   const agentsList = computed(() => {
     return Array.from(agents.value.values()).sort((a, b) => {
       const aPri = a.is_default ? 0 : (STATUS_PRIORITY[a.status] ?? 4)
@@ -30,7 +35,6 @@ export const useAgentsStore = defineStore('agents', () => {
       paused: list.filter(a => a.status === 'paused').length,
       idle: list.filter(a => a.status === 'idle').length,
       error: list.filter(a => a.status === 'error').length,
-      completed: list.filter(a => a.status === 'completed').length,
     }
   })
 
@@ -147,9 +151,12 @@ export const useAgentsStore = defineStore('agents', () => {
       }
 
       case 'result':
+        // Post-2026-05-20: all agents settle into 'idle' after task done.
+        // Oneshot agents are removed seconds later by the cleanup hook;
+        // resumable agents stay idle until the next resume.
         upsertAgent(agent_name, {
-          status: 'completed',
-          lastAction: { message: event.message || 'Completed', timestamp: event.timestamp },
+          status: 'idle',
+          lastAction: { message: event.message || 'Done', timestamp: event.timestamp },
         })
         break
 

--- a/dashboard/src/utils/timeFormat.js
+++ b/dashboard/src/utils/timeFormat.js
@@ -1,0 +1,77 @@
+/**
+ * Pure timestamp helpers — no vue / no pinia deps so they're directly testable.
+ *
+ * Backend serializes timestamps as Unix **seconds** (float), e.g. 1778834375.42.
+ * Passing that straight to `new Date(n)` produces 1970-01-21 because JS Date
+ * treats raw numbers as **milliseconds**. Use `normalizeTs` before constructing
+ * a Date from any backend timestamp.
+ */
+
+/**
+ * Normalize any timestamp value to milliseconds.
+ *
+ * Handles:
+ * - Unix seconds (float or int, e.g. 1775967073.51)
+ * - Unix milliseconds (e.g. 1775967073000)
+ * - ISO 8601 strings (e.g. "2026-04-12T12:30:00Z")
+ * - null / undefined / 0 / NaN → returns null
+ *
+ * Heuristic: numeric values < 1e12 (~year 2001 in ms) are treated as seconds.
+ */
+export function normalizeTs(ts) {
+  if (ts == null || ts === 0 || ts === '') return null
+
+  if (typeof ts === 'number') {
+    if (!Number.isFinite(ts)) return null
+    // seconds → ms (timestamps < 1e12 are definitely in seconds)
+    return ts < 1e12 ? Math.round(ts * 1000) : Math.round(ts)
+  }
+
+  if (typeof ts === 'string') {
+    // Try numeric string first (e.g. "1775967073.51")
+    const num = Number(ts)
+    if (Number.isFinite(num) && num > 0) {
+      return num < 1e12 ? Math.round(num * 1000) : Math.round(num)
+    }
+    // Try ISO / date string
+    const d = new Date(ts)
+    return Number.isFinite(d.getTime()) ? d.getTime() : null
+  }
+
+  return null
+}
+
+/**
+ * Format a timestamp for display: 24h, dd/MM/YYYY.
+ *
+ * @param {number|string|null} ts - raw timestamp (seconds, ms, or ISO string)
+ * @param {Object} opts
+ * @param {boolean} [opts.dateOnly=false] - show only date without time
+ * @param {boolean} [opts.timeOnly=false] - show only time without date
+ * @returns {string} formatted string like "14:30:05 12/04/2026" or "" if invalid
+ */
+export function formatTimestamp(ts, opts = {}) {
+  const ms = normalizeTs(ts)
+  if (ms === null) return ''
+
+  const d = new Date(ms)
+  if (!Number.isFinite(d.getTime())) return ''
+
+  const hh = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  const ss = String(d.getSeconds()).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  const MM = String(d.getMonth() + 1).padStart(2, '0')
+  const yyyy = d.getFullYear()
+
+  if (opts.timeOnly) return `${hh}:${mm}:${ss}`
+  if (opts.dateOnly) return `${dd}/${MM}/${yyyy}`
+
+  // Same day → show time only to save space
+  const now = new Date()
+  if (d.getDate() === now.getDate() && d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear()) {
+    return `${hh}:${mm}:${ss}`
+  }
+
+  return `${hh}:${mm}:${ss} ${dd}/${MM}/${yyyy}`
+}

--- a/dashboard/src/utils/timeFormat.test.js
+++ b/dashboard/src/utils/timeFormat.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { normalizeTs, formatTimestamp } from './timeFormat.js'
+
+// --- normalizeTs ---------------------------------------------------------
+
+test('normalizeTs: Unix seconds float → ms (the bug case)', () => {
+  // Backend serialized this exact value for meeting created_at on 2026-05-15.
+  // Before the fix, `new Date(1778834375.42)` produced 1970-01-21 because JS
+  // treated the number as milliseconds. normalizeTs must scale it to ms.
+  const ms = normalizeTs(1778834375.42)
+  assert.equal(ms, 1778834375420)
+  const year = new Date(ms).getUTCFullYear()
+  assert.equal(year, 2026, `Expected year 2026, got ${year}`)
+})
+
+test('normalizeTs: Unix seconds int → ms', () => {
+  assert.equal(normalizeTs(1778834375), 1778834375000)
+})
+
+test('normalizeTs: Unix milliseconds → unchanged', () => {
+  // Already ≥ 1e12 → kept as-is.
+  assert.equal(normalizeTs(1778834375000), 1778834375000)
+})
+
+test('normalizeTs: numeric string (seconds) → ms', () => {
+  assert.equal(normalizeTs('1778834375.42'), 1778834375420)
+})
+
+test('normalizeTs: numeric string (ms) → unchanged', () => {
+  assert.equal(normalizeTs('1778834375000'), 1778834375000)
+})
+
+test('normalizeTs: ISO 8601 string → ms', () => {
+  const ms = normalizeTs('2026-05-15T08:39:35Z')
+  assert.equal(ms, Date.UTC(2026, 4, 15, 8, 39, 35))
+})
+
+test('normalizeTs: null/undefined/0/empty → null', () => {
+  assert.equal(normalizeTs(null), null)
+  assert.equal(normalizeTs(undefined), null)
+  assert.equal(normalizeTs(0), null)
+  assert.equal(normalizeTs(''), null)
+})
+
+test('normalizeTs: NaN / non-finite → null', () => {
+  assert.equal(normalizeTs(NaN), null)
+  assert.equal(normalizeTs(Infinity), null)
+})
+
+test('normalizeTs: unparseable string → null', () => {
+  assert.equal(normalizeTs('not a date'), null)
+})
+
+// --- formatTimestamp -----------------------------------------------------
+
+test('formatTimestamp: invalid input → empty string', () => {
+  assert.equal(formatTimestamp(null), '')
+  assert.equal(formatTimestamp(0), '')
+  assert.equal(formatTimestamp('garbage'), '')
+})
+
+test('formatTimestamp: Unix seconds renders correct year (not 1970)', () => {
+  // Regression guard: the meeting-time bug surfaced as "Jan 21 1970" because
+  // the seconds-vs-ms heuristic was missing. Asserting the year here pins
+  // that fix in place.
+  const out = formatTimestamp(1778834375.42)
+  assert.ok(out.includes('2026'), `Expected output to contain 2026, got "${out}"`)
+  assert.ok(!out.includes('1970'), `Output must not contain 1970, got "${out}"`)
+})
+
+test('formatTimestamp: dateOnly returns dd/MM/yyyy', () => {
+  const out = formatTimestamp('2026-05-15T08:00:00Z', { dateOnly: true })
+  // Format is local-timezone-dependent but year must be 2026 and slash-separated.
+  assert.match(out, /^\d{2}\/\d{2}\/\d{4}$/)
+  assert.ok(out.endsWith('/2026'))
+})
+
+test('formatTimestamp: timeOnly returns HH:mm:ss', () => {
+  const out = formatTimestamp(1778834375.42, { timeOnly: true })
+  assert.match(out, /^\d{2}:\d{2}:\d{2}$/)
+})

--- a/dashboard/src/views/TeamMonitor.vue
+++ b/dashboard/src/views/TeamMonitor.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { useActivityStream } from '../composables/useActivityStream'
 import { useAgentTurns } from '../composables/useAgentTurns'
 import { apiFetch } from '../api'
@@ -39,9 +39,17 @@ watch(
 
 // Dropdown state
 const showAgentDropdown = ref(false)
+const dropdownSearchInput = ref(null)
 
 function toggleDropdown() {
   showAgentDropdown.value = !showAgentDropdown.value
+  if (showAgentDropdown.value) {
+    // Autofocus the search input so users can type immediately.
+    nextTick(() => dropdownSearchInput.value?.focus())
+  } else {
+    // Clear search when closing so reopening starts clean.
+    dropdownSearch.value = ''
+  }
 }
 
 function closeDropdown(e) {
@@ -55,20 +63,28 @@ function closeDropdown(e) {
 function handleClickOutside(e) {
   if (showAgentDropdown.value && !e.target.closest('.agent-dropdown')) {
     showAgentDropdown.value = false
-  }
-  if (showDisbandMenu.value && !e.target.closest('.disband-dropdown')) {
-    showDisbandMenu.value = false
+    dropdownSearch.value = ''
   }
 }
 onMounted(() => document.addEventListener('click', handleClickOutside))
 onUnmounted(() => document.removeEventListener('click', handleClickOutside))
 
-// Label for the dropdown button
+// Label for the dropdown button. Includes a "· K deletable" suffix
+// whenever the selection contains built-in agents (which view fine but
+// are skipped by bulk-delete). Without it, users see "16 selected" next
+// to a "Delete (11)" badge and can't tell where the 5-agent gap came
+// from — same confusion that prompted this whole thread.
 const dropdownLabel = computed(() => {
-  if (selectedAgents.value.size === 0) return 'All Agents'
+  if (selectedAgents.value.size === 0) return 'All Agents'   // implicit-all (initial)
   if (selectedAgents.value.has('__none__')) return 'None Selected'
   const count = selectedAgents.value.size
-  return `${count} agent${count > 1 ? 's' : ''} selected`
+  const total = store.agentsList.length
+  const deletable = deletableSelectedNames.value.length
+  let main = (total > 0 && count === total)
+    ? `All ${total} selected`
+    : `${count} agent${count > 1 ? 's' : ''} selected`
+  if (deletable < count) main += ` · ${deletable} deletable`
+  return main
 })
 
 // Status helpers (used by dropdown item dots and other shared UI)
@@ -139,59 +155,187 @@ const agentsGrouped = computed(() => {
   return groups
 })
 
-function selectTeam(teamName) {
-  const teamAgents = store.agentsList.filter(a => a.team_name === teamName)
-  const s = new Set(selectedAgents.value)
-  const allSelected = teamAgents.every(a => s.has(a.name))
+// Search-by-name filter for the dropdown. Case-insensitive substring match
+// against agent.name AND team header (so typing a team name still surfaces
+// its members). Empty query → returns all groups untouched.
+const dropdownSearch = ref('')
+const agentsGroupedFiltered = computed(() => {
+  const q = dropdownSearch.value.trim().toLowerCase()
+  if (!q) return agentsGrouped.value
+  const out = []
+  for (const group of agentsGrouped.value) {
+    const headerHit = group.name.toLowerCase().includes(q)
+    const agents = headerHit
+      ? group.agents  // team name matched — keep the whole roster
+      : group.agents.filter(a => a.name.toLowerCase().includes(q))
+    if (agents.length) out.push({ ...group, agents })
+  }
+  return out
+})
+
+/**
+ * Toggle select-all for the agents currently shown in a dropdown group.
+ *
+ * Works for BOTH team groups and the synthetic "Individual Agents" group.
+ * Crucially, operates on ``group.agents`` (which is already narrowed by
+ * the search filter via ``agentsGroupedFiltered``) so users can search
+ * for "agent-0", click the header, and select exactly those matches —
+ * not the entire roster.
+ */
+function toggleGroup(group) {
+  const agents = group.agents || []
+  if (!agents.length) return
+  let s = new Set(selectedAgents.value)
+  // ── Order matters: check size BEFORE stripping the ``__none__``
+  // sentinel — same contract as toggleAgent. Three starting states:
+  //   {__none__}   user explicitly cleared → start blank (size=1, skip
+  //                expand). After delete sentinel, s = {} and we
+  //                proceed to add the clicked group's agents.
+  //   {} (empty)   implicit-all / pre-roster-load → expand to all so
+  //                toggling a group means "subtract from all".
+  //   {names...}   explicit selection → use as-is.
+  // The previous order (delete first, then size check) collapsed
+  // {__none__} into {} → triggered the expand-to-all path → flipped
+  // a "Clear → click team" into "select all-except-team". That's
+  // exactly the 29-selected bug user reported.
+  if (s.size === 0) {
+    s = new Set(store.agentsList.map(a => a.name))
+  }
+  s.delete('__none__')
+  const allSelected = agents.every(a => s.has(a.name))
   if (allSelected) {
-    teamAgents.forEach(a => s.delete(a.name))
+    agents.forEach(a => s.delete(a.name))
   } else {
-    teamAgents.forEach(a => s.add(a.name))
+    agents.forEach(a => s.add(a.name))
   }
-  selectedAgents.value = s.size === store.agentsList.length ? new Set() : s
+  // No auto-collapse to empty when full: the new contract requires
+  // explicit Set membership so destructive actions (bulk delete) know
+  // exactly which agents the user consented to.
+  selectedAgents.value = s
 }
 
-const disbandModal = ref({ visible: false, teamName: '', loading: false, error: '' })
-const showDisbandMenu = ref(false)
+// ── Bulk delete: remove every agent currently in ``selectedAgents`` ──
+//
+// Replaces the old "Disband Team" button: instead of deleting a whole
+// team in one shot, the user picks exactly which agents (via the multi-
+// select dropdown + search) and confirms a single bulk delete.
 
-function requestDisband(teamName) {
-  disbandModal.value = { visible: true, teamName, loading: false, error: '' }
+const bulkDeleteModal = ref({ visible: false, names: [], protected: [], loading: false, error: '' })
+
+// ── Two views of the same selection ────────────────────────────────
+//
+// The dropdown is shared by two concerns:
+//   1. View filter — pick which agents to show in the activity stream.
+//   2. Bulk delete — pick which agents to remove.
+//
+// (1) needs to include built-in agents (Jarvis, PersonalAgent, etc.)
+// because users legitimately want to monitor their conversations.
+// (2) MUST exclude them — they're not deletable by design (backend
+// would reject anyway). So derive two lists from one selection:
+//   - selectedAgentNames     → for any general "what did the user pick"
+//   - deletableSelectedNames → for the bulk-delete action specifically
+// Plus a protected list so the confirm modal can tell the user
+// explicitly which built-ins are being kept, instead of silently
+// dropping them.
+
+function _isBuiltin(agent) {
+  return agent?.type === 'builtin'
 }
 
-function cancelDisband() {
-  disbandModal.value = { visible: false, teamName: '', loading: false, error: '' }
-}
+const selectedAgentNames = computed(() => {
+  const known = new Set(store.agentsList.map(a => a.name))
+  return [...selectedAgents.value].filter(n => n !== '__none__' && known.has(n))
+})
 
-async function confirmDisband() {
-  const name = disbandModal.value.teamName
-  disbandModal.value.loading = true
-  disbandModal.value.error = ''
-  try {
-    const result = await apiFetch(`/api/agents/teams/${encodeURIComponent(name)}`, { method: 'DELETE' })
-    const removedAgents = result.removed_agents || []
-    const removedCount = removedAgents.length
+const deletableSelectedNames = computed(() => {
+  const byName = new Map(store.agentsList.map(a => [a.name, a]))
+  return selectedAgentNames.value.filter(n => !_isBuiltin(byName.get(n)))
+})
 
-    // Reset filter if currently filtering by this team
-    if (filter.value === `team:${name}`) {
-      filter.value = 'all'
-    }
-    disbandModal.value = { visible: false, teamName: '', loading: false, error: '' }
-    showDisbandMenu.value = false
+// Built-ins inside the current selection — surfaced in the confirm
+// modal as "kept" so the user understands why the delete count is
+// smaller than their visible tick count.
+const protectedSelectedNames = computed(() => {
+  const byName = new Map(store.agentsList.map(a => [a.name, a]))
+  return selectedAgentNames.value.filter(n => _isBuiltin(byName.get(n)))
+})
 
-    // Note: agents are removed from the store reactively via SSE 'agent_removed' events
-    // broadcast by the backend. No manual store mutation needed.
-    toast.success(`Team "${name}" disbanded successfully`, {
-      description: `${removedCount} agent${removedCount !== 1 ? 's' : ''} removed: ${removedAgents.join(', ')}`,
-      duration: 5000,
-    })
-  } catch (err) {
-    disbandModal.value.loading = false
-    disbandModal.value.error = err.message || 'Failed to disband team'
-    toast.error(`Failed to disband team "${name}"`, {
-      description: err.message,
-      duration: 5000,
-    })
+const canBulkDelete = computed(() => deletableSelectedNames.value.length > 0)
+
+// Tooltip text reflects all three cases the user might be in: nothing
+// to delete, some deletable, or selection contains only built-ins
+// (visible but protected).
+const bulkDeleteTooltip = computed(() => {
+  const n = deletableSelectedNames.value.length
+  const skipped = protectedSelectedNames.value.length
+  if (n === 0 && skipped > 0) {
+    return `Only built-in agents are selected — built-ins cannot be deleted. Tick some user agents first.`
   }
+  if (n === 0) return 'Select agents from the dropdown first'
+  const plural = n !== 1 ? 's' : ''
+  return skipped > 0
+    ? `Delete ${n} agent${plural} (${skipped} built-in kept)`
+    : `Delete ${n} agent${plural}`
+})
+
+function requestBulkDelete() {
+  if (!canBulkDelete.value) return
+  bulkDeleteModal.value = {
+    visible: true,
+    names: deletableSelectedNames.value.slice(),
+    protected: protectedSelectedNames.value.slice(),
+    loading: false,
+    error: '',
+  }
+}
+
+function cancelBulkDelete() {
+  bulkDeleteModal.value = { visible: false, names: [], protected: [], loading: false, error: '' }
+}
+
+async function confirmBulkDelete() {
+  const names = bulkDeleteModal.value.names
+  if (!names.length) return
+  bulkDeleteModal.value.loading = true
+  bulkDeleteModal.value.error = ''
+  // Fire DELETEs in parallel — independent records, safe to overlap.
+  // Use allSettled so a partial failure surfaces every error rather than
+  // hiding all but the first.
+  const results = await Promise.allSettled(
+    names.map(n => apiFetch(`/api/agents/${encodeURIComponent(n)}`, { method: 'DELETE' })),
+  )
+  const ok = []
+  const fail = []
+  results.forEach((r, i) => {
+    if (r.status === 'fulfilled') ok.push(names[i])
+    else fail.push({ name: names[i], err: r.reason?.message || String(r.reason) })
+  })
+
+  // Clear selection of the agents we actually removed. Backend broadcasts
+  // ``agent_removed`` SSE so the store drops them reactively — we just
+  // need to keep selectedAgents in sync.
+  const s = new Set(selectedAgents.value)
+  ok.forEach(n => s.delete(n))
+  selectedAgents.value = s
+
+  bulkDeleteModal.value.loading = false
+  if (fail.length) {
+    bulkDeleteModal.value.error =
+      `${fail.length}/${names.length} failed:\n` +
+      fail.map(f => `• ${f.name}: ${f.err}`).join('\n')
+    toast.error(`Bulk delete: ${fail.length} of ${names.length} failed`, {
+      description: fail.map(f => `${f.name}: ${f.err}`).join('\n'),
+      duration: 6000,
+    })
+    // Keep modal open so the user can read the per-agent errors.
+    return
+  }
+
+  bulkDeleteModal.value = { visible: false, names: [], protected: [], loading: false, error: '' }
+  toast.success(`Deleted ${ok.length} agent${ok.length !== 1 ? 's' : ''}`, {
+    description: ok.join(', '),
+    duration: 5000,
+  })
 }
 
 /**
@@ -271,27 +415,16 @@ onMounted(() => {
           <span class="stat-pill stat-idle">{{ store.stats.idle }} idle</span>
           <span v-if="store.stats.error" class="stat-pill stat-error">{{ store.stats.error }} error</span>
         </div>
-        <!-- Disband Team dropdown -->
-        <div v-if="teamNames.length" class="disband-dropdown" ref="disbandDropdownRef">
-          <button class="disband-team-btn" @click="showDisbandMenu = !showDisbandMenu">
-            🗑 Disband Team
-            <span class="dropdown-caret" :class="{ open: showDisbandMenu }">▾</span>
-          </button>
-          <Transition name="dropdown-fade">
-            <div v-if="showDisbandMenu" class="disband-menu">
-              <button
-                v-for="tn in teamNames"
-                :key="tn"
-                class="disband-menu-item"
-                @click="requestDisband(tn); showDisbandMenu = false"
-              >
-                <span class="disband-menu-icon">🗑</span>
-                <span>{{ tn }}</span>
-                <span class="disband-menu-count">{{ store.agentsList.filter(a => a.team_name === tn).length }} agents</span>
-              </button>
-            </div>
-          </Transition>
-        </div>
+        <!-- Bulk delete selected (deletable) agents -->
+        <button
+          class="bulk-delete-btn"
+          :disabled="!canBulkDelete"
+          :title="bulkDeleteTooltip"
+          @click="requestBulkDelete"
+        >
+          🗑 Delete Selected
+          <span v-if="canBulkDelete" class="bulk-delete-count">{{ deletableSelectedNames.length }}</span>
+        </button>
       </div>
     </div>
 
@@ -372,10 +505,29 @@ onMounted(() => {
               <span class="dropdown-divider">|</span>
               <button class="dropdown-action" @click="selectedAgents = new Set(['__none__'])">Clear</button>
             </div>
-            <div class="dropdown-list">
-              <template v-for="group in agentsGrouped" :key="group.name">
+            <div class="dropdown-search">
+              <input
+                ref="dropdownSearchInput"
+                v-model="dropdownSearch"
+                class="dropdown-search-input"
+                type="text"
+                placeholder="Search by name…"
+                @keydown.escape.stop="dropdownSearch = ''"
+              />
+              <button
+                v-if="dropdownSearch"
+                class="dropdown-search-clear"
+                title="Clear search"
+                @click="dropdownSearch = ''"
+              >×</button>
+            </div>
+            <div v-if="!agentsGroupedFiltered.length" class="dropdown-empty">
+              No agents match "{{ dropdownSearch }}"
+            </div>
+            <div v-else class="dropdown-list">
+              <template v-for="group in agentsGroupedFiltered" :key="group.name">
                 <!-- Team header -->
-                <div class="dropdown-team-header" @click="group.type === 'team' && selectTeam(group.name)">
+                <div class="dropdown-team-header" @click="toggleGroup(group)">
                   <span v-if="group.color" class="team-dot" :style="{ background: group.color }"></span>
                   <span>{{ group.name }}</span>
                   <span class="dropdown-team-count">{{ group.agents.length }}</span>
@@ -393,6 +545,16 @@ onMounted(() => {
                   />
                   <span class="dropdown-item-dot" :style="{ background: statusColor(a.status) }"></span>
                   <span class="dropdown-item-name">{{ a.name }}</span>
+                  <!-- Built-in agents can be selected for VIEW filter,
+                       but the bulk-delete action skips them. The lock
+                       icon plus title tooltip make that clear up front
+                       so users don't expect a Delete-Selected click to
+                       remove Jarvis et al. -->
+                  <span
+                    v-if="a.type === 'builtin'"
+                    class="dropdown-item-builtin"
+                    title="Built-in agent — protected from bulk delete"
+                  >🔒</span>
                 </label>
               </template>
             </div>
@@ -438,19 +600,31 @@ onMounted(() => {
       This will delete its card file, registry entries, and activity history.
     </ConfirmModal>
 
-    <!-- Disband Team Confirmation Modal -->
+    <!-- Bulk Delete Confirmation Modal -->
     <ConfirmModal
-      :visible="disbandModal.visible"
-      title="Disband Team"
-      confirm-text="Disband Team"
+      :visible="bulkDeleteModal.visible"
+      :title="`Delete ${bulkDeleteModal.names.length} agent${bulkDeleteModal.names.length !== 1 ? 's' : ''}?`"
+      :confirm-text="`Delete ${bulkDeleteModal.names.length}`"
       variant="danger"
-      :loading="disbandModal.loading"
-      :error="disbandModal.error"
-      @confirm="confirmDisband"
-      @cancel="cancelDisband"
+      :loading="bulkDeleteModal.loading"
+      :error="bulkDeleteModal.error"
+      @confirm="confirmBulkDelete"
+      @cancel="cancelBulkDelete"
     >
-      Are you sure you want to disband team <strong>{{ disbandModal.teamName }}</strong>?
-      This will remove all agents, sessions, workspaces, and activity data for this team.
+      <p>The following agents and their conversation history will be permanently removed:</p>
+      <ul class="bulk-delete-list">
+        <li v-for="n in bulkDeleteModal.names" :key="n">{{ n }}</li>
+      </ul>
+      <!-- Built-in agents inside the selection are surfaced explicitly so
+           the user understands why the delete count is smaller than
+           their tick count — never silently dropped. -->
+      <div v-if="bulkDeleteModal.protected.length" class="bulk-delete-protected">
+        <span class="bulk-delete-protected-icon">🔒</span>
+        <div>
+          <strong>{{ bulkDeleteModal.protected.length }} built-in agent{{ bulkDeleteModal.protected.length !== 1 ? 's' : '' }} will be kept:</strong>
+          <span class="bulk-delete-protected-names">{{ bulkDeleteModal.protected.join(', ') }}</span>
+        </div>
+      </div>
     </ConfirmModal>
     </template>
 
@@ -548,6 +722,68 @@ onMounted(() => {
 .stat-running { background: rgba(245, 158, 11, 0.12); color: #f59e0b; }
 .stat-idle { background: rgba(16, 185, 129, 0.12); color: #10b981; }
 .stat-error { background: rgba(239, 68, 68, 0.12); color: #ef4444; }
+
+/* ─── Bulk delete: outline-danger button per design system ─── */
+.bulk-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 32px;
+  padding: 0 12px;
+  background: var(--bg-button);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-body);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.bulk-delete-btn:not(:disabled):hover {
+  border-color: var(--negative-red);
+  color: var(--negative-red);
+}
+
+.bulk-delete-btn:not(:disabled):active {
+  background: rgba(255, 69, 96, 0.08);
+}
+
+.bulk-delete-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.bulk-delete-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  background: var(--negative-red);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 10px;
+}
+
+/* Confirm-modal body list */
+.bulk-delete-list {
+  list-style: disc;
+  padding-left: 20px;
+  margin-top: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+  font-size: 12px;
+  color: var(--text-body);
+}
+
+.bulk-delete-list li {
+  padding: 2px 0;
+}
 
 /* ─── Filter Bar ─── */
 .filter-bar {
@@ -697,6 +933,57 @@ onMounted(() => {
   font-size: 11px;
 }
 
+.dropdown-search {
+  position: relative;
+  padding: 8px 12px;
+  border-bottom: 1px solid #1a1d2e;
+}
+
+.dropdown-search-input {
+  width: 100%;
+  background: #0f1322;
+  border: 1px solid #1f2540;
+  border-radius: 6px;
+  color: #e2e8f0;
+  font-size: 12px;
+  padding: 6px 26px 6px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.dropdown-search-input::placeholder {
+  color: #5b6481;
+}
+
+.dropdown-search-input:focus {
+  border-color: #3b82f6;
+}
+
+.dropdown-search-clear {
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #64748b;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.dropdown-search-clear:hover {
+  color: #cbd5e1;
+}
+
+.dropdown-empty {
+  padding: 14px 12px;
+  font-size: 12px;
+  color: #64748b;
+  text-align: center;
+}
+
 .dropdown-list {
   max-height: 260px;
   overflow-y: auto;
@@ -754,6 +1041,41 @@ onMounted(() => {
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+.dropdown-item-builtin {
+  margin-left: auto;
+  font-size: 11px;
+  opacity: 0.6;
+  flex-shrink: 0;
+  cursor: help;
+}
+
+/* Confirm modal: protected (built-in) agents notice */
+.bulk-delete-protected {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-body);
+}
+
+.bulk-delete-protected-icon {
+  font-size: 14px;
+  line-height: 1.2;
+  flex-shrink: 0;
+}
+
+.bulk-delete-protected-names {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-sub);
+  font-size: 11px;
 }
 
 .dropdown-item-name {
@@ -961,8 +1283,8 @@ onMounted(() => {
     gap: 8px;
   }
 
-  /* Disband button: full width on mobile */
-  .disband-team-btn {
+  /* Bulk delete button: full width on mobile */
+  .bulk-delete-btn {
     width: 100%;
     justify-content: center;
   }


### PR DESCRIPTION
## Summary

Bundles a session worth of cross-cutting fixes + the new template-edit REST API onto one branch. **17 commits across 3 submodules + the main repo.**

## Highlights

### New: live team-template REST API + reload
- `GET / PATCH / POST` on `/api/team-sessions/{sid}/template/*` for editing role config (instruction, servers, skills, server_overrides, model) on a RUNNING team.
- Audit log (`team_template_history` table) — every PATCH / rollback / reset writes a row with field-level granularity.
- `POST /reload` force-kills + respawns named roles via the existing inject_resume path so context + history survive.
- Twin endpoint set on `/api/skills/{name}/reload(-preview)` so a skill edit can fan out to every team that uses it.

### Bridge: event-stream completion model
Replaces dedup-based notify with a transition-based handler + DB-backed idempotency. Fixes the missing-notifications regression from 2026-05-16 and the unsolicited "check inbox" loop after every user inject.

### inject_resume: read live template, not frozen snapshot
`original_config` is captured at first spawn. The resume path now refreshes `servers / server_overrides / instruction / skills / model` from `team_sessions.template.roles[role]` via a single `_resolve()` helper, so template edits (UI or script) are picked up on the next resume. Fixes the 2026-05-18 incident where `playwright` was added to QE but every resume kept the old 7-server list.

### gh CLI in agent shells (Dockerfile + gh_credential_sync + skills)
- `gh=2.68.1` in the base image.
- New `services/gh_credential_sync.py` mirrors `service.github.personal_access_token` from DB into `$GH_CONFIG_DIR/hosts.yml` (mode 0600). File-based — NOT env var — so prompt-injected agents can't `printenv` the token.
- Skills updated with three-tier safety taxonomy (NEVER / ESCALATE / SAFE) and per-role `gh` playbooks.

### Submodule bumps

**fast-agent → 87dc8bf** (branch `feat/orchestrator-team-stabilization`)
- `fix(meeting)`: refuse impersonation via caller-identity check (production 2026-05-20: PM force-skipped all 6 teammates in one meeting).
- `feat(tool-runner)`: cap oversized tool results pre-history (777KB SVG → context overflow → "filesystem MCP missing").
- `fix(spawn-registry)`: reject loose `agent_name` at write boundary (duplicate dashboard card bug).
- `fix(mcp)`: propagate `JARVIS_RUNTIME_RPC_SOCKET` to grandchild MCPs.
- `fix(spawn)`: preserve team identity across auto-resume + lifecycle merge (persistent → resumable).

**mcp-atlassian → 449db5a** (branch `fix/jira-create-project-trash-collision`)
- `fix(jira)`: detect trashed (soft-deleted) project key on create.
- `fix(jira)`: route ADF-comment transitions through v3 on Cloud.
- `feat(jira)`: expose `upload_attachment` / `upload_attachments` MCP tools.

**figma-ui-mcp → df4ecf8** (branch `feat/figma-export-spill-to-disk`)
- `feat(figma)`: spill `export_svg` / `export_image` results to disk (returns `file_path`, never raw bytes inline).

### Dashboard
- New `utils/timeFormat.js` — single source of truth for Unix-seconds-vs-ms normalisation (fixes inline `new Date(ts)` rendering "1970-01-21" all over the UI).
- Turn dedup on `(run_id, turn_idx)` so resume / restart / auto-resume don't overwrite history.
- TeamMonitor: dropdown autofocus, "K deletable" suffix on multi-select, stable alphabetical layout.

### gitignore
`.mcp.json`, `backend/.gh-config/`, `backend/.tool-outputs/` — three paths inlining secrets or runtime artifacts that were silently appearing in everyone's `git status`.

## Test plan

- [x] backend pytest (template service / routes / reload / orchestrator / inject_resume / meeting / skills) — **311 / 311 green**
- [x] mcp-atlassian pytest (jira / servers / toolsets) — **250 / 250 green**
- [x] fast-agent pytest (spawn / tool runner) — **30 / 30 green**
- [x] dashboard `npm run test:unit` — **97 / 97 green**
- [x] GitNexus reindex: 36228 symbols, 101681 edges, 300 flows
- [ ] Manual: edit a running team's QE role via `PATCH /api/team-sessions/{sid}/template/roles/qe` adding playwright; `POST /reload {"roles": ["qe"], "confirm": true}`; verify QE picks up the new tool on respawn.
- [ ] Manual: rotate GitHub PAT in DB; verify `$JARVIS_PERSIST_DIR/.gh-config/hosts.yml` updates AND that an agent running `gh pr view` succeeds.

## Migration notes
- `team_template_history` table created lazily on first PATCH — no schema deploy needed.
- gh CLI auth: backend boot writes `hosts.yml` from existing DB credentials, no manual setup required.
- Default fastagent `filesystem` MCP args drop the never-existing `./jarvis_workspace`; per-role spawns continue to override via `server_overrides`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
