### PR TITLE
feat(voice): provider-agnostic STT lifecycle + feature flags (OSS prep)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,7 +28,26 @@ JARVIS_MASTER_KEY=__GENERATE_JARVIS_MASTER_KEY__
 
 # Voice config (TTS engines, STT, wake-word) lives in the DB and is managed
 # via Settings → Voice in the dashboard. Edge TTS is the bootstrap default —
-# no env var needed.
+# no env var needed for the chosen engine itself.
+#
+# ── Voice backend feature flags ──
+#
+# Allow-lists below gate which engines the UI offers and which
+# build_*_provider factories accept. Disabling a backend that's selected
+# in saved settings raises RuntimeError at startup with the env var
+# name in the message — so the operator knows exactly where to fix.
+#
+# STT: all three current backends are validated for OSS:
+#   faster_whisper — free, local, vi+en code-switch (default selection)
+#   gipformer_vi    — free, local, Vietnamese-only, better VN accents (MIT)
+#   soniox         — paid cloud, 60+ languages, real-time WS endpoint
+STT_BACKENDS_ENABLED=faster_whisper,gipformer_vi,soniox
+#
+# TTS: only the two validated for OSS by default. The rest (system,
+# azure, elevenlabs, openai) ship in code but aren't enabled until the
+# operator opts in — they depend on RealtimeTTS extras and/or paid API
+# keys we haven't validated for the OSS distribution.
+TTS_BACKENDS_ENABLED=edge,soniox
 
 # Roborock Configuration (For IoT features)
 ROBOROCK_USERNAME=

--- a/backend/fastagent.config.yaml
+++ b/backend/fastagent.config.yaml
@@ -74,15 +74,25 @@ mcp:
       args: ["tools/gmail_server.py"]
       env:
          PYTHONUNBUFFERED: "1"
-         # Needed so services.google_oauth can decrypt the Fernet-encrypted
-         # OAuth tokens in system_config via core.secrets_crypto.
+         # JARVIS_API_KEY: auth for any callback into backend HTTP.
+         # JARVIS_MASTER_KEY: required so services.google_oauth can decrypt
+         # the Fernet-encrypted OAuth tokens stored in system_config (via
+         # core.secrets_crypto). MCP's get_default_environment() only
+         # inherits HOME/PATH/SHELL/TERM/USER/LOGNAME, so the master key
+         # MUST be forwarded here or every decrypt in the subprocess returns
+         # "stored secret could not be decrypted (master key rotated?)" —
+         # even right after a successful re-OAuth.
          JARVIS_API_KEY: "${JARVIS_API_KEY}"
+         JARVIS_MASTER_KEY: "${JARVIS_MASTER_KEY}"
     calendar:
       command: "python"
       args: ["tools/calendar_server.py"]
       env:
          PYTHONUNBUFFERED: "1"
+         # See gmail above — calendar shares services.google_oauth and has
+         # the same encrypted-token decrypt dependency.
          JARVIS_API_KEY: "${JARVIS_API_KEY}"
+         JARVIS_MASTER_KEY: "${JARVIS_MASTER_KEY}"
     media-server:
       command: "python"
       args: ["tools/media_server.py"]

--- a/backend/routes/voice.py
+++ b/backend/routes/voice.py
@@ -97,6 +97,44 @@ async def list_engines(_=Depends(verify_api_key)):
     }
 
 
+@router.get("/backends")
+async def list_enabled_voice_backends(_=Depends(verify_api_key)):
+    """Return the current feature-flag allowlist for STT + TTS.
+
+    Frontend uses this to:
+
+    * filter the Settings dropdowns to only show buildable engines (a
+      paid TTS engine the operator hasn't enabled in env should not be
+      offered as a choice that will RuntimeError at save time);
+    * detect when the user's saved preference is now disabled (env
+      var changed between sessions) and fall back to a default that
+      IS in the allowlist, with a visible warning.
+
+    Shape: ``{stt: {enabled: [...], known: [...]}, tts: {...}}``. The
+    ``known`` list is the static set the codebase ships with — useful
+    for the Settings UI to show "this engine exists but is disabled
+    (enable via TTS_BACKENDS_ENABLED in backend/.env)".
+    """
+    from services.stt_backends import (
+        list_enabled_backends as _stt_enabled,
+        list_known_backends as _stt_known,
+    )
+    from services.tts_backends import (
+        list_enabled_engines as _tts_enabled,
+        list_known_engines as _tts_known,
+    )
+    return {
+        "stt": {
+            "enabled": _stt_enabled(),
+            "known": _stt_known(),
+        },
+        "tts": {
+            "enabled": _tts_enabled(),
+            "known": _tts_known(),
+        },
+    }
+
+
 @router.get("/engines/{engine}/voices")
 async def list_engine_voices(engine: str, _=Depends(verify_api_key)):
     """Live voice catalog for an engine. Best-effort — falls back to defaults

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -359,6 +359,14 @@ async def voice_ws(ws: WebSocket) -> None:
         # with the receive loop's writes.
         if name == "final_transcript":
             text = (payload or {}).get("text") or ""
+            # BARGE-IN-DIAG: log every final_transcript arrival so we can
+            # prove from the log whether STT reached this point at all,
+            # and whether the text was empty / dispatched / dropped.
+            logger.info(
+                "[ws_voice] final_transcript received len=%d preview=%r → %s",
+                len(text), text[:60],
+                "dispatch" if text.strip() else "drop(empty)",
+            )
             if text.strip():
                 user_query_pending = True
                 loop.call_soon_threadsafe(_dispatch_user_turn, text.strip())
@@ -367,6 +375,13 @@ async def voice_ws(ws: WebSocket) -> None:
         """Fire-and-forget: schedule a coroutine that handles one full turn."""
         nonlocal agent_task, user_query_pending
         user_query_pending = False
+        # BARGE-IN-DIAG: log dispatch entry + dictation gate + cancel state.
+        agent_state = "none" if agent_task is None else ("done" if agent_task.done() else "active")
+        tts_state = "none" if tts_task is None else ("done" if tts_task.done() else "active")
+        logger.info(
+            "[ws_voice] _dispatch_user_turn entry text=%r dictation=%s agent=%s tts=%s",
+            text[:60], dictation_mode, agent_state, tts_state,
+        )
         # Dictation gate. ``dictation_mode`` is set by the receive loop
         # (also asyncio thread) when the client sends
         # ``{type:'start', mode:'dictation'}``. Checking here keeps both
@@ -376,6 +391,7 @@ async def voice_ws(ws: WebSocket) -> None:
         # populate a text box; skipping the LLM/TTS pipeline below is the
         # whole point of the flag.
         if dictation_mode:
+            logger.info("[ws_voice] _dispatch_user_turn skipped (dictation mode)")
             return
         # Cancel any previous in-flight agent/tts so a barge-in mid-turn
         # cleanly resets to the new user input.
@@ -384,6 +400,7 @@ async def voice_ws(ws: WebSocket) -> None:
         ):
             _cancel_inflight("new_user_turn")
         agent_task = asyncio.create_task(_handle_user_turn(text))
+        logger.info("[ws_voice] _dispatch_user_turn scheduled new agent_task")
 
     async def writer() -> None:
         """Drain the event queue → WebSocket. JSON dicts → text frames; raw
@@ -408,8 +425,25 @@ async def voice_ws(ws: WebSocket) -> None:
     # (~3–10s cold start, +75 MB whisper + 50 MB silero on first run). We
     # announce status events so the UI shows "Loading STT model…" rather
     # than pretending to listen.
+    #
+    # Health probe before reuse: ``state.stt_recorder`` is a process-level
+    # singleton. Pre-fix, a Soniox 408 idle timeout would leave the singleton
+    # object alive with a dead inner WS — every subsequent /ws/voice connect
+    # would reuse it and silently drop all audio (2026-05-29 incident). The
+    # ``is_alive`` probe forces a rebuild when the singleton crashed
+    # (thread died, transitioned to terminal ERROR after consecutive failures).
     stt_service = state.stt_recorder
-    if stt_service is None:
+    needs_rebuild = stt_service is None or not getattr(stt_service, "is_alive", True)
+    if needs_rebuild:
+        if stt_service is not None:
+            logger.warning(
+                "[ws_voice] STT singleton unhealthy "
+                "(is_alive=False) — rebuilding"
+            )
+            try:
+                stt_service.shutdown()
+            except Exception:
+                logger.exception("[ws_voice] old STT singleton shutdown failed")
         await out_queue.put({"type": "stt_loading"})
         try:
             from services.runtime_config import apply_voice_stt_config
@@ -422,7 +456,22 @@ async def voice_ws(ws: WebSocket) -> None:
             await out_queue.put({"type": "stt_ready"})
 
     if stt_service is not None:
+        # Order matters: install hook FIRST so the ``ws_status`` event the
+        # backend emits inside ``resume()`` (e.g. CONNECTING → CONNECTED)
+        # arrives at the frontend chip. set_hook itself replays the
+        # current state, so even before resume() flips anything the UI
+        # gets one event (IDLE) to render off.
         stt_service.set_hook(on_stt_event)
+        # Mic-driven lifecycle: open the upstream WS (Soniox) or unblock
+        # the local worker. Without this the singleton stays IDLE and
+        # silently drops audio. The route's ``finally`` block calls
+        # ``pause()`` to mirror — singletons stay around between sessions
+        # cheaply (no model reload on next mic-on) but the upstream WS
+        # is only held while the user is actively on mic.
+        try:
+            stt_service.resume()
+        except Exception:
+            logger.exception("[ws_voice] STT resume() failed")
 
     async def speak(text: str) -> None:
         """Stream TTS audio chunks back over the socket. Cancellable.
@@ -788,6 +837,17 @@ async def voice_ws(ws: WebSocket) -> None:
         pass
     finally:
         if stt_service is not None:
+            # Mirror of the resume() call above: pause closes the upstream
+            # WS (Soniox) or stops audio gating into the local worker,
+            # but keeps the singleton + thread alive for the next mic-on.
+            # Order matters: pause FIRST so the upstream WS close emits
+            # ``ws_status: idle`` THROUGH the hook before we detach it,
+            # which lets the frontend chip flip off cleanly even if the
+            # operator closes the tab mid-session.
+            try:
+                stt_service.pause()
+            except Exception:
+                logger.exception("[ws_voice] STT pause() failed")
             stt_service.set_hook(None)
         for t in (agent_task, tts_task):
             if t is not None and not t.done():

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -468,8 +468,14 @@ async def voice_ws(ws: WebSocket) -> None:
         # ``pause()`` to mirror — singletons stay around between sessions
         # cheaply (no model reload on next mic-on) but the upstream WS
         # is only held while the user is actively on mic.
+        #
+        # Why to_thread: on cold-boot / rebuild paths the WS thread
+        # hasn't attached its asyncio loop yet, so resume() spins for
+        # up to ~500 ms waiting for ``_loop``. Running it on the event
+        # loop directly would stall every other socket frame for that
+        # window. The thread is cheap (one shot per session).
         try:
-            stt_service.resume()
+            await asyncio.to_thread(stt_service.resume)
         except Exception:
             logger.exception("[ws_voice] STT resume() failed")
 
@@ -840,10 +846,12 @@ async def voice_ws(ws: WebSocket) -> None:
             # Mirror of the resume() call above: pause closes the upstream
             # WS (Soniox) or stops audio gating into the local worker,
             # but keeps the singleton + thread alive for the next mic-on.
-            # Order matters: pause FIRST so the upstream WS close emits
-            # ``ws_status: idle`` THROUGH the hook before we detach it,
-            # which lets the frontend chip flip off cleanly even if the
-            # operator closes the tab mid-session.
+            # Best-effort cleanup — the client is disconnecting anyway, so
+            # any in-flight IDLE ``ws_status`` event the hook would have
+            # surfaced is moot. pause() is fire-and-forget cross-thread
+            # (the real close lands later when ``_run_ws`` notices the
+            # cleared active flag), and set_hook(None) detaches before
+            # that lands; this is intentional, not an ordering bug.
             try:
                 stt_service.pause()
             except Exception:

--- a/backend/services/stt_backends/__init__.py
+++ b/backend/services/stt_backends/__init__.py
@@ -1,13 +1,111 @@
 """Per-backend STT plugins.
 
 Each module in this package exposes a top-level ``build(config)`` callable
-that returns an STT service object duck-typed to ``RealtimeSTTService``
-(``feed_audio``, ``set_hook``, ``start_listen_loop``, ``shutdown``,
-plus the ``on_*`` callback methods).
+that returns an STT service object satisfying
+:class:`services.stt_backends.types.STTServiceProtocol` (feed_audio,
+set_hook, start_listen_loop, resume, pause, shutdown, plus the on_*
+callback methods and is_alive / connection_state properties).
 
 The dispatcher in :mod:`services.stt_realtime` looks up the right
 backend module by ``config["backend"]`` and calls its ``build(config)``.
 Adding a new engine is a 2-touch change: add a registry entry plus a
 new module here. Nothing in ``ws_voice`` or ``runtime_config`` needs to
 care which backend produced the service.
+
+Feature-flag allowlist
+----------------------
+The ``STT_BACKENDS_ENABLED`` env var gates which backends are buildable.
+Useful for OSS distributions that ship with a conservative default and
+let advanced users opt extra backends in.
+
+Format: comma-separated list. Unknown names are silently filtered so a
+typo doesn't crash boot. When the env var is unset, ALL known backends
+are enabled — the dev-machine default; OSS ``.env.example`` writes an
+explicit value so the default never silently flips to include something
+operators haven't opted into.
+
+``stt_realtime.build_stt_service`` consults ``assert_backend_enabled``
+before dispatch; selecting a disabled backend raises ``RuntimeError``
+with the env-var name in the message so the operator knows exactly
+where to fix it.
 """
+from __future__ import annotations
+
+import os
+
+
+#: All STT backends shipped in this codebase. Keep in sync with
+#: ``services.stt_realtime._BACKEND_FACTORIES``. Conformance test in
+#: ``tests/test_stt_protocol_conformance.py`` pins each entry to a class
+#: that implements ``STTServiceProtocol``.
+_KNOWN: frozenset[str] = frozenset({
+    "faster_whisper",
+    "gipformer_vi",
+    "soniox",
+})
+
+
+def _parse_env_list(raw: str) -> set[str]:
+    """Split a comma-separated env value and filter to known backends."""
+    return {
+        s.strip() for s in (raw or "").split(",")
+        if s.strip() and s.strip() in _KNOWN
+    }
+
+
+def _read_enabled() -> set[str]:
+    """Read the current allowlist from the env var. Re-read on every
+    call so monkeypatched env in tests is honoured without module reload.
+
+    Unset env var → all known backends enabled (dev default). OSS
+    ``.env.example`` writes an explicit value so a fresh install never
+    silently inherits a flag-state the operator didn't choose.
+    """
+    raw = os.environ.get("STT_BACKENDS_ENABLED")
+    if raw is None or raw.strip() == "":
+        return set(_KNOWN)
+    return _parse_env_list(raw)
+
+
+def list_known_backends() -> list[str]:
+    """All backend ids the codebase knows about, sorted."""
+    return sorted(_KNOWN)
+
+
+def list_enabled_backends() -> list[str]:
+    """Subset currently enabled per the feature-flag env var, sorted."""
+    return sorted(_read_enabled())
+
+
+def is_backend_enabled(name: str) -> bool:
+    """True iff the backend is both known AND in the current allowlist."""
+    return name in _read_enabled()
+
+
+def assert_backend_enabled(name: str) -> None:
+    """Raise on unknown OR disabled backends with an actionable hint.
+
+    Called by ``build_stt_service`` before dispatch. The message names
+    the env var explicitly so the operator can fix config without
+    spelunking the registry.
+    """
+    if name not in _KNOWN:
+        raise ValueError(
+            f"Unknown STT backend: {name!r}. "
+            f"Known backends: {list_known_backends()}"
+        )
+    if name not in _read_enabled():
+        raise RuntimeError(
+            f"STT backend {name!r} is disabled. "
+            f"Currently enabled: {list_enabled_backends()}. "
+            f"To enable, add it to STT_BACKENDS_ENABLED in backend/.env "
+            f"(comma-separated list)."
+        )
+
+
+__all__ = (
+    "list_known_backends",
+    "list_enabled_backends",
+    "is_backend_enabled",
+    "assert_backend_enabled",
+)

--- a/backend/services/stt_backends/_ws_streaming.py
+++ b/backend/services/stt_backends/_ws_streaming.py
@@ -1,8 +1,9 @@
 """Base class for cloud STT backends that stream PCM over a WebSocket.
 
 The scaffolding here is provider-agnostic: thread + asyncio loop hand-off,
-audio queue, hook fan-out, reconnect with exponential backoff, shutdown
-plumbing. Each cloud provider (Soniox, Deepgram, AssemblyAI, ...)
+audio queue, hook fan-out, mic-driven lifecycle (``pause`` / ``resume``),
+infinite reconnect with exponential backoff, ``ws_status`` event emission,
+shutdown plumbing. Each cloud provider (Soniox, Deepgram, AssemblyAI, …)
 subclasses :class:`WSStreamingSTT` and supplies three small bits:
 
 * ``WS_URL`` — endpoint to connect to
@@ -10,12 +11,35 @@ subclasses :class:`WSStreamingSTT` and supplies three small bits:
 * ``_handle_event(data)`` — parse one inbound message and emit events
   (``self._emit_partial``, ``self._emit_final``, ``self._emit_endpoint``)
 
+Optionally ``_on_connected()`` is called on every (re)connect so subclasses
+can clear per-session accumulators.
+
 Why a base class instead of free helper functions: the per-instance state
-(hook ref, audio queue, asyncio loop) is the awkward part to share, and a
-base class keeps the public surface (``feed_audio`` / ``set_hook`` /
-``start_listen_loop`` / ``shutdown``) identical across providers — the
-voice WS route never has to special-case which cloud STT produced the
-service.
+(hook ref, audio queue, asyncio loop, connection-state machine) is the
+awkward part to share, and a base class keeps the public surface
+(:class:`services.stt_backends.types.STTServiceProtocol`) identical across
+providers — the voice WS route never has to special-case which cloud STT
+produced the service.
+
+Lifecycle vs Soniox 408 idle timeout
+------------------------------------
+
+Soniox closes idle WS with HTTP 408 after ~10 min of no audio. Pre-fix the
+base class exited the reconnect loop on ANY clean close — singleton lived
+on with a dead inner socket; user audio silently dropped on next utterance.
+
+Fix is two-pronged:
+
+1. **Mic-driven lifecycle**: ``ws_voice`` calls ``pause()`` when the
+   frontend disconnects → we close the upstream WS cleanly → Soniox never
+   has an idle window. On next mic-on, ``resume()`` opens a fresh WS.
+
+2. **Infinite reconnect**: even if the WS does drop mid-session (network
+   blip, Soniox restart), the outer ``while not self._closed`` re-enters
+   for both normal close AND exception paths. Only ``shutdown()`` ends
+   the loop. Backoff caps at 10 s; after ``ERROR_CONSECUTIVE_FAILURES``
+   bad attempts in a row we emit ``ws_status: error`` so the route can
+   surface a real failure to the user instead of spinning silently.
 """
 from __future__ import annotations
 
@@ -23,16 +47,33 @@ import asyncio
 import json
 import logging
 import threading
-from typing import Any, Callable, ClassVar, Optional
+from typing import Any, ClassVar, Optional
+
+from services.stt_backends.types import (
+    EventHook,
+    STTConnectionState,
+)
 
 logger = logging.getLogger(__name__)
 
 
-EventHook = Callable[[str, dict[str, Any]], None]
+#: After this many back-to-back failed connect attempts the service
+#: transitions to ``ERROR`` so the route can surface a real problem to the
+#: user. Picked so a ~30 s outage (sleep 0.5+1+2+4+8 = 15.5 s on 5 attempts)
+#: still surfaces while a single transient blip doesn't.
+ERROR_CONSECUTIVE_FAILURES = 5
+
+#: Reconnect backoff bounds (seconds). Start tiny so a normal 408 cycles
+#: back fast; cap at 10 s so a long outage doesn't burn the user.
+BACKOFF_INITIAL = 0.5
+BACKOFF_MAX = 10.0
 
 
 class WSStreamingSTT:
-    """Common scaffolding for WebSocket-based cloud STT providers."""
+    """Common scaffolding for WebSocket-based cloud STT providers.
+
+    Implements :class:`services.stt_backends.types.STTServiceProtocol`.
+    """
 
     #: Override in subclass — ``wss://...`` endpoint URL.
     WS_URL: ClassVar[str] = ""
@@ -53,11 +94,37 @@ class WSStreamingSTT:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None
 
-    # ---- public RealtimeSTTService-compatible surface ---------------------
+        # ── State machine ────────────────────────────────────────────────
+        # ``_active_event`` gates the connect attempts inside ``_run_ws``.
+        # We start INACTIVE — the route's ``resume()`` call on frontend
+        # connect is what opens the upstream WS. That way the singleton
+        # can sit around between voice sessions without holding a Soniox
+        # socket open and burning its idle timer.
+        self._active_event: Optional[asyncio.Event] = None  # bound to loop in _run_ws
+        self._connection_state: STTConnectionState = STTConnectionState.IDLE
+        self._connection_count = 0
+        self._consecutive_failures = 0
+        # Held by ``pause()`` so it can force-close the live WS to break
+        # ``_receiver``'s async-for and let the outer loop fall through to
+        # the ``await _active_event.wait()`` gate.
+        self._current_ws_holder: dict[str, Any] = {"ws": None}
+
+    # ---- public STTServiceProtocol surface ---------------------------
 
     def set_hook(self, hook: Optional[EventHook]) -> None:
+        """Install / clear the event hook. Replays current
+        ``connection_state`` to the new hook so a late subscriber (e.g.
+        page reload mid-utterance) sees the right chip immediately
+        instead of staying "idle" until the next transition.
+        """
         with self._lock:
             self._hook = hook
+        if hook is not None:
+            self._emit("ws_status", {
+                "state": self._connection_state.value,
+                "attempt": self._consecutive_failures,
+                "detail": "hook attached — replay current state",
+            })
 
     def feed_audio(self, pcm_chunk: bytes) -> None:
         if self._closed or self._loop is None or self._audio_queue is None:
@@ -68,6 +135,10 @@ class WSStreamingSTT:
             return
 
     def start_listen_loop(self) -> None:
+        """Boot the background WS thread. Idempotent. The connection
+        won't actually open until ``resume()`` flips the active event —
+        keeps the singleton cheap to construct.
+        """
         if self._thread is not None and self._thread.is_alive():
             return
         t = threading.Thread(
@@ -78,19 +149,107 @@ class WSStreamingSTT:
         self._thread = t
         t.start()
 
+    def resume(self) -> None:
+        """Open the upstream WS. Drives IDLE → CONNECTING → CONNECTED.
+        Idempotent — safe to call when already CONNECTED.
+
+        Thread-safe: the active event lives on the WS thread's loop;
+        we schedule the ``.set()`` cross-thread.
+        """
+        if self._closed:
+            logger.warning("[%s] resume() called after shutdown — ignored", self.LOG_TAG)
+            return
+        if self._loop is None or self._active_event is None:
+            # Thread hasn't booted yet — start_listen_loop wasn't called
+            # before resume. Boot it now; the runner will pick up the
+            # active flag we'll set below as soon as the loop is alive.
+            self.start_listen_loop()
+            # Spin briefly so the runner can attach _loop + _active_event.
+            for _ in range(50):  # ~500 ms cap
+                if self._loop is not None and self._active_event is not None:
+                    break
+                threading.Event().wait(0.01)
+            if self._loop is None or self._active_event is None:
+                logger.error("[%s] resume(): WS thread failed to initialise", self.LOG_TAG)
+                self._set_state(STTConnectionState.ERROR, detail="thread init failed")
+                return
+
+        loop = self._loop
+        active = self._active_event
+        try:
+            loop.call_soon_threadsafe(active.set)
+        except RuntimeError:
+            # Loop already closed — service is effectively dead.
+            self._set_state(STTConnectionState.ERROR, detail="loop closed")
+
+    def pause(self) -> None:
+        """Close the upstream WS cleanly. Drives → IDLE.
+        Idempotent — safe to call when already IDLE.
+        """
+        if self._loop is None or self._active_event is None:
+            return  # Nothing to pause
+
+        loop = self._loop
+        active = self._active_event
+
+        def _do_pause():
+            active.clear()
+            ws = self._current_ws_holder.get("ws")
+            if ws is not None:
+                # Schedule close on the same loop; can't await from sync.
+                asyncio.create_task(_close_ws_quietly(ws))
+
+        try:
+            loop.call_soon_threadsafe(_do_pause)
+        except RuntimeError:
+            pass
+
     def shutdown(self) -> None:
+        """Permanently destroy. Cannot be resumed."""
         if self._closed:
             return
         self._closed = True
+
+        # Wake up any blocked _active_event.wait() so the loop can see
+        # _closed and exit cleanly.
+        if self._loop is not None and self._active_event is not None:
+            try:
+                self._loop.call_soon_threadsafe(self._active_event.set)
+            except RuntimeError:
+                pass
+
+        # Push sentinel to break the audio sender.
         if self._loop is not None and self._audio_queue is not None:
             try:
                 self._loop.call_soon_threadsafe(self._audio_queue.put_nowait, b"")
             except RuntimeError:
                 pass
+
         if self._thread is not None:
             self._thread.join(timeout=2.0)
 
-    # ---- subclass extension points ---------------------------------------
+        self._set_state(STTConnectionState.IDLE, detail="shutdown")
+
+    # ── State accessors ──────────────────────────────────────────────
+
+    @property
+    def is_alive(self) -> bool:
+        """True when the service can still produce transcripts (worker
+        thread alive, not shut down, not in terminal ERROR).
+        """
+        if self._closed:
+            return False
+        if self._connection_state == STTConnectionState.ERROR:
+            return False
+        if self._thread is None:
+            return False
+        return self._thread.is_alive()
+
+    @property
+    def connection_state(self) -> STTConnectionState:
+        return self._connection_state
+
+    # ---- subclass extension points -----------------------------------
 
     def _build_config_message(self) -> dict[str, Any]:
         """Return the JSON object sent immediately after connecting."""
@@ -105,7 +264,7 @@ class WSStreamingSTT:
         (re)connect. Called once after the config message is sent.
         """
 
-    # ---- emit helpers (subclass convenience) -----------------------------
+    # ---- emit helpers (subclass convenience) -------------------------
 
     def _emit(self, event: str, payload: dict[str, Any]) -> None:
         with self._lock:
@@ -126,15 +285,43 @@ class WSStreamingSTT:
             self._emit("final_transcript", {"text": text})
 
     def _emit_endpoint(self) -> None:
-        """Signal end-of-utterance — mirrors RealtimeSTT's ``recording_stop``
-        followed immediately by ``recording_start`` so downstream consumers
-        (voice WS route) reset their per-turn state.
+        """Signal end-of-utterance.
+
+        Emits ``vad_stop`` + ``recording_stop``. Subclasses that detect
+        utterance-start should emit ``recording_start`` from
+        ``_handle_event`` on the first non-empty frame (see Soniox).
+        Re-emitting it here used to cause a destructive race with the
+        voice WS route: ``final_transcript`` arrived first → dispatch
+        scheduled a new agent turn → the trailing ``recording_start``
+        then ran ``_cancel_inflight`` because ``bot_speaking`` for the
+        just-cancelled OLD turn hadn't flipped False yet → the *new*
+        agent task got cancelled before it could run.
         """
         self._emit("vad_stop", {})
         self._emit("recording_stop", {})
-        self._emit("recording_start", {})
 
-    # ---- internals -------------------------------------------------------
+    def _set_state(
+        self,
+        state: STTConnectionState,
+        *,
+        attempt: int | None = None,
+        detail: str = "",
+    ) -> None:
+        """Transition the state machine + emit ``ws_status``.
+
+        Only emits if the state actually changed — keeps the wire quiet
+        when the receiver is just churning frames in CONNECTED.
+        """
+        if state == self._connection_state and detail == "":
+            return
+        self._connection_state = state
+        self._emit("ws_status", {
+            "state": state.value,
+            "attempt": self._consecutive_failures if attempt is None else attempt,
+            "detail": detail,
+        })
+
+    # ---- internals ---------------------------------------------------
 
     def _thread_runner(self) -> None:
         try:
@@ -143,56 +330,167 @@ class WSStreamingSTT:
             logger.exception("[%s] WS thread exited with error", self.LOG_TAG)
 
     async def _run_ws(self) -> None:
+        """The reconnect/lifecycle loop.
+
+        Outer invariant: loop runs forever until ``self._closed``.
+        Inside each iteration we:
+
+          1. Wait for ``_active_event`` (mic on).
+          2. Open WS + send config + drain via gather(sender, receiver).
+          3. On any close (normal OR exception) loop back to step 1 —
+             ``_active_event`` may already have been cleared by a
+             concurrent ``pause()``, which short-circuits the next
+             connect attempt without burning the backoff.
+
+        State transitions emitted via ``_set_state``; never via raw
+        ``_emit("ws_status", …)`` so the in-memory ``_connection_state``
+        and the wire stay in lockstep.
+        """
         try:
             import websockets
         except ImportError as exc:  # pragma: no cover — present via uv.lock
             logger.error("[%s] websockets package not available: %s", self.LOG_TAG, exc)
-            self._emit("error", {"detail": "websockets package not installed"})
+            self._set_state(STTConnectionState.ERROR, detail=f"websockets missing: {exc}")
             return
 
         self._loop = asyncio.get_running_loop()
         self._audio_queue = asyncio.Queue()
+        self._active_event = asyncio.Event()  # Starts CLEARED — resume() flips it on.
 
-        backoff = 1.0
+        backoff = BACKOFF_INITIAL
+
         while not self._closed:
+            # ── Step 1: wait for mic-on (resume()) ──
+            if not self._active_event.is_set():
+                # Only emit IDLE if we're transitioning back to it after a
+                # connected session (so the chip flips off promptly on
+                # pause). Initial boot already sits at IDLE.
+                self._set_state(STTConnectionState.IDLE, detail="paused")
+                await self._active_event.wait()
+                if self._closed:
+                    return
+                # Reset failure counter on a fresh resume — the user just
+                # turned the mic on, treat this as a clean start.
+                self._consecutive_failures = 0
+                backoff = BACKOFF_INITIAL
+
+            # ── Step 2: connect ──
+            attempt_label = self._consecutive_failures + 1
+            self._set_state(
+                STTConnectionState.RECONNECTING if attempt_label > 1
+                else STTConnectionState.CONNECTING,
+                attempt=attempt_label,
+                detail=f"attempt {attempt_label}",
+            )
+
             try:
                 async with websockets.connect(
                     self.WS_URL,
                     max_size=None,
                     ping_interval=20,
                     ping_timeout=20,
+                    close_timeout=5,
                 ) as ws:
+                    self._current_ws_holder["ws"] = ws
                     await ws.send(json.dumps(self._build_config_message()))
                     self._on_connected()
-                    self._emit("recording_start", {})
-                    backoff = 1.0
-                    await asyncio.gather(self._sender(ws), self._receiver(ws))
-                    return
-            except asyncio.CancelledError:
-                raise
-            except Exception:
+                    self._connection_count += 1
+                    self._consecutive_failures = 0
+                    backoff = BACKOFF_INITIAL
+                    self._set_state(
+                        STTConnectionState.CONNECTED,
+                        attempt=0,
+                        detail=f"connected (cycle #{self._connection_count})",
+                    )
+                    logger.info(
+                        "[%s] WS connected (cycle #%d)",
+                        self.LOG_TAG, self._connection_count,
+                    )
+
+                    # Drain audio + inbound until WS closes or an exception.
+                    # Use FIRST_COMPLETED + cancel pending so the sender
+                    # doesn't hang on ``audio_queue.get()`` after the
+                    # receiver returns on a server / pause-initiated WS
+                    # close. ``gather`` would block forever in that case.
+                    sender_t = asyncio.create_task(self._sender(ws))
+                    receiver_t = asyncio.create_task(self._receiver(ws))
+                    try:
+                        done, pending = await asyncio.wait(
+                            {sender_t, receiver_t},
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        # Propagate any exception from the completed task
+                        # so the outer ``except Exception`` path runs the
+                        # reconnect / ERROR flow.
+                        for t in done:
+                            exc = t.exception()
+                            if exc is not None:
+                                raise exc
+                    finally:
+                        for t in (sender_t, receiver_t):
+                            if not t.done():
+                                t.cancel()
+                                try:
+                                    await t
+                                except (asyncio.CancelledError, Exception):
+                                    pass
+
+                # gather returned normally → server closed (idle timeout
+                # or pause() forced close). Outer while re-enters.
+                self._current_ws_holder["ws"] = None
                 if self._closed:
                     return
-                logger.exception(
-                    "[%s] WS loop crashed; reconnecting in %.1fs",
+                if not self._active_event.is_set():
+                    # pause() forced close — silent IDLE, no reconnect noise.
+                    logger.info("[%s] WS closed by pause()", self.LOG_TAG)
+                    continue
+                # Server-initiated close while still active → reconnect.
+                logger.info(
+                    "[%s] WS closed by server; reconnecting in %.1fs",
                     self.LOG_TAG, backoff,
                 )
+
+            except asyncio.CancelledError:
+                self._current_ws_holder["ws"] = None
+                raise
+            except Exception as exc:
+                self._current_ws_holder["ws"] = None
+                if self._closed:
+                    return
+                self._consecutive_failures += 1
+                logger.exception(
+                    "[%s] WS error (failure #%d); reconnecting in %.1fs",
+                    self.LOG_TAG, self._consecutive_failures, backoff,
+                )
+                if self._consecutive_failures >= ERROR_CONSECUTIVE_FAILURES:
+                    # Terminal — surface to the route so it can rebuild.
+                    self._set_state(
+                        STTConnectionState.ERROR,
+                        attempt=self._consecutive_failures,
+                        detail=f"{self._consecutive_failures} consecutive failures: {exc}",
+                    )
+                    # Continue trying anyway; if the network comes back
+                    # we want to recover even without a route rebuild.
+
+            # ── Common backoff ──
+            if not self._closed and self._active_event.is_set():
                 await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, 10.0)
+                backoff = min(backoff * 2, BACKOFF_MAX)
 
     async def _sender(self, ws) -> None:
         assert self._audio_queue is not None
         while True:
             chunk = await self._audio_queue.get()
             if self._closed or chunk == b"":
-                # Most cloud STT providers accept an empty string to signal
-                # end-of-audio; subclasses can override _send_end_of_audio
-                # if their protocol differs.
                 try:
                     await self._send_end_of_audio(ws)
                 except Exception:
                     pass
                 return
+            # Skip audio when paused — the WS is being torn down, no point
+            # sending bytes that will fail mid-flight.
+            if self._active_event is not None and not self._active_event.is_set():
+                continue
             try:
                 await ws.send(chunk)
             except Exception:
@@ -211,3 +509,14 @@ class WSStreamingSTT:
                 logger.debug("[%s] non-JSON message ignored", self.LOG_TAG)
                 continue
             self._handle_event(data)
+
+
+async def _close_ws_quietly(ws) -> None:
+    """Close a WS, swallowing any exception. Used by ``pause()`` which
+    can't await but needs the live socket gone so ``_receiver``'s
+    async-for unblocks.
+    """
+    try:
+        await ws.close()
+    except Exception:
+        pass

--- a/backend/services/stt_backends/gipformer_vi.py
+++ b/backend/services/stt_backends/gipformer_vi.py
@@ -23,7 +23,12 @@ import queue
 import threading
 import urllib.request
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+
+from services.stt_backends.types import (
+    EventHook,
+    STTConnectionState,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,18 +89,28 @@ class GipformerSTTService:
     def __init__(self, recognizer, vad) -> None:
         self._recognizer = recognizer
         self._vad = vad
-        self._hook: Optional[Callable[[str, dict[str, Any]], None]] = None
+        self._hook: Optional[EventHook] = None
         self._lock = threading.Lock()
         self._closed = False
         self._chunks: queue.Queue[bytes] = queue.Queue()
         self._listen_thread: Optional[threading.Thread] = None
         self._was_speaking = False
+        # Mic-driven activation flag — mirrors RealtimeSTTService /
+        # WSStreamingSTT for symmetric ws_voice lifecycle.
+        self._active = False
+        self._connection_state: STTConnectionState = STTConnectionState.IDLE
 
     # ---- hook glue (mirrors RealtimeSTTService) ---------------------------
 
-    def set_hook(self, hook):
+    def set_hook(self, hook: Optional[EventHook]) -> None:
         with self._lock:
             self._hook = hook
+        if hook is not None:
+            self._emit("ws_status", {
+                "state": self._connection_state.value,
+                "attempt": 0,
+                "detail": "hook attached — replay current state",
+            })
 
     def _emit(self, event: str, payload: dict):
         with self._lock:
@@ -131,7 +146,7 @@ class GipformerSTTService:
     # ---- audio path ------------------------------------------------------
 
     def feed_audio(self, pcm_chunk: bytes) -> None:
-        if self._closed:
+        if self._closed or not self._active:
             return
         self._chunks.put(pcm_chunk)
 
@@ -144,12 +159,59 @@ class GipformerSTTService:
         self._listen_thread = t
         t.start()
 
+    def resume(self) -> None:
+        """Activate — local backend, just flips gating flag."""
+        if self._closed:
+            logger.warning("[Gipformer] resume() called after shutdown — ignored")
+            return
+        if self._active and self._connection_state == STTConnectionState.CONNECTED:
+            return
+        self._active = True
+        self._set_state(STTConnectionState.CONNECTED, detail="local backend ready")
+
+    def pause(self) -> None:
+        """Deactivate — drops further audio, drains buffered chunks so a
+        ``resume`` doesn't replay stale audio from the previous session."""
+        if not self._active and self._connection_state == STTConnectionState.IDLE:
+            return
+        self._active = False
+        try:
+            while True:
+                self._chunks.get_nowait()
+        except queue.Empty:
+            pass
+        self._set_state(STTConnectionState.IDLE, detail="paused")
+
+    @property
+    def is_alive(self) -> bool:
+        if self._closed:
+            return False
+        if self._listen_thread is None:
+            return True  # boot pending
+        return self._listen_thread.is_alive()
+
+    @property
+    def connection_state(self) -> STTConnectionState:
+        return self._connection_state
+
+    def _set_state(self, state: STTConnectionState, *, detail: str = "") -> None:
+        if state == self._connection_state and detail == "":
+            return
+        self._connection_state = state
+        self._emit("ws_status", {
+            "state": state.value,
+            "attempt": 0,
+            "detail": detail,
+        })
+
     def shutdown(self) -> None:
         if self._closed:
             return
         self._closed = True
+        self._active = False
         if self._listen_thread is not None:
             self._listen_thread.join(timeout=2.0)
+        self._set_state(STTConnectionState.IDLE, detail="shutdown")
 
     # ---- worker -----------------------------------------------------------
 

--- a/backend/services/stt_backends/soniox.py
+++ b/backend/services/stt_backends/soniox.py
@@ -48,6 +48,14 @@ class SonioxSTTService(WSStreamingSTT):
         # Per-utterance buffer of finalized tokens. Reset on every endpoint.
         self._final_buffer: list[str] = []
         self._provisional_tail: str = ""
+        # Tracks whether we're currently inside an utterance. Used to emit
+        # ``recording_start`` exactly once when the user opens their mouth,
+        # which is what the voice WS route uses as the barge-in trigger
+        # (ws_voice.py:345). Without this, ``recording_start`` only ever
+        # fired from ``_emit_endpoint`` *after* the user finished — so the
+        # bot's TTS kept playing during the user's barge-in for the full
+        # length of the new utterance.
+        self._in_utterance: bool = False
 
     # ---- WSStreamingSTT extension points ---------------------------------
 
@@ -73,6 +81,7 @@ class SonioxSTTService(WSStreamingSTT):
         # don't bleed into the new transcript.
         self._final_buffer.clear()
         self._provisional_tail = ""
+        self._in_utterance = False
 
     def _handle_event(self, data: dict[str, Any]) -> None:
         err_code = data.get("error_code")
@@ -98,6 +107,21 @@ class SonioxSTTService(WSStreamingSTT):
         # firing mid-loop with a stale tail.
         snapshot = "".join(self._final_buffer) + self._provisional_tail
         if snapshot.strip():
+            # First non-empty snapshot after silence = user just started
+            # speaking. Emit ``recording_start`` here so the voice WS route
+            # can fire its barge-in path immediately, instead of waiting
+            # for ``<end>`` to come through ``_emit_endpoint`` — by then
+            # the bot's TTS has already kept playing over the user for
+            # the full duration of their new utterance.
+            if not self._in_utterance:
+                self._in_utterance = True
+                # BARGE-IN-DIAG: prove the early recording_start fires.
+                logger.info(
+                    "[Soniox STT] first content of utterance — emitting "
+                    "recording_start (snapshot=%r)",
+                    snapshot[:60],
+                )
+                self._emit("recording_start", {})
             self._emit_partial(snapshot)
 
         if data.get("finished"):
@@ -110,9 +134,26 @@ class SonioxSTTService(WSStreamingSTT):
         is_final = bool(tk.get("is_final"))
 
         if text == ENDPOINT_TOKEN_TEXT:
-            final = "".join(self._final_buffer).strip()
+            # Fold provisional tail into the final string. Soniox occasionally
+            # emits ``<end>`` before flushing the trailing provisional tokens
+            # as ``is_final=True`` — especially on short utterances after a
+            # barge-in. Without this, ``final`` is empty, ``_emit_final``'s
+            # empty-text guard suppresses the event, and the voice WS never
+            # dispatches the turn. The same content already showed up in the
+            # frontend STT bar via ``_emit_partial`` (which concatenates both
+            # buffers); the user expects exactly that text to be sent.
+            final_buf_text = "".join(self._final_buffer)
+            final = (final_buf_text + self._provisional_tail).strip()
+            # BARGE-IN-DIAG: log endpoint detection so we can prove whether
+            # Soniox actually emitted ``<end>`` and what the final text
+            # composition was (final-buffer vs provisional-tail).
+            logger.info(
+                "[Soniox STT] <end> received: final_buf=%r prov_tail=%r combined=%r",
+                final_buf_text[:60], self._provisional_tail[:60], final[:60],
+            )
             self._final_buffer.clear()
             self._provisional_tail = ""
+            self._in_utterance = False
             self._emit_final(final)
             self._emit_endpoint()
             return

--- a/backend/services/stt_backends/types.py
+++ b/backend/services/stt_backends/types.py
@@ -1,0 +1,152 @@
+"""Provider-agnostic STT service contract.
+
+Defines the surface that ``routes/ws_voice.py`` and ``services/runtime_config.py``
+depend on, so adding a new STT backend (Deepgram, AssemblyAI, Vosk…) is a
+single-file change in ``services/stt_backends/<name>.py`` — no churn in the
+voice WS route, the runtime swap path, or the frontend chip rendering.
+
+Existing backends that satisfy this protocol:
+
+* :class:`services.stt_backends._ws_streaming.WSStreamingSTT` (base for cloud
+  WS providers — Soniox today)
+* :class:`services.stt_realtime.RealtimeSTTService` (local faster-whisper
+  wrapper, always-ready, ``pause``/``resume`` are no-ops)
+* :class:`services.stt_backends.gipformer_vi.GipformerSTTService` (local
+  sherpa-onnx, same always-ready shape)
+
+The connection-state machine + ``ws_status`` event vocabulary belong here
+(not in any concrete backend) because the frontend chip must render the same
+way regardless of which provider drives it.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+class STTConnectionState(str, Enum):
+    """Provider-agnostic readiness state. Frontend mirrors this 1:1.
+
+    Transition graph (only the listed edges are valid):
+
+    ::
+
+        IDLE ──resume()──> CONNECTING ──ack──> CONNECTED ─┐
+         ▲                     │                          │
+         │                     │ error                    │ server close /
+         │                     ▼                          │ network blip
+         │              RECONNECTING <─────────────────────┘
+         │                     │
+         │  pause() / shutdown │ backoff cap exceeded
+         └─────────────────────┴──> ERROR (terminal — caller should rebuild)
+
+    Local backends (faster-whisper, sherpa) skip CONNECTING/RECONNECTING and
+    jump straight to CONNECTED after model init — they have no socket to
+    drop. The state machine is identical; CONNECTING is just instantaneous.
+    """
+
+    IDLE = "idle"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    RECONNECTING = "reconnecting"
+    ERROR = "error"
+
+
+#: Hook callable forwarded by the route. Receives ``(event_name, payload)``.
+EventHook = Callable[[str, dict[str, Any]], None]
+
+
+#: Canonical event vocabulary every backend MUST use via the hook. Adding a
+#: new event requires updating this list + the route's forwarder + the
+#: frontend ``useVoiceSession`` switch — keeping the wire schema tight.
+KNOWN_EVENTS = frozenset({
+    # Connection lifecycle (NEW with the state-machine refactor)
+    "ws_status",          # payload: {"state": STTConnectionState, "attempt": int, "detail": str}
+    # Per-utterance
+    "recording_start",    # user opened mouth
+    "recording_stop",     # user closed mouth (utterance done)
+    "vad_stop",           # VAD detected silence (often coincides with recording_stop)
+    "partial_transcript", # payload: {"text": str}
+    "final_transcript",   # payload: {"text": str}
+    # Errors during streaming (not connection-level — those go via ws_status=ERROR)
+    "error",              # payload: {"detail": str}
+})
+
+
+@runtime_checkable
+class STTServiceProtocol(Protocol):
+    """Contract every STT backend implements. ``ws_voice`` depends on THIS
+    surface only — never on a concrete class.
+
+    Conformance check lives in
+    ``tests/test_stt_protocol_conformance.py``; adding a backend without
+    one of these methods fails CI loudly.
+    """
+
+    # ── Audio I/O ──
+    def feed_audio(self, pcm_chunk: bytes) -> None:
+        """Push 16 kHz mono int16 PCM. Non-blocking. Safe to call from any
+        thread (must internally hand off to the service's own loop)."""
+        ...
+
+    # ── Hook ──
+    def set_hook(self, hook: EventHook | None) -> None:
+        """Install / clear the event hook. Last writer wins."""
+        ...
+
+    # ── Lifecycle ──
+    def start_listen_loop(self) -> None:
+        """Boot the background worker thread (if any). Idempotent.
+
+        Called once at service construction. Distinct from ``resume`` —
+        ``start_listen_loop`` initialises the long-running infrastructure
+        (asyncio loop, model worker), while ``resume`` flips the "active"
+        flag that controls whether audio is actually streamed/processed.
+        """
+        ...
+
+    def resume(self) -> None:
+        """Activate the provider: open the cloud WS / allow audio through
+        the worker. Drives IDLE → CONNECTING → CONNECTED.
+
+        Idempotent. For local providers may be a no-op (always ready).
+        Called by ``ws_voice`` when the frontend WS connects (= mic on).
+        """
+        ...
+
+    def pause(self) -> None:
+        """Deactivate: close the cloud WS / suspend audio processing.
+        Drives any state → IDLE.
+
+        Idempotent. ``resume`` after ``pause`` MUST be cheap (< 2s) — the
+        whole point is that a hot-reuse beats teardown+rebuild on every
+        page reload. Called by ``ws_voice`` when the frontend WS closes.
+        """
+        ...
+
+    def shutdown(self) -> None:
+        """Permanently destroy. Cannot be resumed. Called when the
+        backend itself is being swapped out (settings change) or the
+        backend process is shutting down."""
+        ...
+
+    # ── State ──
+    @property
+    def is_alive(self) -> bool:
+        """True if the service CAN still produce transcripts (worker
+        thread alive, no fatal init failure). False = caller MUST
+        rebuild via ``runtime_config.apply_voice_stt_config``.
+
+        Distinct from ``connection_state`` — a CLOUD backend in
+        RECONNECTING is still "alive" (the worker thread is up, trying);
+        ``is_alive`` only goes False on terminal failure or after
+        ``shutdown()``.
+        """
+        ...
+
+    @property
+    def connection_state(self) -> STTConnectionState:
+        """Current state for UI. Backends emit ``ws_status`` events on
+        every transition; this property is the source of truth for any
+        late subscriber (e.g. frontend reload mid-session)."""
+        ...

--- a/backend/services/stt_realtime.py
+++ b/backend/services/stt_realtime.py
@@ -14,12 +14,14 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+
+from services.stt_backends.types import (
+    EventHook,
+    STTConnectionState,
+)
 
 logger = logging.getLogger(__name__)
-
-
-EventHook = Callable[[str, dict[str, Any]], None]
 
 
 class RealtimeSTTService:
@@ -35,6 +37,12 @@ class RealtimeSTTService:
     callbacks never fire even when audio is being fed. The thread blocks on
     each ``text()`` call until VAD detects a speech-end transition, then
     emits the final transcript via ``on_final`` and loops back.
+
+    Implements :class:`services.stt_backends.types.STTServiceProtocol`. As a
+    local backend the model is always loaded and there is no upstream WS to
+    drop, so ``resume`` / ``pause`` flip an in-process gating flag that the
+    audio path checks — they only emit ``ws_status`` events for UI
+    consistency with cloud providers, not real connection lifecycle.
     """
 
     def __init__(self, recorder, *, language: str = "auto") -> None:
@@ -44,13 +52,30 @@ class RealtimeSTTService:
         self._language = language
         self._closed = False
         self._listen_thread: Optional[threading.Thread] = None
+        # ``_active`` is False until ``resume()`` flips it. Symmetric with
+        # cloud backends so the route's mic-driven lifecycle works the
+        # same for both: mic on → resume() → audio flows; mic off →
+        # pause() → audio drops at feed_audio without tearing down the
+        # listen thread (model stays warm for the next session).
+        self._active = False
+        self._connection_state: STTConnectionState = STTConnectionState.IDLE
 
     # ---- hook management --------------------------------------------------
 
     def set_hook(self, hook: Optional[EventHook]) -> None:
-        """Register the active event consumer. ``None`` detaches."""
+        """Register the active event consumer. ``None`` detaches.
+
+        Replays current ``connection_state`` to a fresh subscriber so a
+        late-attached frontend sees the right chip immediately.
+        """
         with self._lock:
             self._hook = hook
+        if hook is not None:
+            self._emit("ws_status", {
+                "state": self._connection_state.value,
+                "attempt": 0,
+                "detail": "hook attached — replay current state",
+            })
 
     def _emit(self, event: str, payload: dict[str, Any]) -> None:
         with self._lock:
@@ -66,7 +91,7 @@ class RealtimeSTTService:
 
     def feed_audio(self, pcm_chunk: bytes) -> None:
         """Push 16 kHz mono int16 PCM bytes from the WebSocket into the recorder."""
-        if self._closed:
+        if self._closed or not self._active:
             return
         # DEBUG-level amplitude meter so we can diagnose silent-mic issues
         # without spamming production logs. Re-enable by setting
@@ -93,10 +118,65 @@ class RealtimeSTTService:
                 )
         self._recorder.feed_audio(pcm_chunk)
 
+    def resume(self) -> None:
+        """Activate the local backend. Drives IDLE → CONNECTED.
+
+        No real connection to open — the model is already loaded — so this
+        is effectively just flipping ``_active`` so ``feed_audio`` stops
+        dropping. Idempotent.
+        """
+        if self._closed:
+            logger.warning("[STT] resume() called after shutdown — ignored")
+            return
+        if self._active and self._connection_state == STTConnectionState.CONNECTED:
+            return
+        self._active = True
+        self._set_state(STTConnectionState.CONNECTED, detail="local backend ready")
+
+    def pause(self) -> None:
+        """Deactivate the local backend. Drives → IDLE.
+
+        ``feed_audio`` becomes a drop. The listen thread keeps running so
+        the model stays warm for the next ``resume`` (cheap restart).
+        Idempotent.
+        """
+        if not self._active and self._connection_state == STTConnectionState.IDLE:
+            return
+        self._active = False
+        self._set_state(STTConnectionState.IDLE, detail="paused")
+
+    @property
+    def is_alive(self) -> bool:
+        """True while listen thread is alive and the service hasn't been
+        shut down. Distinct from ``_active`` — paused-but-warm is alive.
+        """
+        if self._closed:
+            return False
+        if self._listen_thread is None:
+            # ``start_listen_loop`` not called yet — boot pending.
+            return True
+        return self._listen_thread.is_alive()
+
+    @property
+    def connection_state(self) -> STTConnectionState:
+        return self._connection_state
+
+    def _set_state(self, state: STTConnectionState, *, detail: str = "") -> None:
+        """Transition + emit ``ws_status``. Only emits on actual change."""
+        if state == self._connection_state and detail == "":
+            return
+        self._connection_state = state
+        self._emit("ws_status", {
+            "state": state.value,
+            "attempt": 0,
+            "detail": detail,
+        })
+
     def shutdown(self) -> None:
         if self._closed:
             return
         self._closed = True
+        self._active = False
         # Trip the recorder's interrupt so any pending ``text()`` call in the
         # listen loop returns instead of blocking on VAD forever.
         try:
@@ -110,6 +190,7 @@ class RealtimeSTTService:
             logger.exception("[STT] recorder.shutdown failed")
         if self._listen_thread is not None:
             self._listen_thread.join(timeout=2.0)
+        self._set_state(STTConnectionState.IDLE, detail="shutdown")
 
     def start_listen_loop(self) -> None:
         """Run ``recorder.text()`` in a daemon thread on a never-ending loop.
@@ -226,13 +307,25 @@ def build_stt_service(config: dict[str, Any]):
 
     Heavy imports happen inside each backend module, not here, so loading
     this module stays cheap for tests and non-voice routes.
+
+    The feature-flag check in ``stt_backends.assert_backend_enabled``
+    runs FIRST — selecting a disabled backend (per ``STT_BACKENDS_ENABLED``
+    env var) raises ``RuntimeError`` with the env-var name in the
+    message so the operator can fix config without spelunking.
     """
+    from services.stt_backends import assert_backend_enabled
+
     backend = config.get("backend", "faster_whisper")
+    assert_backend_enabled(backend)  # raises on unknown or disabled
+
     spec = _BACKEND_FACTORIES.get(backend)
     if spec is None:
+        # Should be unreachable — assert_backend_enabled would have raised
+        # ValueError above. Kept as belt-and-braces in case _KNOWN and
+        # _BACKEND_FACTORIES drift.
         raise ValueError(
-            f"Unknown STT backend: {backend!r}. "
-            f"Known backends: {sorted(_BACKEND_FACTORIES)}"
+            f"Backend {backend!r} passed allowlist but has no factory entry. "
+            f"_BACKEND_FACTORIES out of sync with stt_backends._KNOWN."
         )
     mod_path, fn_name = spec.split(":")
     module = __import__(mod_path, fromlist=[fn_name])

--- a/backend/services/tts_backends/__init__.py
+++ b/backend/services/tts_backends/__init__.py
@@ -5,4 +5,103 @@ secrets)`` callable. The dispatcher in :mod:`services.tts_realtime` calls
 it directly when the engine name does not map to a RealtimeTTS engine
 class (Edge has its own optimized path; Soniox uses a hand-rolled
 WebSocket client because RealtimeTTS does not ship a Soniox engine).
+
+Feature-flag allowlist
+----------------------
+The ``TTS_BACKENDS_ENABLED`` env var gates which TTS engines are
+buildable. Matches the STT pattern in :mod:`services.stt_backends`.
+
+OSS-ready engines (per 2026-05-29 decision):
+    * ``edge`` — free, no key required
+    * ``soniox`` — paid cloud, the operator's existing daily-driver
+
+Gated off by default (not validated for OSS):
+    * ``system`` — platform TTS, behaviour varies by OS
+    * ``azure`` — paid, untested
+    * ``elevenlabs`` — paid, untested
+    * ``openai`` — paid, untested
+
+``tts_realtime.build_chat_provider`` consults ``assert_engine_enabled``
+before dispatch; selecting a disabled engine raises ``RuntimeError``
+with the env-var name in the message.
 """
+from __future__ import annotations
+
+import os
+
+
+#: All TTS engines the codebase knows about. Names match what
+#: ``tts_realtime.build_chat_provider`` accepts as ``config["engine"]``.
+#: Edge + Soniox have hand-rolled providers (see ``tts.py`` /
+#: ``tts_backends/soniox.py``); the rest go through RealtimeTTS via
+#: ``_REALTIMETTS_ENGINE_CLS`` in ``tts_realtime.py``.
+_KNOWN: frozenset[str] = frozenset({
+    "edge",
+    "soniox",
+    "system",
+    "azure",
+    "elevenlabs",
+    "openai",
+})
+
+
+#: Conservative OSS default — only engines validated for shipping. See
+#: 2026-05-29 session. Other engines stay in ``_KNOWN`` so operators can
+#: opt them in via ``TTS_BACKENDS_ENABLED``, but they're not default-on.
+_DEFAULT_ENABLED: frozenset[str] = frozenset({"edge", "soniox"})
+
+
+def _parse_env_list(raw: str) -> set[str]:
+    return {
+        s.strip() for s in (raw or "").split(",")
+        if s.strip() and s.strip() in _KNOWN
+    }
+
+
+def _read_enabled() -> set[str]:
+    """Read the current allowlist. Unset env var → conservative default
+    (Edge + Soniox only). Unlike the STT side which defaults to "all
+    known", TTS defaults restrict because the unselected engines depend
+    on RealtimeTTS extras that may not be installed and on paid API keys
+    the operator hasn't set up.
+    """
+    raw = os.environ.get("TTS_BACKENDS_ENABLED")
+    if raw is None or raw.strip() == "":
+        return set(_DEFAULT_ENABLED)
+    return _parse_env_list(raw)
+
+
+def list_known_engines() -> list[str]:
+    return sorted(_KNOWN)
+
+
+def list_enabled_engines() -> list[str]:
+    return sorted(_read_enabled())
+
+
+def is_engine_enabled(name: str) -> bool:
+    return name in _read_enabled()
+
+
+def assert_engine_enabled(name: str) -> None:
+    """Raise on unknown OR disabled engines with an actionable hint."""
+    if name not in _KNOWN:
+        raise ValueError(
+            f"Unknown TTS engine: {name!r}. "
+            f"Known engines: {list_known_engines()}"
+        )
+    if name not in _read_enabled():
+        raise RuntimeError(
+            f"TTS engine {name!r} is disabled. "
+            f"Currently enabled: {list_enabled_engines()}. "
+            f"To enable, add it to TTS_BACKENDS_ENABLED in backend/.env "
+            f"(comma-separated list)."
+        )
+
+
+__all__ = (
+    "list_known_engines",
+    "list_enabled_engines",
+    "is_engine_enabled",
+    "assert_engine_enabled",
+)

--- a/backend/services/tts_realtime.py
+++ b/backend/services/tts_realtime.py
@@ -171,9 +171,17 @@ def build_chat_provider(config: dict[str, Any], secrets: Optional[dict[str, dict
 
     Edge bypasses RealtimeTTS for performance (3-tier chunking, native MP3).
     Other engines go through RealtimeTTS via :class:`RealtimeTTSProvider`.
+
+    Feature-flag gate: ``tts_backends.assert_engine_enabled`` runs FIRST
+    so selecting a disabled engine (per ``TTS_BACKENDS_ENABLED``) raises
+    ``RuntimeError`` with the env-var name in the message.
     """
+    from services.tts_backends import assert_engine_enabled
+
     engine = (config or {}).get("engine") or "edge"
     params = (config or {}).get("params") or {}
+
+    assert_engine_enabled(engine)  # raises on unknown or disabled
 
     if engine == "edge":
         return EdgeTTSProvider(

--- a/backend/tests/e2e/test_soniox_realtime_flow.py
+++ b/backend/tests/e2e/test_soniox_realtime_flow.py
@@ -115,6 +115,10 @@ async def test_soniox_stt_full_websocket_roundtrip(monkeypatch):
     })
     svc.set_hook(hook)
     svc.start_listen_loop()
+    # Mic-driven lifecycle: boot the thread (above) is cheap; only
+    # resume() flips the active flag so the runner actually dials the
+    # upstream. Without this the fake handler never sees the handshake.
+    svc.resume()
 
     # Give the WS thread a beat to connect + send config. The handler keeps
     # us honest: the server only registers the config once the handshake
@@ -189,6 +193,7 @@ async def test_soniox_stt_surfaces_server_error_event(monkeypatch):
     svc = soniox_stt.SonioxSTTService(api_key="sk-bad", params={})
     svc.set_hook(hook)
     svc.start_listen_loop()
+    svc.resume()  # mic-driven: flip active flag so the runner dials
 
     try:
         deadline = time.monotonic() + 5.0

--- a/backend/tests/test_routes/test_voice_routes.py
+++ b/backend/tests/test_routes/test_voice_routes.py
@@ -77,6 +77,81 @@ class TestEnginesEndpoint:
         assert {"voice", "rate"} <= keys
 
 
+class TestBackendsEndpoint:
+    """``GET /api/voice/backends`` — feature-flag allowlist for the
+    Settings UI. See ``test_voice_backend_flags.py`` for the underlying
+    allowlist logic; this class only pins the HTTP wire shape.
+    """
+
+    def test_returns_enabled_and_known_lists(self, client):
+        resp = client.get("/api/voice/backends")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        for section in ("stt", "tts"):
+            assert section in body
+            assert "enabled" in body[section]
+            assert "known" in body[section]
+            assert isinstance(body[section]["enabled"], list)
+            assert isinstance(body[section]["known"], list)
+            # Enabled is always a subset of known
+            assert set(body[section]["enabled"]) <= set(body[section]["known"])
+
+    def test_known_lists_match_static_codebase_view(self, client):
+        """``known`` is the codebase's full known-engines set, NOT a
+        function of the env var. Pinned here so adding a backend (e.g.
+        Deepgram) without updating both the registry AND the known set
+        fails this test loudly."""
+        body = client.get("/api/voice/backends").json()
+        assert {"faster_whisper", "gipformer_vi", "soniox"} <= set(
+            body["stt"]["known"]
+        )
+        assert {"edge", "soniox"} <= set(body["tts"]["known"])
+
+    def test_env_var_restricts_enabled_set(self, client, monkeypatch):
+        """Env var change is honoured per-request (no module reload
+        needed) — frontend can re-query after an operator edits .env
+        and restarts the backend."""
+        monkeypatch.setenv("STT_BACKENDS_ENABLED", "faster_whisper")
+        resp = client.get("/api/voice/backends")
+        body = resp.json()
+        assert body["stt"]["enabled"] == ["faster_whisper"]
+
+    def test_endpoint_requires_auth(self, tmp_path, monkeypatch):
+        """Should NOT serve without a valid bearer token, same as the
+        other voice routes."""
+        # Build a fresh client without the auth header.
+        monkeypatch.setenv("JARVIS_DB_PATH", str(tmp_path / "noauth.db"))
+        monkeypatch.setenv("JARVIS_API_KEY", "voice-routes-test-master-key")
+        from core import auth as core_auth
+        monkeypatch.setattr(core_auth, "JARVIS_API_KEY", "voice-routes-test-master-key")
+        from sqlalchemy import create_engine as _ce
+        from sqlalchemy.orm import sessionmaker
+        from core.database import Base, SETUP_WIZARD_CRITICAL_STEPS, SetupWizardStep
+        eng = _ce(
+            f"sqlite:///{tmp_path / 'noauth.db'}",
+            connect_args={"check_same_thread": False},
+        )
+        Base.metadata.create_all(bind=eng)
+        S = sessionmaker(autocommit=False, autoflush=False, bind=eng)
+        with S() as db:
+            for name in SETUP_WIZARD_CRITICAL_STEPS:
+                db.add(SetupWizardStep(step_name=name, completed=True))
+            db.commit()
+        import core.database as core_db
+        from services import config_service as config_module
+        monkeypatch.setattr(core_db, "SessionLocal", S)
+        monkeypatch.setattr(config_module, "SessionLocal", S)
+        from middleware.setup_gate import _reset_cache_for_tests, refresh_setup_complete
+        _reset_cache_for_tests()
+        refresh_setup_complete()
+        from server import app
+        c = TestClient(app)
+        resp = c.get("/api/voice/backends")
+        assert resp.status_code in (401, 403), (
+            f"Expected 401/403, got {resp.status_code}: {resp.text}"
+        )
+
+
 class TestActiveConfigEndpoint:
     def test_get_returns_defaults_when_unset(self, client):
         resp = client.get("/api/voice/active")

--- a/backend/tests/test_services/test_skill_service_integration.py
+++ b/backend/tests/test_services/test_skill_service_integration.py
@@ -25,8 +25,10 @@ from routes import skills as skill_routes
 
 # Import the REAL fast-agent types we want to integrate against.
 from fast_agent.skills.registry import SkillManifest
+from fast_agent.skills import SKILLS_DEFAULT
 from fast_agent.core.instruction_refresh import (
     McpInstructionCapable,
+    ConfiguredMcpInstructionCapable,
     rebuild_agent_instruction,
 )
 
@@ -49,13 +51,35 @@ class _StubAggregator:
         return {}
 
 
-class _RealProtocolAgent:
-    """An agent stub that satisfies McpInstructionCapable. fast-agent's own
-    rebuild_agent_instruction is exercised against this same shape in
-    fast-agent/tests/.../test_instruction_refresh.py — so if our pipeline
-    works for this stub, it works for the real McpAgent.
+class _MockAgentConfig:
+    """Minimal stand-in for ``fast_agent.config.AgentConfig`` — only the
+    ``skills`` attribute is read by ``resolve_instruction_skill_manifests``.
+    Defaults to ``SKILLS_DEFAULT`` (the sentinel that means "inherit the
+    shared environment skills") so the stub matches a freshly-decorated
+    agent that hasn't been given an explicit skills override.
     """
-    def __init__(self, template: str):
+    def __init__(self):
+        self.skills = SKILLS_DEFAULT
+
+
+class _RealProtocolAgent:
+    """An agent stub that satisfies ``ConfiguredMcpInstructionCapable`` —
+    which extends ``McpInstructionCapable`` with ``.name`` + ``.config``.
+    fast-agent's own ``rebuild_agent_instruction`` is exercised against
+    this same shape in fast-agent/tests/.../test_instruction_refresh.py,
+    so if our pipeline works for this stub, it works for the real
+    McpAgent.
+
+    Adding ``name`` + ``config.skills`` was needed on 2026-05-29 after the
+    fast-agent submodule sync introduced ``resolve_instruction_skill_manifests``
+    (reads ``agent.config.skills``) and propagated ``source=agent.name`` into
+    ``build_instruction`` — both via the new ``ConfiguredMcpInstructionCapable``
+    protocol. The old stub satisfied only the parent ``McpInstructionCapable``
+    surface and failed with AttributeError once the new code paths ran.
+    """
+    def __init__(self, template: str, *, name: str = "TestAgent"):
+        self._name = name
+        self._config = _MockAgentConfig()
         self._instruction = template
         self._instruction_template = template
         self._instruction_context: dict[str, str] = {}
@@ -63,6 +87,14 @@ class _RealProtocolAgent:
         self._skill_registry = None
         self._aggregator = _StubAggregator()
         self._skill_read_tool_name = "read_skill"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def config(self) -> _MockAgentConfig:
+        return self._config
 
     @property
     def instruction(self) -> str:
@@ -110,10 +142,16 @@ class _RealProtocolAgent:
         return self._skill_read_tool_name
 
 
-# Sanity: must satisfy the protocol. If this fails, fast-agent's contract
-# changed and we'd silently lose coverage — fail loudly here instead.
+# Sanity: must satisfy BOTH protocols. ConfiguredMcpInstructionCapable
+# adds .name + .config; the integration tests below exercise code paths
+# that read them, so satisfying only the parent McpInstructionCapable
+# would silently lose coverage on those paths — fail loudly here instead.
 assert isinstance(_RealProtocolAgent("x"), McpInstructionCapable), (
     "fast-agent McpInstructionCapable contract changed — update _RealProtocolAgent"
+)
+assert isinstance(_RealProtocolAgent("x"), ConfiguredMcpInstructionCapable), (
+    "fast-agent ConfiguredMcpInstructionCapable contract changed — "
+    "update _RealProtocolAgent (likely needs name/config additions)"
 )
 
 
@@ -185,7 +223,7 @@ def _wire_real_runtime(monkeypatch, agents_with_skills: dict[str, list[SkillMani
     """
     cfgs: dict[str, _AgentCfg] = {n: _AgentCfg(skills) for n, skills in agents_with_skills.items()}
     instances: dict[str, _RealProtocolAgent] = {
-        n: _RealProtocolAgent(template=f"{n} template:\n\n{{{{agentSkills}}}}\n")
+        n: _RealProtocolAgent(template=f"{n} template:\n\n{{{{agentSkills}}}}\n", name=n)
         for n in agents_with_skills
     }
     # Pre-seed each agent's skill_manifests with its starting list, mimicking

--- a/backend/tests/test_services/test_soniox_stt.py
+++ b/backend/tests/test_services/test_soniox_stt.py
@@ -112,11 +112,17 @@ class TestTokenHandling:
         ]})
         finals = [p["text"] for ev, p in events if ev == "final_transcript"]
         assert finals == ["Hello world"]
-        # Endpoint emits vad_stop → recording_stop → recording_start so the
-        # voice WS route resets its per-turn state and is ready for the
-        # next utterance on the same Soniox connection.
+        # Endpoint emits vad_stop → recording_stop only. The trailing
+        # ``recording_start`` was REMOVED on 2026-05-29 because it raced
+        # with ``final_transcript`` dispatch in the voice WS route: the
+        # late recording_start saw bot_speaking=True from the cancelled
+        # OLD turn and triggered _cancel_inflight on the NEW turn that
+        # had just been scheduled, killing it before it could run.
+        # Utterance-start signalling now lives upstream in
+        # ``_handle_event`` (first non-empty frame after silence), so
+        # ``_emit_endpoint`` only signals "speech ended" cleanly.
         sequence = [ev for ev, _ in events if ev in {"vad_stop", "recording_stop", "recording_start"}]
-        assert sequence == ["vad_stop", "recording_stop", "recording_start"]
+        assert sequence == ["vad_stop", "recording_stop"]
 
         # Buffer must be empty so the next utterance doesn't carry over.
         events.clear()

--- a/backend/tests/test_stt_protocol_conformance.py
+++ b/backend/tests/test_stt_protocol_conformance.py
@@ -1,0 +1,108 @@
+"""Conformance tests for the STT backend Protocol.
+
+Every backend that gets registered in
+``services.stt_realtime._BACKEND_FACTORIES`` MUST implement
+``services.stt_backends.types.STTServiceProtocol``. The duck-typed surface
+(``feed_audio``, ``set_hook``, …, plus the new ``pause`` / ``resume`` /
+``is_alive`` / ``connection_state``) is what ``routes/ws_voice.py`` depends
+on — adding a backend that's missing any of these methods silently breaks
+the mic-driven lifecycle ([[ws lifecycle fix 2026-05-29]]).
+
+These tests fail loud at CI time so the regression doesn't surface as
+"page reload → mic không phản hồi" 9 hours later.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from services.stt_backends.types import STTConnectionState, STTServiceProtocol
+
+
+# (module_path, class_name) for every concrete STT backend in the registry.
+# Imports are deferred to the test body so heavy dependencies (torch,
+# sherpa-onnx) only load when their backend is actually exercised.
+_BACKENDS: list[tuple[str, str]] = [
+    ("services.stt_backends._ws_streaming", "WSStreamingSTT"),
+    ("services.stt_realtime", "RealtimeSTTService"),
+    ("services.stt_backends.soniox", "SonioxSTTService"),
+    ("services.stt_backends.gipformer_vi", "GipformerSTTService"),
+]
+
+
+def _resolve(module_path: str, class_name: str):
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, class_name, None)
+    assert cls is not None, f"{class_name} not found in {module_path}"
+    return cls
+
+
+@pytest.mark.parametrize("module_path,class_name", _BACKENDS)
+def test_backend_has_protocol_methods(module_path: str, class_name: str):
+    """Each backend MUST expose every method named in STTServiceProtocol."""
+    cls = _resolve(module_path, class_name)
+    required_methods = (
+        "feed_audio",
+        "set_hook",
+        "start_listen_loop",
+        "resume",
+        "pause",
+        "shutdown",
+    )
+    missing = [m for m in required_methods if not callable(getattr(cls, m, None))]
+    assert not missing, (
+        f"{class_name} missing methods: {missing}. "
+        f"Every STT backend must implement STTServiceProtocol — see "
+        f"services/stt_backends/types.py."
+    )
+
+
+@pytest.mark.parametrize("module_path,class_name", _BACKENDS)
+def test_backend_has_state_properties(module_path: str, class_name: str):
+    """Each backend MUST expose ``is_alive`` and ``connection_state`` so the
+    route can probe health and forward state to the frontend without
+    special-casing per provider."""
+    cls = _resolve(module_path, class_name)
+    for prop in ("is_alive", "connection_state"):
+        assert hasattr(cls, prop), (
+            f"{class_name} missing property {prop!r}. "
+            f"Required by STTServiceProtocol for ws_status forwarding."
+        )
+
+
+def test_state_enum_values_are_stable_wire_format():
+    """Wire format pin: enum values are the strings the frontend chip
+    renders against. Changing them silently breaks the UI mapping.
+    """
+    assert STTConnectionState.IDLE.value == "idle"
+    assert STTConnectionState.CONNECTING.value == "connecting"
+    assert STTConnectionState.CONNECTED.value == "connected"
+    assert STTConnectionState.RECONNECTING.value == "reconnecting"
+    assert STTConnectionState.ERROR.value == "error"
+
+
+def test_ws_streaming_base_implements_protocol():
+    """Runtime-checkable Protocol guard — subclass instances satisfy
+    isinstance check. Catches silent removal of a method that's still
+    declared on the class statement but stubbed out."""
+    from services.stt_backends._ws_streaming import WSStreamingSTT
+
+    class _Probe(WSStreamingSTT):
+        WS_URL = "wss://localhost:1/__probe__"
+        LOG_TAG = "Probe"
+
+        def _build_config_message(self):
+            return {}
+
+        def _handle_event(self, data):
+            pass
+
+    inst = _Probe()
+    assert isinstance(inst, STTServiceProtocol), (
+        "WSStreamingSTT subclass must satisfy runtime_checkable "
+        "STTServiceProtocol"
+    )
+    # Initial state machine invariants
+    assert inst.connection_state == STTConnectionState.IDLE
+    assert not inst.is_alive  # No thread started yet

--- a/backend/tests/test_subprocess_env_vars.py
+++ b/backend/tests/test_subprocess_env_vars.py
@@ -17,12 +17,14 @@ when agents try to collaborate or save state.
 
 import json
 import os
+import shutil
 import sqlite3
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 
 # ═══════════════════════════════════════════════
@@ -976,3 +978,164 @@ class TestRuntimeRpcSocketMultiHop:
         # In a broken chain, expandvars returns the literal placeholder
         # because the var is unset → approval-server gets ENOENT.
         assert leaked == "${JARVIS_RUNTIME_RPC_SOCKET}"
+
+
+# ═══════════════════════════════════════════════
+# 11. MCP server env: secrets.yaml must override Docker-only defaults
+# ═══════════════════════════════════════════════
+
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    """Mimic FastAgent's startup deep_merge(config, secrets): nested dicts
+    merge recursively, scalars/lists are overlay-wins.
+    """
+    out = dict(base)
+    for k, v in overlay.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+class TestMCPDockerDefaultOverrides:
+    """Pin the 2026-05-29 figma-ui-mcp regression.
+
+    Root cause: ``fastagent.config.yaml`` hard-codes
+    ``figma-ui-mcp.env.FIGMA_BRIDGE_HOST: host.docker.internal`` as the
+    Docker default. Spawned subagents (Trang - Designer in the agile_team
+    template) inherit this value via the parent config's ``env:`` block
+    inside ``isolated_runner.create_child_config()``. The secrets.yaml is
+    copied as-is to the child temp dir, and FastAgent deep_merges them at
+    child startup — so the override lives in secrets.yaml.
+
+    Without the secrets override, the Docker default leaks into local dev:
+    the MCP subprocess tries to connect to a hostname that doesn't resolve
+    outside Docker → ``figma_status`` returns ``pluginConnected: false``
+    even though the Figma Desktop plugin is up and the bridge is reachable
+    on 127.0.0.1:38451.
+
+    Same shape applies to any future MCP server that uses ``*.docker.internal``
+    as a config-level default — secrets.yaml MUST override.
+    """
+
+    @pytest.fixture
+    def merged_mcp_servers(self):
+        config = yaml.safe_load((_BACKEND_DIR / "fastagent.config.yaml").read_text()) or {}
+        secrets = yaml.safe_load((_BACKEND_DIR / "fastagent.secrets.yaml").read_text()) or {}
+        return _deep_merge(config, secrets).get("mcp", {}).get("servers", {})
+
+    def test_figma_bridge_host_overridden_for_local_dev(self, merged_mcp_servers):
+        """After deep_merge(config, secrets), figma-ui-mcp.env.FIGMA_BRIDGE_HOST
+        must NOT resolve to ``host.docker.internal`` — that hostname only
+        exists inside Docker. The override belongs in fastagent.secrets.yaml
+        under ``mcp.servers.figma-ui-mcp.env``.
+        """
+        env = merged_mcp_servers.get("figma-ui-mcp", {}).get("env", {}) or {}
+        host = env.get("FIGMA_BRIDGE_HOST", "")
+
+        assert host, (
+            "FIGMA_BRIDGE_HOST missing from merged figma-ui-mcp env. "
+            "Add `FIGMA_BRIDGE_HOST: 127.0.0.1` (or a Tailscale IP for split-"
+            "machine setups) under mcp.servers.figma-ui-mcp.env in "
+            "fastagent.secrets.yaml."
+        )
+        assert "docker.internal" not in host, (
+            f"FIGMA_BRIDGE_HOST={host!r} still resolves to the Docker default "
+            f"from fastagent.config.yaml. This breaks local dev — the hostname "
+            f"doesn't resolve outside Docker, so the MCP subprocess can't reach "
+            f"the bridge and figma_status reports pluginConnected: false. "
+            f"Add `FIGMA_BRIDGE_HOST: 127.0.0.1` under "
+            f"mcp.servers.figma-ui-mcp.env in fastagent.secrets.yaml."
+        )
+
+    def test_no_docker_only_hostnames_leak_into_merged_config(self, merged_mcp_servers):
+        """Generalized regression catcher — fails loud if any MCP server's
+        merged env still contains ``host.docker.internal``. Same root cause
+        as the figma bug: Docker-only defaults that local dev can't resolve.
+        """
+        offenders: list[str] = []
+        for srv_name, srv_cfg in merged_mcp_servers.items():
+            if not isinstance(srv_cfg, dict):
+                continue
+            env = srv_cfg.get("env", {}) or {}
+            for key, value in env.items():
+                if isinstance(value, str) and "host.docker.internal" in value:
+                    offenders.append(f"{srv_name}.env.{key}={value!r}")
+
+        assert not offenders, (
+            "These merged MCP env values still resolve to Docker-only hostnames "
+            "and will fail silently in local dev:\n  "
+            + "\n  ".join(offenders)
+            + "\nAdd local overrides under mcp.servers.<server>.env in "
+            "fastagent.secrets.yaml for each."
+        )
+
+    def test_spawned_child_config_inherits_secrets_override(self, tmp_path):
+        """End-to-end on the spawn path itself: invoke
+        ``isolated_runner.create_child_config()`` with figma-ui-mcp in the
+        server list, then simulate FastAgent's child-startup deep_merge of
+        the generated child config + the copied child secrets. The resolved
+        ``FIGMA_BRIDGE_HOST`` must NOT be the Docker default.
+
+        This catches a regression that the static merge test above would
+        miss — e.g. if someone refactors create_child_config and stops
+        copying ``fastagent.secrets.yaml`` into the child temp dir
+        (current behaviour: isolated_runner.py:393-399), the static test
+        would still pass but spawned subagents would silently break.
+        """
+        try:
+            from fast_agent.spawn.isolated_runner import create_child_config
+        except ImportError as e:
+            pytest.skip(f"fast_agent.spawn not importable: {e}")
+
+        try:
+            child_dir = create_child_config(
+                project_dir=str(_BACKEND_DIR),
+                workspace_dir=str(tmp_path),
+                servers=["figma-ui-mcp"],
+            )
+        except Exception as e:
+            pytest.skip(
+                f"create_child_config raised — backend runtime layout may "
+                f"differ in CI: {e}"
+            )
+
+        try:
+            child_config_path = Path(child_dir) / "fastagent.config.yaml"
+            child_secrets_path = Path(child_dir) / "fastagent.secrets.yaml"
+
+            assert child_config_path.exists(), (
+                "create_child_config did not write fastagent.config.yaml"
+            )
+            assert child_secrets_path.exists(), (
+                "create_child_config did not copy fastagent.secrets.yaml into "
+                "the child temp dir. Without secrets, FastAgent's startup "
+                "deep_merge has nothing to overlay → config.yaml's Docker "
+                "defaults leak through. Check "
+                "isolated_runner.create_child_config (the shutil.copy2 "
+                "around line 393-399 must run unconditionally)."
+            )
+
+            child_config = yaml.safe_load(child_config_path.read_text()) or {}
+            child_secrets = yaml.safe_load(child_secrets_path.read_text()) or {}
+            merged = _deep_merge(child_config, child_secrets)
+
+            env = (
+                merged.get("mcp", {}).get("servers", {})
+                .get("figma-ui-mcp", {}).get("env", {}) or {}
+            )
+            host = env.get("FIGMA_BRIDGE_HOST", "")
+
+            assert "docker.internal" not in host, (
+                f"Spawned subagent's figma-ui-mcp got FIGMA_BRIDGE_HOST={host!r}. "
+                f"The Docker default leaked through the spawn path. Either the "
+                f"secrets override is missing (check fastagent.secrets.yaml) OR "
+                f"the spawn path stopped copying secrets into the child temp "
+                f"dir (check isolated_runner.create_child_config lines 393-399)."
+            )
+        finally:
+            shutil.rmtree(child_dir, ignore_errors=True)

--- a/backend/tests/test_subprocess_env_vars.py
+++ b/backend/tests/test_subprocess_env_vars.py
@@ -1001,6 +1001,17 @@ def _deep_merge(base: dict, overlay: dict) -> dict:
     return out
 
 
+@pytest.mark.skipif(
+    not (_BACKEND_DIR / "fastagent.secrets.yaml").exists(),
+    reason=(
+        "fastagent.secrets.yaml is gitignored — these are local-dev "
+        "regression catchers for the Docker-default override. CI has no "
+        "secrets to verify; skip rather than emit false-positive failures. "
+        "Locally, the absence of this file means the override hasn't been "
+        "configured yet, which is itself a setup bug — see the class "
+        "docstring for the fix."
+    ),
+)
 class TestMCPDockerDefaultOverrides:
     """Pin the 2026-05-29 figma-ui-mcp regression.
 

--- a/backend/tests/test_voice_backend_flags.py
+++ b/backend/tests/test_voice_backend_flags.py
@@ -1,0 +1,209 @@
+"""Feature-flag tests for STT/TTS backends.
+
+The OSS build ships with a conservative allowlist (free local STT only,
+Edge + Soniox for TTS) and lets the operator opt extra backends in via
+``STT_BACKENDS_ENABLED`` / ``TTS_BACKENDS_ENABLED`` env vars. These tests
+pin:
+
+* the allowlist semantics (env var → enabled set);
+* the factory's "disabled backend selected → RuntimeError with actionable
+  hint" contract;
+* the .env.example defaults so the OSS-default never silently flips to
+  include a paid backend.
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+
+# ═══════════════════════════════════════════════
+# STT feature flag
+# ═══════════════════════════════════════════════
+
+
+class TestSTTFeatureFlag:
+    """Pins ``services.stt_backends`` allowlist + factory gating."""
+
+    def test_known_backends_list(self):
+        from services.stt_backends import list_known_backends
+        assert set(list_known_backends()) == {
+            "faster_whisper", "gipformer_vi", "soniox",
+        }
+
+    def test_default_allowlist_includes_all_known_oss_ready(self, monkeypatch):
+        """All 3 STT backends are OSS-ready (per 2026-05-29 decision), so
+        the default allowlist includes them all when env var is unset."""
+        monkeypatch.delenv("STT_BACKENDS_ENABLED", raising=False)
+        # Re-import to pick up cleared env
+        import services.stt_backends as mod
+        importlib.reload(mod)
+        assert set(mod.list_enabled_backends()) == {
+            "faster_whisper", "gipformer_vi", "soniox",
+        }
+
+    def test_env_var_restricts_allowlist(self, monkeypatch):
+        monkeypatch.setenv("STT_BACKENDS_ENABLED", "faster_whisper")
+        import services.stt_backends as mod
+        importlib.reload(mod)
+        assert mod.list_enabled_backends() == ["faster_whisper"]
+        assert mod.is_backend_enabled("faster_whisper") is True
+        assert mod.is_backend_enabled("soniox") is False
+
+    def test_unknown_backend_in_env_is_filtered(self, monkeypatch):
+        """Typo in env var must not crash — just gets filtered out so
+        the actual known backends still work."""
+        monkeypatch.setenv("STT_BACKENDS_ENABLED", "faster_whisper,bogusbackend")
+        import services.stt_backends as mod
+        importlib.reload(mod)
+        assert "bogusbackend" not in mod.list_enabled_backends()
+        assert "faster_whisper" in mod.list_enabled_backends()
+
+    def test_disabled_backend_raises_on_build(self, monkeypatch):
+        """Selecting a disabled backend in settings must fail loud at
+        build time with an actionable message."""
+        monkeypatch.setenv("STT_BACKENDS_ENABLED", "faster_whisper")
+        import services.stt_backends as mod
+        importlib.reload(mod)
+        from services.stt_realtime import build_stt_service
+
+        with pytest.raises(RuntimeError) as exc:
+            build_stt_service({"backend": "soniox", "params": {}})
+        msg = str(exc.value)
+        assert "soniox" in msg
+        assert "disabled" in msg.lower()
+        assert "STT_BACKENDS_ENABLED" in msg, (
+            "Error must name the env var so the operator knows where to fix"
+        )
+
+    def test_unknown_backend_raises_distinct_error(self, monkeypatch):
+        """Unknown backend (typo in settings) is a separate failure mode
+        from disabled — gives the right hint to the operator."""
+        monkeypatch.setenv("STT_BACKENDS_ENABLED",
+                           "faster_whisper,gipformer_vi,soniox")
+        import services.stt_backends as mod
+        importlib.reload(mod)
+        from services.stt_realtime import build_stt_service
+
+        with pytest.raises(ValueError) as exc:
+            build_stt_service({"backend": "nonexistent", "params": {}})
+        assert "Unknown" in str(exc.value) or "unknown" in str(exc.value)
+
+
+# ═══════════════════════════════════════════════
+# TTS feature flag
+# ═══════════════════════════════════════════════
+
+
+class TestTTSFeatureFlag:
+    """Pins ``services.tts_backends`` allowlist + factory gating.
+
+    OSS-ready as of 2026-05-29: ``edge``, ``soniox``. Other RealtimeTTS
+    engines (system, azure, elevenlabs, openai) are gated off by default.
+    """
+
+    def test_known_engines_list(self):
+        from services.tts_backends import list_known_engines
+        assert set(list_known_engines()) == {
+            "edge", "soniox", "system", "azure", "elevenlabs", "openai",
+        }
+
+    def test_default_allowlist_is_conservative(self, monkeypatch):
+        """OSS default = free + tested only (edge, soniox). Paid /
+        untested engines are opt-in."""
+        monkeypatch.delenv("TTS_BACKENDS_ENABLED", raising=False)
+        import services.tts_backends as mod
+        importlib.reload(mod)
+        assert set(mod.list_enabled_engines()) == {"edge", "soniox"}
+
+    def test_env_var_can_enable_extra_engine(self, monkeypatch):
+        monkeypatch.setenv("TTS_BACKENDS_ENABLED", "edge,soniox,elevenlabs")
+        import services.tts_backends as mod
+        importlib.reload(mod)
+        assert "elevenlabs" in mod.list_enabled_engines()
+        assert mod.is_engine_enabled("elevenlabs") is True
+
+    def test_disabled_engine_raises_on_build(self, monkeypatch):
+        monkeypatch.setenv("TTS_BACKENDS_ENABLED", "edge,soniox")
+        import services.tts_backends as mod
+        importlib.reload(mod)
+        from services.tts_realtime import build_chat_provider
+
+        with pytest.raises(RuntimeError) as exc:
+            build_chat_provider({"engine": "elevenlabs", "params": {}})
+        msg = str(exc.value)
+        assert "elevenlabs" in msg
+        assert "disabled" in msg.lower()
+        assert "TTS_BACKENDS_ENABLED" in msg
+
+    def test_edge_default_engine_remains_buildable(self, monkeypatch):
+        """The default selected engine for OSS (Edge) must always be
+        callable — it's the fallback when user's saved preference is
+        for a disabled engine."""
+        monkeypatch.delenv("TTS_BACKENDS_ENABLED", raising=False)
+        import services.tts_backends as mod
+        importlib.reload(mod)
+        assert mod.is_engine_enabled("edge") is True
+
+
+# ═══════════════════════════════════════════════
+# .env.example contract
+# ═══════════════════════════════════════════════
+
+
+class TestEnvExampleContract:
+    """The ``.env.example`` shipped with OSS sets the safe defaults that
+    new operators inherit on ``cp .env.example .env``. These tests pin
+    the wire so a refactor never silently exposes paid engines.
+    """
+
+    @pytest.fixture
+    def env_example(self) -> str:
+        path = _BACKEND_DIR / ".env.example"
+        assert path.exists(), (
+            ".env.example missing — required for OSS-ready feature-flag "
+            "defaults. See plan in 2026-05-29 session."
+        )
+        return path.read_text()
+
+    def test_stt_default_includes_all_oss_ready_backends(self, env_example):
+        """All 3 STT backends are OSS-ready, so .env.example should set
+        STT_BACKENDS_ENABLED to include them (operators can prune to
+        local-only if they don't have a Soniox API key)."""
+        assert "STT_BACKENDS_ENABLED=" in env_example
+        # Pull just the value of that line (last non-comment occurrence)
+        line = next(
+            (l for l in env_example.splitlines()
+             if l.startswith("STT_BACKENDS_ENABLED=")),
+            None,
+        )
+        assert line is not None
+        value = line.split("=", 1)[1].strip().strip('"').strip("'")
+        enabled = {s.strip() for s in value.split(",")}
+        assert {"faster_whisper", "gipformer_vi", "soniox"} <= enabled
+
+    def test_tts_default_excludes_paid_untested_engines(self, env_example):
+        """system / azure / elevenlabs / openai are not tested for OSS —
+        must NOT appear in the default allowlist."""
+        assert "TTS_BACKENDS_ENABLED=" in env_example
+        line = next(
+            (l for l in env_example.splitlines()
+             if l.startswith("TTS_BACKENDS_ENABLED=")),
+            None,
+        )
+        assert line is not None
+        value = line.split("=", 1)[1].strip().strip('"').strip("'")
+        enabled = {s.strip() for s in value.split(",")}
+        for blocked in ("azure", "elevenlabs", "openai", "system"):
+            assert blocked not in enabled, (
+                f".env.example's TTS_BACKENDS_ENABLED must not include "
+                f"{blocked!r} (not tested for OSS, see 2026-05-29)."
+            )
+        # Tested + ready set
+        assert "edge" in enabled
+        assert "soniox" in enabled

--- a/backend/tests/test_ws_streaming_lifecycle.py
+++ b/backend/tests/test_ws_streaming_lifecycle.py
@@ -1,0 +1,327 @@
+"""Unit tests for WSStreamingSTT lifecycle: state machine, hook replay,
+pause/resume gating, ``is_alive`` semantics.
+
+The full async reconnect loop (``_run_ws``) is exercised by a
+mock-websockets path so we don't depend on a live cloud STT server in CI.
+Real upstream reconnect behaviour is verified manually + by the 2026-05-29
+session log analysis (Soniox 408 + auto-recover).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+from services.stt_backends._ws_streaming import (
+    BACKOFF_INITIAL,
+    ERROR_CONSECUTIVE_FAILURES,
+    WSStreamingSTT,
+)
+from services.stt_backends.types import STTConnectionState
+
+
+class _ProbeBackend(WSStreamingSTT):
+    """Minimal concrete backend used by every test."""
+    WS_URL = "wss://probe.test/__unused__"
+    LOG_TAG = "Probe STT"
+
+    def __init__(self):
+        super().__init__(sample_rate=16000)
+        self.config_messages_sent: list[dict] = []
+        self.events_received: list[dict] = []
+
+    def _build_config_message(self):
+        msg = {"probe": True, "sr": self._sample_rate}
+        self.config_messages_sent.append(msg)
+        return msg
+
+    def _handle_event(self, data):
+        self.events_received.append(data)
+
+
+# ═══════════════════════════════════════════════
+# 1. State machine (synchronous, no thread)
+# ═══════════════════════════════════════════════
+
+
+class TestStateMachineSync:
+    """Test the parts callable WITHOUT the WS thread running."""
+
+    def test_initial_state_is_idle(self):
+        svc = _ProbeBackend()
+        assert svc.connection_state == STTConnectionState.IDLE
+
+    def test_initial_is_alive_false_no_thread(self):
+        """is_alive is False before start_listen_loop because the
+        worker thread hasn't been booted yet."""
+        svc = _ProbeBackend()
+        assert svc.is_alive is False
+
+    def test_set_hook_replays_current_state(self):
+        """set_hook MUST emit one ws_status event so a late subscriber
+        (e.g. frontend reload mid-session) sees the right chip state."""
+        svc = _ProbeBackend()
+        events: list[tuple[str, dict]] = []
+        svc.set_hook(lambda n, p: events.append((n, p)))
+        assert len(events) == 1
+        assert events[0][0] == "ws_status"
+        assert events[0][1]["state"] == "idle"
+
+    def test_set_hook_none_does_not_emit(self):
+        svc = _ProbeBackend()
+        # Should not raise; should not enqueue anything (no hook to call).
+        svc.set_hook(None)
+
+    def test_set_state_emits_ws_status(self):
+        svc = _ProbeBackend()
+        events: list[tuple[str, dict]] = []
+        svc.set_hook(lambda n, p: events.append((n, p)))
+        events.clear()  # discard replay
+        svc._set_state(STTConnectionState.CONNECTING, detail="opening")
+        assert events == [
+            ("ws_status", {"state": "connecting", "attempt": 0, "detail": "opening"})
+        ]
+        assert svc.connection_state == STTConnectionState.CONNECTING
+
+    def test_set_state_idempotent_does_not_re_emit(self):
+        """Calling _set_state with the SAME state + no detail must not
+        flood the wire — the chip already knows."""
+        svc = _ProbeBackend()
+        events: list[tuple[str, dict]] = []
+        svc.set_hook(lambda n, p: events.append((n, p)))
+        events.clear()
+        svc._set_state(STTConnectionState.CONNECTED)
+        svc._set_state(STTConnectionState.CONNECTED)
+        # Only the first transition emits (the second is a no-op)
+        assert len(events) == 1
+
+    def test_emit_partial_skips_empty(self):
+        svc = _ProbeBackend()
+        events: list[tuple[str, dict]] = []
+        svc.set_hook(lambda n, p: events.append((n, p)))
+        events.clear()
+        svc._emit_partial("")
+        svc._emit_partial("   ")
+        svc._emit_partial("hello")
+        assert len(events) == 1
+        assert events[0] == ("partial_transcript", {"text": "hello"})
+
+    def test_emit_endpoint_emits_vad_stop_and_recording_stop_only(self):
+        """The 2026-05-29 race fix removed the trailing recording_start
+        from _emit_endpoint. This test pins that fix so a refactor can't
+        silently re-introduce the duplicate that races with final_transcript
+        dispatch.
+        """
+        svc = _ProbeBackend()
+        events: list[tuple[str, dict]] = []
+        svc.set_hook(lambda n, p: events.append((n, p)))
+        events.clear()
+        svc._emit_endpoint()
+        names = [e[0] for e in events]
+        assert names == ["vad_stop", "recording_stop"], (
+            f"_emit_endpoint must emit only vad_stop+recording_stop. "
+            f"Got: {names}. If recording_start is back, the barge-in "
+            f"auto-submit race from 2026-05-29 will recur."
+        )
+
+    def test_shutdown_marks_closed_and_not_alive(self):
+        svc = _ProbeBackend()
+        svc.shutdown()
+        assert svc.is_alive is False
+
+
+# ═══════════════════════════════════════════════
+# 2. Lifecycle with mocked websockets.connect
+# ═══════════════════════════════════════════════
+
+
+class _FakeWS:
+    """Async-context-manager compatible fake of a websockets ClientProtocol.
+
+    Supports:
+        await ws.send(payload)        # records frames
+        async for msg in ws:           # yields scripted server messages then closes
+        await ws.close()
+    """
+    def __init__(self, server_msgs: list[Any] | None = None):
+        self._server_msgs = list(server_msgs or [])
+        self.sent_frames: list[Any] = []
+        self._closed = asyncio.Event()
+
+    async def send(self, payload):
+        if self._closed.is_set():
+            raise ConnectionError("closed")
+        self.sent_frames.append(payload)
+
+    async def close(self):
+        self._closed.set()
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        # Yield each scripted server message in turn; on exhaustion, wait
+        # until close() is called so the receiver doesn't spin.
+        for msg in self._server_msgs:
+            yield msg
+        await self._closed.wait()
+
+
+def _patch_websockets_connect(monkeypatch, ws_factory):
+    """Patch websockets.connect to return ws_factory()-built fakes.
+
+    ws_factory is a callable returning a (_FakeWS, optional close-delay)
+    pair or just a _FakeWS.
+    """
+    @asynccontextmanager
+    async def _fake_connect(*args, **kwargs):
+        ws = ws_factory()
+        try:
+            yield ws
+        finally:
+            await ws.close()
+
+    import websockets
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+
+
+@pytest.mark.asyncio
+async def test_resume_drives_idle_to_connected(monkeypatch):
+    """resume() → state transitions IDLE → CONNECTING → CONNECTED, and
+    the config message is sent to the upstream WS."""
+
+    svc = _ProbeBackend()
+    events: list[tuple[str, dict]] = []
+    svc.set_hook(lambda n, p: events.append((n, p)))
+
+    fake_ws = _FakeWS(server_msgs=[])  # server stays quiet
+    _patch_websockets_connect(monkeypatch, lambda: fake_ws)
+
+    # Run _run_ws as a background task in THIS event loop (bypassing the
+    # service's normal asyncio.run-in-a-thread plumbing). resume() then
+    # toggles the active event, allowing the loop to attempt connect.
+    run_task = asyncio.create_task(svc._run_ws())
+    # Let _run_ws bind _loop and _active_event before resume() probes them
+    await asyncio.sleep(0.01)
+    svc.resume()
+    # Give the loop time to fire connect + send config + emit CONNECTED
+    await asyncio.sleep(0.05)
+
+    # Verify state + events
+    assert svc.connection_state == STTConnectionState.CONNECTED
+    state_events = [p["state"] for n, p in events if n == "ws_status"]
+    assert "connecting" in state_events
+    assert "connected" in state_events
+
+    # Config message was sent on the wire
+    assert len(fake_ws.sent_frames) == 1
+    sent = json.loads(fake_ws.sent_frames[0])
+    assert sent == {"probe": True, "sr": 16000}
+
+    # Clean shutdown so the test doesn't leave a coroutine hanging
+    svc.shutdown()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except asyncio.TimeoutError:
+        run_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_pause_after_connected_closes_ws_and_idles(monkeypatch):
+    """pause() forces the live WS closed → outer loop sees clear active
+    event → emits IDLE without reconnecting."""
+
+    svc = _ProbeBackend()
+    events: list[tuple[str, dict]] = []
+    svc.set_hook(lambda n, p: events.append((n, p)))
+
+    fake_ws = _FakeWS(server_msgs=[])
+    _patch_websockets_connect(monkeypatch, lambda: fake_ws)
+
+    run_task = asyncio.create_task(svc._run_ws())
+    await asyncio.sleep(0.01)
+    svc.resume()
+    await asyncio.sleep(0.05)
+    assert svc.connection_state == STTConnectionState.CONNECTED
+
+    events.clear()
+    svc.pause()
+    await asyncio.sleep(0.1)
+
+    assert svc.connection_state == STTConnectionState.IDLE
+    state_events = [p["state"] for n, p in events if n == "ws_status"]
+    assert "idle" in state_events
+
+    svc.shutdown()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except asyncio.TimeoutError:
+        run_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_consecutive_failures_drives_to_error_state(monkeypatch):
+    """ERROR_CONSECUTIVE_FAILURES connection exceptions in a row → state
+    transitions to ERROR. Service keeps trying (the loop doesn't exit) so
+    a transient outage that recovers will heal — but the chip surfaces
+    the problem to the user.
+    """
+    svc = _ProbeBackend()
+    events: list[tuple[str, dict]] = []
+    svc.set_hook(lambda n, p: events.append((n, p)))
+
+    # Every connect raises; backoff capped so the test runs fast.
+    @asynccontextmanager
+    async def always_fail(*args, **kwargs):
+        raise ConnectionRefusedError("no server")
+        yield  # pragma: no cover
+
+    import services.stt_backends._ws_streaming as mod
+    monkeypatch.setattr(mod, "BACKOFF_INITIAL", 0.005)
+    monkeypatch.setattr(mod, "BACKOFF_MAX", 0.01)
+
+    import websockets
+    monkeypatch.setattr(websockets, "connect", always_fail)
+
+    run_task = asyncio.create_task(svc._run_ws())
+    await asyncio.sleep(0.01)
+    svc.resume()
+
+    # Wait long enough for ERROR_CONSECUTIVE_FAILURES failures
+    # (5 * 0.01s backoff cap = ~50 ms plus overhead)
+    for _ in range(20):
+        await asyncio.sleep(0.05)
+        if svc.connection_state == STTConnectionState.ERROR:
+            break
+
+    assert svc.connection_state == STTConnectionState.ERROR, (
+        f"Expected ERROR state after {ERROR_CONSECUTIVE_FAILURES} failures, "
+        f"got {svc.connection_state.value}"
+    )
+    # The service should still be alive — the loop keeps trying. is_alive
+    # checks the worker thread, which doesn't exist in this test (we ran
+    # _run_ws directly as a coroutine), so this is only about state.
+
+    svc.shutdown()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except asyncio.TimeoutError:
+        run_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_resume_after_shutdown_is_noop(monkeypatch):
+    """resume() after shutdown() must not re-open the connection. The
+    contract is permanent destruction."""
+    svc = _ProbeBackend()
+    events: list[tuple[str, dict]] = []
+    svc.set_hook(lambda n, p: events.append((n, p)))
+
+    svc.shutdown()
+    events.clear()
+    svc.resume()  # Should warn-and-return, NOT crash, NOT emit CONNECTING
+    state_events = [p["state"] for n, p in events if n == "ws_status"]
+    assert "connecting" not in state_events

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="My Jarvis — AI Agents Dashboard" />
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="jfx" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#818CF8"/>
+      <stop offset="55%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#22D3EE"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#jfx)"/>
+  <path d="M11 8 H22 M19 8 V20 a5 5 0 0 1 -10 0"
+        fill="none" stroke="#fff" stroke-width="3"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/chat/ChatHeader.vue
+++ b/frontend/src/components/chat/ChatHeader.vue
@@ -44,6 +44,28 @@ const voiceStrip = computed(() => {
 
 const isVoiceOn = computed(() => voice.status.value !== 'idle' && voice.status.value !== 'error')
 
+// WS chip drives off the UPSTREAM STT WebSocket state (wsStatus), not the
+// frontend↔backend ws_voice state (isVoiceOn). Reason: pre-fix, frontend
+// had a healthy WS to the backend while Soniox WS was dead — chip showed
+// green but mic input silently dropped (2026-05-29 incident). Now green
+// ⇔ Soniox really is connected and audio is reaching it.
+//
+// Wire format matches STTConnectionState in
+// backend/services/stt_backends/types.py:
+//   'idle' (mic off)       → grey "OFF"
+//   'connecting'           → amber "WS…"
+//   'connected'            → green "WS"
+//   'reconnecting'         → amber pulse "RECONNECT"
+//   'error'                → red "WS ERR"
+const wsChip = computed(() => {
+  const s = voice.wsStatus?.value || 'idle'
+  if (s === 'connected')    return { label: 'WS',       cls: 'chip-success', pulse: false }
+  if (s === 'connecting')   return { label: 'WS…',      cls: 'chip-warning', pulse: true }
+  if (s === 'reconnecting') return { label: 'RECONNECT', cls: 'chip-warning', pulse: true }
+  if (s === 'error')        return { label: 'WS ERR',   cls: 'chip-danger',  pulse: false }
+  return                      { label: 'OFF',      cls: 'chip-muted',   pulse: false }
+})
+
 function selectAgent(name) {
   emit('switch-agent', name)
   showDropdown.value = false
@@ -78,9 +100,9 @@ function selectAgent(name) {
       </div>
     </div>
 
-    <!-- SSE chip placeholder (existing chat-stream is HTTP-stream not WS; surface voice WS state here) -->
-    <span class="hd-chip" :class="isVoiceOn ? 'chip-success' : 'chip-muted'">
-      <span class="hd-chip-dot" /> {{ isVoiceOn ? 'WS' : 'OFF' }}
+    <!-- WS chip reflects upstream STT WebSocket state (not frontend↔backend). -->
+    <span class="hd-chip" :class="wsChip.cls" :title="`Soniox/STT WS state: ${voice.wsStatus?.value || 'idle'}`">
+      <span class="hd-chip-dot" :class="{ pulse: wsChip.pulse }" /> {{ wsChip.label }}
     </span>
 
     <!-- Switch agent -->
@@ -232,10 +254,27 @@ function selectAgent(name) {
   background: var(--bg-3);
   color: var(--text-muted);
 }
+.hd-chip.chip-warning {
+  background: var(--warning-bg);
+  color: var(--warning);
+  border-color: rgba(245, 158, 11, 0.30);
+}
+.hd-chip.chip-danger {
+  background: var(--danger-bg);
+  color: var(--danger);
+  border-color: rgba(239, 68, 68, 0.30);
+}
 .hd-chip-dot {
   width: 5px; height: 5px; border-radius: 50%;
   background: currentColor;
   box-shadow: 0 0 6px currentColor;
+}
+.hd-chip-dot.pulse {
+  animation: hd-chip-pulse 0.9s ease-in-out infinite;
+}
+@keyframes hd-chip-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(1.3); }
 }
 
 .hd-switch { position: relative; }

--- a/frontend/src/components/chat/ChatMessages.vue
+++ b/frontend/src/components/chat/ChatMessages.vue
@@ -69,20 +69,15 @@ watch(
   },
 )
 
-// Resolve the last assistant message id (used to show INTERRUPTED on the
-// most recent jarvis bubble when voice.wasInterrupted is true).
-const lastAssistantMsgId = computed(() => {
-  for (let i = props.messages.length - 1; i >= 0; i--) {
-    if (props.messages[i].role === 'assistant') return props.messages[i].id
-  }
-  return null
-})
-
+// Per-message INTERRUPTED flag (set by chatStore.markMessageInterrupted
+// when the LLM-in-progress placeholder gets cancelled mid-generation —
+// see useVoiceSession.js ``tts_interruption`` handler). Was previously
+// derived from ``voice.wasInterrupted`` (a single global ref) + last
+// assistant message id, which tagged the wrong bubble whenever a barge-in
+// happened *after* the LLM had already finalised (Case B — only TTS was
+// cancelled, the message itself was complete).
 function isInterrupted(msg) {
-  return msg.role === 'assistant'
-    && !msg.isStreaming
-    && voice.wasInterrupted.value
-    && msg.id === lastAssistantMsgId.value
+  return msg.role === 'assistant' && msg.isInterrupted === true
 }
 
 function isBargeIn(msg) {

--- a/frontend/src/components/chat/VoiceBar.vue
+++ b/frontend/src/components/chat/VoiceBar.vue
@@ -3,20 +3,13 @@
  * VoiceBar — single-strip hands-free toggle.
  *
  * Sits between ChatHeader and ChatMessages. The bar shows mic toggle,
- * a live waveform, status pill, partial transcript, and an Interrupt button
- * while the agent is talking. Conversation messages themselves are NOT
- * rendered here — they go straight into the normal chat message panel via
- * chatStore (addUserMessage / addAgentMessagePlaceholder / finalizeAgentMessage),
+ * status pill, live transcript, and an Interrupt button while the agent
+ * is talking. Conversation messages themselves are NOT rendered here —
+ * they go straight into the normal chat message panel via chatStore
+ * (addUserMessage / addAgentMessagePlaceholder / finalizeAgentMessage),
  * so voice and typed turns share one UI.
- *
- * Restyle (Track 5):
- *   - Match design tokens (var(--bg-1), var(--bg-2), var(--primary), etc).
- *   - Status pill uses primary/accent/warning/danger tokens.
- *   - Added live waveform driven by AnalyserNode (~40px height). Falls back
- *     to a sin-wave placeholder if the analyser is unavailable.
- *   - Composable (useVoiceSession) UNCHANGED — read-only consumer here.
  */
-import { computed, ref, watch, onBeforeUnmount } from 'vue'
+import { computed } from 'vue'
 import { useVoiceSession } from '../../composables/useVoiceSession.js'
 
 const session = useVoiceSession()
@@ -47,74 +40,6 @@ async function toggle() {
   if (isOn.value) await session.stop()
   else await session.start()
 }
-
-// ── Waveform ──────────────────────────────────────────────────────────────
-// Renders a sin-wave placeholder (live, animated) into the canvas. The
-// existing useVoiceSession doesn't expose its AudioContext analyser, so we
-// keep this as a visual indicator only — pulse amplitude depends on
-// `isOn` and `session.isUserSpeaking` for an obvious on/off feel. Doing the
-// drawing inside the component keeps composable contract untouched.
-const canvasRef = ref(null)
-const dpr = typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1
-let rafId = null
-let t0 = 0
-
-function drawFrame(ts) {
-  rafId = requestAnimationFrame(drawFrame)
-  const canvas = canvasRef.value
-  if (!canvas) return
-  const ctx = canvas.getContext('2d')
-  if (!ctx) return
-  if (!t0) t0 = ts
-  const dt = (ts - t0) / 1000
-  const w = canvas.width
-  const h = canvas.height
-  ctx.clearRect(0, 0, w, h)
-  // Idle = flat hairline. Active = larger wave. Speaking = denser.
-  const amplitude = isOn.value
-    ? (session.status.value === 'speaking' ? h * 0.34 : h * 0.22)
-    : 1
-  const freq = session.status.value === 'speaking' ? 6 : 3
-  const speed = session.isUserSpeaking.value ? 3 : 1.6
-  ctx.strokeStyle = isOn.value
-    ? (session.status.value === 'speaking'
-        ? 'rgba(129, 140, 248, 0.95)'  // primary-hover
-        : 'rgba(34, 211, 238, 0.85)')  // accent
-    : 'rgba(123, 128, 148, 0.4)'        // text-muted
-  ctx.lineWidth = 1.5 * dpr
-  ctx.beginPath()
-  const steps = 96
-  for (let i = 0; i <= steps; i++) {
-    const x = (i / steps) * w
-    const phase = (i / steps) * Math.PI * 2 * freq + dt * speed * Math.PI
-    const y = h / 2 + Math.sin(phase) * amplitude * (0.6 + 0.4 * Math.sin(dt * 1.3 + i * 0.1))
-    if (i === 0) ctx.moveTo(x, y)
-    else ctx.lineTo(x, y)
-  }
-  ctx.stroke()
-}
-
-function startDrawing() {
-  if (rafId) return
-  rafId = requestAnimationFrame(drawFrame)
-}
-function stopDrawing() {
-  if (rafId) cancelAnimationFrame(rafId)
-  rafId = null
-  const canvas = canvasRef.value
-  if (canvas) canvas.getContext('2d')?.clearRect(0, 0, canvas.width, canvas.height)
-}
-
-watch(canvasRef, (el) => {
-  if (!el) return
-  // Resize canvas to its CSS size × DPR so the line is crisp.
-  const rect = el.getBoundingClientRect()
-  el.width = Math.max(1, Math.floor(rect.width * dpr))
-  el.height = Math.max(1, Math.floor(rect.height * dpr))
-  startDrawing()
-})
-
-onBeforeUnmount(stopDrawing)
 </script>
 
 <template>
@@ -133,8 +58,6 @@ onBeforeUnmount(stopDrawing)
       </svg>
       <span class="mic-label">{{ isOn ? 'Stop' : 'Mic' }}</span>
     </button>
-
-    <canvas ref="canvasRef" class="waveform" aria-hidden="true" />
 
     <span
       class="status-pill"
@@ -210,15 +133,6 @@ onBeforeUnmount(stopDrawing)
 }
 .mic-btn svg { flex-shrink: 0; }
 .mic-label { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; }
-
-.waveform {
-  flex: 0 1 280px;
-  height: 32px;
-  width: 280px;
-  border-radius: var(--r-sm);
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-}
 
 .status-pill {
   display: inline-flex;
@@ -311,13 +225,7 @@ onBeforeUnmount(stopDrawing)
 
 @media (max-width: 640px) {
   .voice-bar { gap: 8px; padding: 8px 12px; flex-wrap: wrap; min-height: 0; }
-  .waveform { flex: 1 1 100%; width: 100%; height: 28px; order: 5; }
-  .transcript { display: none; }
-  /* Idle voice bar = empty waveform + tiny "MIC OFF" pill. On phone
-     that was eating ~90px of chrome above the messages. Collapse the
-     bar to a single 40px row by hiding the waveform until the user
-     activates voice. Pill + button stay so the affordance is reachable. */
-  .voice-bar:not(.on) .waveform { display: none; }
+  .transcript { flex: 1 1 100%; white-space: normal; order: 5; }
   .voice-bar:not(.on) { padding: 6px 12px; }
 }
 </style>

--- a/frontend/src/composables/useVoiceSession.js
+++ b/frontend/src/composables/useVoiceSession.js
@@ -43,6 +43,16 @@ export function useVoiceSession() {
 function _createVoiceSession() {
   const chatStore = useChatStore()
   const status = ref('idle')  // 'idle' | 'connecting' | 'loading_stt' | 'listening' | 'thinking' | 'speaking' | 'error'
+  // wsStatus mirrors the upstream STT WebSocket lifecycle (Soniox, Deepgram,
+  // …) — distinct from ``status`` which tracks the FRONTEND↔BACKEND ws_voice
+  // socket. Frontend chip renders off this so a green pill always means
+  // "STT really is connected and audio is reaching it", not "frontend has
+  // a WS to the backend". See [[ws lifecycle fix 2026-05-29]].
+  //
+  // Values match ``STTConnectionState`` in
+  // backend/services/stt_backends/types.py:
+  //   'idle' | 'connecting' | 'connected' | 'reconnecting' | 'error'
+  const wsStatus = ref('idle')
   const error = ref('')
   const partialTranscript = ref('')
   const lastFinalTranscript = ref('')
@@ -171,6 +181,12 @@ function _createVoiceSession() {
           break
         case 'recording_start': isUserSpeaking.value = true; break
         case 'recording_stop':  isUserSpeaking.value = false; break
+        case 'ws_status':
+          // Upstream STT WS state (idle/connecting/connected/reconnecting/error).
+          // Drives the WS chip in the chat header; does NOT replace the
+          // existing ``status`` ref which tracks the frontend↔backend WS.
+          wsStatus.value = msg.state || 'idle'
+          break
 
         case 'user_message': {
           // Push the user turn into chatStore so it appears in the main
@@ -293,16 +309,34 @@ function _createVoiceSession() {
           status.value = ws.value?.readyState === 1 ? 'listening' : 'idle'
           break
         case 'tts_interruption':
-          wasInterrupted.value = true
           // Same as barge_in_ack: stop any audio that already shipped from
           // server before the cancellation propagated, so the user's voice
           // gets the floor instantly instead of competing with bot residue.
           _flushPlaybackQueue()
-          // User barge-in or manual Interrupt — they already know what
-          // happened, so silently drop the in-flight placeholder instead of
-          // leaving "(interrupted by user)" noise in the chat. The previous
-          // (already-finalised) assistant message, if any, stays as-is.
-          _dropPending()
+          // Distinguish Case A vs Case B by the presence of a streaming
+          // placeholder:
+          //   * Case A — LLM still generating: ``pendingAgentMsgId`` set,
+          //     ``assistant_message`` hasn't landed yet. The placeholder
+          //     represents *this* turn so we mark it INTERRUPTED in place
+          //     instead of dropping it (keeps a visible "the bot was cut
+          //     off here" marker rather than a phantom missing turn).
+          //   * Case B — LLM finished, only TTS was cancelled: pending is
+          //     null, the assistant message has already been finalised.
+          //     Nothing on the chat side was interrupted — just the audio
+          //     — so we leave every bubble alone.
+          //
+          // ``wasInterrupted`` (global ref) remains set so the user-side
+          // BARGE-IN chip still lands on the most recent user message in
+          // both cases (the user *did* barge in either way).
+          if (pendingAgentMsgId !== null) {
+            wasInterrupted.value = true
+            if (typeof chatStore.markMessageInterrupted === 'function') {
+              try { chatStore.markMessageInterrupted(pendingAgentMsgId) } catch {}
+            }
+            pendingAgentMsgId = null
+          } else {
+            wasInterrupted.value = true  // for user-side BARGE-IN chip only
+          }
           status.value = ws.value?.readyState === 1 ? 'listening' : 'idle'
           break
         case 'error':
@@ -522,6 +556,11 @@ function _createVoiceSession() {
       audioContext.value = null
     }
     status.value = 'idle'
+    // The backend would emit ws_status: idle inside its pause() flow, but
+    // the WS is already torn down by the time we run — guarantee chip
+    // flips off immediately rather than waiting for a frame that won't
+    // arrive.
+    wsStatus.value = 'idle'
     isUserSpeaking.value = false
     partialTranscript.value = ''
   }
@@ -548,7 +587,7 @@ function _createVoiceSession() {
   })
 
   return {
-    status, error,
+    status, wsStatus, error,
     partialTranscript, lastFinalTranscript,
     isUserSpeaking, wasInterrupted, sessionId,
     wakeWordHits, events,

--- a/frontend/src/stores/chat.js
+++ b/frontend/src/stores/chat.js
@@ -323,6 +323,28 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   /**
+   * Mark a streaming placeholder as INTERRUPTED — the LLM was cancelled
+   * mid-generation (typically by a user barge-in over voice). Differs
+   * from ``setMessageError`` because no error happened: the user just
+   * cut the bot off. Differs from ``removeMessage`` because we keep
+   * the bubble visible so the user can see *which* turn was cut.
+   *
+   * Per-message flag (instead of a global ``wasInterrupted`` ref) so
+   * the chip lands on the right bubble — a global ref would also tag
+   * any already-finalised previous message every time TTS gets cut
+   * post-LLM (the false-positive bug for Case B).
+   */
+  function markMessageInterrupted(messageId) {
+    const conv = activeConversation.value
+    if (!conv) return
+    const msg = conv.messages.find(m => m.id === messageId)
+    if (!msg) return
+    msg.isStreaming = false
+    msg.isInterrupted = true
+    conv.updatedAt = Date.now()
+  }
+
+  /**
    * Mark a streaming message as errored (in-memory only).
    */
   function setMessageError(messageId, errorText) {
@@ -371,5 +393,6 @@ export const useChatStore = defineStore('chat', () => {
     finalizeAgentMessage,
     removeMessage,
     setMessageError,
+    markMessageInterrupted,
   }
 })

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -11,7 +11,6 @@
  *       - ChatHeader (agent, voice readiness)
  *       - VoiceBar (mic toggle + waveform + status pill)
  *       - ChatMessages (bubble stream with STT caret / TTS dots / interrupt)
- *       - Voice status footer ("VAD active" / "transcribed ✓" / etc.)
  *       - ChatInput
  *       - hidden TTS audio element
  */
@@ -72,27 +71,6 @@ const currentAgent = computed(() => {
   const name = chatStore.activeAgentName
   return agentsStore.agentsList.find(a => a.name === name) || null
 })
-
-// Voice status footer label — distilled from useVoiceSession state. The
-// "barge-in · interrupting" state is the wasInterrupted flag tied to the
-// transient between barge_in_ack and the next tts_start/listening.
-const STATUS_FOOTER_LABEL = {
-  idle: '',
-  connecting: 'connecting…',
-  loading_stt: 'loading stt model…',
-  listening: 'VAD active',
-  thinking: 'transcribed ✓ · awaiting reply',
-  speaking: 'speaking…',
-  error: 'error',
-}
-const statusFooter = computed(() => {
-  if (voice.wasInterrupted.value) return 'barge-in · interrupting'
-  return STATUS_FOOTER_LABEL[voice.status.value] || ''
-})
-const statusFooterActive = computed(() =>
-  ['listening', 'thinking', 'speaking', 'connecting', 'loading_stt'].includes(voice.status.value)
-  || voice.wasInterrupted.value,
-)
 
 async function handleStop({ mode }) {
   // Hard mode is destructive: SIGTERMs running subagents. We do NOT
@@ -259,12 +237,6 @@ function handleSwitchAgent(name) {
         </button>
       </div>
 
-      <!-- Status footer (above input) -->
-      <div v-if="statusFooter" class="status-footer">
-        <span class="status-footer-dot" :class="{ pulse: statusFooterActive }" />
-        <span class="status-footer-text">{{ statusFooter }}</span>
-      </div>
-
       <ChatInput
         :isStreaming="isStreaming"
         @send="handleSend"
@@ -327,34 +299,6 @@ function handleSwitchAgent(name) {
 .conv-overlay-enter-from, .conv-overlay-leave-to { opacity: 0; }
 .conv-overlay-enter-from .conv-slide-panel,
 .conv-overlay-leave-to .conv-slide-panel { transform: translateX(-100%); }
-
-/* Status footer */
-.status-footer {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 24px;
-  background: var(--bg-1);
-  border-top: 1px solid var(--border);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-muted);
-  letter-spacing: 0.08em;
-}
-.status-footer-dot {
-  width: 6px; height: 6px;
-  border-radius: 50%;
-  background: var(--text-muted);
-}
-.status-footer-dot.pulse {
-  background: var(--accent);
-  animation: status-pulse 1.2s ease-in-out infinite;
-}
-@keyframes status-pulse {
-  0%, 100% { opacity: 1;    transform: scale(1);    }
-  50%      { opacity: 0.45; transform: scale(1.4);  }
-}
 
 /* TTS Now Playing */
 .tts-now-playing {

--- a/frontend/src/views/settings/SettingsVoice.vue
+++ b/frontend/src/views/settings/SettingsVoice.vue
@@ -26,6 +26,20 @@ const engines = ref({ tts: {}, stt: {} })
 const active = ref({ tts_chat: null, tts_stories: null, stt: null })
 const secretsStatus = ref({})
 const requirements = ref({})
+// Feature-flag allowlist from GET /api/voice/backends. Drives the
+// engine/backend dropdowns: disabled options are hidden so a user can't
+// pick something the backend will RuntimeError on at save. See
+// services/stt_backends/__init__.py + services/tts_backends/__init__.py.
+const enabledFlags = ref({
+  stt: { enabled: [], known: [] },
+  tts: { enabled: [], known: [] },
+})
+function isSttBackendEnabled(id) {
+  return enabledFlags.value.stt.enabled.includes(id)
+}
+function isTtsEngineEnabled(id) {
+  return enabledFlags.value.tts.enabled.includes(id)
+}
 
 const previewing = ref(null)  // 'chat' | 'stories' | null
 const previewError = ref('')
@@ -64,14 +78,37 @@ const activeWakeBackend = computed({
 
 onMounted(async () => {
   try {
-    const [reg, cur, sec] = await Promise.all([
+    const [reg, cur, sec, flags] = await Promise.all([
       apiFetch('/api/voice/engines'),
       apiFetch('/api/voice/active'),
       apiFetch('/api/voice/secrets'),
+      // Feature-flag allowlist (STT_BACKENDS_ENABLED / TTS_BACKENDS_ENABLED).
+      // Drives dropdown filtering + fallback-on-disabled below.
+      apiFetch('/api/voice/backends'),
     ])
     engines.value = reg
     active.value = cur
     secretsStatus.value = sec.engines || {}
+    enabledFlags.value = flags || { stt: { enabled: [], known: [] }, tts: { enabled: [], known: [] } }
+    // Fallback when the saved preference is now disabled (operator
+    // changed env between sessions). Pick the first enabled option of
+    // the same kind so the UI never shows an unselectable engine.
+    const sttSel = active.value.stt?.backend
+    if (sttSel && !enabledFlags.value.stt.enabled.includes(sttSel)) {
+      const fallback = enabledFlags.value.stt.enabled[0]
+      if (fallback) {
+        console.warn(`[voice] STT backend "${sttSel}" disabled — falling back to "${fallback}"`)
+        active.value.stt.backend = fallback
+      }
+    }
+    const ttsSel = active.value.tts_chat?.engine
+    if (ttsSel && !enabledFlags.value.tts.enabled.includes(ttsSel)) {
+      const fallback = enabledFlags.value.tts.enabled[0]
+      if (fallback) {
+        console.warn(`[voice] TTS engine "${ttsSel}" disabled — falling back to "${fallback}"`)
+        active.value.tts_chat.engine = fallback
+      }
+    }
     // Probe requirements for every engine that declares either binaries or
     // secrets — TTS and STT alike, so cloud STT backends (Soniox, ...) get
     // the same "ready / missing key" badge as paid TTS engines.
@@ -301,21 +338,26 @@ const chatProviderLabel = computed(() => {
         </header>
 
         <div class="provider-grid">
-          <button
-            v-for="(spec, id) in engines.tts"
-            :key="id"
-            type="button"
-            class="provider-card"
-            :class="{ selected: active.tts_chat?.engine === id }"
-            @click="changeChatEngine(id)"
-          >
-            <span class="provider-title">
-              {{ spec.label }}
-              <span v-if="(secretsStatus[id]?.api_key) || (spec.secrets?.length === 0)" class="mini-dot" title="Ready"></span>
-            </span>
-            <span class="provider-sub">{{ badgesFor(spec).join(' · ') || spec.description }}</span>
-          </button>
+          <template v-for="(spec, id) in engines.tts" :key="id">
+            <button
+              v-if="isTtsEngineEnabled(id)"
+              type="button"
+              class="provider-card"
+              :class="{ selected: active.tts_chat?.engine === id }"
+              @click="changeChatEngine(id)"
+            >
+              <span class="provider-title">
+                {{ spec.label }}
+                <span v-if="(secretsStatus[id]?.api_key) || (spec.secrets?.length === 0)" class="mini-dot" title="Ready"></span>
+              </span>
+              <span class="provider-sub">{{ badgesFor(spec).join(' · ') || spec.description }}</span>
+            </button>
+          </template>
         </div>
+        <p v-if="enabledFlags.tts.known.length > enabledFlags.tts.enabled.length" class="provider-flag-hint">
+          {{ enabledFlags.tts.known.length - enabledFlags.tts.enabled.length }} TTS engine(s) hidden by
+          <code>TTS_BACKENDS_ENABLED</code> in <code>backend/.env</code>.
+        </p>
 
         <div v-if="chatEngineSpec" class="provider-hint">
           <strong>{{ chatEngineSpec.label }}</strong> — {{ chatEngineSpec.description }}
@@ -467,18 +509,23 @@ const chatProviderLabel = computed(() => {
         </header>
 
         <div class="provider-grid">
-          <button
-            v-for="(spec, id) in engines.stt"
-            :key="id"
-            type="button"
-            class="provider-card"
-            :class="{ selected: sttBackendId === id }"
-            @click="changeSttBackend(id)"
-          >
-            <span class="provider-title">{{ spec.label }}</span>
-            <span class="provider-sub">{{ (spec.badges || []).join(' · ') || spec.description }}</span>
-          </button>
+          <template v-for="(spec, id) in engines.stt" :key="id">
+            <button
+              v-if="isSttBackendEnabled(id)"
+              type="button"
+              class="provider-card"
+              :class="{ selected: sttBackendId === id }"
+              @click="changeSttBackend(id)"
+            >
+              <span class="provider-title">{{ spec.label }}</span>
+              <span class="provider-sub">{{ (spec.badges || []).join(' · ') || spec.description }}</span>
+            </button>
+          </template>
         </div>
+        <p v-if="enabledFlags.stt.known.length > enabledFlags.stt.enabled.length" class="provider-flag-hint">
+          {{ enabledFlags.stt.known.length - enabledFlags.stt.enabled.length }} STT backend(s) hidden by
+          <code>STT_BACKENDS_ENABLED</code> in <code>backend/.env</code>.
+        </p>
 
         <div v-if="sttSpec" class="provider-hint">
           <strong>{{ sttSpec.label }}</strong> — {{ sttSpec.description }}
@@ -747,6 +794,21 @@ const chatProviderLabel = computed(() => {
   font-size: 13px; line-height: 1.45;
   color: var(--text);
   display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+}
+
+.provider-flag-hint {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+.provider-flag-hint code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 1px 5px;
+  background: var(--bg-3);
+  border-radius: var(--r-xs);
+  color: var(--text-dim);
 }
 
 /* ── Form rows ────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Three-commit bundle that prepares the voice pipeline for OSS shipping:

1. **Backend STT lifecycle + flags** — full WSStreamingSTT rewrite, mic-driven, infinite reconnect, `ws_status` state machine; STT/TTS feature-flag allowlist; new `GET /api/voice/backends`; Gmail subprocess `JARVIS_MASTER_KEY` forward.
2. **Frontend chip + UX cleanup** — chat-header WS chip now mirrors upstream Soniox state (not frontend↔backend); Settings dropdown filters by feature flag with auto-fallback; barge-in Case A vs B per-message INTERRUPTED; remove fake waveform; brand-gradient favicon.
3. **Tests** — 132 tests across 6 files: Protocol conformance, lifecycle, flag gating, MCP env regression guards, /backends endpoint wire shape.

## Why

**Pre-fix root cause (2026-05-29 incident):** Soniox closes idle WS with HTTP 408 after ~10 min. The base class exited its reconnect loop on _normal_ close, leaving the process-level singleton holding a dead socket. Page reload reused it — audio silently dropped for ~9 hours until restart. UI chip was green the whole time.

**Fix invariant:** chip green ⇔ provider really is connected and audio is reaching it. Mic-driven (`pause`/`resume`) means the upstream WS is only held while the user is on mic, so Soniox never times out in the first place. Reconnect is defence in depth.

## What changes

### Backend
- `services/stt_backends/types.py` (NEW) — `STTServiceProtocol`, `STTConnectionState` enum, `KNOWN_EVENTS` vocab
- `services/stt_backends/_ws_streaming.py` — lifecycle rewrite (`_active` Event, `pause`/`resume`, infinite reconnect, `ws_status` emit, `FIRST_COMPLETED` gather, ERROR after 5 consecutive failures)
- `services/stt_backends/soniox.py` — `_in_utterance` flag emits canonical `recording_start` on first non-empty frame
- `services/stt_realtime.py` + `gipformer_vi.py` — implement Protocol (local backends: `feed_audio` gated by `_active`, `pause`/`resume` flip the flag + emit `ws_status` for UI consistency)
- `services/stt_backends/__init__.py` + `services/tts_backends/__init__.py` — feature-flag allowlist (`STT_BACKENDS_ENABLED`, `TTS_BACKENDS_ENABLED`)
- `routes/voice.py` — `GET /api/voice/backends` for Settings UI
- `routes/ws_voice.py` — `is_alive` health probe + `resume()` on connect + `pause()` on disconnect
- `fastagent.config.yaml` — `JARVIS_MASTER_KEY` forward to gmail/calendar MCP env (fixes "stored secret could not be decrypted")
- `.env.example` — documented STT_BACKENDS_ENABLED (`faster_whisper,gipformer_vi,soniox`) + TTS_BACKENDS_ENABLED (`edge,soniox`)

### Frontend
- `composables/useVoiceSession.js` — `wsStatus` ref + `ws_status` event handler; barge-in Case A/B distinction
- `components/chat/ChatHeader.vue` — WS chip drives off `wsStatus` (5 states: idle/connecting/connected/reconnecting/error) with pulse animation
- `components/chat/VoiceBar.vue` — removed fake sin-wave waveform, transcript fills the recovered space
- `components/chat/ChatMessages.vue` + `stores/chat.js` — per-message `isInterrupted` flag
- `views/ChatView.vue` — removed redundant status footer
- `views/settings/SettingsVoice.vue` — calls `/api/voice/backends` on mount, filters dropdowns, auto-fallback when saved preference disabled
- `index.html` + `public/favicon.svg` — brand-gradient "J" monogram

### Tests (132 total, all green)
- `test_stt_protocol_conformance.py` (NEW, 10) — every backend implements Protocol; enum wire format stable
- `test_ws_streaming_lifecycle.py` (NEW, 13) — state machine, hook replay, pause/resume, race-fix `_emit_endpoint`, mock-WS reconnect+ERROR
- `test_voice_backend_flags.py` (NEW, 13) — allowlist semantics, factory gating, `.env.example` contract
- `test_subprocess_env_vars.py` — `TestMCPDockerDefaultOverrides` (3) — Figma regression guard
- `test_routes/test_voice_routes.py` — `TestBackendsEndpoint` (+4) — wire shape + auth
- `test_services/test_soniox_stt.py` — updated stale endpoint test to match race fix

## Not in this PR

- **`backend/fast-agent` submodule pointer bump** — held back: 5 pre-existing tests in `test_skill_service_integration.py::TestRealRuntimeIntegration` fail against the synced submodule (`AttributeError: '_RealProtocolAgent' object has no attribute 'name'` in `fast_agent/core/instruction_refresh.py:365`). Separate concern — needs upstream investigation. The STT abstraction here is independent of the submodule version.
- **`backend/uv.lock`** — tied to the submodule version; held back together.
- **Audio URL `[[[AUDIO_URL: …]]]` marker not triggering audio playback** — reported during this session; will debug after this lands (story-TTS path vs chat-TTS path mismatch).

## Test plan

- [x] All 131 touched-file + closely-related tests pass (`pytest tests/test_stt_protocol_conformance.py tests/test_ws_streaming_lifecycle.py tests/test_voice_backend_flags.py tests/test_subprocess_env_vars.py tests/test_routes/test_voice_routes.py tests/test_services/test_soniox_stt.py tests/test_routes/test_ws_voice.py -q`)
- [x] Backend restart smoke: PID swap verified, `/api/health` returns ok, `/api/voice/backends` returns 401 without auth (correctly gated)
- [ ] Manual e2e on `localhost:3000/chat`:
  - Hard reload → bật Mic → chip "WS…" → "WS" green within ~1-2s
  - Rút Wifi 5s → chip "RECONNECT" amber → cắm lại → chip "WS" green within ~1-2s
  - Tắt Mic → chip "OFF" within < 500ms
  - Đợi 10+ phút có mic on → chip vẫn "WS" (mic-driven means no idle 408)
  - Vào Settings → Voice → chỉ thấy 3 STT backends + 2 TTS engines (`edge`, `soniox`); `system/azure/elevenlabs/openai` không hiện
- [ ] Barge-in 2 case:
  - Case A (LLM streaming) → nói chen → text cũ + INTERRUPTED chip + transcript mới auto-submit
  - Case B (LLM done, TTS playing) → nói chen → text cũ KHÔNG có chip, TTS dừng, transcript mới auto-submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)