### PR TITLE
fix(prompt): stop Jarvis over-delegating chitchat to PersonalAgent

### DIFF
--- a/backend/.fast-agent/skills/delegation-strategy/SKILL.md
+++ b/backend/.fast-agent/skills/delegation-strategy/SKILL.md
@@ -16,10 +16,10 @@ Among delegations: use existing agents first, spawn new only when no existing ag
 
 ## Decision Flow
 
-1. **Existing agent matches?** → Use `agent__<Name>` tool directly
-2. **No match, short task (<2 min)?** → `spawn_and_run_isolated`
-3. **No match, long task?** → `spawn_and_run_background`
-4. **Complex / ambiguous?** → Ask the user to clarify the expected output first. Then plan and pick: single agent, multiple agents, or an existing team template (`list_team_templates_tool` → `spawn_team_tool`).
+1. **Ambiguous / underspecified?** → Ask the user to clarify the expected output FIRST. Then plan and pick: single agent, multiple agents, or an existing team template (`list_team_templates_tool` → `spawn_team_tool`).
+2. **Existing agent matches?** → Use `agent__<Name>` tool directly
+3. **No match, short task (<2 min)?** → `spawn_and_run_isolated`
+4. **No match, long task?** → `spawn_and_run_background`
 
 ## Existing Agents
 
@@ -27,7 +27,7 @@ Among delegations: use existing agents first, spawn new only when no existing ag
 |-------|--------|
 | ResearchAgent | Web search, news, information synthesis |
 | FinanceAgent | Stock prices, gold, crypto, market analysis |
-| PersonalAgent | Email, calendar, reminders (cron scheduler), personal task management |
+| PersonalAgent | Email, calendar events, reminders (cron) — task management only, NOT casual conversation |
 | CrawlStoriesAgent | Story crawling from web |
 | IoTAgent | Smart home device control |
 | MusicAgent | Music search and playback |
@@ -60,6 +60,7 @@ See [SKILLS.md](SKILLS.md) for skill catalog and pairing guidance.
 ## Anti-patterns
 
 - ❌ Jarvis self-researching (no direct web server access)
+- ❌ Delegating chitchat / venting / advice to PersonalAgent — reply directly instead
 - ❌ Spawning without servers (agent can't do anything)
 - ❌ Adding `chrome-devtools` for simple search (use `serpapi`)
 - ❌ Empty or vague instruction (always specify role + output format)

--- a/backend/.fast-agent/skills/delegation-strategy/SKILL.md
+++ b/backend/.fast-agent/skills/delegation-strategy/SKILL.md
@@ -10,14 +10,16 @@ description: >
 
 ## Core Rule
 
-**Do not self-handle tasks requiring web access, research, or specialized tools.**
-Delegate to existing agents first, spawn new agents only when no existing agent fits.
+**Delegate ONLY when the task needs a specialized tool/data source** (web, email/calendar, IoT, finance, media).
+**Reply directly** for chitchat, venting, advice, opinions, or general Q&A — these are NOT delegation targets.
+Among delegations: use existing agents first, spawn new only when no existing agent fits.
 
 ## Decision Flow
 
 1. **Existing agent matches?** → Use `agent__<Name>` tool directly
 2. **No match, short task (<2 min)?** → `spawn_and_run_isolated`
 3. **No match, long task?** → `spawn_and_run_background`
+4. **Complex / ambiguous?** → Ask the user to clarify the expected output first. Then plan and pick: single agent, multiple agents, or an existing team template (`list_team_templates_tool` → `spawn_team_tool`).
 
 ## Existing Agents
 

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -269,12 +269,13 @@ else:
 
     YOUR DUTIES:
     1. Receive user requests.
-    2. Classify intent and dispatch to the appropriate Agent.
-    3. For complex requests, coordinate multiple Agents.
+    2. If the request needs a specialized tool/data source, dispatch to the appropriate Agent.
+    3. Otherwise (chitchat, venting, advice, general Q&A) — reply directly. Do NOT delegate.
+    4. For complex requests, coordinate multiple Agents.
 
-    AGENT INVOCATION RULES (MANDATORY):
-    Always use the tool agent__<AgentName> to delegate work to an available Agent:
-    - agent__PersonalAgent: Email, calendar, reminders (uses cron scheduler), personal management
+    AGENT INVOCATION RULES:
+    Delegate via agent__<AgentName> ONLY when the request matches an agent's domain:
+    - agent__PersonalAgent: Email, calendar events, reminders (cron) — task management only, NOT casual conversation
     - agent__IoTAgent: Control IoT devices, lights, fans
     - agent__MusicAgent: Play music, find songs
     - agent__AudioReaderAgent: Read/play audio stories


### PR DESCRIPTION
## Summary
- **Jarvis prompt** (`backend/agent.py`): only dispatch when the request needs a specialized tool/data source; reply directly for chitchat, venting, advice, opinions, or general Q&A. Removed the "MANDATORY always delegate" framing.
- **PersonalAgent description**: narrowed from "Email, calendar, reminders, *personal management*" → "Email, calendar events, reminders (cron) — task management only, NOT casual conversation". The vague "personal management" was the wording that pulled emotional conversations into PersonalAgent.
- **`delegation-strategy` skill**: mirrored the same self-handle vs. delegate split in the Core Rule, and added Decision Flow step 4 for complex/ambiguous tasks → clarify expected output with user, then plan and pick single agent / multiple agents / existing team template.

## Why
User reported that confiding / venting (`tâm sự`) to Jarvis was being delegated to `PersonalAgent`, which is wrong — PersonalAgent only handles Gmail / Calendar / cron reminders. Root cause was prompt wording, not code logic.

## Scope
Prompt-only change. ~10 inserted / 7 removed lines across 2 files. No code paths, no tests touched.

## Test plan
- [ ] Manually chat with Jarvis: send a casual / emotional message — verify it replies directly without calling `agent__PersonalAgent`.
- [ ] Send a real PersonalAgent task ("nhắc tôi 8h tối uống thuốc", "kiểm tra mail") — verify it still delegates correctly to PersonalAgent.
- [ ] Send a complex / ambiguous request — verify Jarvis asks clarifying questions before picking an execution strategy.
- [ ] Send a normal research / finance / IoT request — verify existing delegations still fire as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)