### PR TITLE
chore: ignore vite major bumps + mark xiaozhi as Inactive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # Vite major bumps break config/plugin API (verified: v6→v8 PR #39 broke
+      # build + e2e CI). Hold majors for separate manual migration PRs.
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor:
         update-types:

--- a/xiaozhi_integration/README.md
+++ b/xiaozhi_integration/README.md
@@ -1,6 +1,6 @@
 # Xiaozhi MCP Integration
 
-> 🧪 **Status: Experimental integration.** This module is experimental — the interface (tool names, env vars, pipe architecture) may change or be removed without backwards-compat guarantees. Not recommended for production use.
+> 🚧 **Status: Inactive (paused).** This module is not currently being developed. Code is left in-tree for reference; **no security patches will be applied** to its dependencies until work resumes. Run at your own risk if you fork this directory standalone. The Jarvis backend deploy does not load these packages — vulnerabilities only matter when running the standalone xiaozhi MCP server.
 
 Bridges a [Xiaozhi](https://xiaozhi.me) ESP32 voice device with the Jarvis backend over the Model Context Protocol (MCP). The Xiaozhi device sends a voice request to Xiaozhi Cloud; Cloud forwards it to a local MCP server (`jarvis_mcp_server.py`) over a WebSocket relay (`mcp_pipe.py`); the MCP server calls the Jarvis HTTP API and returns the answer (plus optional audio URL for media playback).
 


### PR DESCRIPTION
## Summary

Two follow-ups after #31 landed:

1. **`.github/dependabot.yml`** — add ignore rule for `vite` major bumps. PR #39 (vite 6→8) broke build-dashboard + e2e CI because v6→v8 changes config + plugin API. Majors will be done as separate manual migration PRs; minor/patch still flow through the npm-minor group.
2. **`xiaozhi_integration/README.md`** — escalate status callout from 🧪 Experimental → 🚧 Inactive (paused). Module is not actively developed; backend deploy does not import these packages, so authlib/fastmcp CVEs in `xiaozhi_integration/uv.lock` don't affect production.

Pairs with dismissing Dependabot alerts #68 (authlib) and #76 (fastmcp) on the alerts page with reason `not_used`.

## Test plan

- [ ] CI green
- [ ] After merge, Dependabot does not re-open a vite major PR next cycle (verify by waiting one weekly tick or manually clicking "Check for updates")
- [ ] xiaozhi README renders the Inactive callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)