### PR TITLE
chore: add dependabot.yml for weekly dep + base-image bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # Python backend
+  - package-ecosystem: pip
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-minor:
+        update-types:
+          - minor
+          - patch
+
+  # Vue/Vite dashboard
+  - package-ecosystem: npm
+    directory: /dashboard
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions workflow pins
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+
+  # Base image FROM pins in Dockerfiles
+  - package-ecosystem: docker
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` covering 4 ecosystems: pip (backend), npm (dashboard), github-actions, docker (backend Dockerfile base-image pins).
- Minor/patch bumps grouped per ecosystem so a quiet week ships as 1 PR per ecosystem, not 20. Major bumps still get their own PR (they need individual review).
- `open-pull-requests-limit` capped at 5 for code ecosystems, 3 for github-actions/docker — keeps the queue from flooding.

## Why now

- Pairs with the "Dependabot version updates" toggle we just enabled in repo settings (Code security → Dependabot version updates). Without a config file, the toggle is inert.
- Independent of "Dependabot security updates" (which auto-PRs CVE fixes regardless of this file).
- One of the last items before flipping the repo public — proactive dep hygiene is a signal contributors look for.

## Test plan

- [ ] CI green
- [ ] After merge, wait ~10–15 min and check `https://github.com/omnigentx/jarvis/network/updates` shows 4 ecosystem entries
- [ ] First weekly PR batch arrives within 7 days — verify groups behave (minor/patch in one PR, major separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)