### PR TITLE
fix(agents): surface real MCP/skill load state in agent details

### DIFF
--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -1126,6 +1126,11 @@ def _merge_spawn_tool_status(
     mcp_status.servers (per-server is_connected + error_message) into the
     unified ``{server: {tools, status, error}}`` shape that the built-in agent
     path also returns.
+
+    Note: the ``mcp_servers`` payload emitted by isolated_runner._emit_mcp_status
+    carries BOTH ``status`` ("connected"/"failed") and ``is_connected`` (bool).
+    We read ``is_connected``; the spawn_progress_bridge log path reads ``status``.
+    Both fields are load-bearing — dropping either silently regresses one reader.
     """
     result: dict[str, dict] = {}
     for server_name, tools_list in (rt_tools or {}).items():

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -9,6 +9,7 @@ import re
 import logging
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import json as _json
 import yaml
@@ -334,18 +335,70 @@ RELOAD_SIGNAL = Path(__file__).parent.parent / ".fast-agent" / ".reload_needed"
 
 
 def _get_agent_skills(agent_name: str) -> list[dict]:
-    """Read resolved skills from FastAgent runtime AgentConfig."""
+    """Return per-skill load status for the agent details UI.
+
+    Each entry carries ``status``:
+      * ``"loaded"`` — manifest was resolved + injected into the live agent.
+      * ``"failed"`` — requested by name in config but missing from the live
+        agent's resolved manifests (file missing, parse error, etc).
+
+    The live agent's ``skill_manifests`` is the authoritative source of what
+    the agent actually sees; the raw ``config.skills`` field (preserved by
+    ``_apply_skills_to_agent_configs``) is the request log used to compute
+    the failed delta.
+    """
     try:
         agent_data = fast.agents.get(agent_name)
         if not agent_data:
             return []
         config = agent_data.get("config")
-        if not config or not hasattr(config, "skill_manifests"):
+        if not config:
             return []
-        return [
-            {"name": m.name, "description": m.description, "content": m.body or ""}
-            for m in config.skill_manifests
+
+        # Loaded manifests — prefer the live agent instance (post-init), fall
+        # back to the resolved config list if the runtime isn't ready yet.
+        loaded: list = []
+        if state.agent_app is not None:
+            instance = state.agent_app.get_agent(agent_name)
+            if instance is not None:
+                loaded = list(getattr(instance, "skill_manifests", None) or [])
+        if not loaded:
+            loaded = list(getattr(config, "skill_manifests", None) or [])
+
+        result = [
+            {
+                "name": m.name,
+                "description": m.description or "",
+                "content": m.body or "",
+                "status": "loaded",
+            }
+            for m in loaded
         ]
+        loaded_names = {m.name for m in loaded}
+
+        # Requested-but-not-loaded — string entries in raw config.skills
+        # may be either bare skill names ("user-context") or directory paths
+        # (".fast-agent/skills/user-context"). Fast-agent resolves both via
+        # SkillRegistry to a SkillManifest whose ``name`` is the directory
+        # basename, so we compare by basename to avoid false-positive
+        # "failed" entries for path-style refs. Non-string entries
+        # (Path/SkillRegistry/SkillManifest) reference directories rather
+        # than a specific skill, so we can't diff them.
+        requested = getattr(config, "skills", None)
+        if isinstance(requested, (list, tuple)):
+            for item in requested:
+                if not isinstance(item, str) or not item:
+                    continue
+                basename = item.rstrip("/").split("/")[-1]
+                if basename in loaded_names:
+                    continue
+                result.append({
+                    "name": basename,
+                    "description": "",
+                    "content": "",
+                    "status": "failed",
+                })
+        return result
     except Exception as e:
         logger.debug("[AGENTS API] Failed to get skills for %s: %s", agent_name, e)
         return []
@@ -382,11 +435,23 @@ def _safe_load_activity_data(raw_json: str | None):
         return None
 
 
-def _get_runtime_tools(agent_name: str) -> dict[str, list[dict]]:
-    """Get runtime MCP tool metadata grouped by server.
-    
-    Returns {server_name: [{"name": ..., "description": ...}, ...]}.
-    Falls back to config.tools (names only) if aggregator unavailable.
+def _get_runtime_tools(agent_name: str) -> dict[str, dict]:
+    """Return per-MCP-server runtime attach status + tool list.
+
+    Shape:
+        {
+          server_name: {
+            "tools": [{"name", "description"}, ...],
+            "status": "connected" | "failed",
+            "error": "",  # filled in by _enrich_mcp_errors_async for failed servers
+          }
+        }
+
+    ``connected`` servers come from ``aggregator._server_to_tool_map`` (only
+    populated on successful attach). ``failed`` servers are computed as
+    ``_configured_server_names - _attached_server_names`` so requested-but-
+    unreachable MCPs surface in the UI with a red badge instead of being
+    silently dropped.
     """
     try:
         if state.agent_app is None:
@@ -397,22 +462,65 @@ def _get_runtime_tools(agent_name: str) -> dict[str, list[dict]]:
         aggregator = getattr(agent_instance, "_aggregator", None)
         if aggregator is None:
             return {}
-        server_tool_map = getattr(aggregator, "_server_to_tool_map", None)
-        if not server_tool_map:
-            return {}
-        result = {}
+
+        server_tool_map = getattr(aggregator, "_server_to_tool_map", {}) or {}
+        configured = set(getattr(aggregator, "_configured_server_names", []) or [])
+        attached = set(getattr(aggregator, "_attached_server_names", []) or [])
+
+        result: dict[str, dict] = {}
         for server_name, namespaced_tools in server_tool_map.items():
-            result[server_name] = [
-                {
-                    "name": nt.tool.name,
-                    "description": getattr(nt.tool, "description", "") or "",
-                }
-                for nt in namespaced_tools
-            ]
+            result[server_name] = {
+                "tools": [
+                    {
+                        "name": nt.tool.name,
+                        "description": getattr(nt.tool, "description", "") or "",
+                    }
+                    for nt in namespaced_tools
+                ],
+                "status": "connected",
+                "error": "",
+            }
+        for server_name in configured - attached:
+            if server_name in result:
+                continue
+            result[server_name] = {
+                "tools": [],
+                "status": "failed",
+                "error": "",
+            }
         return result
     except Exception as e:
         logger.debug("[AGENTS API] Failed to get runtime tools for %s: %s", agent_name, e)
         return {}
+
+
+async def _enrich_mcp_errors_async(agent_name: str, tools: dict[str, dict]) -> None:
+    """Fill ``error`` on failed entries of ``tools`` using live ServerStatus.
+
+    Only called from the detail endpoint to avoid awaiting per-server probes
+    on the (high-fanout) list endpoint.
+    """
+    failed_servers = [
+        name for name, info in tools.items() if info.get("status") == "failed"
+    ]
+    if not failed_servers:
+        return
+    try:
+        if state.agent_app is None:
+            return
+        agent_instance = state.agent_app.get_agent(agent_name)
+        if agent_instance is None or not hasattr(agent_instance, "get_server_status"):
+            return
+        status_map = await agent_instance.get_server_status()
+        for server_name in failed_servers:
+            srv = status_map.get(server_name)
+            if srv is None:
+                continue
+            err = getattr(srv, "error_message", None) or ""
+            if err:
+                tools[server_name]["error"] = str(err)
+    except Exception as e:
+        logger.debug("[AGENTS API] Failed to enrich MCP errors for %s: %s", agent_name, e)
 
 
 # Icon mapping — the only hardcoded metadata (not available in runtime)
@@ -468,7 +576,7 @@ def _build_agent_dict(name: str, agent_data: dict) -> dict:
         "parent_agent": parent_agent,
         "is_default": getattr(config, "default", False),
         "skills": _get_agent_skills(name),
-        "tools": _get_runtime_tools(name) or dict(getattr(config, "tools", {}) or {}),
+        "tools": _get_runtime_tools(name),
         "status": "idle",
     }
 
@@ -813,13 +921,18 @@ async def get_agent(name: str):
     # 1. Check fast-agent runtime (static/dynamic agents)
     agent_data = fast.agents.get(name)
     if agent_data:
-        return _build_agent_dict(name, agent_data)
-    
+        detail = _build_agent_dict(name, agent_data)
+        # Probe live ServerStatus only for the detail endpoint so failed MCP
+        # servers expose their error_message in the UI tooltip. The list
+        # endpoint deliberately skips this to keep the fanout cheap.
+        await _enrich_mcp_errors_async(name, detail.get("tools") or {})
+        return detail
+
     # 2. Fall back to spawn registry (team/spawned agents)
     spawn_detail = _build_spawn_agent_detail(name)
     if spawn_detail:
         return spawn_detail
-    
+
     raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
 
 
@@ -903,79 +1016,34 @@ def _build_spawn_agent_detail(name: str) -> dict | None:
     
     # --- Prefer runtime_config (from live agent) over original_config (template) ---
     rt_cfg = record.get("runtime_config") or {}
-    
+    mcp_status = record.get("mcp_status") or {}
+
+    # Requested skill names — preserved from the spawn input so we can compute
+    # the "requested but failed to load" diff without re-reading template YAML.
+    requested_skill_names = _parse_skill_names(orig_cfg.get("skills"))
+
+    runtime_pending = not rt_cfg
+
     if rt_cfg:
-        # Runtime config available — use resolved data from the live agent
         instruction = rt_cfg.get("resolved_instruction", "")
-        spawn_skills = rt_cfg.get("skills", [])
-        tools = rt_cfg.get("tools", {})
+        loaded_skills_raw = rt_cfg.get("skills") or []
+        rt_tools = rt_cfg.get("tools") or {}
+        spawn_skills = _merge_skill_status(loaded_skills_raw, requested_skill_names)
+        tools = _merge_spawn_tool_status(rt_tools, mcp_status.get("servers") or {})
         # Populate servers from runtime tools keys if not already set
         if not servers and tools:
             servers = list(tools.keys())
-
     else:
-        # If original_config has no skills, try to fill from team template YAML
-        # (The spawn registry may have servers/instruction but skills=[] due to 
-        # a bug where spawn_team_members_for_session used wrong skills_dir)
-        if not orig_cfg.get("skills") and role and team_name:
-            tmpl_cfg = _load_role_config_from_template(role)
-            if tmpl_cfg:
-                # Fill skills from template
-                if tmpl_cfg.get("skills"):
-                    orig_cfg["skills"] = tmpl_cfg["skills"]
-                # Also fill empty fields from template
-                if not orig_cfg.get("servers") and tmpl_cfg.get("servers"):
-                    orig_cfg["servers"] = tmpl_cfg["servers"]
-                if not servers and orig_cfg.get("servers"):
-                    servers = orig_cfg["servers"]
-                if not model and tmpl_cfg.get("model"):
-                    model = tmpl_cfg["model"]
-        
-        # --- Resolve skills (names → descriptions from disk) ---
-        skill_names = []
-        if orig_cfg.get("skills"):
-            raw_skills = orig_cfg["skills"]
-            if isinstance(raw_skills, str):
-                skill_names = [s.strip() for s in raw_skills.split(",") if s.strip()]
-            elif isinstance(raw_skills, list):
-                skill_names = [s for s in raw_skills if s]
-        
-        spawn_skills = []
-        skill_manifests = []
-        if skill_names:
-            try:
-                from fast_agent.spawn.config_reader import get_skills as _load_skills
-                skills_dir = Path(__file__).parent.parent / ".fast-agent" / "skills"
-                skill_manifests = _load_skills(skills_dir, *skill_names)
-                for m in skill_manifests:
-                    spawn_skills.append({"name": m.name, "description": m.description or "", "content": m.body or ""})
-            except Exception as e:
-                logger.warning("[AGENTS API] Failed resolving skills for %s: %s", name, e)
-                spawn_skills = [{"name": s, "description": "", "content": ""} for s in skill_names]
-        
-        # --- Resolve instruction (inject skills via {{agentSkills}} placeholder) ---
+        # Runtime introspection not yet delivered — surface a pending state and
+        # let the dashboard refetch on the `runtime_config_ready` push instead
+        # of lying with template data the live agent might not actually see.
         instruction = orig_cfg.get("instruction", "") or record.get("task", "")
-        
-        if skill_manifests:
-            try:
-                from fast_agent.skills.registry import format_skills_for_prompt
-                skills_block = format_skills_for_prompt(skill_manifests)
-                if "{{agentSkills}}" in instruction:
-                    instruction = instruction.replace("{{agentSkills}}", skills_block)
-                elif "{agentSkills}" in instruction:
-                    instruction = instruction.replace("{agentSkills}", skills_block)
-                else:
-                    instruction = f"{instruction}\n\n{skills_block}"
-            except Exception as e:
-                logger.debug("[AGENTS API] Failed formatting skills for %s: %s", name, e)
-        
         context = orig_cfg.get("context", "")
         if context:
             instruction = f"{instruction}\n\n--- Context ---\n{context}"
-        
-        # --- Resolve MCP server tools (from main agent's runtime) ---
-        tools = _get_spawn_server_tools(servers)
-    
+        spawn_skills = []
+        tools = {}
+
     return {
         "name": name,
         "description": f"Team agent ({role})" if role else "Spawned agent",
@@ -989,6 +1057,7 @@ def _build_spawn_agent_detail(name: str) -> dict | None:
         "is_default": False,
         "skills": spawn_skills,
         "tools": tools,
+        "runtime_pending": runtime_pending,
         "status": record.get("status", "idle"),
         "role": role,
         "run_id": record.get("run_id", ""),
@@ -998,89 +1067,93 @@ def _build_spawn_agent_detail(name: str) -> dict | None:
     }
 
 
-def _load_role_config_from_template(role: str) -> dict:
-    """Load role config from team template YAML files.
-    
-    Scans all templates in team_templates/ to find the role key
-    and returns its config (skills, servers, instruction, model).
-    Used as fallback when original_config is not in the DB.
-    """
-    templates_dir = Path(__file__).parent.parent / "team_templates"
-    if not templates_dir.exists():
-        return {}
-    
-    try:
-        import yaml
-        for tmpl_file in templates_dir.glob("*.yaml"):
-            with open(tmpl_file) as f:
-                tmpl = yaml.safe_load(f) or {}
-            roles = tmpl.get("roles", {})
-            if role in roles:
-                role_cfg = roles[role]
-                return {
-                    "skills": role_cfg.get("skills", []),
-                    "servers": role_cfg.get("servers", []),
-                    "instruction": role_cfg.get("instruction", ""),
-                    "model": role_cfg.get("model", ""),
-                }
-    except Exception as e:
-        logger.debug("[AGENTS API] Failed loading template for role %s: %s", role, e)
-    return {}
+def _parse_skill_names(raw: Any) -> list[str]:
+    """Return clean skill name list from the spawn record's ``original_config``."""
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        return [s.strip() for s in raw.split(",") if s.strip()]
+    if isinstance(raw, list):
+        names: list[str] = []
+        for item in raw:
+            if isinstance(item, str) and item:
+                names.append(item)
+            elif isinstance(item, dict) and item.get("name"):
+                names.append(item["name"])
+        return names
+    return []
 
 
-def _get_spawn_server_tools(server_names: list[str]) -> dict[str, list[dict]]:
-    """Get MCP server tools for spawned agents.
-    
-    Strategy:
-    1. Scan static agents' aggregators (covers servers shared with main process)
-    2. Fall back to mcp_server_tools DB table (populated by runtime_config events)
+def _merge_skill_status(loaded_raw: list, requested_names: list[str]) -> list[dict]:
+    """Tag each skill with ``loaded`` / ``failed`` so the UI can render badges.
+
+    ``loaded_raw`` is the runtime_config payload from the child process —
+    each entry already has ``name`` / ``description`` / ``content``.
+    ``requested_names`` came from the spawn input; anything in that list
+    missing from ``loaded_raw`` is treated as a load failure.
     """
-    if not server_names:
-        return {}
-    
-    result = {}
-    remaining = set(server_names)
-    
-    # --- Layer 1: static agent aggregators ---
-    try:
-        if state.agent_app is not None:
-            for agent_name in fast.agents:
-                agent_instance = state.agent_app.get_agent(agent_name)
-                if agent_instance is None:
-                    continue
-                aggregator = getattr(agent_instance, "_aggregator", None)
-                if aggregator is None:
-                    continue
-                server_tool_map = getattr(aggregator, "_server_to_tool_map", None)
-                if not server_tool_map:
-                    continue
-                
-                for svr in list(remaining):
-                    if svr in server_tool_map:
-                        result[svr] = [
-                            {
-                                "name": nt.tool.name,
-                                "description": getattr(nt.tool, "description", "") or "",
-                            }
-                            for nt in server_tool_map[svr]
-                        ]
-                        remaining.discard(svr)
-    except Exception as e:
-        logger.debug("[AGENTS API] Aggregator scan error: %s", e)
-    
-    # --- Layer 2: mcp_server_tools DB table (single source of truth) ---
-    if remaining and state.registry_db:
-        try:
-            cached = state.registry_db.get_server_tools(list(remaining))
-            result.update(cached)
-            remaining -= set(cached.keys())
-        except Exception as e:
-            logger.debug("[AGENTS API] DB tool lookup error: %s", e)
-    
-    if remaining:
-        logger.debug("[AGENTS API] No tools found for servers: %s", remaining)
-    
+    result: list[dict] = []
+    loaded_names: set[str] = set()
+    for entry in loaded_raw:
+        if not isinstance(entry, dict):
+            continue
+        entry_name = entry.get("name") or ""
+        if not entry_name:
+            continue
+        loaded_names.add(entry_name)
+        result.append({
+            "name": entry_name,
+            "description": entry.get("description") or "",
+            "content": entry.get("content") or "",
+            "status": "loaded",
+        })
+    for name in requested_names:
+        if name in loaded_names:
+            continue
+        result.append({
+            "name": name,
+            "description": "",
+            "content": "",
+            "status": "failed",
+        })
     return result
+
+
+def _merge_spawn_tool_status(
+    rt_tools: dict, mcp_servers: dict
+) -> dict[str, dict]:
+    """Combine runtime_config.tools (per-server tool lists, attach-only) with
+    mcp_status.servers (per-server is_connected + error_message) into the
+    unified ``{server: {tools, status, error}}`` shape that the built-in agent
+    path also returns.
+    """
+    result: dict[str, dict] = {}
+    for server_name, tools_list in (rt_tools or {}).items():
+        result[server_name] = {
+            "tools": list(tools_list) if isinstance(tools_list, list) else [],
+            "status": "connected",
+            "error": "",
+        }
+    for server_name, info in (mcp_servers or {}).items():
+        if not isinstance(info, dict):
+            continue
+        is_connected = info.get("is_connected")
+        status = "connected" if is_connected else "failed"
+        error = info.get("error") or ""
+        existing = result.get(server_name)
+        if existing is None:
+            result[server_name] = {
+                "tools": [],
+                "status": status,
+                "error": str(error or ""),
+            }
+        else:
+            existing["status"] = status
+            if error:
+                existing["error"] = str(error)
+    return result
+
+
 
 
 @router.post("", dependencies=[Depends(verify_api_key)])

--- a/backend/services/spawn_progress_bridge.py
+++ b/backend/services/spawn_progress_bridge.py
@@ -793,6 +793,9 @@ class SpawnProgressBridge:
             len(runtime_config["tools"]),
         )
 
+        # Push: tell dashboard the runtime introspection is ready so AgentDetail can refetch.
+        self._broadcast_runtime_ready(agent_name, run_id, raw)
+
     def _handle_mcp_status(self, agent_name: str, data: dict, raw: dict) -> None:
         """Persist MCP health status from spawned agent.
 
@@ -832,6 +835,29 @@ class SpawnProgressBridge:
                 "[MCP_STATUS] ✅ %s: %d/%d all connected",
                 agent_name, total_connected, total_configured,
             )
+
+        # Push: tell dashboard MCP status changed so AgentDetail can refetch.
+        if run_id:
+            self._broadcast_runtime_ready(agent_name, run_id, raw)
+
+    def _broadcast_runtime_ready(self, agent_name: str, run_id: str, raw: dict) -> None:
+        """Notify dashboard subscribers that the agent's runtime introspection
+        (resolved skills / MCP attach status) has been updated, so AgentDetail
+        can refetch without polling."""
+        try:
+            from services.activity_stream import activity_stream_manager
+            import time
+
+            activity_stream_manager.broadcast({
+                "agent_name": agent_name,
+                "event_type": "runtime_config_ready",
+                "message": "",
+                "data": {"agent_name": agent_name, "run_id": run_id},
+                "run_id": run_id,
+                "timestamp": raw.get("timestamp") or time.time(),
+            })
+        except Exception as e:
+            logger.warning("Failed to broadcast runtime_config_ready: %s", e)
 
     # ── Active-meeting awareness for completion notifications ──
 

--- a/backend/tests/test_routes/test_agents.py
+++ b/backend/tests/test_routes/test_agents.py
@@ -69,7 +69,10 @@ class TestBuildAgentDict:
         assert result["instruction"] == "Do testing"
         assert result["model"] == "openai.gpt-4o"
         assert result["servers"] == ["server-a", "server-b"]
-        assert result["tools"] == {"server-a": ["tool1"]}
+        # tools now ALWAYS comes from the live aggregator (not config). With no
+        # state.agent_app in tests we expect an empty dict; see
+        # ``test_runtime_tools_*`` below for the populated paths.
+        assert result["tools"] == {}
 
     def test_builtin_type(self, mock_fast):
         """Agent NOT in _agent_card_sources → type='builtin'."""
@@ -362,3 +365,345 @@ class TestAgentTimelineJsonParsing:
 
     def test_valid_timeline_data_json_still_parses(self):
         assert timeline_safe_load_activity_data('{"tool_name": "send_email"}') == {"tool_name": "send_email"}
+
+
+# ──────────────────────────────────────────────
+# Failed-status surface — built-in agent path
+# ──────────────────────────────────────────────
+
+
+class _StubManifest:
+    """Stand-in for ``SkillManifest`` carrying only the fields the route reads."""
+    def __init__(self, name, description="", body=""):
+        self.name = name
+        self.description = description
+        self.body = body
+
+
+class _StubAggregator:
+    def __init__(self, attached, configured, server_tool_map):
+        self._attached_server_names = attached
+        self._configured_server_names = configured
+        self._server_to_tool_map = server_tool_map
+
+
+class _StubAgent:
+    def __init__(self, *, skill_manifests=None, aggregator=None, server_status=None):
+        self.skill_manifests = skill_manifests or []
+        self._aggregator = aggregator
+        self.instruction = ""
+        self._server_status = server_status or {}
+
+    async def get_server_status(self):
+        return self._server_status
+
+
+class _StubAgentApp:
+    def __init__(self, agents):
+        self._agents = agents
+
+    def get_agent(self, name):
+        return self._agents.get(name)
+
+
+class _StubNamespacedTool:
+    def __init__(self, name, description=""):
+        from types import SimpleNamespace
+        self.tool = SimpleNamespace(name=name, description=description)
+        self.server_name = ""
+        self.namespaced_tool_name = name
+
+
+class TestGetAgentSkills:
+    """``_get_agent_skills`` must tag each entry with loaded/failed status."""
+
+    def test_loaded_only(self, mock_fast):
+        loaded = [_StubManifest("alpha", "alpha desc", "alpha body")]
+        mock_fast.agents = {
+            "A": _make_agent_data(config_kwargs={
+                "skills": ["alpha"],
+                "skill_manifests": loaded,
+            })
+        }
+        stub_app = _StubAgentApp({"A": _StubAgent(skill_manifests=loaded)})
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = stub_app
+            from routes.agents import _get_agent_skills
+            result = _get_agent_skills("A")
+        assert [s["name"] for s in result] == ["alpha"]
+        assert result[0]["status"] == "loaded"
+        assert result[0]["content"] == "alpha body"
+
+    def test_requested_but_missing_marked_failed(self, mock_fast):
+        loaded = [_StubManifest("alpha", "alpha desc")]
+        mock_fast.agents = {
+            "A": _make_agent_data(config_kwargs={
+                "skills": ["alpha", "beta-missing"],
+                "skill_manifests": loaded,
+            })
+        }
+        stub_app = _StubAgentApp({"A": _StubAgent(skill_manifests=loaded)})
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = stub_app
+            from routes.agents import _get_agent_skills
+            result = _get_agent_skills("A")
+        by_name = {s["name"]: s for s in result}
+        assert by_name["alpha"]["status"] == "loaded"
+        assert by_name["beta-missing"]["status"] == "failed"
+        assert by_name["beta-missing"]["content"] == ""
+
+    def test_path_style_request_compares_by_basename(self, mock_fast):
+        """Card-based agents list skills as paths (".fast-agent/skills/X"),
+        but fast-agent resolves to a manifest whose ``name`` is the basename.
+        The diff must compare by basename so loaded skills don't get
+        false-positive 'failed' entries when both forms refer to the same
+        skill."""
+        loaded = [_StubManifest("user-context"), _StubManifest("finance")]
+        mock_fast.agents = {
+            "FA": _make_agent_data(config_kwargs={
+                # Mix path-style and bare-name; both should be recognised.
+                "skills": [
+                    ".fast-agent/skills/user-context",
+                    ".fast-agent/skills/finance",
+                    ".fast-agent/skills/missing-skill",
+                    "another-missing",
+                ],
+                "skill_manifests": loaded,
+            })
+        }
+        stub_app = _StubAgentApp({"FA": _StubAgent(skill_manifests=loaded)})
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = stub_app
+            from routes.agents import _get_agent_skills
+            result = _get_agent_skills("FA")
+        by_name = {s["name"]: s["status"] for s in result}
+        assert by_name == {
+            "user-context": "loaded",
+            "finance": "loaded",
+            "missing-skill": "failed",
+            "another-missing": "failed",
+        }
+
+    def test_falls_back_to_config_manifests_without_live_instance(self, mock_fast):
+        loaded = [_StubManifest("alpha")]
+        mock_fast.agents = {
+            "A": _make_agent_data(config_kwargs={
+                "skills": ["alpha"],
+                "skill_manifests": loaded,
+            })
+        }
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = None
+            from routes.agents import _get_agent_skills
+            result = _get_agent_skills("A")
+        assert len(result) == 1
+        assert result[0]["status"] == "loaded"
+
+
+class TestGetRuntimeTools:
+    """``_get_runtime_tools`` must surface failed MCP servers as a 'failed' entry."""
+
+    def test_connected_servers_only(self, mock_fast):
+        agg = _StubAggregator(
+            attached={"alpha"},
+            configured={"alpha"},
+            server_tool_map={"alpha": [_StubNamespacedTool("ping")]},
+        )
+        stub_app = _StubAgentApp({"A": _StubAgent(aggregator=agg)})
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = stub_app
+            from routes.agents import _get_runtime_tools
+            tools = _get_runtime_tools("A")
+        assert tools["alpha"]["status"] == "connected"
+        assert tools["alpha"]["tools"] == [{"name": "ping", "description": ""}]
+
+    def test_includes_failed_servers_with_empty_tools(self, mock_fast):
+        agg = _StubAggregator(
+            attached={"alpha"},
+            configured={"alpha", "beta"},
+            server_tool_map={"alpha": [_StubNamespacedTool("ping")]},
+        )
+        stub_app = _StubAgentApp({"A": _StubAgent(aggregator=agg)})
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = stub_app
+            from routes.agents import _get_runtime_tools
+            tools = _get_runtime_tools("A")
+        assert tools["alpha"]["status"] == "connected"
+        assert tools["beta"]["status"] == "failed"
+        assert tools["beta"]["tools"] == []
+
+
+class TestEnrichMcpErrorsAsync:
+    """``_enrich_mcp_errors_async`` should fill error messages on failed entries."""
+
+    @pytest.mark.asyncio
+    async def test_fills_error_from_server_status(self, mock_fast):
+        from types import SimpleNamespace
+        status = {"beta": SimpleNamespace(error_message="connect timeout")}
+        stub_app = _StubAgentApp({"A": _StubAgent(server_status=status)})
+        tools = {"beta": {"tools": [], "status": "failed", "error": ""}}
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = stub_app
+            from routes.agents import _enrich_mcp_errors_async
+            await _enrich_mcp_errors_async("A", tools)
+        assert tools["beta"]["error"] == "connect timeout"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_failed_entries(self, mock_fast):
+        stub_app = _StubAgentApp({"A": _StubAgent(server_status={})})
+        tools = {"alpha": {"tools": [], "status": "connected", "error": ""}}
+        with patch("routes.agents.fast", mock_fast), \
+             patch("routes.agents.state") as st:
+            st.agent_app = stub_app
+            from routes.agents import _enrich_mcp_errors_async
+            await _enrich_mcp_errors_async("A", tools)
+        assert tools["alpha"]["error"] == ""
+
+
+# ──────────────────────────────────────────────
+# Spawn detail — runtime_pending + merge helpers
+# ──────────────────────────────────────────────
+
+
+class TestSpawnAgentDetailRuntimePending:
+    """When runtime_config has not arrived yet, the detail dict must surface
+    a pending state instead of synthesising data from the team template."""
+
+    def _registry_with(self, record):
+        class _DB:
+            def find_by_name(self, name):
+                return [record]
+        return _DB()
+
+    def test_runtime_pending_true_without_runtime_config(self):
+        record = {
+            "agent_name": "Linh - PM",
+            "role": "PM",
+            "team_name": "ScrumTeam",
+            "original_config": {"skills": ["pm-skill"], "servers": ["github"]},
+            "status": "running",
+            "started_at": 1000,
+        }
+        import services.shared_state as _state
+        with patch.object(_state, "registry_db", self._registry_with(record)):
+            from routes.agents import _build_spawn_agent_detail
+            detail = _build_spawn_agent_detail("Linh - PM")
+        assert detail["runtime_pending"] is True
+        assert detail["skills"] == []
+        assert detail["tools"] == {}
+
+    def test_runtime_pending_false_when_runtime_config_present(self):
+        record = {
+            "agent_name": "Linh - PM",
+            "role": "PM",
+            "team_name": "ScrumTeam",
+            "original_config": {"skills": ["pm-skill", "missing-skill"], "servers": []},
+            "runtime_config": {
+                "resolved_instruction": "be PM",
+                "skills": [{"name": "pm-skill", "description": "pm", "content": "..."}],
+                "tools": {"github": [{"name": "search_issues"}]},
+            },
+            "mcp_status": {
+                "servers": {
+                    "github": {"is_connected": True, "error": ""},
+                    "atlassian": {"is_connected": False, "error": "missing token"},
+                },
+            },
+            "status": "idle",
+            "started_at": 1000,
+        }
+        import services.shared_state as _state
+        with patch.object(_state, "registry_db", self._registry_with(record)):
+            from routes.agents import _build_spawn_agent_detail
+            detail = _build_spawn_agent_detail("Linh - PM")
+
+        assert detail["runtime_pending"] is False
+        by_name = {s["name"]: s for s in detail["skills"]}
+        assert by_name["pm-skill"]["status"] == "loaded"
+        assert by_name["missing-skill"]["status"] == "failed"
+        assert detail["tools"]["github"]["status"] == "connected"
+        assert detail["tools"]["atlassian"]["status"] == "failed"
+        assert detail["tools"]["atlassian"]["error"] == "missing token"
+
+
+class TestMergeHelpers:
+    """Pure-function tests for the merge helpers used by the spawn path."""
+
+    def test_parse_skill_names_handles_string_and_list(self):
+        from routes.agents import _parse_skill_names
+        assert _parse_skill_names("a, b ,c") == ["a", "b", "c"]
+        assert _parse_skill_names(["a", "b"]) == ["a", "b"]
+        assert _parse_skill_names([{"name": "x"}, "y"]) == ["x", "y"]
+        assert _parse_skill_names(None) == []
+
+    def test_merge_skill_status_tags_failed(self):
+        from routes.agents import _merge_skill_status
+        loaded = [{"name": "a", "description": "d", "content": "c"}]
+        out = _merge_skill_status(loaded, ["a", "b"])
+        by_name = {s["name"]: s for s in out}
+        assert by_name["a"]["status"] == "loaded"
+        assert by_name["b"]["status"] == "failed"
+
+    def test_merge_spawn_tool_status_marks_disconnected_servers(self):
+        from routes.agents import _merge_spawn_tool_status
+        rt = {"alpha": [{"name": "ping"}]}
+        mcp = {
+            "alpha": {"is_connected": True, "error": ""},
+            "beta": {"is_connected": False, "error": "no route"},
+        }
+        out = _merge_spawn_tool_status(rt, mcp)
+        assert out["alpha"]["status"] == "connected"
+        assert out["beta"]["status"] == "failed"
+        assert out["beta"]["error"] == "no route"
+
+
+# ──────────────────────────────────────────────
+# Runtime-ready broadcast (spawn_progress_bridge)
+# ──────────────────────────────────────────────
+
+
+class TestRuntimeReadyBroadcast:
+    """``_handle_runtime_config`` must broadcast a ``runtime_config_ready``
+    event so the dashboard refetches without polling."""
+
+    def test_handle_runtime_config_broadcasts(self):
+        from services import spawn_progress_bridge as spb
+
+        broadcasted = []
+
+        class _Stream:
+            def broadcast(self, payload):
+                broadcasted.append(payload)
+
+        class _Registry:
+            def upsert_record(self, *_args, **_kwargs):
+                pass
+
+            def bulk_upsert_server_tools(self, *_args, **_kwargs):
+                return 0
+
+        bridge = spb.SpawnProgressBridge.__new__(spb.SpawnProgressBridge)
+        bridge._registry_db = _Registry()
+        bridge._request_id = None
+        bridge._pm = None
+
+        with patch.object(spb, "logger", MagicMock()), \
+             patch("services.activity_stream.activity_stream_manager", _Stream()):
+            bridge._handle_runtime_config(
+                "Linh - PM",
+                {"resolved_instruction": "x", "skills": [], "tools": {}},
+                {"run_id": "run-001"},
+            )
+
+        events = [b["event_type"] for b in broadcasted]
+        assert "runtime_config_ready" in events
+        ev = next(b for b in broadcasted if b["event_type"] == "runtime_config_ready")
+        assert ev["agent_name"] == "Linh - PM"
+        assert ev["run_id"] == "run-001"

--- a/backend/tests/test_routes/test_agents.py
+++ b/backend/tests/test_routes/test_agents.py
@@ -707,3 +707,46 @@ class TestRuntimeReadyBroadcast:
         ev = next(b for b in broadcasted if b["event_type"] == "runtime_config_ready")
         assert ev["agent_name"] == "Linh - PM"
         assert ev["run_id"] == "run-001"
+
+    def test_handle_mcp_status_broadcasts(self):
+        """``_handle_mcp_status`` mirrors ``_handle_runtime_config``: after
+        persisting MCP attach state it must publish a refresh event so the
+        dashboard picks up the new connection / error info without polling."""
+        from services import spawn_progress_bridge as spb
+
+        broadcasted = []
+
+        class _Stream:
+            def broadcast(self, payload):
+                broadcasted.append(payload)
+
+        class _Registry:
+            def upsert_record(self, *_args, **_kwargs):
+                pass
+
+        bridge = spb.SpawnProgressBridge.__new__(spb.SpawnProgressBridge)
+        bridge._registry_db = _Registry()
+        bridge._request_id = None
+        bridge._pm = None
+
+        with patch.object(spb, "logger", MagicMock()), \
+             patch("services.activity_stream.activity_stream_manager", _Stream()):
+            bridge._handle_mcp_status(
+                "Linh - PM",
+                {
+                    "total_configured": 2,
+                    "total_connected": 1,
+                    "total_failed": 1,
+                    "servers": {
+                        "alpha": {"is_connected": True},
+                        "beta": {"is_connected": False, "error": "no route"},
+                    },
+                },
+                {"run_id": "run-002"},
+            )
+
+        events = [b["event_type"] for b in broadcasted]
+        assert "runtime_config_ready" in events
+        ev = next(b for b in broadcasted if b["event_type"] == "runtime_config_ready")
+        assert ev["agent_name"] == "Linh - PM"
+        assert ev["run_id"] == "run-002"

--- a/dashboard/src/views/AgentDetail.vue
+++ b/dashboard/src/views/AgentDetail.vue
@@ -58,17 +58,29 @@ onMounted(() => {
 // runtime introspection it broadcasts `runtime_config_ready` over the global
 // activity stream. AppLayout already opens that EventSource at boot and routes
 // events through agentsStore.recentEvents, so we just listen here.
+//
+// We walk newly-prepended events from the head until the last one we already
+// processed instead of just reading events[0]. Vue coalesces same-tick array
+// mutations, so if a runtime_config_ready and an unrelated event land in the
+// same microtask, an events[0] check would miss the one that isn't last.
+let _lastSeenEvent = null
 const _stopRuntimeWatch = watch(
   () => store.recentEvents,
   (events) => {
     if (!events?.length) return
-    const ev = events[0]
-    if (
-      ev?.event_type === 'runtime_config_ready'
-      && ev?.agent_name === agentName.value
-    ) {
-      fetchAgentDetail()
+    let hit = false
+    for (let i = 0; i < events.length; i++) {
+      if (events[i] === _lastSeenEvent) break
+      const ev = events[i]
+      if (
+        ev?.event_type === 'runtime_config_ready'
+        && ev?.agent_name === agentName.value
+      ) {
+        hit = true
+      }
     }
+    _lastSeenEvent = events[0]
+    if (hit) fetchAgentDetail()
   },
   { flush: 'post' },
 )

--- a/dashboard/src/views/AgentDetail.vue
+++ b/dashboard/src/views/AgentDetail.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, reactive, computed, onMounted, watch } from 'vue'
+import { ref, reactive, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAgentsStore } from '../stores/agents'
 import { apiFetch } from '../api'
@@ -40,7 +40,7 @@ const expandedMessages = ref(new Set())
 const agentName = computed(() => route.params.name)
 const liveAgent = computed(() => store.agents.get(agentName.value))
 
-onMounted(async () => {
+async function fetchAgentDetail() {
   try {
     agentDetail.value = await apiFetch(`/api/agents/${agentName.value}`)
   } catch (e) {
@@ -48,7 +48,31 @@ onMounted(async () => {
   } finally {
     isLoading.value = false
   }
+}
+
+onMounted(() => {
+  fetchAgentDetail()
 })
+
+// Push-based refresh: when SpawnProgressBridge finishes persisting an agent's
+// runtime introspection it broadcasts `runtime_config_ready` over the global
+// activity stream. AppLayout already opens that EventSource at boot and routes
+// events through agentsStore.recentEvents, so we just listen here.
+const _stopRuntimeWatch = watch(
+  () => store.recentEvents,
+  (events) => {
+    if (!events?.length) return
+    const ev = events[0]
+    if (
+      ev?.event_type === 'runtime_config_ready'
+      && ev?.agent_name === agentName.value
+    ) {
+      fetchAgentDetail()
+    }
+  },
+  { flush: 'post' },
+)
+onUnmounted(() => _stopRuntimeWatch())
 
 const tabs = [
   { id: 'overview', label: 'Overview' },
@@ -308,6 +332,14 @@ const attachBusy = ref(false)
 const attachToast = ref('')
 
 const isAgentCardBased = computed(() => agent.value?.type === 'card')
+// "Defined in agent.py" warning ONLY applies to truly built-in agents
+// (Jarvis, PersonalAgent, etc). Team/dynamic agents are spawned at runtime
+// and their config lives in the spawn registry, not agent.py.
+const isBuiltinAgent = computed(() => agent.value?.type === 'builtin')
+const isSpawnedAgent = computed(() => {
+  const t = agent.value?.type
+  return t === 'team' || t === 'dynamic'
+})
 
 const attachableSkills = computed(() => {
   // Skills in the global library that aren't already attached to this agent.
@@ -319,7 +351,7 @@ const attachableSkills = computed(() => {
 
 async function attachSkill(skillName) {
   if (attachBusy.value) return
-  if (!isAgentCardBased.value) {
+  if (isBuiltinAgent.value) {
     const proceed = await confirm({
       title: `Attach to ${agentName.value}?`,
       message:
@@ -327,6 +359,17 @@ async function attachSkill(skillName) {
         `'${skillName}' will only apply at runtime and revert when the ` +
         `backend restarts unless you also add it to ${agentName.value}'s ` +
         `get_skills(...) call.`,
+      confirmText: 'Attach (runtime only)',
+      variant: 'warning',
+    })
+    if (!proceed) return
+  } else if (isSpawnedAgent.value) {
+    const proceed = await confirm({
+      title: `Attach to ${agentName.value}?`,
+      message:
+        `${agentName.value} is a spawned agent. Attaching '${skillName}' ` +
+        `only affects the live instance — it will be lost when the agent ` +
+        `stops. Edit the team template to persist this change across spawns.`,
       confirmText: 'Attach (runtime only)',
       variant: 'warning',
     })
@@ -353,9 +396,14 @@ async function attachSkill(skillName) {
 }
 
 async function detachSkill(skillName) {
-  const message = isAgentCardBased.value
-    ? `'${skillName}' will be removed from ${agentName.value}. The skill itself stays in the library.`
-    : `${agentName.value} is code-based. Detaching only applies at runtime; the skill will reattach on next backend restart unless you remove it from agent.py.`
+  let message
+  if (isAgentCardBased.value) {
+    message = `'${skillName}' will be removed from ${agentName.value}. The skill itself stays in the library.`
+  } else if (isSpawnedAgent.value) {
+    message = `${agentName.value} is a spawned agent. Detaching only affects the live instance; '${skillName}' will reattach on the next spawn unless you also edit the team template.`
+  } else {
+    message = `${agentName.value} is code-based. Detaching only applies at runtime; the skill will reattach on next backend restart unless you remove it from agent.py.`
+  }
   const proceed = await confirm({
     title: `Detach from ${agentName.value}?`,
     message,
@@ -387,16 +435,23 @@ onMounted(() => {
   fetchSkillsMeta()
 })
 
-// Per-server tool data for accordion display
+// Per-server tool data for accordion display.
+// Backend now returns ``{server: {tools, status, error}}`` so the UI can
+// surface MCP attach failures alongside the connected servers. We also
+// tolerate the legacy ``{server: [tool, ...]}`` shape so the component
+// keeps rendering during the deploy window.
 const serverTools = computed(() => {
   const tools = agent.value?.tools || {}
-  const servers = agent.value?.servers || []
-  return servers.map(srv => {
-    const srvTools = tools[srv] || []
+  return Object.entries(tools).map(([name, info]) => {
+    const isLegacy = Array.isArray(info)
+    const rawList = isLegacy ? info : (info?.tools || [])
+    const status = isLegacy ? 'connected' : (info?.status || 'connected')
     return {
-      name: srv,
-      connected: true,
-      tools: srvTools.map(t => {
+      name,
+      status,
+      connected: status === 'connected',
+      error: isLegacy ? '' : (info?.error || ''),
+      tools: rawList.map(t => {
         if (typeof t === 'string') return { name: t, description: '' }
         return { name: t.name, description: t.description || '' }
       }),
@@ -408,7 +463,8 @@ const serverTools = computed(() => {
 const allTools = computed(() => {
   const tools = agent.value?.tools || {}
   const result = []
-  for (const [server, toolList] of Object.entries(tools)) {
+  for (const [server, info] of Object.entries(tools)) {
+    const toolList = Array.isArray(info) ? info : (info?.tools || [])
     for (const tool of toolList) {
       const name = typeof tool === 'string' ? tool : tool.name
       result.push({ server, name })
@@ -416,6 +472,15 @@ const allTools = computed(() => {
   }
   return result
 })
+
+const runtimePending = computed(() => !!agent.value?.runtime_pending)
+
+const failedSkillCount = computed(
+  () => (agent.value?.skills || []).filter(s => s.status === 'failed').length,
+)
+const failedServerCount = computed(
+  () => serverTools.value.filter(s => !s.connected).length,
+)
 
 // Total tool count across all servers
 const totalToolCount = computed(() => allTools.value.length)
@@ -553,16 +618,36 @@ function historyBadgeLabel(type) {
           <!-- Left Column -->
           <div class="overview-col">
             <!-- Skills Panel -->
-            <div class="panel" v-if="agent.skills?.length">
+            <div class="panel" v-if="runtimePending || agent.skills?.length">
               <div class="panel-header">
-                <h3>Skills ({{ agent.skills.length }})</h3>
+                <h3>
+                  Skills ({{ agent.skills?.length || 0 }})
+                  <span v-if="failedSkillCount" class="header-failed-pill" :title="`${failedSkillCount} skill(s) failed to load`">
+                    {{ failedSkillCount }} failed
+                  </span>
+                </h3>
                 <button class="view-all-link" @click="activeTab = 'skills'">View All →</button>
               </div>
-              <div class="skill-list">
-                <div v-for="skill in agent.skills" :key="skill.name" class="skill-item">
+              <div v-if="runtimePending" class="runtime-pending-skeleton">
+                <div class="skeleton-row" />
+                <div class="skeleton-row" />
+                <div class="skeleton-row" />
+                <span class="runtime-pending-label">Waiting for agent runtime…</span>
+              </div>
+              <div v-else class="skill-list">
+                <div
+                  v-for="skill in agent.skills"
+                  :key="skill.name"
+                  class="skill-item"
+                  :class="`skill-status-${skill.status || 'loaded'}`"
+                  :title="skill.status === 'failed' ? `${skill.name} was requested but did not load` : ''"
+                >
                   <span class="skill-icon">⚡</span>
                   <div class="skill-info">
-                    <span class="skill-name">{{ skill.name }}</span>
+                    <span class="skill-name">
+                      {{ skill.name }}
+                      <span v-if="skill.status === 'failed'" class="badge badge-failed">● Failed</span>
+                    </span>
                     <span v-if="skill.description" class="skill-desc">{{ skill.description }}</span>
                   </div>
                 </div>
@@ -595,16 +680,34 @@ function historyBadgeLabel(type) {
           <!-- Right Column -->
           <div class="overview-col">
             <!-- MCP Servers Panel -->
-            <div class="panel" v-if="agent.servers?.length">
+            <div class="panel" v-if="runtimePending || serverTools.length">
               <div class="panel-header">
-                <h3>MCP Servers ({{ agent.servers.length }})</h3>
+                <h3>
+                  MCP Servers ({{ serverTools.length }})
+                  <span v-if="failedServerCount" class="header-failed-pill" :title="`${failedServerCount} server(s) failed to attach`">
+                    {{ failedServerCount }} failed
+                  </span>
+                </h3>
                 <button class="view-all-link" @click="activeTab = 'servers'">View All →</button>
               </div>
-              <div class="server-list">
-                <div v-for="srv in agent.servers" :key="srv" class="server-item">
+              <div v-if="runtimePending" class="runtime-pending-skeleton">
+                <div class="skeleton-row" />
+                <div class="skeleton-row" />
+                <div class="skeleton-row" />
+                <span class="runtime-pending-label">Waiting for agent runtime…</span>
+              </div>
+              <div v-else class="server-list">
+                <div
+                  v-for="srv in serverTools"
+                  :key="srv.name"
+                  class="server-item"
+                  :class="`server-status-${srv.status}`"
+                  :title="srv.error || ''"
+                >
                   <div class="server-icon">🔌</div>
-                  <span class="server-name">{{ srv }}</span>
-                  <span class="badge badge-connected">● Connected</span>
+                  <span class="server-name">{{ srv.name }}</span>
+                  <span v-if="srv.connected" class="badge badge-connected">● Connected</span>
+                  <span v-else class="badge badge-failed">● Failed</span>
                 </div>
               </div>
             </div>
@@ -616,7 +719,9 @@ function historyBadgeLabel(type) {
                 <button class="view-all-link" @click="activeTab = 'instruction'">Expand →</button>
               </div>
               <div class="instruction-preview">
-                <MarkdownRenderer :content="instructionPreview" content-type="markdown" />
+                <!-- See INSTRUCTION TAB note: render as text so XML tags
+                     used by fast-agent's skill injection stay visible. -->
+                <MarkdownRenderer :content="instructionPreview" content-type="text" />
               </div>
               <div v-if="hasMoreInstruction" class="instruction-more">
                 … {{ instructionLineCount - 12 }} more lines
@@ -628,11 +733,17 @@ function historyBadgeLabel(type) {
 
       <!-- ===== SKILLS TAB ===== -->
       <div v-else-if="activeTab === 'skills'" class="animate-fade-in">
-        <div v-if="!isAgentCardBased" class="code-agent-banner">
+        <div v-if="isBuiltinAgent" class="code-agent-banner">
           <strong>This agent is defined in code (agent.py).</strong>
           Attach/detach changes apply at runtime — they revert on backend
           restart unless you also edit
           <code>get_skills(...)</code> in agent.py.
+        </div>
+        <div v-else-if="isSpawnedAgent" class="code-agent-banner">
+          <strong>This is a spawned agent.</strong>
+          Skill changes here only affect the live instance — when the agent
+          stops or the team is torn down, all attachments are lost. Edit the
+          team template to make changes persistent across spawns.
         </div>
         <p v-if="attachToast" class="attach-toast">{{ attachToast }}</p>
         <div class="skills-tab-toolbar">
@@ -673,12 +784,21 @@ function historyBadgeLabel(type) {
             </button>
           </div>
         </div>
-        <div v-if="agent.skills?.length" class="accordion-list">
+        <div v-if="runtimePending" class="runtime-pending-skeleton runtime-pending-skeleton-large">
+          <div class="skeleton-row" />
+          <div class="skeleton-row" />
+          <div class="skeleton-row" />
+          <span class="runtime-pending-label">Waiting for agent runtime to report which skills it actually loaded…</span>
+        </div>
+        <div v-else-if="agent.skills?.length" class="accordion-list">
           <div
             v-for="skill in agent.skills"
             :key="skill.name"
             class="accordion-card skill-accordion-card"
-            :class="{ 'accordion-expanded': expandedSkills[skill.name] }"
+            :class="[
+              { 'accordion-expanded': expandedSkills[skill.name] },
+              `skill-status-${skill.status || 'loaded'}`,
+            ]"
           >
             <!-- Skill Header -->
             <div class="accordion-header skill-accordion-header">
@@ -696,6 +816,11 @@ function historyBadgeLabel(type) {
                       class="skill-builtin-badge"
                       title="Ships with Jarvis. Editable, but cannot be deleted."
                     >Built-in</span>
+                    <span
+                      v-if="skill.status === 'failed'"
+                      class="badge badge-failed"
+                      title="The agent requested this skill but it failed to load (missing file, parse error, or wrong skills dir). It is NOT injected into the agent's prompt."
+                    >● Failed</span>
                   </span>
                   <span v-if="skill.description" class="skill-header-preview">
                     {{ skill.description }}
@@ -771,12 +896,21 @@ function historyBadgeLabel(type) {
 
       <!-- ===== MCP SERVERS TAB ===== -->
       <div v-else-if="activeTab === 'servers'" class="animate-fade-in">
-        <div v-if="serverTools.length" class="accordion-list">
+        <div v-if="runtimePending" class="runtime-pending-skeleton runtime-pending-skeleton-large">
+          <div class="skeleton-row" />
+          <div class="skeleton-row" />
+          <div class="skeleton-row" />
+          <span class="runtime-pending-label">Waiting for agent runtime to report which MCP servers actually attached…</span>
+        </div>
+        <div v-else-if="serverTools.length" class="accordion-list">
           <div
             v-for="srv in serverTools"
             :key="srv.name"
             class="accordion-card"
-            :class="{ 'accordion-expanded': expandedServers[srv.name] }"
+            :class="[
+              { 'accordion-expanded': expandedServers[srv.name] },
+              `server-status-${srv.status}`,
+            ]"
           >
             <!-- Accordion Header -->
             <button class="accordion-header" @click="toggleServer(srv.name)">
@@ -784,19 +918,30 @@ function historyBadgeLabel(type) {
                 <span class="accordion-icon">🔌</span>
                 <span class="accordion-title">{{ srv.name }}</span>
                 <span class="badge badge-connected" v-if="srv.connected">● Connected</span>
-                <span class="badge badge-disconnected" v-else>● Disconnected</span>
+                <span
+                  class="badge badge-failed"
+                  v-else
+                  :title="srv.error || 'MCP server failed to attach. The agent does NOT see these tools.'"
+                >● Failed</span>
               </div>
               <div class="accordion-header-right">
                 <span class="accordion-tool-count" v-if="srv.tools.length">
                   {{ srv.tools.length }} tool{{ srv.tools.length !== 1 ? 's' : '' }}
                 </span>
-                <span class="accordion-tool-count muted" v-else>Tools not available</span>
+                <span class="accordion-tool-count muted" v-else-if="srv.connected">Tools not available</span>
+                <span class="accordion-tool-count muted" v-else>0 tools</span>
                 <span class="accordion-chevron" :class="{ 'chevron-open': expandedServers[srv.name] }">›</span>
               </div>
             </button>
 
             <!-- Accordion Body -->
-            <div v-if="expandedServers[srv.name] && srv.tools.length" class="accordion-body">
+            <div v-if="expandedServers[srv.name]" class="accordion-body">
+              <div v-if="!srv.connected && srv.error" class="server-error-banner">
+                <strong>Attach error:</strong> {{ srv.error }}
+              </div>
+              <div v-else-if="!srv.connected" class="server-error-banner muted">
+                MCP server is not attached. No error message reported.
+              </div>
               <div
                 v-for="tool in srv.tools"
                 :key="tool.name"
@@ -817,16 +962,21 @@ function historyBadgeLabel(type) {
             </div>
           </div>
         </div>
-        <div v-else class="empty-state">No MCP servers connected</div>
+        <div v-else class="empty-state">No MCP servers configured</div>
       </div>
 
       <!-- ===== INSTRUCTION TAB ===== -->
       <div v-else-if="activeTab === 'instruction'" class="animate-fade-in">
         <div class="panel">
           <div class="instruction-full">
+            <!-- Render as text: fast-agent injects literal XML-like tags
+                 (<available_skills>, <skill>, <scripts>, <references>, ...)
+                 into the prompt. Markdown sanitization strips unknown HTML
+                 tags so those would silently disappear, misleading the user
+                 about what the LLM actually sees. -->
             <MarkdownRenderer
               :content="agent.instruction || 'No instruction configured'"
-              :content-type="agent.instruction ? 'markdown' : 'text'"
+              content-type="text"
             />
           </div>
         </div>
@@ -1067,6 +1217,84 @@ function historyBadgeLabel(type) {
   font-size: 11px;
   color: #ef4444;
   margin-left: auto;
+}
+.badge-failed {
+  font-size: 11px;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  margin-left: auto;
+}
+.header-failed-pill {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  padding: 1px 8px;
+  border-radius: 10px;
+  vertical-align: middle;
+}
+.skill-status-failed .skill-name,
+.skill-status-failed .accordion-title {
+  color: #f87171;
+}
+.skill-status-failed .skill-icon,
+.skill-status-failed .skill-accordion-icon {
+  opacity: 0.55;
+}
+.server-status-failed .server-name,
+.server-status-failed .accordion-title {
+  color: #f87171;
+}
+.server-status-failed .server-icon,
+.server-status-failed .accordion-icon {
+  opacity: 0.55;
+}
+.server-error-banner {
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  color: #fca5a5;
+  font-size: 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin: 8px 0;
+}
+.server-error-banner.muted {
+  background: rgba(239, 68, 68, 0.04);
+  color: #9ca3af;
+}
+.runtime-pending-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+}
+.runtime-pending-skeleton-large {
+  padding: 24px 0;
+}
+.skeleton-row {
+  height: 14px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 0%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.04) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s linear infinite;
+}
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.runtime-pending-label {
+  font-size: 12px;
+  color: var(--color-text-muted, #8b8fa3);
+  margin-top: 6px;
 }
 
 /* ── Buttons ── */

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -10,17 +10,17 @@ export default defineConfig({
   ],
 
   server: {
-    port: 3000,
+    port: Number(process.env.VITE_PORT || 3000),
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: process.env.VITE_PROXY_TARGET || 'http://localhost:8000',
         changeOrigin: true,
       },
       // /ws/voice + any future WebSocket route. ws:true is required for the
       // upgrade handshake; without it the dev frontend can't open a socket
       // and the VoiceBar mic toggle just spins on "Connecting…".
       '/ws': {
-        target: 'ws://localhost:8000',
+        target: (process.env.VITE_PROXY_TARGET || 'http://localhost:8000').replace(/^http/, 'ws'),
         ws: true,
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary

- Agent details UI was reading from **static config** and always rendering "Connected" — masking the MCP attach failures and missing-skill resolution errors that fast-agent silently swallows. Users were reassured about tools their agents could not actually call.
- This PR makes the panel **faithfully reflect what the live agent runtime sees**: failed MCP servers show a red badge with the attach error in a tooltip; requested-but-unresolved skills show as failed; spawned agents show a pending skeleton instead of fabricating template data while the live introspection is in flight.
- Push-based refresh: `SpawnProgressBridge` broadcasts a new `runtime_config_ready` event over the existing activity stream — **no polling** added.

## Why

The dashboard claimed agents had tools they couldn't use. Across 8 agents in my local backend that's:
- 4–5 "skills" listed but unresolved on Finance/Research/CrawlStories cards (50% silent miss)
- MCP servers shown green when their stdio subprocess never started

The user's review intuition matched: ["nó chỉ show ra cho user yên tâm thôi, chứ thực tế chưa chắc nó đã thấy"](../jarvis-2-workspace).

## What changed

**Backend (`backend/routes/agents.py`):**
- `_get_agent_skills` diffs raw `config.skills` (requested) vs the live agent's `skill_manifests` (loaded). Path-style refs (`".fast-agent/skills/X"`) compared by basename so card-based agents don't get false-positive failed rows.
- `_get_runtime_tools` returns `{server: {tools, status, error}}` including `_configured - _attached` as failed entries.
- `_enrich_mcp_errors_async` (new) populates `error` via `agent.get_server_status()` on the detail endpoint only — keeps the list endpoint cheap.
- `_build_spawn_agent_detail`: drops the team-template fallback for `skills`/`tools`; returns `runtime_pending=true` until the child process emits its `runtime_config` event.
- Helper pure functions: `_parse_skill_names`, `_merge_skill_status`, `_merge_spawn_tool_status`.
- Removed orphans: `_load_role_config_from_template`, `_get_spawn_server_tools` (no callers after fallback path was deleted).

**Backend (`backend/services/spawn_progress_bridge.py`):**
- `_broadcast_runtime_ready` helper. Called from `_handle_runtime_config` and `_handle_mcp_status` after the DB upsert, so connected dashboards refetch push-based.

**Frontend (`dashboard/src/views/AgentDetail.vue`):**
- `serverTools` / `allTools` adapted to the new shape (with legacy `Array` fallback during the deploy window).
- Red badges on failed skills/servers, count chip in panel headers, error banner in the server accordion body.
- Pulse-shimmer skeleton when `runtime_pending`.
- Watches `store.recentEvents` for `runtime_config_ready` matching the current agent → refetch. No polling.
- Instruction tab switched to `content-type="text"` — markdown sanitiser was stripping fast-agent's literal `<available_skills>`, `<skill>`, `<scripts>` template tags, lying about what the LLM actually sees.
- Banner "Defined in agent.py" now keys on `type==='builtin'` (was `!card`); spawned `team`/`dynamic` agents get an accurate "ephemeral, edit team template to persist" message.

**Dev convenience (`dashboard/vite.config.js`):**
- `VITE_PORT` / `VITE_PROXY_TARGET` env overrides (defaults unchanged). Lets a second workspace run side-by-side without editing the file.

## Tests

- `tests/test_routes/test_agents.py`: 16 new tests, 38 total pass. Covers loaded-vs-failed surface, path-style skill normalization, async error enrichment, `runtime_pending=true` when runtime_config absent, merge helpers, and `runtime_config_ready` broadcast.
- All 308 route tests pass.

## Test plan

- [ ] Open Agent Details for a built-in agent → MCP Servers tab shows real attach state; expand a failed server → see attach error.
- [ ] Open Agent Details for a card-based agent (FinanceAgent / ResearchAgent) → no false-positive failed skills despite path-style refs in YAML.
- [ ] Spawn a team agent → before runtime_config event arrives, panels show pulse skeleton; once child emits, panels populate without manual refresh.
- [ ] Open Instruction tab for any agent that uses skills → fast-agent's `<available_skills>` block renders literally instead of being stripped.
- [ ] Open spawned agent's Skills tab → banner says "spawned agent, ephemeral" (not "defined in code (agent.py)").

🤖 Generated with [Claude Code](https://claude.com/claude-code)