### PR TITLE
feat(voice): Soniox realtime STT + TTS + chat dictation mic

### DIFF
--- a/backend/routes/voice.py
+++ b/backend/routes/voice.py
@@ -173,14 +173,24 @@ async def list_secrets_status(_=Depends(verify_api_key)):
 
     UI uses this to render "Set" / "Not set" badges on each engine card so
     the user knows whether they can pick a paid engine without entering keys
-    again.
+    again. Iterates both TTS and STT registries so cloud STT backends
+    (Soniox, etc.) can surface their own API-key slot from the STT card —
+    a user who only picks the cloud STT shouldn't have to first pick the
+    matching TTS engine just to enter the key.
     """
     cs = _config_service()
     out: dict[str, dict[str, bool]] = {}
-    for engine, spec in registry.list_tts_engines().items():
+    seen: set[str] = set()
+    for engine, spec in (
+        list(registry.list_tts_engines().items())
+        + list(registry.list_stt_backends().items())
+    ):
+        if engine in seen:
+            continue
         slots = spec.get("secrets", []) or []
         if not slots:
             continue
+        seen.add(engine)
         out[engine] = {
             slot: bool(cs.get("voice", f"secrets.{engine}.{slot}"))
             for slot in slots
@@ -203,7 +213,7 @@ async def delete_secret(engine: str, slot: str, _=Depends(verify_api_key)):
     """Clear a previously-set secret — frees the user from manual SQL surgery
     when rotating away from a paid engine.
     """
-    spec = registry.get_tts_engine(engine)
+    spec = registry.get_tts_engine(engine) or registry.get_stt_backend(engine)
     if not spec or slot not in spec.get("secrets", []):
         raise HTTPException(400, f"Engine {engine!r} has no declared secret {slot!r}")
     cs = _config_service()
@@ -213,7 +223,7 @@ async def delete_secret(engine: str, slot: str, _=Depends(verify_api_key)):
 
 @router.get("/requirements/{engine}")
 async def check_requirements(engine: str, _=Depends(verify_api_key)):
-    spec = registry.get_tts_engine(engine)
+    spec = registry.get_tts_engine(engine) or registry.get_stt_backend(engine)
     if not spec:
         raise HTTPException(404, f"Unknown engine {engine!r}")
     cs = _config_service()

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -284,6 +284,14 @@ async def voice_ws(ws: WebSocket) -> None:
     tts_task: Optional[asyncio.Task] = None
     user_query_pending = False  # set when STT finalises text but agent task hasn't started yet
     bot_speaking = False        # True from tts_start to tts_end / interruption
+    # Dictation mode: client picked the bottom mic in ChatInput (press-to-talk
+    # transcription) instead of the top hands-free button. In this mode the
+    # STT pipeline runs as usual but ``final_transcript`` does NOT trigger
+    # the LLM agent turn — the client is using transcripts to populate a
+    # text input the user will edit + submit manually. The flag is flipped
+    # by ``{"type":"start","mode":"dictation"}`` and never resets within a
+    # session (one socket = one role).
+    dictation_mode = False
     # AEC diagnostic — when bot is speaking, we copy incoming mic PCM into
     # this buffer + track RMS so we can prove whether echoCancellation is
     # actually scrubbing the loudspeaker bleed. Dumped to a WAV at tts_end.
@@ -346,7 +354,14 @@ async def voice_ws(ws: WebSocket) -> None:
         # Mark a user turn as ready to dispatch on the asyncio side. The
         # actual scheduling happens in the main receive loop so we stay on
         # the event-loop thread for create_task.
-        if name == "final_transcript":
+        #
+        # Dictation mode short-circuits here: the client wants the raw
+        # transcript (already emitted via the standard ``final_transcript``
+        # event a few lines up) so it can put it in a text box for the user
+        # to edit. Skipping ``_dispatch_user_turn`` keeps the LLM + TTS
+        # pipeline cold, which is the whole point — no wasted tokens, no
+        # bot voice talking back.
+        if name == "final_transcript" and not dictation_mode:
             text = (payload or {}).get("text") or ""
             if text.strip():
                 user_query_pending = True
@@ -755,7 +770,14 @@ async def voice_ws(ws: WebSocket) -> None:
                     logger.info("[ws_voice diag] frontend report: %s", payload)
                 elif kind == "stop":
                     return
-                # "start" is a noop — accepting the socket already starts
+                elif kind == "start":
+                    # Accepting the socket already starts the STT pipeline; the
+                    # client sends ``start`` mostly as a handshake-ack. The
+                    # one piece of payload we honour is ``mode: "dictation"``
+                    # which gates LLM/TTS dispatch on ``final_transcript``.
+                    if payload.get("mode") == "dictation":
+                        dictation_mode = True
+                        logger.info("[ws_voice] dictation mode enabled for this session")
     except WebSocketDisconnect:
         pass
     finally:

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -353,15 +353,11 @@ async def voice_ws(ws: WebSocket) -> None:
 
         # Mark a user turn as ready to dispatch on the asyncio side. The
         # actual scheduling happens in the main receive loop so we stay on
-        # the event-loop thread for create_task.
-        #
-        # Dictation mode short-circuits here: the client wants the raw
-        # transcript (already emitted via the standard ``final_transcript``
-        # event a few lines up) so it can put it in a text box for the user
-        # to edit. Skipping ``_dispatch_user_turn`` keeps the LLM + TTS
-        # pipeline cold, which is the whole point — no wasted tokens, no
-        # bot voice talking back.
-        if name == "final_transcript" and not dictation_mode:
+        # the event-loop thread for create_task. The dictation gate lives
+        # inside ``_dispatch_user_turn`` (single-threaded — asyncio loop
+        # only) so the worker thread never reads the flag concurrently
+        # with the receive loop's writes.
+        if name == "final_transcript":
             text = (payload or {}).get("text") or ""
             if text.strip():
                 user_query_pending = True
@@ -371,6 +367,16 @@ async def voice_ws(ws: WebSocket) -> None:
         """Fire-and-forget: schedule a coroutine that handles one full turn."""
         nonlocal agent_task, user_query_pending
         user_query_pending = False
+        # Dictation gate. ``dictation_mode`` is set by the receive loop
+        # (also asyncio thread) when the client sends
+        # ``{type:'start', mode:'dictation'}``. Checking here keeps both
+        # the read and the write on the event-loop thread, which is the
+        # only way to make the gate race-free without a lock — the client
+        # wants the raw transcript (already emitted upstream) so it can
+        # populate a text box; skipping the LLM/TTS pipeline below is the
+        # whole point of the flag.
+        if dictation_mode:
+            return
         # Cancel any previous in-flight agent/tts so a barge-in mid-turn
         # cleanly resets to the new user input.
         if (agent_task is not None and not agent_task.done()) or (

--- a/backend/services/stt_backends/_ws_streaming.py
+++ b/backend/services/stt_backends/_ws_streaming.py
@@ -1,0 +1,213 @@
+"""Base class for cloud STT backends that stream PCM over a WebSocket.
+
+The scaffolding here is provider-agnostic: thread + asyncio loop hand-off,
+audio queue, hook fan-out, reconnect with exponential backoff, shutdown
+plumbing. Each cloud provider (Soniox, Deepgram, AssemblyAI, ...)
+subclasses :class:`WSStreamingSTT` and supplies three small bits:
+
+* ``WS_URL`` — endpoint to connect to
+* ``_build_config_message()`` — JSON config sent immediately after connect
+* ``_handle_event(data)`` — parse one inbound message and emit events
+  (``self._emit_partial``, ``self._emit_final``, ``self._emit_endpoint``)
+
+Why a base class instead of free helper functions: the per-instance state
+(hook ref, audio queue, asyncio loop) is the awkward part to share, and a
+base class keeps the public surface (``feed_audio`` / ``set_hook`` /
+``start_listen_loop`` / ``shutdown``) identical across providers — the
+voice WS route never has to special-case which cloud STT produced the
+service.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from typing import Any, Callable, ClassVar, Optional
+
+logger = logging.getLogger(__name__)
+
+
+EventHook = Callable[[str, dict[str, Any]], None]
+
+
+class WSStreamingSTT:
+    """Common scaffolding for WebSocket-based cloud STT providers."""
+
+    #: Override in subclass — ``wss://...`` endpoint URL.
+    WS_URL: ClassVar[str] = ""
+
+    #: Override in subclass — logging tag, e.g. ``"Soniox STT"``.
+    LOG_TAG: ClassVar[str] = "WS STT"
+
+    def __init__(self, *, sample_rate: int = 16000) -> None:
+        if not self.WS_URL:
+            raise NotImplementedError(f"{type(self).__name__} must set WS_URL")
+        self._sample_rate = int(sample_rate)
+
+        self._hook: Optional[EventHook] = None
+        self._lock = threading.Lock()
+        self._closed = False
+
+        self._audio_queue: Optional[asyncio.Queue[bytes]] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+
+    # ---- public RealtimeSTTService-compatible surface ---------------------
+
+    def set_hook(self, hook: Optional[EventHook]) -> None:
+        with self._lock:
+            self._hook = hook
+
+    def feed_audio(self, pcm_chunk: bytes) -> None:
+        if self._closed or self._loop is None or self._audio_queue is None:
+            return
+        try:
+            self._loop.call_soon_threadsafe(self._audio_queue.put_nowait, pcm_chunk)
+        except RuntimeError:
+            return
+
+    def start_listen_loop(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        t = threading.Thread(
+            target=self._thread_runner,
+            name=f"{type(self).__name__}-loop",
+            daemon=True,
+        )
+        self._thread = t
+        t.start()
+
+    def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._loop is not None and self._audio_queue is not None:
+            try:
+                self._loop.call_soon_threadsafe(self._audio_queue.put_nowait, b"")
+            except RuntimeError:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+    # ---- subclass extension points ---------------------------------------
+
+    def _build_config_message(self) -> dict[str, Any]:
+        """Return the JSON object sent immediately after connecting."""
+        raise NotImplementedError
+
+    def _handle_event(self, data: dict[str, Any]) -> None:
+        """Parse one inbound JSON message and emit events as appropriate."""
+        raise NotImplementedError
+
+    def _on_connected(self) -> None:
+        """Hook for subclasses to reset per-session accumulators on
+        (re)connect. Called once after the config message is sent.
+        """
+
+    # ---- emit helpers (subclass convenience) -----------------------------
+
+    def _emit(self, event: str, payload: dict[str, Any]) -> None:
+        with self._lock:
+            hook = self._hook
+        if hook is None:
+            return
+        try:
+            hook(event, payload)
+        except Exception:
+            logger.exception("[%s] hook raised on %s", self.LOG_TAG, event)
+
+    def _emit_partial(self, text: str) -> None:
+        if text and text.strip():
+            self._emit("partial_transcript", {"text": text})
+
+    def _emit_final(self, text: str) -> None:
+        if text and text.strip():
+            self._emit("final_transcript", {"text": text})
+
+    def _emit_endpoint(self) -> None:
+        """Signal end-of-utterance — mirrors RealtimeSTT's ``recording_stop``
+        followed immediately by ``recording_start`` so downstream consumers
+        (voice WS route) reset their per-turn state.
+        """
+        self._emit("vad_stop", {})
+        self._emit("recording_stop", {})
+        self._emit("recording_start", {})
+
+    # ---- internals -------------------------------------------------------
+
+    def _thread_runner(self) -> None:
+        try:
+            asyncio.run(self._run_ws())
+        except Exception:
+            logger.exception("[%s] WS thread exited with error", self.LOG_TAG)
+
+    async def _run_ws(self) -> None:
+        try:
+            import websockets
+        except ImportError as exc:  # pragma: no cover — present via uv.lock
+            logger.error("[%s] websockets package not available: %s", self.LOG_TAG, exc)
+            self._emit("error", {"detail": "websockets package not installed"})
+            return
+
+        self._loop = asyncio.get_running_loop()
+        self._audio_queue = asyncio.Queue()
+
+        backoff = 1.0
+        while not self._closed:
+            try:
+                async with websockets.connect(
+                    self.WS_URL,
+                    max_size=None,
+                    ping_interval=20,
+                    ping_timeout=20,
+                ) as ws:
+                    await ws.send(json.dumps(self._build_config_message()))
+                    self._on_connected()
+                    self._emit("recording_start", {})
+                    backoff = 1.0
+                    await asyncio.gather(self._sender(ws), self._receiver(ws))
+                    return
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if self._closed:
+                    return
+                logger.exception(
+                    "[%s] WS loop crashed; reconnecting in %.1fs",
+                    self.LOG_TAG, backoff,
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 10.0)
+
+    async def _sender(self, ws) -> None:
+        assert self._audio_queue is not None
+        while True:
+            chunk = await self._audio_queue.get()
+            if self._closed or chunk == b"":
+                # Most cloud STT providers accept an empty string to signal
+                # end-of-audio; subclasses can override _send_end_of_audio
+                # if their protocol differs.
+                try:
+                    await self._send_end_of_audio(ws)
+                except Exception:
+                    pass
+                return
+            try:
+                await ws.send(chunk)
+            except Exception:
+                return
+
+    async def _send_end_of_audio(self, ws) -> None:
+        await ws.send("")
+
+    async def _receiver(self, ws) -> None:
+        async for msg in ws:
+            if isinstance(msg, (bytes, bytearray)):
+                continue
+            try:
+                data = json.loads(msg)
+            except json.JSONDecodeError:
+                logger.debug("[%s] non-JSON message ignored", self.LOG_TAG)
+                continue
+            self._handle_event(data)

--- a/backend/services/stt_backends/soniox.py
+++ b/backend/services/stt_backends/soniox.py
@@ -1,0 +1,148 @@
+"""Soniox real-time STT backend.
+
+Streams 16 kHz int16 PCM (fed via ``feed_audio``) to
+``wss://stt-rt.soniox.com/transcribe-websocket`` and forwards transcripts
+through the same hook surface as :class:`services.stt_realtime.RealtimeSTTService`.
+
+The thread/queue/reconnect/hook scaffolding lives in
+:mod:`services.stt_backends._ws_streaming`. This module only encodes the
+Soniox-specific protocol bits (config-message shape, ``<end>`` endpoint
+token, error format) so adding the next cloud STT (Deepgram, AssemblyAI,
+Google) is a sibling file with the same shape.
+
+Endpoint detection: with ``enable_endpoint_detection=true`` Soniox emits a
+special ``{"text": "<end>", "is_final": true}`` token whenever the model
+decides the speaker stopped. We flush the accumulated finalized tokens as
+the next ``final_transcript`` and reset.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from services.stt_backends._ws_streaming import WSStreamingSTT
+
+logger = logging.getLogger(__name__)
+
+SONIOX_STT_WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket"
+ENDPOINT_TOKEN_TEXT = "<end>"
+
+
+class SonioxSTTService(WSStreamingSTT):
+    """Soniox-flavoured cloud STT over the shared WS streaming base."""
+
+    WS_URL: ClassVar[str] = SONIOX_STT_WS_URL
+    LOG_TAG: ClassVar[str] = "Soniox STT"
+
+    def __init__(self, *, api_key: str, params: dict[str, Any]) -> None:
+        if not api_key:
+            raise ValueError("Soniox STT requires an API key")
+        super().__init__(sample_rate=int(params.get("sample_rate") or 16000))
+
+        self._api_key = api_key
+        self._model = params.get("model") or "stt-rt-v4"
+        self._language_hints = _parse_language_hints(params.get("language_hints"))
+        self._enable_language_id = bool(params.get("enable_language_identification"))
+        self._enable_diarization = bool(params.get("enable_speaker_diarization"))
+
+        # Per-utterance buffer of finalized tokens. Reset on every endpoint.
+        self._final_buffer: list[str] = []
+        self._provisional_tail: str = ""
+
+    # ---- WSStreamingSTT extension points ---------------------------------
+
+    def _build_config_message(self) -> dict[str, Any]:
+        cfg: dict[str, Any] = {
+            "api_key": self._api_key,
+            "model": self._model,
+            "audio_format": "pcm_s16le",
+            "sample_rate": self._sample_rate,
+            "num_channels": 1,
+            "enable_endpoint_detection": True,
+        }
+        if self._language_hints:
+            cfg["language_hints"] = self._language_hints
+        if self._enable_language_id:
+            cfg["enable_language_identification"] = True
+        if self._enable_diarization:
+            cfg["enable_speaker_diarization"] = True
+        return cfg
+
+    def _on_connected(self) -> None:
+        # Clean slate on (re)connect so leftovers from a dropped session
+        # don't bleed into the new transcript.
+        self._final_buffer.clear()
+        self._provisional_tail = ""
+
+    def _handle_event(self, data: dict[str, Any]) -> None:
+        err_code = data.get("error_code")
+        if err_code:
+            logger.error("[Soniox STT] error %s: %s", err_code, data.get("error_message"))
+            self._emit("error", {
+                "detail": data.get("error_message") or f"soniox error {err_code}",
+            })
+            return
+
+        for tk in data.get("tokens") or []:
+            self._handle_token(tk)
+
+        if data.get("finished"):
+            # ``async for msg in ws`` will exit on its own once the server
+            # closes the socket; no explicit return-from-receiver needed.
+            return
+
+    def _handle_token(self, tk: dict[str, Any]) -> None:
+        text = tk.get("text") or ""
+        is_final = bool(tk.get("is_final"))
+
+        if text == ENDPOINT_TOKEN_TEXT:
+            final = "".join(self._final_buffer).strip()
+            self._final_buffer.clear()
+            self._provisional_tail = ""
+            self._emit_final(final)
+            self._emit_endpoint()
+            return
+
+        if is_final:
+            self._final_buffer.append(text)
+            self._provisional_tail = ""
+        else:
+            # Soniox emits provisional tokens that may be revised; track only
+            # the latest non-final text so the running partial doesn't snowball.
+            self._provisional_tail = text
+
+        snapshot = "".join(self._final_buffer) + self._provisional_tail
+        self._emit_partial(snapshot)
+
+
+def _parse_language_hints(raw: Any) -> list[str]:
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        return [s.strip() for s in raw.split(",") if s.strip()]
+    if isinstance(raw, (list, tuple)):
+        return [str(s).strip() for s in raw if str(s).strip()]
+    return []
+
+
+def build(config: dict[str, Any]) -> SonioxSTTService:
+    """Factory used by :mod:`services.stt_realtime._BACKEND_FACTORIES`.
+
+    The API key is loaded from the same encrypted ``voice.secrets.soniox.api_key``
+    slot that the TTS engine uses — Soniox issues one key per account that
+    works against both STT and TTS endpoints, so duplicating slots would
+    only invite drift.
+    """
+    from services.config_service import config_service as _cs
+
+    api_key = _cs.get("voice", "secrets.soniox.api_key")
+    if not api_key:
+        raise RuntimeError(
+            "Soniox STT selected but no API key configured. "
+            "Set it under Settings → Voice → Soniox."
+        )
+
+    params = dict(config.get("params") or {})
+    svc = SonioxSTTService(api_key=api_key, params=params)
+    svc.start_listen_loop()
+    return svc

--- a/backend/services/stt_backends/soniox.py
+++ b/backend/services/stt_backends/soniox.py
@@ -83,8 +83,22 @@ class SonioxSTTService(WSStreamingSTT):
             })
             return
 
+        # Soniox packs *all* current non-final tokens into every frame —
+        # the next frame fully replaces the previous provisional sequence
+        # rather than appending to it. Reset the provisional accumulator
+        # before iterating so a multi-token frame like
+        # ``[{"text":"hello ","is_final":False}, {"text":"world","is_final":False}]``
+        # ends up as ``"hello world"`` instead of just the last token.
+        # Finals stay sticky in ``_final_buffer`` until the next ``<end>``.
+        self._provisional_tail = ""
         for tk in data.get("tokens") or []:
             self._handle_token(tk)
+        # One partial-emit per frame, AFTER consuming every token, so the
+        # snapshot reflects the full provisional sequence rather than
+        # firing mid-loop with a stale tail.
+        snapshot = "".join(self._final_buffer) + self._provisional_tail
+        if snapshot.strip():
+            self._emit_partial(snapshot)
 
         if data.get("finished"):
             # ``async for msg in ws`` will exit on its own once the server
@@ -105,14 +119,11 @@ class SonioxSTTService(WSStreamingSTT):
 
         if is_final:
             self._final_buffer.append(text)
-            self._provisional_tail = ""
         else:
-            # Soniox emits provisional tokens that may be revised; track only
-            # the latest non-final text so the running partial doesn't snowball.
-            self._provisional_tail = text
-
-        snapshot = "".join(self._final_buffer) + self._provisional_tail
-        self._emit_partial(snapshot)
+            # Provisional accumulator — frame-scoped (cleared in
+            # ``_handle_event`` before the loop). Concatenate so a frame
+            # carrying multiple provisional tokens lands in order.
+            self._provisional_tail += text
 
 
 def _parse_language_hints(raw: Any) -> list[str]:
@@ -131,11 +142,13 @@ def build(config: dict[str, Any]) -> SonioxSTTService:
     The API key is loaded from the same encrypted ``voice.secrets.soniox.api_key``
     slot that the TTS engine uses — Soniox issues one key per account that
     works against both STT and TTS endpoints, so duplicating slots would
-    only invite drift.
+    only invite drift. Both halves go through ``get_engine_secrets`` so
+    decryption / hot-reload / future caching tweaks land on one read path.
     """
     from services.config_service import config_service as _cs
+    from services.voice_config import get_engine_secrets
 
-    api_key = _cs.get("voice", "secrets.soniox.api_key")
+    api_key = get_engine_secrets(_cs, "soniox").get("api_key")
     if not api_key:
         raise RuntimeError(
             "Soniox STT selected but no API key configured. "

--- a/backend/services/stt_realtime.py
+++ b/backend/services/stt_realtime.py
@@ -217,6 +217,7 @@ def _patch_torch_hub_trust() -> None:
 _BACKEND_FACTORIES: dict[str, str] = {
     "faster_whisper": "services.stt_backends.faster_whisper:build",
     "gipformer_vi":   "services.stt_backends.gipformer_vi:build",
+    "soniox":         "services.stt_backends.soniox:build",
 }
 
 

--- a/backend/services/tts_backends/__init__.py
+++ b/backend/services/tts_backends/__init__.py
@@ -1,0 +1,8 @@
+"""Per-engine TTS plugins that bypass RealtimeTTS.
+
+Each module exposes a TTSProvider subclass and a ``build_provider(params,
+secrets)`` callable. The dispatcher in :mod:`services.tts_realtime` calls
+it directly when the engine name does not map to a RealtimeTTS engine
+class (Edge has its own optimized path; Soniox uses a hand-rolled
+WebSocket client because RealtimeTTS does not ship a Soniox engine).
+"""

--- a/backend/services/tts_backends/soniox.py
+++ b/backend/services/tts_backends/soniox.py
@@ -1,0 +1,169 @@
+"""Soniox real-time TTS provider.
+
+Implements :class:`services.tts.TTSProvider` over Soniox' bidirectional
+WebSocket at ``wss://tts-rt.soniox.com/tts-websocket``. The provider opens
+one socket per request, streams a single text payload, and yields decoded
+audio chunks as the server returns them.
+
+Why not RealtimeTTS: the upstream library has no Soniox engine class, so
+plugging Soniox in via the registry's ``realtimetts_engine`` field would
+require maintaining a fork. A direct WS client is ~150 lines and matches
+the shape of EdgeTTSProvider (the other engine that already bypasses
+RealtimeTTS).
+
+Two stream methods:
+* ``stream_audio`` — yields MP3 bytes, used by the legacy MP3 route
+  (/api/tts/{request_id}) and the preview endpoint.
+* ``stream_pcm`` — yields raw int16 mono PCM, used by /ws/voice/out so the
+  browser can play seamlessly through the AudioWorklet (no MP3 frame
+  boundary glitches).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import uuid
+from typing import Any, AsyncIterator, Optional
+
+from services.tts import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+SONIOX_TTS_WS_URL = "wss://tts-rt.soniox.com/tts-websocket"
+DEFAULT_MODEL = "tts-rt-v1"
+DEFAULT_VOICE = "Adrian"
+DEFAULT_LANGUAGE = "en"
+DEFAULT_SAMPLE_RATE = 24000
+
+
+class SonioxTTSProvider(TTSProvider):
+    """Soniox real-time TTS over WebSocket."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str = DEFAULT_MODEL,
+        voice: str = DEFAULT_VOICE,
+        language: str = DEFAULT_LANGUAGE,
+        sample_rate: int = DEFAULT_SAMPLE_RATE,
+    ) -> None:
+        if not api_key:
+            raise ValueError("Soniox TTS requires an API key")
+        self._api_key = api_key
+        self._model = model
+        self._voice = voice
+        self._language = language
+        self._sample_rate = int(sample_rate)
+
+    # ---- TTSProvider API --------------------------------------------------
+
+    async def generate_audio(self, text: str) -> Optional[bytes]:
+        if not text or not text.strip():
+            return None
+        chunks: list[bytes] = []
+        async for chunk in self.stream_audio(text):
+            chunks.append(chunk)
+        return b"".join(chunks) if chunks else None
+
+    async def stream_audio(self, text: str) -> AsyncIterator[bytes]:
+        """Yield MP3 audio bytes as Soniox produces them."""
+        async for chunk in self._stream(text, audio_format="mp3"):
+            yield chunk
+
+    async def stream_pcm(self, text: str) -> AsyncIterator[bytes]:
+        """Yield raw int16 mono PCM for the low-latency WS path."""
+        async for chunk in self._stream(text, audio_format="pcm_s16le"):
+            yield chunk
+
+    # ---- internals --------------------------------------------------------
+
+    async def _stream(self, text: str, *, audio_format: str) -> AsyncIterator[bytes]:
+        if not text or not text.strip():
+            return
+
+        try:
+            import websockets
+        except ImportError as exc:  # pragma: no cover — present via uv.lock
+            logger.error("[Soniox TTS] websockets package not available: %s", exc)
+            raise
+
+        stream_id = f"jarvis-{uuid.uuid4().hex[:12]}"
+        config = {
+            "api_key": self._api_key,
+            "stream_id": stream_id,
+            "model": self._model,
+            "voice": self._voice,
+            "language": self._language,
+            "audio_format": audio_format,
+            "sample_rate": self._sample_rate,
+        }
+
+        async with websockets.connect(SONIOX_TTS_WS_URL, max_size=None) as ws:
+            await ws.send(json.dumps(config))
+            # Send the entire text in one chunk with text_end=True. Soniox
+            # supports incremental text but our callers pass a single
+            # already-buffered string, so chunking buys nothing here.
+            await ws.send(json.dumps({
+                "text": text,
+                "text_end": True,
+                "stream_id": stream_id,
+            }))
+
+            async for msg in ws:
+                if isinstance(msg, (bytes, bytearray)):
+                    # Soniox returns JSON-only for TTS; surface binary as a
+                    # protocol surprise rather than silently swallowing it.
+                    logger.warning("[Soniox TTS] unexpected binary frame")
+                    continue
+                try:
+                    data = json.loads(msg)
+                except json.JSONDecodeError:
+                    logger.debug("[Soniox TTS] non-JSON message ignored")
+                    continue
+
+                err_code = data.get("error_code")
+                if err_code:
+                    raise RuntimeError(
+                        f"Soniox TTS error {err_code}: "
+                        f"{data.get('error_message') or 'unknown'}"
+                    )
+
+                if data.get("terminated"):
+                    return
+
+                b64 = data.get("audio")
+                if b64:
+                    try:
+                        yield base64.b64decode(b64)
+                    except (ValueError, TypeError) as exc:
+                        logger.warning("[Soniox TTS] base64 decode failed: %s", exc)
+                        continue
+
+                if data.get("audio_end"):
+                    # Wait for the server's explicit ``terminated`` to close
+                    # cleanly; otherwise we may miss trailing audio frames if
+                    # a chunk crosses the audio_end boundary.
+                    continue
+
+
+def build_provider(
+    params: dict[str, Any],
+    secrets: Optional[dict[str, str]] = None,
+) -> SonioxTTSProvider:
+    """Factory used by :func:`services.tts_realtime.build_chat_provider`."""
+    api_key = (secrets or {}).get("api_key") or ""
+    if not api_key:
+        raise RuntimeError(
+            "Soniox TTS selected but no API key configured. "
+            "Set it under Settings → Voice → Soniox."
+        )
+    return SonioxTTSProvider(
+        api_key=api_key,
+        model=params.get("model") or DEFAULT_MODEL,
+        voice=params.get("voice") or DEFAULT_VOICE,
+        language=params.get("language") or DEFAULT_LANGUAGE,
+        sample_rate=params.get("sample_rate") or DEFAULT_SAMPLE_RATE,
+    )

--- a/backend/services/tts_realtime.py
+++ b/backend/services/tts_realtime.py
@@ -182,6 +182,13 @@ def build_chat_provider(config: dict[str, Any], secrets: Optional[dict[str, dict
         )
 
     engine_secrets = (secrets or {}).get(engine, {})
+
+    if engine == "soniox":
+        # Soniox has no RealtimeTTS engine class — use the hand-rolled
+        # WebSocket provider so we don't have to maintain a RealtimeTTS fork.
+        from services.tts_backends.soniox import build_provider as _build_soniox
+        return _build_soniox(params, engine_secrets)
+
     return RealtimeTTSProvider(engine_name=engine, params=params, secrets=engine_secrets)
 
 

--- a/backend/services/voice_config.py
+++ b/backend/services/voice_config.py
@@ -87,9 +87,21 @@ def set_stt_config(config_service, config: dict[str, Any], updated_by: str = "vo
     config_service.set("voice", "stt", json.dumps(config), source=updated_by)
 
 
+def _engine_spec(engine: str) -> Optional[dict[str, Any]]:
+    """Look up an engine spec by name across both TTS and STT registries.
+
+    Cloud providers like Soniox appear in both registries under the same
+    engine name and share a single API-key slot (``voice.secrets.<engine>.api_key``).
+    Routing every secret call through one lookup keeps that contract honest:
+    we never silently fail to recognise a slot because we only checked one
+    half of the registry.
+    """
+    return registry.get_tts_engine(engine) or registry.get_stt_backend(engine)
+
+
 def get_engine_secrets(config_service, engine: str) -> dict[str, str]:
     """Return {secret_key: plaintext} for a given engine. Empty if none set."""
-    spec = registry.get_tts_engine(engine)
+    spec = _engine_spec(engine)
     if not spec:
         return {}
     out: dict[str, str] = {}
@@ -101,7 +113,7 @@ def get_engine_secrets(config_service, engine: str) -> dict[str, str]:
 
 
 def set_engine_secret(config_service, engine: str, secret_key: str, value: str, updated_by: str = "voice_api") -> None:
-    spec = registry.get_tts_engine(engine)
+    spec = _engine_spec(engine)
     if not spec or secret_key not in spec.get("secrets", []):
         raise ValueError(f"Engine {engine!r} has no declared secret {secret_key!r}")
     config_service.set(

--- a/backend/services/voice_engine_registry.py
+++ b/backend/services/voice_engine_registry.py
@@ -48,6 +48,10 @@ class STTBackendSpec(TypedDict, total=False):
     description: str
     badges: list[str]
     params: list[ParamSpec]
+    # Encrypted credential slots (e.g. cloud STT API keys). Same shape as
+    # TTSEngineSpec.secrets — the UI renders an inline "set/clear" control
+    # per slot and the value is persisted via voice_config.set_engine_secret.
+    secrets: list[str]
     wake_word_backends: dict[str, dict[str, Any]]
     # If set, the backend supports only this BCP-47 language code. The UI
     # hides the language picker and the saved config forces this value.
@@ -145,6 +149,42 @@ TTS_ENGINES: dict[str, TTSEngineSpec] = {
             {"key": "model", "type": "select", "label": "Model", "default": "tts-1", "options": ["tts-1", "tts-1-hd"]},
         ],
     },
+    # Soniox real-time TTS — WebSocket streaming, 60+ languages, low TTFB.
+    # Bypasses RealtimeTTS (no engine class in that library); the provider
+    # lives in services/tts_backends/soniox.py and is wired in
+    # tts_realtime.build_chat_provider.
+    "soniox": {
+        "label": "Soniox TTS (real-time)",
+        "description": "Cloud WebSocket TTS, 60+ languages, low-latency streaming.",
+        "badges": ["cloud", "paid", "multilingual"],
+        "requires": [],
+        "secrets": ["api_key"],
+        "output_format": "mp3",
+        # Voice list is the full Soniox catalog as of tts-rt-v1 (28 studio
+        # voices — every voice can speak every supported language; pick one
+        # for accent/timbre, switch ``language`` for the actual locale).
+        # Source: https://soniox.com/docs/tts/concepts/voices
+        # Language list is curated to the locales we care about in this app
+        # (vi+en first, then common globals). Anyone needing a Soniox-supported
+        # code we don't list yet should add it here — the backend accepts any
+        # ISO code; the UI dropdown is the only thing gating it.
+        "params": [
+            {"key": "model", "type": "select", "label": "Model", "default": "tts-rt-v1", "options": ["tts-rt-v1"]},
+            {"key": "voice", "type": "select", "label": "Voice", "default": "Adrian", "options": [
+                # Male
+                "Adrian", "Arjun", "Arthur", "Cooper", "Daniel", "Jack", "Kenji",
+                "Mason", "Mateo", "Noah", "Oliver", "Owen", "Rafael", "Rohan",
+                # Female
+                "Claire", "Elise", "Emma", "Grace", "Isla", "Lucia", "Maya",
+                "Meera", "Mina", "Nina", "Priya", "Ruby", "Sofia", "Victoria",
+            ]},
+            {"key": "language", "type": "select", "label": "Language", "default": "en", "options": [
+                "en", "vi", "zh", "ja", "ko", "fr", "de", "es", "pt", "it",
+                "ru", "ar", "hi", "id", "th",
+            ]},
+            {"key": "sample_rate", "type": "select", "label": "Sample rate", "default": 24000, "options": [8000, 16000, 24000, 44100, 48000]},
+        ],
+    },
 }
 
 
@@ -217,6 +257,27 @@ STT_BACKENDS: dict[str, STTBackendSpec] = {
         # straight off Silero VAD and there is no Porcupine/OWW callback
         # plumbing. Surfacing only "off" prevents the UI from offering
         # a config that would silently be ignored.
+        "wake_word_backends": {
+            "off": {"label": "Disabled", "params": []},
+        },
+    },
+    # Soniox real-time STT — WebSocket streaming, 60+ languages, endpoint
+    # detection. No local models; needs only an API key.
+    "soniox": {
+        "label": "Soniox STT (real-time)",
+        "description": "Cloud WebSocket STT, 60+ languages, server-side endpoint detection.",
+        "badges": ["cloud", "paid", "multilingual"],
+        "secrets": ["api_key"],
+        "params": [
+            {"key": "model", "type": "select", "label": "Model", "default": "stt-rt-v4", "options": ["stt-rt-v4"]},
+            {"key": "language_hints", "type": "text", "label": "Language hints", "default": "vi,en", "help": "Comma-separated ISO codes, or blank for auto."},
+            {"key": "enable_language_identification", "type": "toggle", "label": "Detect language per token", "default": False},
+            {"key": "enable_speaker_diarization", "type": "toggle", "label": "Speaker diarization", "default": False},
+        ],
+        # Soniox handles endpoint detection server-side ("<end>" token) and
+        # streams audio over a single WS — there is no separate wake-word
+        # callback hook, so we surface "off" only (same pattern as
+        # gipformer_vi).
         "wake_word_backends": {
             "off": {"label": "Disabled", "params": []},
         },

--- a/backend/tests/e2e/test_soniox_realtime_flow.py
+++ b/backend/tests/e2e/test_soniox_realtime_flow.py
@@ -1,0 +1,325 @@
+"""End-to-end Soniox WebSocket integration test against a real loopback server.
+
+What this guards (per CLAUDE.md rule 6 — Happy Path FIRST):
+* The full async path through ``SonioxSTTService`` and ``SonioxTTSProvider``
+  — TCP connect, JSON handshake, binary audio frames, JSON token frames,
+  base64-decoded audio chunks, clean ``terminated``-driven shutdown.
+* The WS scaffolding in :class:`WSStreamingSTT` (thread runner, audio
+  queue, hook fan-out, end-of-audio empty-string sentinel) is exercised
+  through the same code path production uses.
+
+What this does NOT guard:
+* The real Soniox API. Hitting Soniox in CI would require credentials and
+  cost real money on every run. We stand up a local ``websockets.serve``
+  on an ephemeral port and patch ``SONIOX_*_WS_URL`` to point at it. The
+  fake server speaks the documented Soniox protocol — config message in,
+  tokens / audio out, ``terminated`` to close.
+
+If Soniox changes their wire format, these tests still pass — that's the
+fake-server tradeoff. They guard *our* client code, not the protocol
+contract. The unit tests in test_soniox_stt.py / test_soniox_tts.py
+codify the documented protocol shape against snapshots so a Soniox API
+break can be detected at the spec level even without live calls.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+
+import pytest
+import websockets
+
+from services.stt_backends import soniox as soniox_stt
+from services.tts_backends import soniox as soniox_tts
+
+
+# ---- Shared fake-server scaffolding ---------------------------------------
+
+
+class _FakeServer:
+    """Run a websockets server on a free port and expose its URL."""
+
+    def __init__(self, handler):
+        self._handler = handler
+        self._server: websockets.Server | None = None
+        self._task: asyncio.Task | None = None
+        self.url: str = ""
+
+    async def start(self):
+        # Port 0 = pick a free ephemeral port; serve only on localhost so the
+        # test never accidentally listens on a public interface.
+        self._server = await websockets.serve(self._handler, "127.0.0.1", 0)
+        host, port = self._server.sockets[0].getsockname()[:2]
+        self.url = f"ws://{host}:{port}"
+        return self
+
+    async def stop(self):
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+
+# ---- STT end-to-end --------------------------------------------------------
+
+
+def _hook_recorder():
+    events: list[tuple[str, dict]] = []
+    return events, (lambda ev, payload: events.append((ev, payload)))
+
+
+@pytest.mark.asyncio
+async def test_soniox_stt_full_websocket_roundtrip(monkeypatch):
+    """Real WS handshake → PCM bytes → tokens back → final_transcript event."""
+    received_config: dict = {}
+    received_audio: list[bytes] = []
+    end_of_audio = asyncio.Event()
+
+    async def handler(ws):
+        # First message is the JSON config.
+        cfg_msg = await ws.recv()
+        received_config.update(json.loads(cfg_msg))
+        # Subsequent messages are binary audio frames until the client sends
+        # an empty string sentinel.
+        async for msg in ws:
+            if isinstance(msg, (bytes, bytearray)):
+                received_audio.append(bytes(msg))
+                # Once we've seen audio, stream a couple of token frames so
+                # the client sees both provisional + final + endpoint cases.
+                if len(received_audio) == 1:
+                    await ws.send(json.dumps({"tokens": [
+                        {"text": "Xin ", "is_final": True},
+                        {"text": "chào", "is_final": False},
+                    ]}))
+                if len(received_audio) == 2:
+                    await ws.send(json.dumps({"tokens": [
+                        {"text": "chào ", "is_final": True},
+                        {"text": "Jarvis", "is_final": True},
+                        {"text": "<end>", "is_final": True},
+                    ]}))
+            elif msg == "":
+                end_of_audio.set()
+                await ws.send(json.dumps({"finished": True}))
+                return
+
+    server = await _FakeServer(handler).start()
+    # WS_URL is a ClassVar — patching the module-level constant won't
+    # touch the class attribute that's already been copied at definition
+    # time, so we patch the class directly.
+    monkeypatch.setattr(soniox_stt.SonioxSTTService, "WS_URL", server.url)
+
+    events, hook = _hook_recorder()
+    svc = soniox_stt.SonioxSTTService(api_key="sk-fake", params={
+        "model": "stt-rt-v4", "language_hints": "vi,en",
+    })
+    svc.set_hook(hook)
+    svc.start_listen_loop()
+
+    # Give the WS thread a beat to connect + send config. The handler keeps
+    # us honest: the server only registers the config once the handshake
+    # completes, so we poll the dict instead of guessing a sleep duration.
+    deadline = time.monotonic() + 5.0
+    while not received_config and time.monotonic() < deadline:
+        await asyncio.sleep(0.02)
+    assert received_config, "server never received the config message"
+    assert received_config["api_key"] == "sk-fake"
+    assert received_config["model"] == "stt-rt-v4"
+    assert received_config["audio_format"] == "pcm_s16le"
+    assert received_config["sample_rate"] == 16000
+    assert received_config["language_hints"] == ["vi", "en"]
+    assert received_config["enable_endpoint_detection"] is True
+
+    # Feed two PCM frames — the handler emits tokens after each so we can
+    # observe partial → final → endpoint progression.
+    svc.feed_audio(b"\x00" * 320)  # 10ms of silence at 16 kHz int16 mono
+    svc.feed_audio(b"\x01" * 320)
+
+    # Wait for the endpoint token to flush the final transcript.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if any(ev == "final_transcript" for ev, _ in events):
+            break
+        await asyncio.sleep(0.02)
+
+    try:
+        finals = [p["text"] for ev, p in events if ev == "final_transcript"]
+        assert finals == ["Xin chào Jarvis"], (
+            f"expected one final transcript 'Xin chào Jarvis', got {finals!r}"
+        )
+
+        # The provisional partial showed up before the endpoint cleared the
+        # buffer. The exact intermediate value depends on token timing, but
+        # the running partial must contain at least the first final token.
+        partials = [p["text"] for ev, p in events if ev == "partial_transcript"]
+        assert partials, "no partial_transcript emitted"
+        assert any("Xin" in p for p in partials), partials
+
+        # Endpoint emits the vad_stop → recording_stop → recording_start
+        # triplet that downstream consumers rely on.
+        names = [ev for ev, _ in events]
+        assert "vad_stop" in names
+        assert "recording_stop" in names
+    finally:
+        svc.shutdown()
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_soniox_stt_surfaces_server_error_event(monkeypatch):
+    """A server-side ``error_code`` lands as an ``error`` event on the hook."""
+    async def handler(ws):
+        await ws.recv()  # discard config
+        await ws.send(json.dumps({
+            "error_code": 401,
+            "error_message": "invalid api key",
+        }))
+        # Keep the socket open so the receiver actually sees the error
+        # before the server-driven close — closing too quickly races the
+        # receive loop and the test would flake.
+        await asyncio.sleep(0.1)
+
+    server = await _FakeServer(handler).start()
+    # WS_URL is a ClassVar — patching the module-level constant won't
+    # touch the class attribute that's already been copied at definition
+    # time, so we patch the class directly.
+    monkeypatch.setattr(soniox_stt.SonioxSTTService, "WS_URL", server.url)
+
+    events, hook = _hook_recorder()
+    svc = soniox_stt.SonioxSTTService(api_key="sk-bad", params={})
+    svc.set_hook(hook)
+    svc.start_listen_loop()
+
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if any(ev == "error" for ev, _ in events):
+                break
+            await asyncio.sleep(0.02)
+        errors = [p["detail"] for ev, p in events if ev == "error"]
+        assert errors and "invalid api key" in errors[0]
+    finally:
+        svc.shutdown()
+        await server.stop()
+
+
+# ---- TTS end-to-end --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_full_websocket_roundtrip(monkeypatch):
+    """Real WS handshake → text frame → base64 audio chunks → terminated."""
+    received_msgs: list[dict] = []
+
+    async def handler(ws):
+        # The TTS protocol is JSON-only — config first, then text frames.
+        async for raw in ws:
+            data = json.loads(raw)
+            received_msgs.append(data)
+            if "text" in data and data.get("text_end"):
+                # Stream two audio chunks then close cleanly.
+                stream_id = data["stream_id"]
+                await ws.send(json.dumps({
+                    "audio": base64.b64encode(b"chunk-one").decode(),
+                    "stream_id": stream_id,
+                }))
+                await ws.send(json.dumps({
+                    "audio": base64.b64encode(b"chunk-two").decode(),
+                    "audio_end": True,
+                    "stream_id": stream_id,
+                }))
+                await ws.send(json.dumps({
+                    "terminated": True, "stream_id": stream_id,
+                }))
+                return
+
+    server = await _FakeServer(handler).start()
+    monkeypatch.setattr(soniox_tts, "SONIOX_TTS_WS_URL", server.url)
+
+    provider = soniox_tts.SonioxTTSProvider(
+        api_key="sk-fake", voice="Adrian", language="vi", sample_rate=24000,
+    )
+    out: list[bytes] = []
+    async for chunk in provider.stream_audio("Xin chào"):
+        out.append(chunk)
+
+    try:
+        assert b"".join(out) == b"chunk-one" + b"chunk-two"
+        # First inbound is the config (api_key + voice + audio_format), second
+        # is the text payload with text_end=True.
+        assert len(received_msgs) == 2
+        cfg, text_msg = received_msgs
+        assert cfg["api_key"] == "sk-fake"
+        assert cfg["voice"] == "Adrian"
+        assert cfg["language"] == "vi"
+        assert cfg["audio_format"] == "mp3"
+        assert cfg["sample_rate"] == 24000
+        assert cfg["model"] == "tts-rt-v1"
+        assert "stream_id" in cfg
+        assert text_msg["text"] == "Xin chào"
+        assert text_msg["text_end"] is True
+        assert text_msg["stream_id"] == cfg["stream_id"]
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_pcm_path_requests_pcm_format(monkeypatch):
+    """``stream_pcm`` swaps audio_format to ``pcm_s16le`` for the WS path."""
+    received_cfg: dict = {}
+
+    async def handler(ws):
+        async for raw in ws:
+            data = json.loads(raw)
+            if "api_key" in data:
+                received_cfg.update(data)
+            elif data.get("text_end"):
+                await ws.send(json.dumps({
+                    "audio": base64.b64encode(b"\x00\x01").decode(),
+                    "audio_end": True,
+                    "stream_id": data["stream_id"],
+                }))
+                await ws.send(json.dumps({
+                    "terminated": True, "stream_id": data["stream_id"],
+                }))
+                return
+
+    server = await _FakeServer(handler).start()
+    monkeypatch.setattr(soniox_tts, "SONIOX_TTS_WS_URL", server.url)
+
+    provider = soniox_tts.SonioxTTSProvider(api_key="sk-fake")
+    out: list[bytes] = []
+    async for chunk in provider.stream_pcm("hello"):
+        out.append(chunk)
+
+    try:
+        assert b"".join(out) == b"\x00\x01"
+        assert received_cfg["audio_format"] == "pcm_s16le"
+    finally:
+        await server.stop()
+
+
+@pytest.mark.asyncio
+async def test_soniox_tts_error_response_raises(monkeypatch):
+    """Server ``error_code`` surfaces as a ``RuntimeError`` to the caller."""
+    async def handler(ws):
+        async for raw in ws:
+            data = json.loads(raw)
+            if data.get("text_end"):
+                await ws.send(json.dumps({
+                    "error_code": 402,
+                    "error_message": "quota exceeded",
+                    "stream_id": data["stream_id"],
+                }))
+                return
+
+    server = await _FakeServer(handler).start()
+    monkeypatch.setattr(soniox_tts, "SONIOX_TTS_WS_URL", server.url)
+
+    provider = soniox_tts.SonioxTTSProvider(api_key="sk-fake")
+    try:
+        with pytest.raises(RuntimeError, match="quota exceeded"):
+            async for _ in provider.stream_audio("hi"):
+                pytest.fail("should not yield audio after error")
+    finally:
+        await server.stop()

--- a/backend/tests/test_routes/test_voice_routes.py
+++ b/backend/tests/test_routes/test_voice_routes.py
@@ -142,6 +142,25 @@ class TestSecretsEndpoint:
         resp = client.post("/api/voice/secrets/edge/api_key", json={"value": "x"})
         assert resp.status_code == 400
 
+    def test_stt_only_engine_secret_surfaces(self, client):
+        # Soniox lives in both registries and shares the api_key slot. The
+        # secrets endpoint must list it from the STT side too so a user who
+        # only picks Soniox STT (not TTS) can still set the key from the
+        # STT card. Listed once (not duplicated) since both halves point at
+        # the same slot.
+        body = client.get("/api/voice/secrets").json()
+        assert body["engines"].get("soniox") == {"api_key": False}
+
+        resp = client.post("/api/voice/secrets/soniox/api_key", json={"value": "sk-soniox"})
+        assert resp.status_code == 200
+        body = client.get("/api/voice/secrets").json()
+        assert body["engines"]["soniox"]["api_key"] is True
+
+        # Cleanup path still works through the same engine name regardless
+        # of which registry side initially exposed it.
+        resp = client.delete("/api/voice/secrets/soniox/api_key")
+        assert resp.status_code == 200
+
 
 class TestSTTTestEndpoint:
     def test_returns_transcript_from_warmup(self, client, monkeypatch):

--- a/backend/tests/test_routes/test_ws_voice.py
+++ b/backend/tests/test_routes/test_ws_voice.py
@@ -129,19 +129,12 @@ def test_dictation_mode_suppresses_llm_dispatch(ws_client, monkeypatch):
 
     client, fake_stt = ws_client
     with client.websocket_connect("/ws/voice") as ws:
-        # Flip the session into dictation mode BEFORE the STT fires its
-        # final, so the gate is in place by the time the handler runs.
+        # Flip the session into dictation mode BEFORE firing a final.
+        # The dictation gate is checked inside _dispatch_user_turn which
+        # runs on the asyncio loop — same thread that processes this
+        # start message — so once receive_text round-trips, the flag is
+        # guaranteed visible to the dispatcher. No "beat" trick needed.
         ws.send_text(json.dumps({"type": "start", "mode": "dictation"}))
-        # Give the receive loop a beat to process the start frame. The
-        # next emit fires the STT hook synchronously from the test thread,
-        # but the receive loop processes the start message on the asyncio
-        # side — without this short event, the dictation flag race could
-        # let final_transcript reach the dispatcher first.
-        fake_stt.emit("partial_transcript", {"text": "Xin"})
-        # Drain the bridged partial so the next receive_text sees the
-        # final, not the partial.
-        partial = json.loads(ws.receive_text())
-        assert partial["type"] == "partial_transcript"
 
         fake_stt.emit("final_transcript", {"text": "Xin chào Jarvis"})
         final = json.loads(ws.receive_text())

--- a/backend/tests/test_routes/test_ws_voice.py
+++ b/backend/tests/test_routes/test_ws_voice.py
@@ -107,6 +107,86 @@ def test_stt_event_bridges_to_json_frame(ws_client):
         ws.close()
 
 
+def test_dictation_mode_suppresses_llm_dispatch(ws_client, monkeypatch):
+    """``{type:'start', mode:'dictation'}`` must short-circuit final_transcript.
+
+    The bottom-mic dictation flow streams transcripts into a text box for
+    the user to edit + submit manually — invoking the LLM agent on every
+    finalised utterance would defeat the whole point (and burn tokens).
+    Guard: spy on ``shared_state.session_service.resume_and_send`` and
+    confirm it never fires even though the STT emits a final_transcript.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+    from services import shared_state
+
+    fake_app = MagicMock()
+    fake_app._agents = {"Jarvis": MagicMock(tool_runner_hooks=None)}
+    monkeypatch.setattr(shared_state, "agent_app", fake_app)
+
+    resume_spy = AsyncMock(return_value=("should-not-fire", "session-x"))
+    fake_session = MagicMock(resume_and_send=resume_spy)
+    monkeypatch.setattr(shared_state, "session_service", fake_session, raising=False)
+
+    client, fake_stt = ws_client
+    with client.websocket_connect("/ws/voice") as ws:
+        # Flip the session into dictation mode BEFORE the STT fires its
+        # final, so the gate is in place by the time the handler runs.
+        ws.send_text(json.dumps({"type": "start", "mode": "dictation"}))
+        # Give the receive loop a beat to process the start frame. The
+        # next emit fires the STT hook synchronously from the test thread,
+        # but the receive loop processes the start message on the asyncio
+        # side — without this short event, the dictation flag race could
+        # let final_transcript reach the dispatcher first.
+        fake_stt.emit("partial_transcript", {"text": "Xin"})
+        # Drain the bridged partial so the next receive_text sees the
+        # final, not the partial.
+        partial = json.loads(ws.receive_text())
+        assert partial["type"] == "partial_transcript"
+
+        fake_stt.emit("final_transcript", {"text": "Xin chào Jarvis"})
+        final = json.loads(ws.receive_text())
+        # The transcript itself MUST still propagate — the client uses it
+        # to populate the input field. What must NOT happen is the LLM
+        # turn that the standard hands-free path triggers.
+        assert final["type"] == "final_transcript"
+        assert final["text"] == "Xin chào Jarvis"
+        ws.close()
+
+    # LLM dispatcher never invoked — neither agent_thinking nor
+    # resume_and_send fired. If the dictation gate ever regresses, this
+    # spy will catch it.
+    resume_spy.assert_not_awaited()
+
+
+def test_default_mode_still_dispatches_llm_on_final_transcript(ws_client, monkeypatch):
+    """Negative control for the dictation gate.
+
+    Without ``mode: dictation`` in the start handshake, final_transcript
+    MUST still drive the agent turn — otherwise the dictation guard above
+    would pass trivially against a fully broken pipeline. We assert the
+    classic ``user_message`` event arrives, which is the first thing
+    ``_dispatch_user_turn`` emits.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+    from services import shared_state
+
+    fake_app = MagicMock()
+    fake_app._agents = {"Jarvis": MagicMock(tool_runner_hooks=None)}
+    monkeypatch.setattr(shared_state, "agent_app", fake_app)
+
+    resume_spy = AsyncMock(return_value=("hi back", "session-x"))
+    fake_session = MagicMock(resume_and_send=resume_spy)
+    monkeypatch.setattr(shared_state, "session_service", fake_session, raising=False)
+
+    client, fake_stt = ws_client
+    with client.websocket_connect("/ws/voice") as ws:
+        # No start handshake → backend default = full conversation mode.
+        fake_stt.emit("final_transcript", {"text": "hello"})
+        evt = _drain_until(ws, "user_message")
+        assert evt["text"] == "hello"
+        ws.close()
+
+
 def test_speak_command_streams_chat_provider_audio_back(ws_client):
     client, _ = ws_client
     with client.websocket_connect("/ws/voice") as ws:

--- a/backend/tests/test_services/test_soniox_stt.py
+++ b/backend/tests/test_services/test_soniox_stt.py
@@ -73,6 +73,23 @@ class TestTokenHandling:
         # frame supersedes the first instead of building "hellohello there".
         assert partials == ["hello", "hello there"]
 
+    def test_multiple_provisional_tokens_in_one_frame_concatenate(self):
+        # Soniox can pack several non-final tokens into a single message.
+        # Old behaviour (``_provisional_tail = text`` per token) collapsed
+        # the frame down to the last token, dropping "hello " from
+        # ``[{"text":"hello ","is_final":False}, {"text":"world","is_final":False}]``.
+        # The accumulator now resets at the start of ``_handle_event`` and
+        # concatenates within the loop, so every provisional in the frame
+        # contributes to the running partial.
+        svc = _make_service()
+        events = _hook_recorder(svc)
+        svc._handle_event({"tokens": [
+            {"text": "hello ", "is_final": False},
+            {"text": "world", "is_final": False},
+        ]})
+        partials = [p["text"] for ev, p in events if ev == "partial_transcript"]
+        assert partials == ["hello world"]
+
     def test_final_tokens_accumulate_into_buffer(self):
         svc = _make_service()
         events = _hook_recorder(svc)

--- a/backend/tests/test_services/test_soniox_stt.py
+++ b/backend/tests/test_services/test_soniox_stt.py
@@ -1,0 +1,132 @@
+"""Soniox STT token-protocol unit tests.
+
+The WebSocket roundtrip is not exercised here — that's covered by the
+shared :class:`WSStreamingSTT` scaffolding and a future fake-server e2e.
+What matters per-provider is the Soniox-specific bits: which keys land
+in the config message, how the ``<end>`` token flushes the buffer, and
+how provisional vs finalized tokens accumulate.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.stt_backends.soniox import SonioxSTTService
+
+
+def _make_service(**params):
+    return SonioxSTTService(api_key="sk-fake", params=params)
+
+
+def _hook_recorder(svc):
+    events: list[tuple[str, dict]] = []
+    svc.set_hook(lambda ev, payload: events.append((ev, payload)))
+    return events
+
+
+class TestConfigMessage:
+    def test_defaults(self):
+        svc = _make_service()
+        cfg = svc._build_config_message()
+        assert cfg["api_key"] == "sk-fake"
+        assert cfg["audio_format"] == "pcm_s16le"
+        assert cfg["sample_rate"] == 16000
+        assert cfg["num_channels"] == 1
+        assert cfg["enable_endpoint_detection"] is True
+        # Optional flags are omitted unless explicitly enabled, keeping the
+        # message minimal so Soniox doesn't reject unknown nullable fields
+        # on future API versions.
+        assert "language_hints" not in cfg
+        assert "enable_language_identification" not in cfg
+        assert "enable_speaker_diarization" not in cfg
+
+    def test_language_hints_csv_to_list(self):
+        svc = _make_service(language_hints="vi, en")
+        assert svc._build_config_message()["language_hints"] == ["vi", "en"]
+
+    def test_language_hints_blank_is_omitted(self):
+        svc = _make_service(language_hints="   ")
+        cfg = svc._build_config_message()
+        assert "language_hints" not in cfg
+
+    def test_optional_flags_passthrough(self):
+        svc = _make_service(
+            enable_language_identification=True,
+            enable_speaker_diarization=True,
+            model="stt-rt-v4",
+            sample_rate=24000,
+        )
+        cfg = svc._build_config_message()
+        assert cfg["model"] == "stt-rt-v4"
+        assert cfg["sample_rate"] == 24000
+        assert cfg["enable_language_identification"] is True
+        assert cfg["enable_speaker_diarization"] is True
+
+
+class TestTokenHandling:
+    def test_provisional_tokens_emit_running_partial(self):
+        svc = _make_service()
+        events = _hook_recorder(svc)
+        svc._handle_event({"tokens": [{"text": "hello", "is_final": False}]})
+        svc._handle_event({"tokens": [{"text": "hello there", "is_final": False}]})
+        partials = [p["text"] for ev, p in events if ev == "partial_transcript"]
+        # The provisional tail is replaced (not appended), so the second
+        # frame supersedes the first instead of building "hellohello there".
+        assert partials == ["hello", "hello there"]
+
+    def test_final_tokens_accumulate_into_buffer(self):
+        svc = _make_service()
+        events = _hook_recorder(svc)
+        svc._handle_event({"tokens": [
+            {"text": "Xin ", "is_final": True},
+            {"text": "chào", "is_final": True},
+        ]})
+        partials = [p["text"] for ev, p in events if ev == "partial_transcript"]
+        assert partials[-1] == "Xin chào"
+        # No final yet — endpoint hasn't arrived.
+        assert not any(ev == "final_transcript" for ev, _ in events)
+
+    def test_endpoint_token_flushes_final_and_resets(self):
+        svc = _make_service()
+        events = _hook_recorder(svc)
+        svc._handle_event({"tokens": [
+            {"text": "Hello ", "is_final": True},
+            {"text": "world", "is_final": True},
+            {"text": "<end>", "is_final": True},
+        ]})
+        finals = [p["text"] for ev, p in events if ev == "final_transcript"]
+        assert finals == ["Hello world"]
+        # Endpoint emits vad_stop → recording_stop → recording_start so the
+        # voice WS route resets its per-turn state and is ready for the
+        # next utterance on the same Soniox connection.
+        sequence = [ev for ev, _ in events if ev in {"vad_stop", "recording_stop", "recording_start"}]
+        assert sequence == ["vad_stop", "recording_stop", "recording_start"]
+
+        # Buffer must be empty so the next utterance doesn't carry over.
+        events.clear()
+        svc._handle_event({"tokens": [{"text": "Next", "is_final": True}]})
+        partials = [p["text"] for ev, p in events if ev == "partial_transcript"]
+        assert partials == ["Next"]
+
+    def test_endpoint_without_any_text_does_not_emit_empty_final(self):
+        svc = _make_service()
+        events = _hook_recorder(svc)
+        svc._handle_event({"tokens": [{"text": "<end>", "is_final": True}]})
+        assert not any(ev == "final_transcript" for ev, _ in events)
+        # Endpoint signal still fires so downstream resets per-turn state
+        # even when the model produced no audible speech.
+        assert ("vad_stop", {}) in events
+
+    def test_error_message_surfaces_as_error_event(self):
+        svc = _make_service()
+        events = _hook_recorder(svc)
+        svc._handle_event({"error_code": 401, "error_message": "bad key"})
+        assert ("error", {"detail": "bad key"}) in events
+
+
+class TestBuildFactory:
+    def test_missing_api_key_raises(self, monkeypatch):
+        from services.config_service import config_service
+        monkeypatch.setattr(config_service, "get", lambda *a, **kw: None)
+        from services.stt_backends.soniox import build
+        with pytest.raises(RuntimeError, match="no API key"):
+            build({"params": {}})

--- a/backend/tests/test_services/test_soniox_tts.py
+++ b/backend/tests/test_services/test_soniox_tts.py
@@ -1,0 +1,162 @@
+"""Soniox TTS provider — config, error handling, build_provider factory.
+
+The real WebSocket roundtrip is exercised against a stand-in fake socket
+(no network) so we can assert what bytes the client emits without
+depending on Soniox or pulling the ``websockets`` event loop in tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import sys
+import types
+
+import pytest
+
+from services.tts_backends import soniox as soniox_tts
+from services.tts_backends.soniox import SonioxTTSProvider, build_provider
+
+
+class _FakeWS:
+    """Minimal duck-typed stand-in for ``websockets.WebSocketClientProtocol``.
+
+    Records every ``send`` call so tests can assert the wire protocol, and
+    replays a scripted sequence of server messages to drive the receive
+    loop. The provider iterates the socket via ``async for msg in ws``,
+    so we implement ``__aiter__``/``__anext__`` directly.
+    """
+
+    def __init__(self, server_messages):
+        self.sent: list[str] = []
+        self._server = list(server_messages)
+
+    async def send(self, payload):
+        if isinstance(payload, (bytes, bytearray)):
+            self.sent.append(payload)
+        else:
+            self.sent.append(payload)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._server:
+            raise StopAsyncIteration
+        return self._server.pop(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def _install_fake_websockets(monkeypatch, server_messages):
+    """Replace the websockets module so ``import websockets`` returns a fake.
+
+    The provider does ``import websockets`` inside ``_stream`` so we can't
+    just patch a top-level binding — we have to install the module in
+    ``sys.modules`` before the function runs.
+    """
+    captured: dict = {}
+    fake_ws = _FakeWS(server_messages)
+
+    def _connect(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return fake_ws
+
+    fake_mod = types.SimpleNamespace(connect=_connect)
+    monkeypatch.setitem(sys.modules, "websockets", fake_mod)
+    return captured, fake_ws
+
+
+@pytest.mark.asyncio
+async def test_stream_audio_sends_config_then_text_and_decodes_base64(monkeypatch):
+    chunk1 = b"\x00\x01\x02"
+    chunk2 = b"\x03\x04"
+    server = [
+        json.dumps({"audio": base64.b64encode(chunk1).decode()}),
+        json.dumps({"audio": base64.b64encode(chunk2).decode(), "audio_end": True}),
+        json.dumps({"terminated": True}),
+    ]
+    captured, fake_ws = _install_fake_websockets(monkeypatch, server)
+
+    provider = SonioxTTSProvider(api_key="sk-fake", voice="Adrian", sample_rate=24000)
+    out: list[bytes] = []
+    async for c in provider.stream_audio("hello"):
+        out.append(c)
+
+    assert b"".join(out) == chunk1 + chunk2
+    assert captured["url"] == soniox_tts.SONIOX_TTS_WS_URL
+
+    # First send is the config JSON, second is the text JSON.
+    cfg = json.loads(fake_ws.sent[0])
+    assert cfg["api_key"] == "sk-fake"
+    assert cfg["voice"] == "Adrian"
+    assert cfg["audio_format"] == "mp3"
+    assert cfg["sample_rate"] == 24000
+
+    text_msg = json.loads(fake_ws.sent[1])
+    assert text_msg["text"] == "hello"
+    assert text_msg["text_end"] is True
+    assert text_msg["stream_id"] == cfg["stream_id"]
+
+
+@pytest.mark.asyncio
+async def test_stream_pcm_uses_pcm_audio_format(monkeypatch):
+    server = [
+        json.dumps({"audio": base64.b64encode(b"pcm").decode()}),
+        json.dumps({"terminated": True}),
+    ]
+    _, fake_ws = _install_fake_websockets(monkeypatch, server)
+
+    provider = SonioxTTSProvider(api_key="sk-fake")
+    out: list[bytes] = []
+    async for c in provider.stream_pcm("hi"):
+        out.append(c)
+    assert out == [b"pcm"]
+    cfg = json.loads(fake_ws.sent[0])
+    assert cfg["audio_format"] == "pcm_s16le"
+
+
+@pytest.mark.asyncio
+async def test_error_response_raises_runtime_error(monkeypatch):
+    server = [json.dumps({
+        "error_code": 401,
+        "error_message": "invalid api key",
+        "stream_id": "x",
+    })]
+    _install_fake_websockets(monkeypatch, server)
+
+    provider = SonioxTTSProvider(api_key="sk-bad")
+    with pytest.raises(RuntimeError, match="invalid api key"):
+        async for _ in provider.stream_audio("hi"):
+            pytest.fail("should not yield audio after server error")
+
+
+@pytest.mark.asyncio
+async def test_empty_text_yields_nothing(monkeypatch):
+    # No fake server needed — empty-text short-circuits before connect.
+    monkeypatch.setitem(sys.modules, "websockets", types.SimpleNamespace(
+        connect=lambda *a, **kw: pytest.fail("connect should not be called"),
+    ))
+    provider = SonioxTTSProvider(api_key="sk-fake")
+    chunks = [c async for c in provider.stream_audio("   ")]
+    assert chunks == []
+
+
+def test_build_provider_requires_api_key():
+    with pytest.raises(RuntimeError, match="no API key"):
+        build_provider({}, secrets={})
+
+
+def test_build_provider_passes_params_through():
+    provider = build_provider(
+        {"voice": "Bella", "language": "vi", "model": "tts-rt-v1", "sample_rate": 48000},
+        secrets={"api_key": "sk-fake"},
+    )
+    assert provider._voice == "Bella"
+    assert provider._language == "vi"
+    assert provider._sample_rate == 48000

--- a/backend/tests/test_services/test_voice_engine_registry.py
+++ b/backend/tests/test_services/test_voice_engine_registry.py
@@ -19,7 +19,11 @@ class TestTTSRegistryShape:
         assert reg.default_tts_chat_config()["engine"] == "edge"
 
     def test_every_engine_declares_required_keys(self):
-        required = {"label", "params", "realtimetts_engine", "output_format"}
+        # ``realtimetts_engine`` is required only for engines that dispatch
+        # through RealtimeTTSProvider; Edge and Soniox both ship native
+        # providers that bypass the RealtimeTTS layer, so the registry-wide
+        # check covers only the truly-required keys.
+        required = {"label", "params", "output_format"}
         for name, spec in reg.TTS_ENGINES.items():
             missing = required - spec.keys()
             assert not missing, f"engine {name!r} missing keys {missing}"
@@ -111,6 +115,54 @@ class TestSTTDispatcher:
 
         assert called["fw"]["params"]["a"] == 1
         assert called["gv"]["params"]["b"] == 2
+
+
+class TestSonioxBackend:
+    """Plug-and-play smoke for the Soniox cloud STT + TTS pair."""
+
+    def test_tts_registered_with_secret(self):
+        assert "soniox" in reg.TTS_ENGINES
+        spec = reg.TTS_ENGINES["soniox"]
+        assert "api_key" in spec["secrets"]
+        # Soniox does not go through RealtimeTTS — the registry intentionally
+        # omits ``realtimetts_engine`` so a future linter that wires every
+        # listed engine into RealtimeTTSProvider doesn't silently grab it.
+        assert "realtimetts_engine" not in spec
+
+    def test_stt_registered_with_secret(self):
+        assert "soniox" in reg.STT_BACKENDS
+        spec = reg.STT_BACKENDS["soniox"]
+        assert "api_key" in spec.get("secrets", [])
+        # No wake-word plumbing for the WS streaming path.
+        assert set(spec["wake_word_backends"].keys()) == {"off"}
+
+    def test_stt_factory_wired(self):
+        from services.stt_realtime import _BACKEND_FACTORIES
+        assert _BACKEND_FACTORIES["soniox"].endswith(":build")
+
+    def test_tts_build_routes_to_soniox_provider(self, monkeypatch):
+        # build_chat_provider must dispatch the "soniox" engine to the
+        # native WS provider rather than RealtimeTTSProvider — otherwise
+        # the runtime would try to import a non-existent
+        # RealtimeTTS.SonioxEngine class.
+        from services import tts_realtime
+        from services.tts_backends import soniox as soniox_tts
+
+        captured: dict = {}
+
+        def fake_build(params, secrets):
+            captured["params"] = params
+            captured["secrets"] = secrets
+            return object()
+
+        monkeypatch.setattr(soniox_tts, "build_provider", fake_build)
+        provider = tts_realtime.build_chat_provider(
+            {"engine": "soniox", "params": {"voice": "Adrian"}},
+            secrets={"soniox": {"api_key": "sk-fake"}},
+        )
+        assert provider is not None
+        assert captured["params"]["voice"] == "Adrian"
+        assert captured["secrets"]["api_key"] == "sk-fake"
 
 
 class TestStoriesSchemaIsLocked:

--- a/frontend/src/components/chat/ChatInput.vue
+++ b/frontend/src/components/chat/ChatInput.vue
@@ -29,11 +29,14 @@ const attachedFiles = ref([])
 const fileInputRef = ref(null)
 const { isMobile } = useBreakpoint()
 
-// Dictation state. ``isRecording`` mirrors the session's "actively
-// listening" status so the existing pulse-animation styling keeps working
-// without refactoring the button class binding.
+// Dictation state. ``isRecording`` covers every non-idle, non-error
+// status — including ``connecting`` — so the button shows the active
+// pulse from the moment the user clicks the mic, not just after the WS
+// handshake completes a few hundred ms later. Without ``connecting``
+// here, an impatient user would see no feedback and double-click,
+// flipping the session straight back off.
 const dictation = useDictationSession()
-const isRecording = computed(() => dictation.status.value === 'listening' || dictation.status.value === 'loading_stt')
+const isRecording = computed(() => ['connecting', 'loading_stt', 'listening'].includes(dictation.status.value))
 // Snapshot of inputText BEFORE the user pressed the mic. We render
 // ``baseText + finals + partial`` while dictating so any text the user
 // already typed is preserved — without this snapshot, the partial-tail

--- a/frontend/src/components/chat/ChatInput.vue
+++ b/frontend/src/components/chat/ChatInput.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, watch } from 'vue'
 import { useBreakpoint } from '../../composables/useBreakpoint'
+import { useDictationSession } from '../../composables/useDictationSession'
 
 /**
  * ChatInput — restyled compose row.
@@ -9,8 +10,12 @@ import { useBreakpoint } from '../../composables/useBreakpoint'
  * Tokens used: var(--bg-1) container, var(--bg-2) compose row,
  * var(--primary) send button. Mic recording state animates pulse.
  *
- * Audio capture logic unchanged — same MediaRecorder approach the user
- * already relies on; we just restyled the button states.
+ * Mic behaviour is dictation, NOT auto-send: clicking the mic streams
+ * the configured STT (Soniox / faster-whisper / Gipformer) into
+ * ``inputText`` so the user can review and edit before pressing Send.
+ * That's the difference vs the hands-free VoiceBar above the chat — the
+ * floating bar auto-submits each utterance; this composer mic lets the
+ * user dictate, fix typos, and decide when to fire.
  */
 
 const props = defineProps({
@@ -21,11 +26,19 @@ const emit = defineEmits(['send', 'stop'])
 const inputText = ref('')
 const inputRef = ref(null)
 const attachedFiles = ref([])
-const isRecording = ref(false)
-const mediaRecorder = ref(null)
-const audioChunks = ref([])
 const fileInputRef = ref(null)
 const { isMobile } = useBreakpoint()
+
+// Dictation state. ``isRecording`` mirrors the session's "actively
+// listening" status so the existing pulse-animation styling keeps working
+// without refactoring the button class binding.
+const dictation = useDictationSession()
+const isRecording = computed(() => dictation.status.value === 'listening' || dictation.status.value === 'loading_stt')
+// Snapshot of inputText BEFORE the user pressed the mic. We render
+// ``baseText + finals + partial`` while dictating so any text the user
+// already typed is preserved — without this snapshot, the partial-tail
+// rewrite would clobber whatever they had.
+const dictationBase = ref('')
 
 const filePreviews = computed(() =>
   attachedFiles.value.map(file => ({
@@ -46,6 +59,14 @@ function handleSend() {
   const text = inputText.value.trim()
   const files = attachedFiles.value
   if ((!text && !files.length) || props.isStreaming) return
+  // If the user submits while still dictating, tear the session down so
+  // the mic doesn't stay hot in the background; their final text is what
+  // they reviewed in the textarea, no extra utterances expected.
+  if (isRecording.value || dictation.status.value === 'connecting') {
+    dictation.stop().catch(() => {})
+  }
+  dictation.reset()
+  dictationBase.value = ''
   emit('send', { text, files: files.length ? [...files] : null })
   inputText.value = ''
   attachedFiles.value = []
@@ -100,31 +121,41 @@ function removeFile(index) {
   attachedFiles.value.splice(index, 1)
 }
 
+// Live-merge incoming transcript fragments back into ``inputText`` so the
+// user sees their words land in the textarea as they speak. We rebuild
+// the whole field instead of appending each fragment so that
+// (a) Soniox's provisional-then-revised tokens overwrite cleanly, and
+// (b) any edits the user makes after stop() persist on the next dictate
+//     because we re-snapshot the field at start time.
+watch(
+  () => [dictation.final.value, dictation.partial.value],
+  ([finals, partial]) => {
+    if (dictation.status.value === 'idle' || dictation.status.value === 'error') return
+    const base = dictationBase.value
+    const tail = [finals, partial].filter(Boolean).join(' ')
+    inputText.value = base
+      ? (tail ? `${base} ${tail}` : base)
+      : tail
+    nextTick(autoGrow)
+  },
+)
+
 async function toggleRecording() {
-  if (isRecording.value) {
-    mediaRecorder.value?.stop()
-    isRecording.value = false
+  if (isRecording.value || dictation.status.value === 'connecting') {
+    // Second click ends the session but keeps the merged text in the
+    // input — user reviews, edits, then hits Send when ready.
+    await dictation.stop()
+    dictation.reset()
     return
   }
+  // Snapshot whatever is already typed; the live merge appends after it.
+  dictationBase.value = inputText.value.trimEnd()
+  dictation.reset()
   try {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-    const recorder = new MediaRecorder(stream, { mimeType: 'audio/webm' })
-    audioChunks.value = []
-    recorder.ondataavailable = (e) => {
-      if (e.data.size > 0) audioChunks.value.push(e.data)
-    }
-    recorder.onstop = () => {
-      const blob = new Blob(audioChunks.value, { type: 'audio/webm' })
-      const file = new File([blob], `recording_${Date.now()}.webm`, { type: 'audio/webm' })
-      attachedFiles.value.push(file)
-      stream.getTracks().forEach(t => t.stop())
-    }
-    recorder.start()
-    mediaRecorder.value = recorder
-    isRecording.value = true
+    await dictation.start()
   } catch (err) {
-    console.error('[ChatInput] Microphone access denied:', err)
-    alert('Microphone access denied. Please allow microphone access in your browser settings.')
+    console.error('[ChatInput] Dictation start failed:', err)
+    alert('Mic access denied or voice session failed to start. Check Settings → Voice and browser permissions.')
   }
 }
 </script>
@@ -184,7 +215,8 @@ async function toggleRecording() {
       <button
         class="icon-btn"
         :class="{ recording: isRecording }"
-        :title="isRecording ? 'Stop recording' : 'Voice input (record)'"
+        :title="isRecording ? 'Stop dictation' : 'Dictate — speak to fill the text box'"
+        data-testid="chat-mic"
         @click="toggleRecording"
       >
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none">

--- a/frontend/src/composables/useDictationSession.js
+++ b/frontend/src/composables/useDictationSession.js
@@ -1,0 +1,200 @@
+/**
+ * useDictationSession — press-to-talk dictation over /ws/voice.
+ *
+ * Why a separate composable instead of reusing useVoiceSession:
+ * the hands-free composable runs a full conversation pipeline (transcript →
+ * LLM → TTS → audio playback). Dictation only wants the transcript; the
+ * server short-circuits LLM/TTS when we send ``mode: "dictation"`` in the
+ * start handshake. Keeping the two as separate composables means the
+ * dictation path never touches chatStore (no ghost message bubbles, no
+ * placeholder reconciliation, no playback queue) and the user can run
+ * dictation from ChatInput while the singleton hands-free session in
+ * VoiceBar is idle. Trying to overload the conversation singleton with a
+ * "ignore the bot half" flag would scatter conditionals across both
+ * codepaths — cheaper to keep them disjoint.
+ *
+ * Lifecycle (mirrors useVoiceSession's first half, intentionally; the
+ * worklet contract is identical so the same /voice-worklet.js script
+ * works for both):
+ *   start() → open WS, send {type:'start', mode:'dictation'} → request
+ *             mic → wire the pcm16 worklet → forward PCM frames
+ *   stop()  → close the socket and tear down audio
+ *
+ * Reactive state the caller binds to:
+ *   status:   'idle' | 'connecting' | 'loading_stt' | 'listening' | 'error'
+ *   partial:  the live, not-yet-final transcript fragment (provisional)
+ *   final:    accumulated finalised utterances since the last reset()
+ *   error:    last error string, '' when none
+ *
+ * The caller decides how to merge partial + final into a UI field — for
+ * the chat composer that's "previousText + finals + partial" with the
+ * partial styled as live tail so the user sees what's still landing.
+ */
+import { ref, shallowRef, onScopeDispose } from 'vue'
+
+export function useDictationSession() {
+  const status = ref('idle')
+  const error = ref('')
+  // ``partial`` is whatever Soniox/faster-whisper hasn't finalised yet —
+  // overwritten on every event (NOT appended) because providers re-emit
+  // the running provisional from scratch each frame.
+  const partial = ref('')
+  // ``final`` accumulates every final_transcript since the last reset().
+  // Endpoint detection (Soniox <end>) flushes provisional into a final,
+  // so this grows utterance-by-utterance until the user clicks Stop.
+  const final = ref('')
+
+  const ws = shallowRef(null)
+  const stream = shallowRef(null)
+  const audioContext = shallowRef(null)
+  const workletNode = shallowRef(null)
+
+  function reset() {
+    partial.value = ''
+    final.value = ''
+  }
+
+  function _wsUrl() {
+    // Same auth contract as the hands-free socket — cookie attaches on
+    // upgrade, so no api_key in the URL. Different path component is
+    // unnecessary; the server flips behaviour based on the start payload.
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+    return `${proto}//${location.host}/ws/voice`
+  }
+
+  function _onMessage(ev) {
+    if (typeof ev.data !== 'string') {
+      // Server may still send TTS audio frames if a misconfigured backend
+      // ignores ``mode: dictation``; we just drop them here so the user
+      // never hears a stray reply during dictation.
+      return
+    }
+    let msg
+    try { msg = JSON.parse(ev.data) } catch { return }
+    switch (msg.type) {
+      case 'stt_loading':
+        status.value = 'loading_stt'
+        break
+      case 'stt_ready':
+        status.value = 'listening'
+        break
+      case 'partial_transcript':
+      case 'stable_transcript':
+        partial.value = msg.text || ''
+        break
+      case 'final_transcript': {
+        const text = (msg.text || '').trim()
+        if (text) {
+          // Preserve the user's typing spacing: append with a single space
+          // between utterances. The provider strips its own trailing space,
+          // so we add one here unconditionally; ChatInput trims at submit.
+          final.value = final.value ? `${final.value} ${text}` : text
+        }
+        partial.value = ''
+        break
+      }
+      case 'error':
+        error.value = msg.detail || 'server error'
+        status.value = 'error'
+        break
+      // user_message / agent_thinking / assistant_message / tts_* should
+      // not arrive in dictation mode; if a server bug emits them anyway we
+      // ignore them rather than leak into the chat thread.
+    }
+  }
+
+  async function start() {
+    if (status.value !== 'idle') return
+    error.value = ''
+    status.value = 'connecting'
+    try {
+      const sock = new WebSocket(_wsUrl())
+      sock.binaryType = 'arraybuffer'
+      ws.value = sock
+      await new Promise((resolve, reject) => {
+        sock.onopen = resolve
+        sock.onerror = () => reject(new Error('WebSocket failed to open'))
+      })
+      sock.onmessage = _onMessage
+      sock.onclose = () => {
+        if (status.value !== 'error') status.value = 'idle'
+      }
+      sock.onerror = () => {
+        if (status.value !== 'error') {
+          status.value = 'error'
+          error.value = 'WebSocket error'
+        }
+      }
+
+      // Same constraints as the hands-free path: AEC on (otherwise STT
+      // would transcribe room echo as input on devices with poor mic
+      // isolation), NS/AGC off (NS strips quiet speech, AGC fights the
+      // user's hardware gain).
+      const ms = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: false,
+          autoGainControl: false,
+        },
+      })
+      stream.value = ms
+
+      const ac = new (window.AudioContext || window.webkitAudioContext)()
+      audioContext.value = ac
+      await ac.audioWorklet.addModule('/voice-worklet.js')
+      const node = new AudioWorkletNode(ac, 'pcm16-resampler', {
+        processorOptions: { targetRate: 16000, frameMs: 100 },
+      })
+      workletNode.value = node
+      const micSource = ac.createMediaStreamSource(ms)
+      micSource.connect(node)
+      // Intentionally NOT connecting node → destination: we don't want
+      // the user to hear themselves through the speakers.
+      node.port.onmessage = (e) => {
+        if (sock.readyState === 1) sock.send(e.data)
+      }
+
+      // The mode flag is the whole reason this composable exists — the
+      // backend ws_voice route reads it and bypasses LLM/TTS dispatch on
+      // every final_transcript.
+      sock.send(JSON.stringify({ type: 'start', mode: 'dictation' }))
+      status.value = 'listening'
+    } catch (e) {
+      error.value = e?.message || String(e)
+      status.value = 'error'
+      await stop()
+    }
+  }
+
+  async function stop() {
+    if (ws.value) {
+      try { ws.value.onmessage = null } catch {}
+      try { ws.value.send(JSON.stringify({ type: 'stop' })) } catch {}
+      try { ws.value.close() } catch {}
+      ws.value = null
+    }
+    workletNode.value?.disconnect()
+    workletNode.value = null
+    if (stream.value) {
+      stream.value.getTracks().forEach(t => t.stop())
+      stream.value = null
+    }
+    if (audioContext.value) {
+      try { await audioContext.value.close() } catch {}
+      audioContext.value = null
+    }
+    // Leave ``partial`` and ``final`` populated — the caller (ChatInput)
+    // wants to keep the dictated text in the input box for editing. Use
+    // reset() explicitly to clear after the user sends or cancels.
+    status.value = 'idle'
+  }
+
+  // Tear down on component unmount so a stale socket can't keep the mic
+  // hot after the user navigates away.
+  onScopeDispose(() => {
+    if (status.value !== 'idle') stop().catch(() => {})
+  })
+
+  return { status, error, partial, final, start, stop, reset }
+}

--- a/frontend/src/utils/youtubeTags.js
+++ b/frontend/src/utils/youtubeTags.js
@@ -42,7 +42,25 @@ export function parseYoutubeTags(text) {
   return { text: cleaned, videoIds }
 }
 
-export function youtubeEmbedUrl(videoId) {
+// In-session set of videoIds we've already rendered. ``youtubeEmbedUrl``
+// flips ``autoplay`` off the second time it sees an id, so scrolling back
+// through history (or switching conversations) doesn't fire a fresh
+// autoplay attempt for every old embed in the thread. Browsers would
+// block most of those (no gesture context for the historical message)
+// but the iframe still loads with the autoplay query, which is wasted
+// network + noise. Module-level Map persists for the page lifetime —
+// reloading the tab counts as a fresh start, which is the right scope.
+const _seenVideoIds = new Set()
+
+/**
+ * @param {string} videoId
+ * @param {{ autoplayIfFresh?: boolean }} [opts]
+ *   ``autoplayIfFresh`` (default true): set ``?autoplay=1`` the first
+ *   time this session sees ``videoId``. Pass ``false`` to force
+ *   ``autoplay=0`` regardless (history view, preview cards, tests).
+ */
+export function youtubeEmbedUrl(videoId, opts = {}) {
+  const { autoplayIfFresh = true } = opts
   // `youtube-nocookie.com` is the privacy-enhanced variant — recommended
   // by Google for embedded players, identical UX, no cookie set until the
   // user actually presses play.
@@ -58,5 +76,15 @@ export function youtubeEmbedUrl(videoId) {
   // ``rel=0`` keeps the "Up next" recommendations limited to the same
   // channel when playback ends, avoiding random suggestion thumbnails
   // taking over the player on a chat page.
-  return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?autoplay=1&rel=0`
+  const isFreshSighting = autoplayIfFresh && !_seenVideoIds.has(videoId)
+  if (isFreshSighting) _seenVideoIds.add(videoId)
+  const autoplay = isFreshSighting ? '1' : '0'
+  return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?autoplay=${autoplay}&rel=0`
+}
+
+// Test-only helper: resets the session-scoped autoplay cache so a unit
+// test asserting first-sight behavior doesn't have to monkeypatch the
+// module. Not part of the public app surface.
+export function _resetYoutubeAutoplayCacheForTests() {
+  _seenVideoIds.clear()
 }

--- a/frontend/src/utils/youtubeTags.js
+++ b/frontend/src/utils/youtubeTags.js
@@ -46,5 +46,17 @@ export function youtubeEmbedUrl(videoId) {
   // `youtube-nocookie.com` is the privacy-enhanced variant — recommended
   // by Google for embedded players, identical UX, no cookie set until the
   // user actually presses play.
-  return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}`
+  //
+  // ``autoplay=1`` makes the chat feel responsive: the user asked for a
+  // song ("phát nhạc <bài>"), the agent replied with the embed, and the
+  // music starts without an extra click. Browsers gate autoplay-with-sound
+  // behind a "user has interacted with the page" check — the user's typed
+  // /api/chat/stream message counts, so this works on the same turn. The
+  // iframe element in ChatMessages.vue already lists ``autoplay`` in its
+  // ``allow`` attribute; the URL param is the missing half.
+  //
+  // ``rel=0`` keeps the "Up next" recommendations limited to the same
+  // channel when playback ends, avoiding random suggestion thumbnails
+  // taking over the player on a chat page.
+  return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(videoId)}?autoplay=1&rel=0`
 }

--- a/frontend/src/utils/youtubeTags.test.js
+++ b/frontend/src/utils/youtubeTags.test.js
@@ -1,7 +1,11 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { parseYoutubeTags, youtubeEmbedUrl } from './youtubeTags.js'
+import {
+  parseYoutubeTags,
+  youtubeEmbedUrl,
+  _resetYoutubeAutoplayCacheForTests,
+} from './youtubeTags.js'
 
 test('no tag → text unchanged, videoIds empty', () => {
   const out = parseYoutubeTags('Hello world')
@@ -88,13 +92,55 @@ test('tag on its own line → leftover blank line is collapsed', () => {
   assert.equal(out.text.includes('PLAY:'), false)
 })
 
-test('youtubeEmbedUrl builds nocookie URL with id encoded + autoplay', () => {
+test('youtubeEmbedUrl: first sighting → autoplay=1, second → autoplay=0', () => {
   // autoplay=1 + rel=0 are user-facing behaviour, not implementation
   // detail — pin them so a future refactor that drops either flag is a
-  // visible diff in the PR rather than a silent UX regression.
+  // visible diff in the PR rather than a silent UX regression. The
+  // session cache makes subsequent calls for the same id fall back to
+  // autoplay=0 so scrolling back through history doesn't fire fresh
+  // autoplay attempts on every embed in the thread.
+  _resetYoutubeAutoplayCacheForTests()
   assert.equal(
     youtubeEmbedUrl('dQw4w9WgXcQ'),
     'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0'
+  )
+  // Second call for the same id during the same session — history-scroll
+  // or conversation re-mount — must NOT request autoplay again.
+  assert.equal(
+    youtubeEmbedUrl('dQw4w9WgXcQ'),
+    'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=0&rel=0'
+  )
+})
+
+test('youtubeEmbedUrl: each distinct id gets its own first-sight autoplay', () => {
+  // Two different videos in one session — both deserve the
+  // "freshly emitted" autoplay since each is an independent agent
+  // action the user just initiated.
+  _resetYoutubeAutoplayCacheForTests()
+  assert.equal(
+    youtubeEmbedUrl('aaaaaa1111A'),
+    'https://www.youtube-nocookie.com/embed/aaaaaa1111A?autoplay=1&rel=0'
+  )
+  assert.equal(
+    youtubeEmbedUrl('bbbbbb2222B'),
+    'https://www.youtube-nocookie.com/embed/bbbbbb2222B?autoplay=1&rel=0'
+  )
+})
+
+test('youtubeEmbedUrl: autoplayIfFresh=false forces autoplay=0', () => {
+  // Opt-out path for callers that render an embed in a non-active
+  // context (preview cards, history-only views, tests) where firing
+  // autoplay would be wrong regardless of the cache state.
+  _resetYoutubeAutoplayCacheForTests()
+  assert.equal(
+    youtubeEmbedUrl('cccccc3333C', { autoplayIfFresh: false }),
+    'https://www.youtube-nocookie.com/embed/cccccc3333C?autoplay=0&rel=0'
+  )
+  // A subsequent call WITH autoplayIfFresh true should still get
+  // autoplay=1 — opt-out doesn't poison the cache.
+  assert.equal(
+    youtubeEmbedUrl('cccccc3333C'),
+    'https://www.youtube-nocookie.com/embed/cccccc3333C?autoplay=1&rel=0'
   )
 })
 
@@ -102,6 +148,7 @@ test('youtubeEmbedUrl encodes characters defensively', () => {
   // Defence-in-depth: even though the parser only emits sanitized ids,
   // the embed helper must not blindly concatenate. If a caller bypasses
   // the parser, encodeURIComponent prevents URL injection.
+  _resetYoutubeAutoplayCacheForTests()
   assert.equal(
     youtubeEmbedUrl('a/b'),
     'https://www.youtube-nocookie.com/embed/a%2Fb?autoplay=1&rel=0'

--- a/frontend/src/utils/youtubeTags.test.js
+++ b/frontend/src/utils/youtubeTags.test.js
@@ -88,10 +88,13 @@ test('tag on its own line → leftover blank line is collapsed', () => {
   assert.equal(out.text.includes('PLAY:'), false)
 })
 
-test('youtubeEmbedUrl builds nocookie URL with id encoded', () => {
+test('youtubeEmbedUrl builds nocookie URL with id encoded + autoplay', () => {
+  // autoplay=1 + rel=0 are user-facing behaviour, not implementation
+  // detail — pin them so a future refactor that drops either flag is a
+  // visible diff in the PR rather than a silent UX regression.
   assert.equal(
     youtubeEmbedUrl('dQw4w9WgXcQ'),
-    'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ'
+    'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1&rel=0'
   )
 })
 
@@ -101,6 +104,6 @@ test('youtubeEmbedUrl encodes characters defensively', () => {
   // the parser, encodeURIComponent prevents URL injection.
   assert.equal(
     youtubeEmbedUrl('a/b'),
-    'https://www.youtube-nocookie.com/embed/a%2Fb'
+    'https://www.youtube-nocookie.com/embed/a%2Fb?autoplay=1&rel=0'
   )
 })

--- a/frontend/src/views/settings/SettingsVoice.vue
+++ b/frontend/src/views/settings/SettingsVoice.vue
@@ -882,11 +882,23 @@ input[type="range"] {
      of the scroll container. Faded top edge so the panel content below
      it doesn't visibly cut off through transparent space. */
   position: sticky;
+  /* iOS Safari's soft keyboard sits on top of the visual viewport and
+     shrinks the layout viewport; ``bottom: 0`` alone collides with the
+     keyboard. ``env(safe-area-inset-bottom)`` adds the home-indicator
+     gutter; the padding-bottom hardens the gap on iOS without
+     re-measuring on every keystroke. Desktop browsers ignore the env()
+     fallback (resolves to 0) so this is iOS-only insurance. */
   bottom: 0;
+  padding-bottom: max(4px, env(safe-area-inset-bottom));
   margin-top: 8px;
-  padding: 14px 0 4px;
+  padding-top: 14px;
   background: linear-gradient(180deg, transparent 0%, var(--bg-1, #0b1020) 35%, var(--bg-1, #0b1020) 100%);
-  z-index: 5;
+  /* Bumped from 5 → 30 so native popovers that float over the panel
+     (voice-name <select> dropdown, reveal-eye tooltip, paid-engine
+     hint pill) don't render UNDER the sticky band. 30 is the same tier
+     SettingsGeneral.vue uses for its own sticky save row — keeps the
+     two settings tabs visually consistent. */
+  z-index: 30;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/settings/SettingsVoice.vue
+++ b/frontend/src/views/settings/SettingsVoice.vue
@@ -874,7 +874,19 @@ input[type="range"] {
 
 .footer-row {
   display: flex; justify-content: flex-end; align-items: center;
-  gap: 12px; margin-top: 4px;
+  gap: 12px;
+  /* Sticky so "Save changes" is always reachable — without this, a long
+     panel (engine picker → params → secret form) pushes the button below
+     the viewport on first visit, leaving the user staring at form fields
+     with no obvious way to commit them. The sticky band rides the bottom
+     of the scroll container. Faded top edge so the panel content below
+     it doesn't visibly cut off through transparent space. */
+  position: sticky;
+  bottom: 0;
+  margin-top: 8px;
+  padding: 14px 0 4px;
+  background: linear-gradient(180deg, transparent 0%, var(--bg-1, #0b1020) 35%, var(--bg-1, #0b1020) 100%);
+  z-index: 5;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/views/settings/SettingsVoice.vue
+++ b/frontend/src/views/settings/SettingsVoice.vue
@@ -72,9 +72,19 @@ onMounted(async () => {
     engines.value = reg
     active.value = cur
     secretsStatus.value = sec.engines || {}
-    const checks = Object.entries(reg.tts || {})
-      .filter(([_, spec]) => (spec.requires?.length || spec.secrets?.length))
-      .map(async ([id]) => [id, await apiFetch(`/api/voice/requirements/${id}`)])
+    // Probe requirements for every engine that declares either binaries or
+    // secrets — TTS and STT alike, so cloud STT backends (Soniox, ...) get
+    // the same "ready / missing key" badge as paid TTS engines.
+    const probeIds = new Set()
+    for (const [id, spec] of Object.entries(reg.tts || {})) {
+      if (spec.requires?.length || spec.secrets?.length) probeIds.add(id)
+    }
+    for (const [id, spec] of Object.entries(reg.stt || {})) {
+      if (spec.requires?.length || spec.secrets?.length) probeIds.add(id)
+    }
+    const checks = Array.from(probeIds).map(
+      async (id) => [id, await apiFetch(`/api/voice/requirements/${id}`)]
+    )
     for (const [id, req] of await Promise.all(checks)) requirements.value[id] = req
   } catch (e) {
     error.value = e?.message || String(e)
@@ -188,6 +198,12 @@ async function testStt() {
 
 const secretInput = ref({})
 const secretReveal = ref({})
+function _hasReqOrSecrets(engine) {
+  const tts = engines.value.tts?.[engine]
+  const stt = engines.value.stt?.[engine]
+  return !!(tts?.requires?.length || tts?.secrets?.length
+         || stt?.requires?.length || stt?.secrets?.length)
+}
 async function setSecret(engine, slot) {
   const key = `${engine}.${slot}`
   const val = secretInput.value[key]
@@ -199,7 +215,7 @@ async function setSecret(engine, slot) {
   secretInput.value[key] = ''
   const sec = await apiFetch('/api/voice/secrets')
   secretsStatus.value = sec.engines || {}
-  if ((engines.value.tts[engine]?.requires?.length || engines.value.tts[engine]?.secrets?.length)) {
+  if (_hasReqOrSecrets(engine)) {
     requirements.value[engine] = await apiFetch(`/api/voice/requirements/${engine}`)
   }
 }
@@ -207,7 +223,7 @@ async function clearSecret(engine, slot) {
   await apiFetch(`/api/voice/secrets/${engine}/${slot}`, { method: 'DELETE' })
   const sec = await apiFetch('/api/voice/secrets')
   secretsStatus.value = sec.engines || {}
-  if ((engines.value.tts[engine]?.requires?.length || engines.value.tts[engine]?.secrets?.length)) {
+  if (_hasReqOrSecrets(engine)) {
     requirements.value[engine] = await apiFetch(`/api/voice/requirements/${engine}`)
   }
 }
@@ -466,6 +482,9 @@ const chatProviderLabel = computed(() => {
 
         <div v-if="sttSpec" class="provider-hint">
           <strong>{{ sttSpec.label }}</strong> — {{ sttSpec.description }}
+          <span v-if="reqBadgeFor(sttBackendId)" class="key-status" :class="reqBadgeFor(sttBackendId).tone === 'ok' ? 'stored' : 'missing'">
+            {{ reqBadgeFor(sttBackendId).text }}
+          </span>
           <span v-if="sttSpec.language_locked" class="key-status stored">
             language locked: {{ sttSpec.language_locked }}
           </span>
@@ -527,6 +546,44 @@ const chatProviderLabel = computed(() => {
               />
             </div>
           </template>
+
+          <!-- Per-backend secrets (cloud STT API keys, e.g. Soniox). The
+               TTS panel renders the same shape; UI is duplicated rather
+               than extracted because the param/secret form is the only
+               non-trivial bit and refactoring two of them under a single
+               component is more churn than it's worth right now. -->
+          <div v-for="slot in (sttSpec?.secrets || [])" :key="slot" class="field">
+            <label :for="`stt-secret-${sttBackendId}-${slot}`">
+              Secret · {{ slot }}
+              <span v-if="(secretsStatus[sttBackendId] || {})[slot]" class="key-status stored">stored · hidden</span>
+              <span v-else class="key-status missing">not set</span>
+            </label>
+            <div class="input-group">
+              <input
+                :id="`stt-secret-${sttBackendId}-${slot}`"
+                class="pwd-input"
+                :type="secretReveal[`${sttBackendId}.${slot}`] ? 'text' : 'password'"
+                autocomplete="off"
+                :placeholder="(secretsStatus[sttBackendId] || {})[slot] ? 'Leave blank to keep current' : 'Paste API key'"
+                :value="secretInput[`${sttBackendId}.${slot}`] || ''"
+                @input="secretInput[`${sttBackendId}.${slot}`] = $event.target.value"
+              />
+              <button type="button" class="icon-btn" @click="secretReveal[`${sttBackendId}.${slot}`] = !secretReveal[`${sttBackendId}.${slot}`]">
+                <svg v-if="secretReveal[`${sttBackendId}.${slot}`]" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                </svg>
+                <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </button>
+            </div>
+            <div class="action-row" style="margin-top: 8px;">
+              <button type="button" class="btn ghost" :disabled="!(secretsStatus[sttBackendId] || {})[slot]" @click="clearSecret(sttBackendId, slot)">Clear</button>
+              <button type="button" class="btn primary" :disabled="!secretInput[`${sttBackendId}.${slot}`]" @click="setSecret(sttBackendId, slot)">Save key</button>
+            </div>
+          </div>
         </template>
 
         <div class="action-row">

--- a/frontend/tests/e2e/fixtures/settings_voice_soniox.yaml
+++ b/frontend/tests/e2e/fixtures/settings_voice_soniox.yaml
@@ -1,0 +1,216 @@
+# Settings → Voice, Soniox plug-and-play flow.
+#
+# What this fixture stages:
+#   * GET /api/voice/engines returns the full registry including the new
+#     ``soniox`` TTS engine AND the ``soniox`` STT backend. The UI iterates
+#     ``engines.tts`` / ``engines.stt`` and renders a card per entry — so
+#     adding Soniox here is exactly what the live backend would emit.
+#   * GET /api/voice/active starts with the bootstrap defaults (Edge for
+#     chat, faster-whisper for STT). The flow exercises switching both to
+#     Soniox and persisting via POST /api/voice/active.
+#   * GET /api/voice/secrets reports no soniox.api_key on file, then flips
+#     to ``{api_key: true}`` after the user pastes the key and clicks Save.
+#   * GET /api/voice/requirements/soniox is asked on mount (Soniox declares
+#     ``secrets: ["api_key"]`` so the requirements probe iterates it).
+#     Initially ``ok: false`` because no key is set; the spec asserts the
+#     "set api_key" pill renders.
+#
+# Backend contract this asserts:
+#   * voice_engine_registry exposes ``soniox`` under both list_tts_engines
+#     and list_stt_backends
+#   * voice_config.set_chat_config accepts engine=soniox + nested params
+#   * voice_config.set_stt_config accepts backend=soniox + nested params +
+#     wake_word.backend=off (only wake-word option for Soniox)
+#   * routes/voice.list_secrets_status dedupes the shared "soniox" key
+
+backend_source:
+  - "backend/services/voice_engine_registry.py::TTS_ENGINES['soniox']"
+  - "backend/services/voice_engine_registry.py::STT_BACKENDS['soniox']"
+  - "backend/routes/voice.py::list_engines"
+  - "backend/routes/voice.py::list_secrets_status"
+  - "backend/routes/voice.py::set_active_config"
+  - "backend/routes/voice.py::set_secret"
+  - "backend/routes/voice.py::check_requirements"
+  - "dashboard/src/views/settings/SettingsVoice.vue::changeChatEngine, changeSttBackend, setSecret, save"
+
+notes: |
+  ``GET /api/voice/secrets`` and ``GET /api/voice/requirements/soniox``
+  are sequenced — the spec triggers a state flip when the user saves the
+  api_key, after which the secrets list must report ``api_key: true`` and
+  the requirements badge must flip from "set api_key" to "ready". Both
+  responses are arrays so the second-and-later GETs see the new state.
+
+responses:
+  # SettingsGeneral mounts before the Voice tab is selected and fires
+  # settings.store.fetchAll() → GET /api/settings. Stubbed empty so the
+  # Voice flow doesn't have to assert on a category that isn't relevant.
+  "GET /api/settings":
+    status: 200
+    json:
+      categories: {}
+
+  # ── Registry surface ────────────────────────────────────────────────
+  "GET /api/voice/engines":
+    status: 200
+    json:
+      tts:
+        edge:
+          label: "Microsoft Edge TTS"
+          description: "Free, no API key, native vi-VN + en-US voices."
+          badges: ["free", "cloud", "vi+en"]
+          requires: []
+          secrets: []
+          realtimetts_engine: "EdgeEngine"
+          output_format: "mp3"
+          params:
+            - key: "voice"
+              type: "select"
+              label: "Voice"
+              default: "vi-VN-NamMinhNeural"
+              options: ["vi-VN-NamMinhNeural", "vi-VN-HoaiMyNeural"]
+            - key: "rate"
+              type: "text"
+              label: "Speech rate"
+              default: "+20%"
+        soniox:
+          label: "Soniox TTS (real-time)"
+          description: "Cloud WebSocket TTS, 60+ languages, low-latency streaming."
+          badges: ["cloud", "paid", "multilingual"]
+          requires: []
+          secrets: ["api_key"]
+          output_format: "mp3"
+          params:
+            - key: "model"
+              type: "select"
+              label: "Model"
+              default: "tts-rt-v1"
+              options: ["tts-rt-v1"]
+            - key: "voice"
+              type: "text"
+              label: "Voice"
+              default: "Adrian"
+            - key: "language"
+              type: "text"
+              label: "Language"
+              default: "en"
+            - key: "sample_rate"
+              type: "select"
+              label: "Sample rate"
+              default: 24000
+              options: [8000, 16000, 24000, 44100, 48000]
+      stt:
+        faster_whisper:
+          label: "faster-whisper (local)"
+          description: "Local inference."
+          badges: ["free", "local"]
+          params:
+            - key: "model"
+              type: "select"
+              label: "Final model"
+              default: "base"
+              options: ["tiny", "base", "small"]
+            - key: "language"
+              type: "select"
+              label: "Language"
+              default: "auto"
+              options: ["auto", "vi", "en"]
+          wake_word_backends:
+            off:
+              label: "Disabled"
+              params: []
+        soniox:
+          label: "Soniox STT (real-time)"
+          description: "Cloud WebSocket STT, 60+ languages, server-side endpoint detection."
+          badges: ["cloud", "paid", "multilingual"]
+          secrets: ["api_key"]
+          params:
+            - key: "model"
+              type: "select"
+              label: "Model"
+              default: "stt-rt-v4"
+              options: ["stt-rt-v4"]
+            - key: "language_hints"
+              type: "text"
+              label: "Language hints"
+              default: "vi,en"
+          wake_word_backends:
+            off:
+              label: "Disabled"
+              params: []
+
+  # ── Active config (bootstrap defaults) ──────────────────────────────
+  "GET /api/voice/active":
+    status: 200
+    json:
+      tts_chat:
+        engine: "edge"
+        params: { voice: "vi-VN-NamMinhNeural", rate: "+20%" }
+      tts_stories:
+        voice: "vi-VN-NamMinhNeural"
+        rate: "+20%"
+      stt:
+        backend: "faster_whisper"
+        params: { model: "base", language: "auto" }
+        wake_word: { backend: "off", params: {} }
+
+  # ── Secrets status — flips after the user saves a key ───────────────
+  "GET /api/voice/secrets":
+    - status: 200
+      json:
+        engines:
+          elevenlabs: { api_key: false }
+          openai: { api_key: false }
+          azure: { api_key: false }
+          soniox: { api_key: false }
+    # After POST /api/voice/secrets/soniox/api_key, the next GET reflects
+    # the new state — proves we don't render a stale pill.
+    - status: 200
+      json:
+        engines:
+          elevenlabs: { api_key: false }
+          openai: { api_key: false }
+          azure: { api_key: false }
+          soniox: { api_key: true }
+
+  # ── Requirements per engine (probed for every engine with secrets) ──
+  # SettingsVoice.vue iterates both TTS + STT and probes any engine that
+  # declares ``requires`` or ``secrets``.
+  "GET /api/voice/requirements/soniox":
+    - status: 200
+      json:
+        ok: false
+        missing_binaries: []
+        secrets_present: { api_key: false }
+    - status: 200
+      json:
+        ok: true
+        missing_binaries: []
+        secrets_present: { api_key: true }
+  "GET /api/voice/requirements/elevenlabs":
+    status: 200
+    json:
+      ok: false
+      missing_binaries: ["mpv"]
+      secrets_present: { api_key: false }
+  "GET /api/voice/requirements/openai":
+    status: 200
+    json:
+      ok: false
+      missing_binaries: ["ffmpeg"]
+      secrets_present: { api_key: false }
+  "GET /api/voice/requirements/azure":
+    status: 200
+    json:
+      ok: false
+      missing_binaries: []
+      secrets_present: { api_key: false, region: false }
+
+  # ── Secret CRUD — the spec POSTs the key, the recorder asserts body ─
+  "POST /api/voice/secrets/soniox/api_key":
+    status: 200
+    json: { status: "ok" }
+
+  # ── Active config save — Soniox for both TTS chat AND STT ───────────
+  "POST /api/voice/active":
+    status: 200
+    json: { status: "ok" }

--- a/frontend/tests/e2e/flows/chat-input-dictation.spec.ts
+++ b/frontend/tests/e2e/flows/chat-input-dictation.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * E2E flow: ChatInput dictation — press-to-talk → text in textarea.
+ *
+ * Guards the user-visible path that lets a user click the bottom mic,
+ * speak, and end up with editable text in the chat composer (instead of
+ * an auto-submitted message like the hands-free VoiceBar does):
+ *
+ *   1. Click mic → component opens a WS to /ws/voice, sends
+ *      {type:'start', mode:'dictation'} as the handshake.
+ *   2. We push partial_transcript / final_transcript JSON frames; the
+ *      textarea reflects them live (provisional + finals merged).
+ *   3. Second mic click stops dictation but keeps the merged text — the
+ *      user edits a typo, then clicks Send. The send event fires with
+ *      the EDITED text, proving dictation does NOT auto-submit.
+ *
+ * Why mock the WebSocket + audio capture: the dictation pipeline needs
+ * a live /ws/voice plus a mic. In CI we have neither, so we stub:
+ *   - page.routeWebSocket for the /ws/voice frames.
+ *   - navigator.mediaDevices.getUserMedia + AudioContext + AudioWorklet
+ *     so the audio capture half no-ops without throwing. We never need
+ *     real PCM because the stubbed WS doesn't actually transcribe.
+ */
+
+import type { Page, WebSocketRoute } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+/**
+ * Stub the audio capture path so getUserMedia + AudioContext +
+ * AudioWorkletNode resolve to no-op instances. The dictation composable
+ * awaits each step, so the stubs return correctly-shaped objects rather
+ * than ``undefined`` — otherwise an awaited promise would throw and
+ * short-circuit before the WS handshake.
+ */
+async function stubMicCapture(page: Page) {
+  await page.addInitScript(() => {
+    const fakeTrack = {
+      stop() {},
+      getSettings: () => ({}),
+      getCapabilities: () => ({}),
+    }
+    const fakeStream = {
+      getAudioTracks: () => [fakeTrack],
+      getTracks: () => [fakeTrack],
+    }
+    Object.defineProperty(window.navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: async () => fakeStream },
+    })
+    class FakeAudioWorklet { async addModule() {} }
+    class FakeAudioContext {
+      audioWorklet = new FakeAudioWorklet()
+      currentTime = 0
+      sampleRate = 48000
+      createMediaStreamSource() { return { connect() {} } }
+      async close() {}
+    }
+    class FakeAudioWorkletNode {
+      port = { onmessage: null }
+      disconnect() {}
+    }
+    // @ts-expect-error — replacing globals for test
+    window.AudioContext = FakeAudioContext
+    // @ts-expect-error
+    window.AudioWorkletNode = FakeAudioWorkletNode
+  })
+}
+
+test('mic dictates into textarea, user edits, send fires edited text — no auto-submit', async ({ page }) => {
+  await seedApiKey(page)
+  await stubMicCapture(page)
+  await mockBackend(page, [NOISE])
+
+  // Capture the routed WebSocket so the test can push server-side frames
+  // on demand. routeWebSocket fires once per opened socket; we stash the
+  // route reference + log every inbound client frame so assertions can
+  // verify the handshake payload.
+  let routedWS: WebSocketRoute | null = null
+  const inboundFrames: string[] = []
+  await page.routeWebSocket(/\/ws\/voice$/, (ws) => {
+    routedWS = ws
+    ws.onMessage((data) => {
+      const s = typeof data === 'string' ? data : '<binary>'
+      inboundFrames.push(s)
+      try {
+        const msg = JSON.parse(s)
+        if (msg.type === 'start') {
+          // Ack the handshake exactly like the real backend would so the
+          // composable's status flips to 'listening'.
+          ws.send(JSON.stringify({ type: 'stt_ready' }))
+        }
+      } catch { /* binary PCM frames — ignore */ }
+    })
+  })
+
+  await page.goto('/chat')
+
+  const mic = page.getByTestId('chat-mic')
+  await expect(mic).toBeVisible()
+  const textarea = page.locator('textarea.textarea')
+  await expect(textarea).toBeVisible()
+
+  // ── (1) First click opens the WS + handshake ────────────────────────
+  await mic.click()
+  await expect.poll(() => inboundFrames.find((m) => m.includes('"type":"start"'))).toBeTruthy()
+  const startMsg = JSON.parse(inboundFrames.find((m) => m.includes('"type":"start"'))!)
+  expect(startMsg.mode).toBe('dictation')
+
+  // Button flipped to the active state — title swap is the user-visible
+  // signal; the .recording class drives the pulse styling.
+  await expect(mic).toHaveAttribute('title', /Stop dictation/)
+
+  // ── (2) Drive transcripts from the stubbed server ───────────────────
+  // Provisional partial → live tail in textarea. Then a final that flips
+  // the partial into the accumulated finals buffer.
+  expect(routedWS).not.toBeNull()
+  await routedWS!.send(JSON.stringify({ type: 'partial_transcript', text: 'Xin chào' }))
+  await expect.poll(() => textarea.inputValue()).toContain('Xin chào')
+
+  await routedWS!.send(JSON.stringify({ type: 'final_transcript', text: 'Xin chào Jarvis' }))
+  await expect.poll(() => textarea.inputValue()).toContain('Xin chào Jarvis')
+
+  // ── (3) Second click stops dictation, text stays for editing ────────
+  await mic.click()
+  await expect(mic).toHaveAttribute('title', /Dictate/)
+
+  // Edit the dictated text — add punctuation that no STT would produce.
+  await textarea.click()
+  await textarea.fill('Xin chào Jarvis, làm ơn giúp tôi.')
+
+  // ── (4) Click Send — fires with the EDITED text, NOT the dictated raw
+  // The send button is the only enabled non-mic non-attach button in the
+  // composer once there's text; locate by class to dodge i18n.
+  await page.locator('.send-btn').first().click()
+  // handleSend clears the textarea after emitting — proves the send path
+  // ran, and that dictation didn't auto-submit before we got the edit in.
+  await expect.poll(() => textarea.inputValue()).toBe('')
+})

--- a/frontend/tests/e2e/flows/chat-youtube-embed.spec.ts
+++ b/frontend/tests/e2e/flows/chat-youtube-embed.spec.ts
@@ -34,7 +34,9 @@ const VIDEO_ID = 'dQw4w9WgXcQ'
 // composer, which browsers count as the gesture that unlocks
 // sound-autoplay. ``rel=0`` keeps the post-playback recommendation
 // thumbnails within the same channel. Pin both flags here so a future
-// refactor that drops either is a visible diff.
+// refactor that drops either is a visible diff. ``autoplay=1`` only
+// fires on the FIRST sighting per session — second mount of the same
+// videoId (history scrollback) gets ``autoplay=0`` from the cache.
 const EXPECTED_SRC = `https://www.youtube-nocookie.com/embed/${VIDEO_ID}?autoplay=1&rel=0`
 
 test('PLAY tag → YouTube iframe renders, literal tag is hidden', async ({

--- a/frontend/tests/e2e/flows/chat-youtube-embed.spec.ts
+++ b/frontend/tests/e2e/flows/chat-youtube-embed.spec.ts
@@ -29,7 +29,13 @@ const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
 const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
 
 const VIDEO_ID = 'dQw4w9WgXcQ'
-const EXPECTED_SRC = `https://www.youtube-nocookie.com/embed/${VIDEO_ID}`
+// ``autoplay=1`` lets the song start without an extra click after the
+// agent's response — the user already pressed Enter on the chat
+// composer, which browsers count as the gesture that unlocks
+// sound-autoplay. ``rel=0`` keeps the post-playback recommendation
+// thumbnails within the same channel. Pin both flags here so a future
+// refactor that drops either is a visible diff.
+const EXPECTED_SRC = `https://www.youtube-nocookie.com/embed/${VIDEO_ID}?autoplay=1&rel=0`
 
 test('PLAY tag → YouTube iframe renders, literal tag is hidden', async ({
   page,

--- a/frontend/tests/e2e/flows/settings-voice-soniox.spec.ts
+++ b/frontend/tests/e2e/flows/settings-voice-soniox.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * E2E flow: Settings → Voice — Soniox plug-and-play.
+ *
+ * Guards the user-visible path that lets a fresh user enable the cloud
+ * Soniox TTS + STT pair from the Voice tab:
+ *
+ *   1. Soniox cards appear in BOTH panels (TTS chat + STT) — the UI is
+ *      registry-driven (``v-for="(spec, id) in engines.tts/stt"``), so
+ *      the only way they'd be missing is a backend regression. The spec
+ *      asserts the card label is visible inside the right panel.
+ *   2. Selecting Soniox STT reveals an "Secret · api_key" row with a
+ *      masked input + "Save key" button (mirrors the TTS-side secret
+ *      UI). The pill starts at "not set", and ``reqBadgeFor(sttBackendId)``
+ *      shows "set api_key" until the key is saved.
+ *   3. Pasting a key + clicking Save fires POST
+ *      /api/voice/secrets/soniox/api_key. The fixture flips the next
+ *      ``GET /api/voice/secrets`` and ``GET /api/voice/requirements/soniox``
+ *      to "key present / ready", so the UI's "stored · hidden" and
+ *      "ready" pills must visibly update — proves the panel re-reads
+ *      state post-save instead of trusting the prior fetch.
+ *   4. Clicking "Save changes" persists the combined active config via
+ *      POST /api/voice/active. The recorder asserts the body contains
+ *      both ``tts_chat.engine === 'soniox'`` and ``stt.backend === 'soniox'``
+ *      — Settings → Voice writes both in a single payload.
+ *
+ * Why a happy-path-only flow: the unit + backend e2e tests already cover
+ * validator failures, WS protocol errors, and the SSoT contract that
+ * Soniox shares one ``api_key`` slot across TTS+STT. The Playwright cost
+ * is best spent on the live click-flow most users will follow.
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, NetworkRecorder, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+test('Soniox surfaces in both panels, secret save flips pills, active config persists both', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const backend = await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'settings_voice_soniox.yaml'),
+  ])
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+
+  await page.goto('/settings')
+
+  // Click the Voice tab — General is the default mount, so the Voice
+  // panel doesn't render until activation. The tab list lives in
+  // SettingsView.vue and uses plain buttons keyed by their visible label.
+  await page.getByRole('button', { name: 'Voice', exact: true }).click()
+
+  // ── (1) Soniox card appears in BOTH TTS chat AND STT panels ───────────
+  //
+  // The two panels both use ``.provider-card`` so we scope by the panel's
+  // ``<h2>`` heading to disambiguate. ``filter({ has: ... })`` walks the
+  // ancestor chain inside the harness so a missing heading fails loud
+  // instead of silently matching the wrong panel.
+  const ttsPanel = page
+    .locator('.panel-card')
+    .filter({ has: page.getByRole('heading', { name: /Chat & Notification Voice/i }) })
+  const sttPanel = page
+    .locator('.panel-card')
+    .filter({ has: page.getByRole('heading', { name: /Speech recognition/i }) })
+
+  await expect(
+    ttsPanel.getByRole('button', { name: /Soniox TTS \(real-time\)/i }),
+  ).toBeVisible()
+  await expect(
+    sttPanel.getByRole('button', { name: /Soniox STT \(real-time\)/i }),
+  ).toBeVisible()
+
+  // ── (2) Selecting Soniox STT reveals the api_key secret row ───────────
+  //
+  // Before clicking, the STT panel shows faster-whisper params (no
+  // secret input). After clicking Soniox STT, the panel must render the
+  // "Secret · api_key" field with the "not set" pill and the "Save key"
+  // button. We assert on the label text because the field id is
+  // dynamically built from the backend id (``stt-secret-soniox-api_key``)
+  // and would silently change if someone refactored that template.
+  await sttPanel.getByRole('button', { name: /Soniox STT \(real-time\)/i }).click()
+
+  // Anchor on the visible label "Secret · api_key" — placed by the
+  // template right above the masked input. The "not set" pill is part
+  // of the same <label>, so we assert both at once.
+  const sttSecretLabel = sttPanel.getByText('Secret · api_key', { exact: false })
+  await expect(sttSecretLabel).toBeVisible()
+  await expect(sttPanel.getByText('not set', { exact: true })).toBeVisible()
+
+  // The requirements probe ran on mount; with no key on file the badge
+  // says "set api_key".  The badge text is built by ``reqBadgeFor`` —
+  // missing slot key surfaces as "set api_key" (joined with the slot name).
+  await expect(sttPanel.getByText('set api_key', { exact: false })).toBeVisible()
+
+  // ── (3) Save the key — POST /api/voice/secrets/soniox/api_key ─────────
+  //
+  // The input id format is ``stt-secret-<backendId>-<slot>``; we use
+  // ``getByPlaceholder`` to stay decoupled. The placeholder text comes
+  // from the template ("Paste API key" when no value on file).
+  const keyInput = sttPanel.getByPlaceholder('Paste API key')
+  await keyInput.fill('sk-soniox-test-key')
+
+  const saveKeyBtn = sttPanel.getByRole('button', { name: 'Save key', exact: true })
+  await expect(saveKeyBtn).toBeEnabled()
+  const [secretResp] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/voice/secrets/soniox/api_key',
+    ),
+    saveKeyBtn.click(),
+  ])
+  expect(secretResp.status()).toBe(200)
+  const secretCall = recorder.assertContains(
+    'POST',
+    '/api/voice/secrets/soniox/api_key',
+  )
+  expect((secretCall.body as { value: string }).value).toBe('sk-soniox-test-key')
+
+  // After save: pill flips to "stored · hidden" and the requirements
+  // badge flips to "ready". Without the re-fetch, neither would update —
+  // this guards the post-save reload path in ``setSecret``.
+  await expect(sttPanel.getByText('stored · hidden', { exact: true })).toBeVisible()
+  await expect(sttPanel.getByText('ready', { exact: true })).toBeVisible()
+
+  // ── (4) Also pick Soniox TTS, then Save changes — verify both land ────
+  await ttsPanel.getByRole('button', { name: /Soniox TTS \(real-time\)/i }).click()
+
+  const saveAllBtn = page.getByRole('button', { name: 'Save changes', exact: true })
+  await expect(saveAllBtn).toBeEnabled()
+  const [activeResp] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/voice/active',
+    ),
+    saveAllBtn.click(),
+  ])
+  expect(activeResp.status()).toBe(200)
+
+  const activeCall = recorder.assertContains('POST', '/api/voice/active')
+  const body = activeCall.body as {
+    tts_chat: { engine: string; params: Record<string, unknown> }
+    stt: {
+      backend: string
+      params: Record<string, unknown>
+      wake_word: { backend: string }
+    }
+  } | null
+  expect(body?.tts_chat.engine).toBe('soniox')
+  expect(body?.stt.backend).toBe('soniox')
+  // Default params from the registry should be carried through verbatim —
+  // proves changeChatEngine / changeSttBackend seed defaults rather than
+  // leaving params empty (which would make the backend's validator pass
+  // but the runtime fail when building the provider).
+  expect(body?.tts_chat.params.model).toBe('tts-rt-v1')
+  expect(body?.tts_chat.params.voice).toBe('Adrian')
+  expect(body?.stt.params.model).toBe('stt-rt-v4')
+  expect(body?.stt.wake_word.backend).toBe('off')
+
+  if (backend.unexpected.length > 0) {
+    console.log('UNEXPECTED:', JSON.stringify(backend.unexpected, null, 2))
+  }
+  expect(backend.unexpected.length).toBe(0)
+})


### PR DESCRIPTION
## Summary

Two related changes, separate commits for review:

1. **Soniox realtime STT + TTS as plug-and-play voice provider** (`aaf89da`)
   - New WebSocket clients for `wss://stt-rt.soniox.com/transcribe-websocket` and `wss://tts-rt.soniox.com/tts-websocket`.
   - Registry-driven — Soniox surfaces automatically in Settings → Voice with 28 voices + 15 ISO languages (vi + en first).
   - Soniox shares one `api_key` slot across TTS and STT (`voice.secrets.soniox.api_key`) — voice_config + routes/voice now look up engines in either registry so a user picking only Soniox STT can still set the key from the STT card.
   - Pulled the WS-streaming scaffolding (thread + queue + hook + reconnect) into a `WSStreamingSTT` base class so the next cloud STT (Deepgram/AssemblyAI) is a sibling-file change.

2. **Bottom-mic dictation in ChatInput** (`d4f52ff`)
   - Replaces MediaRecorder→WebM-attach with press-to-talk transcription.
   - Backend accepts `{type:'start', mode:'dictation'}` on `/ws/voice`; gates `_dispatch_user_turn` so LLM/TTS stays cold while transcripts still propagate.
   - New `useDictationSession` composable disjoint from `useVoiceSession` (the hands-free conversation pipeline).
   - User speaks → text streams into the textarea → user edits → user hits Send. The hands-free VoiceBar's auto-submit behaviour is untouched.

## Test plan

Verified locally on `feat/soniox-realtime-tts-stt`:

- [x] Backend unit tests — 762 service + route tests pass
  - [x] `test_voice_engine_registry.py` (new `TestSonioxBackend` class)
  - [x] `test_soniox_stt.py` — 11 token-protocol assertions (config message, `<end>` endpoint flush, provisional/final accumulation)
  - [x] `test_soniox_tts.py` — 6 provider tests
  - [x] `test_voice_routes.py::test_stt_only_engine_secret_surfaces`
  - [x] `test_ws_voice.py::test_dictation_mode_suppresses_llm_dispatch` + negative-control `test_default_mode_still_dispatches_llm_on_final_transcript`
- [x] Backend e2e against real loopback `websockets.serve()` — `test_soniox_realtime_flow.py` (5 tests: STT roundtrip with `<end>` flush, STT server error, TTS roundtrip, PCM format swap, TTS quota error)
- [x] Frontend Playwright suite — 49/49 pass including
  - [x] `settings-voice-soniox.spec.ts` — pick Soniox in both panels → save API key → pills flip → Save changes posts correct body
  - [x] `chat-input-dictation.spec.ts` — mic click → mocked WS pushes transcripts → textarea fills → user edits → Send fires edited text
- [x] Manual smoke
  - [x] Open `localhost:3001/settings` → Voice → Soniox TTS card lists 28 voices (Adrian default) + 15 language dropdown (en, vi first)
  - [x] Soniox STT card renders secret slot with "set api_key" pill until key is saved
  - [x] Live Soniox API call (requires real API key) — not exercised in CI

## Notes for reviewer

- WS_URL is a `ClassVar` on `WSStreamingSTT` — patching `SONIOX_STT_WS_URL` module constant won't reach it; tests must patch the class attribute (`monkeypatch.setattr(soniox_stt.SonioxSTTService, "WS_URL", ...)`).
- The dictation backend gate is a local var in `voice_ws`, read by `on_stt_event` and assigned by the receive loop in the same function scope — no `nonlocal` needed.
- `dashboard/` is left untouched; `frontend/` is the canonical UI per `fdb6be5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)