### PR TITLE
OSS hardening: 13 fixes from pre-release security review

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,85 @@
+Jarvis
+Copyright 2026 Phuc Nguyen Van and Jarvis contributors
+
+This product is distributed under the MIT License (see LICENSE).
+
+It also bundles or depends on third-party software licensed under the
+Apache License, Version 2.0 (or other compatible terms). The full
+license texts are preserved alongside each component. The attributions
+below satisfy Section 4(d) of the Apache License where applicable.
+
+
+================================================================
+fast-agent  —  Apache License 2.0
+================================================================
+  Path:     backend/fast-agent/   (git submodule)
+  License:  backend/fast-agent/LICENSE
+  Notice:   backend/fast-agent/NOTICE   (reproduced below)
+  Upstream: https://github.com/evalstate/fast-agent
+  Fork:     https://github.com/omnigentx/fast-agent
+
+  ----- begin fast-agent NOTICE -----
+  OpenAI Codex
+  Copyright 2025 OpenAI
+
+  This repository includes a Python port of the openai/codex apply_patch
+  tool, licensed under the Apache 2.0 license.
+  ----- end fast-agent NOTICE -----
+
+
+================================================================
+Anthropic Skills  —  Apache License 2.0
+================================================================
+  Path:     backend/.fast-agent/skills/<skill-name>/
+  Upstream: https://github.com/anthropics/skills
+  License:  each skill ships its own LICENSE.txt next to SKILL.md.
+
+  Twelve skills are vendored as on-demand built-ins:
+
+    algorithmic-art         brand-guidelines        canvas-design
+    claude-api              frontend-design         internal-comms
+    mcp-builder             skill-creator           slack-gif-creator
+    theme-factory           web-artifacts-builder   webapp-testing
+
+  Vendored as exact copies (commit dd410c4). No modifications were
+  made to the upstream skill content.
+
+
+================================================================
+sherpa-onnx  —  Apache License 2.0
+================================================================
+  Pinned:   backend/pyproject.toml  (sherpa-onnx==1.10.46)
+  Upstream: https://github.com/k2-fsa/sherpa-onnx
+  License:  bundled inside the published wheel distribution.
+
+  Optional STT backend (Gipformer-65M Vietnamese) — only loaded when
+  the user selects ``gipformer_vi`` in voice settings.
+
+
+================================================================
+RealtimeSTT  /  RealtimeTTS  —  see upstream forks
+================================================================
+  Paths:    backend/realtimestt_src/   (git submodule)
+            backend/realtimetts_src/   (git submodule)
+  Upstream: https://github.com/KoljaB/RealtimeSTT
+            https://github.com/KoljaB/RealtimeTTS
+  Forks:    https://github.com/omnigentx/RealtimeSTT
+            https://github.com/omnigentx/RealtimeTTS
+  License:  preserved inside each submodule.
+
+
+================================================================
+Other runtime dependencies
+================================================================
+  Standard Python and JavaScript packages declared in
+  backend/pyproject.toml, frontend/package.json, and the respective
+  uv.lock / package-lock.json files. Each ships its own license
+  metadata via its package manager; we do not duplicate them here.
+
+
+----------------------------------------------------------------
+Skills authored in this repository
+----------------------------------------------------------------
+  In-house skills under backend/.fast-agent/skills/ without a sibling
+  LICENSE.txt inherit this repository's root MIT LICENSE. See
+  SKILL_LICENSING.md for the policy and any documented exceptions.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,39 @@ Jarvis is a `fast-agent` application. A root agent (Jarvis) delegates tool calls
 
 Pull requests welcome. Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening one.
 
+## Privacy & external APIs
+
+Voice and chat features can route through cloud providers. What
+leaves your host per backend:
+
+**TTS (text-to-speech)** — sends the text body:
+
+| Engine     | Network egress         | Default |
+|------------|------------------------|---------|
+| edge       | Microsoft Edge TTS API | ✅      |
+| soniox     | Soniox (US)            | opt-in  |
+| elevenlabs | ElevenLabs (US)        | opt-in  |
+| openai     | OpenAI (US)            | opt-in  |
+| azure      | Microsoft Azure        | opt-in  |
+| system     | Local only             | opt-in  |
+
+**STT (speech-to-text)** — sends audio frames:
+
+| Engine          | Network egress | Default |
+|-----------------|----------------|---------|
+| faster_whisper  | Local only     | ✅      |
+| gipformer_vi    | Local only     | opt-in  |
+| soniox          | Soniox (US)    | opt-in  |
+
+**Chat LLM** — your messages + tool outputs are sent to whichever
+provider you configure (Anthropic / OpenAI / OpenRouter / local
+Ollama / etc). Pick the one whose privacy policy fits your data.
+
+For sensitive content, choose a local-only path: `faster_whisper`
+STT + `system` TTS + Ollama for the chat LLM. Settings → Voice
+shows a **Cloud** / **Local** chip next to every engine in the
+picker so you can tell at a glance.
+
 ## Security
 
 Found a vulnerability? See [`SECURITY.md`](SECURITY.md). Please don't file public issues for security bugs.

--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ Found a vulnerability? See [`SECURITY.md`](SECURITY.md). Please don't file publi
 ## License
 
 [MIT](LICENSE) © 2026 Phuc Nguyen Van.
+
+Jarvis bundles third-party components under their own terms (Apache-2.0
+and others). See [`NOTICE`](NOTICE) for the attribution list.

--- a/SKILL_LICENSING.md
+++ b/SKILL_LICENSING.md
@@ -1,0 +1,59 @@
+# Skill licensing policy
+
+Skills live in `backend/.fast-agent/skills/<skill-name>/`. Each is either
+**in-house** (authored in this repository) or **vendored** (copied from an
+upstream Apache-2.0 source). The license of each skill is decided by the
+presence and content of its `LICENSE.txt`:
+
+| Status                                 | License        | Where to find it             |
+| -------------------------------------- | -------------- | ---------------------------- |
+| `LICENSE.txt` present, Apache 2.0      | Apache 2.0     | Sibling `LICENSE.txt`        |
+| `LICENSE.txt` absent (in-house)        | MIT (root)     | `/LICENSE` at the repo root  |
+| `LICENSE.txt` absent (documented exc.) | See note below | This file                    |
+
+The default for **any skill without a sibling `LICENSE.txt`** is the
+repo's root MIT LICENSE. This rule covers the ~54 in-house skills
+(e.g. `terminal-execution`, `jarvis-infra`, `music-playback`,
+`personal-assistant`, …) and stays stable regardless of which skills are
+added later.
+
+## Apache 2.0 — vendored from upstream
+
+Twelve skills vendored from Anthropic ship their own `LICENSE.txt`:
+
+```
+algorithmic-art        brand-guidelines       canvas-design
+claude-api             frontend-design        internal-comms
+mcp-builder            skill-creator          slack-gif-creator
+theme-factory          web-artifacts-builder  webapp-testing
+```
+
+Source: <https://github.com/anthropics/skills>. Vendored as exact copies
+in commit `dd410c4` — see [`NOTICE`](NOTICE) for attribution.
+
+## Documented exceptions
+
+### `doc-coauthoring`
+
+`backend/.fast-agent/skills/doc-coauthoring/` is vendored from Anthropic
+but ships **without** a `LICENSE.txt` because the upstream copy did not
+include one at vendor time. Anthropic publishes their skills under
+Apache 2.0, so `doc-coauthoring` is treated as Apache 2.0 here as well
+— the missing `LICENSE.txt` is mirrored from upstream rather than a
+licensing decision on our side. If the upstream skill later adds a
+`LICENSE.txt`, re-vendor and the default Apache-2.0 path applies.
+
+## What about contributing a new skill?
+
+Contributors authoring a new skill **in this repository** do NOT need to
+drop a `LICENSE.txt` into the skill directory — the root MIT LICENSE
+covers it automatically by the rule above.
+
+If you VENDOR a third-party skill, please:
+
+1. Add its upstream `LICENSE` / `LICENSE.txt` next to the skill's
+   `SKILL.md` so the per-directory rule keeps working.
+2. Update [`NOTICE`](NOTICE) with the source URL and (if Apache-2.0)
+   the attribution.
+3. If you modify any vendored file, mark it with a "Modified from
+   upstream" header so Apache 2.0 §4(b) is satisfied.

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -13,6 +13,7 @@ Two paths are accepted:
 When ``JARVIS_API_KEY`` is empty (dev / fresh install pre-Setup) auth is
 open — the Setup-Gate middleware blocks the API surface anyway.
 """
+import hmac
 import logging
 import os
 import time
@@ -103,9 +104,9 @@ async def verify_api_key(
     # Legacy fallbacks.  Both compared against the live module global so
     # an in-process key rotation takes effect immediately.
     query_key = request.query_params.get("api_key")
-    if query_key and query_key == JARVIS_API_KEY:
+    if query_key and hmac.compare_digest(query_key, JARVIS_API_KEY):
         return True
-    if credentials and credentials.credentials == JARVIS_API_KEY:
+    if credentials and hmac.compare_digest(credentials.credentials, JARVIS_API_KEY):
         return True
 
     raise HTTPException(
@@ -129,9 +130,9 @@ async def verify_optional_api_key(
         return True
 
     query_key = request.query_params.get("api_key")
-    if query_key and query_key == JARVIS_API_KEY:
+    if query_key and hmac.compare_digest(query_key, JARVIS_API_KEY):
         return True
-    if credentials and credentials.credentials == JARVIS_API_KEY:
+    if credentials and hmac.compare_digest(credentials.credentials, JARVIS_API_KEY):
         return True
 
     return False

--- a/backend/core/logging_config.py
+++ b/backend/core/logging_config.py
@@ -108,3 +108,23 @@ def setup_logging():
     for noisy in ("httpcore", "httpx", "uvicorn.access", "uvicorn.error",
                    "mcp.server.fastmcp", "mcp.client"):
         logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    # Defense-in-depth: scrub secret-looking values from every log line.
+    # Attached at handler level (not logger level) so records propagated
+    # from child loggers are also caught.
+    from helpers.logging_filters import RedactSecretsFilter
+    redact = RedactSecretsFilter()
+    _attach_filter_once(root_logger.handlers, redact)
+    for child_name in ("story_server", "iot_server", "library_server",
+                       "background_jobs", "tts_pregen_job", "spawn_activity"):
+        _attach_filter_once(logging.getLogger(child_name).handlers, redact)
+
+
+def _attach_filter_once(handlers, flt):
+    """Attach ``flt`` to each handler, skipping handlers that already
+    carry a filter of the same class (the same handler instance is shared
+    across multiple named loggers, so this loop visits it more than once)."""
+    flt_cls = type(flt)
+    for h in handlers:
+        if not any(isinstance(existing, flt_cls) for existing in h.filters):
+            h.addFilter(flt)

--- a/backend/core/logging_config.py
+++ b/backend/core/logging_config.py
@@ -7,6 +7,8 @@ import sys
 import logging
 from logging.handlers import RotatingFileHandler
 
+from helpers.logging_filters import RedactingFormatter
+
 # Logs directory (relative to backend/)
 LOGS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
 
@@ -22,7 +24,13 @@ def setup_logging():
     root_logger = logging.getLogger()
     root_logger.setLevel(getattr(logging, DEFAULT_LOG_LEVEL, logging.INFO))
 
-    formatter = logging.Formatter(LOG_FORMAT)
+    # Use the redacting formatter on every handler so the rendered output
+    # (including exception tracebacks from exc_info=True) is scrubbed of
+    # secret-looking values.  Pair this with the handler-level
+    # RedactSecretsFilter below — filter catches record.msg early so other
+    # consumers see the scrubbed text; formatter catches the final render
+    # including traceback text the filter cannot reach.
+    formatter = RedactingFormatter(LOG_FORMAT)
 
     # Remove only FileHandlers pointing to old locations (cleanup legacy)
     for handler in root_logger.handlers[:]:

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -8,7 +8,6 @@ services:
     volumes:
       - ./:/app
       - /app/.venv
-      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - PYTHONUNBUFFERED=1
       - LOG_CONSOLE_LEVEL=${LOG_CONSOLE_LEVEL:-INFO}

--- a/backend/helpers/http_errors.py
+++ b/backend/helpers/http_errors.py
@@ -1,0 +1,53 @@
+"""Helpers for HTTP error responses that don't leak internals.
+
+Routes used to do ``raise HTTPException(500, detail=str(exc))`` which
+ships the underlying message — file paths, library names, schema bits,
+``__cause__`` chains — back to the client. Authenticated client only,
+so the practical risk is low, but it's a pattern static analysers flag
+on first pass and it's trivial to centralise.
+
+``safe_500`` logs the real exception (with traceback) server-side and
+returns a generic dict payload. Use it for 5xx server errors only.
+For 4xx, the existing ``detail=...`` is usually intentional information
+(``"approval not found"``) so don't blanket-replace those.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+
+
+def safe_500(
+    exc: BaseException,
+    logger: logging.Logger,
+    reason: str = "internal_error",
+    *,
+    status_code: int = 500,
+) -> HTTPException:
+    """Build an :class:`HTTPException` with a generic dict body, after
+    logging the real exception (with traceback) to ``logger``.
+
+    Args:
+        exc: the caught exception. Logged with ``exc_info`` so the full
+            stack lands in the server-side log without leaking back to
+            the client.
+        logger: the route's module-level logger; the [ROUTE] prefix tag
+            keeps grepping easy.
+        reason: short machine-readable tag for the client side
+            (``"create_failed"``, ``"stats_failed"``, …). Stable strings
+            so a frontend can switch on them if it wants to.
+        status_code: defaults to 500; pass 503 for "external resource
+            down" / "service unavailable" semantics if you keep the
+            original status when changing the body.
+
+    Returns:
+        An :class:`HTTPException` with ``detail={"error": "internal_error",
+        "reason": reason}``. Raise this from the caller.
+    """
+    logger.error("[ROUTE] %dxx — %s: %s", status_code // 100, reason, exc, exc_info=True)
+    return HTTPException(
+        status_code=status_code,
+        detail={"error": "internal_error", "reason": reason},
+    )

--- a/backend/helpers/http_safety.py
+++ b/backend/helpers/http_safety.py
@@ -1,0 +1,65 @@
+"""HTTP fetch helpers with safety bounds.
+
+Used by the story crawl loops where each iteration pulls one chapter
+from an arbitrary URL. Without a body cap a hostile (or just bloated)
+chapter page can stream gigabytes into RAM + disk; 2000 such chapters
+in a single crawl job is the disk-fill scenario.
+"""
+
+from __future__ import annotations
+
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Per-response caps. 10 MB is comfortable headroom for any text chapter
+# observed in practice (Vietnamese fiction chapters land at 5-50 KB).
+MAX_CHAPTER_BYTES = 10 * 1024 * 1024
+WARN_CHAPTER_BYTES = 5 * 1024 * 1024
+
+
+def get_capped_text(
+    url: str,
+    *,
+    headers: dict | None = None,
+    timeout=10,
+    max_bytes: int = MAX_CHAPTER_BYTES,
+    warn_bytes: int = WARN_CHAPTER_BYTES,
+) -> tuple[int, str]:
+    """GET ``url`` with a streamed body + byte cap.
+
+    Returns ``(status_code, text)``. Lets the caller handle 429 / non-200
+    the same way they would after ``requests.get`` — only the body read
+    is changed: streamed, byte-capped, decoded to ``str``.
+
+    * Bytes above ``warn_bytes``: emit a warning, keep reading.
+    * Bytes above ``max_bytes``: stop reading; the partial body that fit
+      under the cap is returned. The caller treats it like a short page.
+    """
+    resp = requests.get(url, headers=headers or {}, timeout=timeout, stream=True)
+    try:
+        chunks: list[bytes] = []
+        total = 0
+        warned = False
+        for chunk in resp.iter_content(8192):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if not warned and total > warn_bytes:
+                logger.warning(
+                    "Response from %s exceeded %d bytes — will cap at %d",
+                    url[:80], warn_bytes, max_bytes,
+                )
+                warned = True
+            if total > max_bytes:
+                logger.warning(
+                    "Response from %s truncated at %d bytes",
+                    url[:80], max_bytes,
+                )
+                break
+            chunks.append(chunk)
+        encoding = resp.encoding or resp.apparent_encoding or "utf-8"
+        return resp.status_code, b"".join(chunks).decode(encoding, errors="replace")
+    finally:
+        resp.close()

--- a/backend/helpers/logging_filters.py
+++ b/backend/helpers/logging_filters.py
@@ -70,6 +70,13 @@ class RedactSecretsFilter(logging.Filter):
     Apply to handlers (not loggers) so the scrub catches records propagated
     from child loggers too. On any internal error the record passes through
     unchanged — log delivery is more important than perfect redaction.
+
+    NOTE: this filter only touches ``record.msg`` / merged args. It does
+    NOT see the rendered exception traceback emitted by handlers that use
+    ``exc_info=True`` — that text is produced by
+    :py:meth:`logging.Formatter.formatException` and bypasses the filter
+    chain. Pair this filter with :class:`RedactingFormatter` on every
+    handler to scrub the traceback too.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
@@ -85,3 +92,27 @@ class RedactSecretsFilter(logging.Filter):
             # Logging path must never raise. Best-effort only.
             pass
         return True
+
+
+class RedactingFormatter(logging.Formatter):
+    """Formatter that scrubs the *fully rendered* log line, including the
+    exception traceback that :class:`RedactSecretsFilter` cannot reach.
+
+    ``Logger.error("X", exc_info=True)`` and ``logger.exception(...)`` cause
+    the formatter to append a traceback produced by
+    :py:meth:`logging.Formatter.formatException`. If a secret is stuffed
+    in a frame's local repr or in an exception message, the filter chain
+    has already finished and the secret lands in the file untouched.
+
+    Attaching this formatter to every handler closes that gap by running
+    ``redact_secrets`` over the final output. Never raises — on regex
+    failure it falls back to the unredacted superclass output.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        text = super().format(record)
+        try:
+            return redact_secrets(text)
+        except Exception:
+            # Same rule as the filter: logging path must never raise.
+            return text

--- a/backend/helpers/logging_filters.py
+++ b/backend/helpers/logging_filters.py
@@ -1,0 +1,87 @@
+"""Logging filters — defensive scrub for secret-looking values.
+
+Attached to every handler by ``core.logging_config.setup_logging`` so that
+any log line touching the root logger (or any of the named child loggers
+configured there) has secret-like substrings replaced with ``***``.
+
+This is defense-in-depth: the codebase tries not to log secrets in the
+first place, but a future contributor adding ``logger.debug("config=%s",
+config)`` where ``config`` contains an api_key would otherwise leak it
+to ``logs/jarvis.log`` (and any future APM that ships log lines off-box).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+# Keywords whose value should be redacted in log lines.
+_SECRET_KEYS = (
+    "api_key", "api-key", "apikey",
+    "access_token", "access-token",
+    "auth_token", "auth-token",
+    "secret_key", "secret-key",
+    "password", "passwd",
+    "secret",
+    "token",
+)
+
+# "Authorization" gets its own pattern: the value may be multi-word
+# ("Bearer <jwt>", "Basic <b64>") which the generic KV value class would
+# truncate at the first whitespace.
+_AUTHZ_RE = re.compile(
+    r"(?i)(\bauthorization\s*[\'\"]?\s*[:=]\s*[\'\"]?)"
+    r"([^\'\",}\])]+)"
+)
+
+# Generic key=value / "key": "value" for keywords whose value is a single
+# token. Stops at whitespace / common JSON-dict closers / quotes so the
+# surrounding structure stays intact.
+_KV_RE = re.compile(
+    r"(?i)(\b(?:" + "|".join(re.escape(k) for k in _SECRET_KEYS) + r")\b"
+    r"\s*[\'\"]?\s*[:=]\s*[\'\"]?)"
+    r"([^\s\'\",}\])]+)"
+)
+
+# Standalone "Bearer <token>" anywhere in the line (when not preceded by
+# "Authorization:" — that case is handled by _AUTHZ_RE first).
+_BEARER_RE = re.compile(r"(?i)(\bbearer\s+)(\S+)")
+
+
+def redact_secrets(text: str) -> str:
+    """Replace secret-looking values inside ``text`` with ``***``.
+
+    Idempotent and safe for log lines, JSON snippets, env-style assignments,
+    and ``Authorization: Bearer <token>`` headers. Never raises.
+    """
+    if not text:
+        return text
+    # Apply Authorization first so the multi-word value (Bearer + token)
+    # is consumed before the standalone Bearer/KV patterns run.
+    text = _AUTHZ_RE.sub(r"\1***", text)
+    text = _BEARER_RE.sub(r"\1***", text)
+    text = _KV_RE.sub(r"\1***", text)
+    return text
+
+
+class RedactSecretsFilter(logging.Filter):
+    """Logging filter that scrubs secret-looking values from every record.
+
+    Apply to handlers (not loggers) so the scrub catches records propagated
+    from child loggers too. On any internal error the record passes through
+    unchanged — log delivery is more important than perfect redaction.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        try:
+            formatted = record.getMessage()
+            redacted = redact_secrets(formatted)
+            if redacted != formatted:
+                # ``record.getMessage()`` already merged %-args; clear args so
+                # downstream formatters don't try to merge them a second time.
+                record.msg = redacted
+                record.args = None
+        except Exception:
+            # Logging path must never raise. Best-effort only.
+            pass
+        return True

--- a/backend/helpers/path_safety.py
+++ b/backend/helpers/path_safety.py
@@ -1,0 +1,57 @@
+"""Path-safety helpers — small, focused traversal guards.
+
+The story crawl / TTS-pregen pipeline accepts directory and filename
+components that originate from web-scraped page titles or DB rows
+populated by LLM tool calls. Anything that joins those into a path
+must guard against ``..`` and absolute paths sneaking through.
+
+``safe_story_path`` is the one helper everyone should use. It:
+
+* rejects empty / non-string parts,
+* rejects ``.`` and ``..`` exactly (the dot-traversal escape),
+* rejects any part containing a path separator (``/`` or ``\\``),
+* resolves the final candidate path and re-asserts it stays under
+  the base directory — catches symlink games and other edge cases
+  the simple checks above miss.
+
+Vietnamese diacritics and other Unicode are preserved. Callers that
+want a *cosmetic* clean (e.g. strip ``?`` and ``*`` for Windows
+filesystems) should run their own ``re.sub`` BEFORE calling this
+helper; it is intentionally not opinionated about presentation.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Union
+
+_BAD_CHARS = {"/", "\\", "\x00"}
+
+
+def safe_story_path(base: Union[Path, str], *parts: str) -> Path:
+    """Safely join ``parts`` under ``base``.
+
+    Returns the resolved :class:`~pathlib.Path` on success.
+
+    Raises :class:`ValueError` when any part is empty, ``.``, ``..``,
+    contains a path separator, or when the resolved candidate escapes
+    ``base`` (e.g. via symlink).
+    """
+    base_path = Path(base).resolve()
+
+    for p in parts:
+        if not isinstance(p, str) or not p:
+            raise ValueError(f"Empty or non-string path component: {p!r}")
+        if p in (".", ".."):
+            raise ValueError(f"Path traversal component: {p!r}")
+        if any(c in p for c in _BAD_CHARS):
+            raise ValueError(f"Path separator in component: {p!r}")
+
+    candidate = base_path.joinpath(*parts).resolve()
+    # Allow equality (parts == empty after rejection above, would not reach
+    # here) only on the base itself — and in practice we always have ≥1 part.
+    if base_path != candidate and base_path not in candidate.parents:
+        raise ValueError(f"Path escapes sandbox: {candidate} not under {base_path}")
+
+    return candidate

--- a/backend/helpers/story_reader.py
+++ b/backend/helpers/story_reader.py
@@ -4,7 +4,9 @@ import re
 import json
 import time
 import logging
+from pathlib import Path
 
+from helpers.path_safety import safe_story_path
 from helpers.text_processing import clean_text_for_tts
 
 logger = logging.getLogger(__name__)
@@ -16,9 +18,16 @@ def handle_read_local(story_title: str, chapter_filename: str, library_manager, 
     Reads local chapter text, creates a library entry, saves TTS text.
     Returns dict with keys: book_id, tts_text on success, or error on failure.
     """
-    path = os.path.join("data/stories", story_title, chapter_filename)
+    # PendingAction payload originates from LLM tool calls — guard against
+    # `../../etc/passwd`-style chapter_filename or story_title before any
+    # filesystem touch.
+    try:
+        path = safe_story_path(Path("data") / "stories", story_title, chapter_filename)
+    except ValueError as e:
+        logger.warning(f"handle_read_local rejected unsafe payload {story_title!r}/{chapter_filename!r}: {e}")
+        return {"error": "Invalid story/chapter path"}
 
-    if not os.path.exists(path):
+    if not path.exists():
         return {"error": f"File not found: {story_title}/{chapter_filename}"}
 
     try:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
   # Optional STT backend: Gipformer-65M Vietnamese (sherpa-onnx runtime).
   # Wheel ships prebuilt for macOS/Linux/Windows; only loaded when the
   # user picks the gipformer_vi backend in the voice settings.
+  # Licensing: the Gipformer model weights are MIT; sherpa-onnx itself
+  # is Apache-2.0 (attribution in the root NOTICE file). Both ship as
+  # data inside the wheel — see NOTICE for redistribution terms.
   # Pin to 1.10.46 — last version that bundles libonnxruntime in the wheel.
   # 1.12+ wheels drop the bundled dylib and require an external onnxruntime
   # install whose ABI version exactly matches what sherpa-onnx was built

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -18,6 +18,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from core.auth import verify_api_key
+from helpers.http_errors import safe_500
 from agent import fast
 import time as _time
 
@@ -1176,7 +1177,7 @@ async def create_agent(agent: AgentCreate):
         status = 409 if "already exists" in msg else 400
         raise HTTPException(status_code=status, detail=msg)
     except RuntimeError as e:
-        raise HTTPException(status_code=503, detail=str(e))
+        raise safe_500(e, logger, "agent_create_unavailable", status_code=503) from e
 
     activity_stream_manager.broadcast({
         "agent_name": agent.name,
@@ -1208,7 +1209,7 @@ async def update_agent(name: str, update: AgentUpdate):
         status = 404 if "not found" in msg else 400
         raise HTTPException(status_code=status, detail=msg)
     except RuntimeError as e:
-        raise HTTPException(status_code=503, detail=str(e))
+        raise safe_500(e, logger, "agent_update_unavailable", status_code=503) from e
 
     logger.info("[AGENTS API] Updated agent: %s", name)
     return {"status": "updated", "name": name}

--- a/backend/routes/approvals.py
+++ b/backend/routes/approvals.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel, Field
 
 from core.auth import verify_api_key
+from helpers.http_errors import safe_500
 from services.approval_service import approval_service
 
 logger = logging.getLogger(__name__)
@@ -58,8 +59,7 @@ async def create_approval(req: CreateApprovalRequest):
         result = approval_service.create_approval(req.model_dump())
         return result
     except Exception as e:
-        logger.error("[APPROVAL] Create failed: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise safe_500(e, logger, "approval_create_failed") from e
 
 
 @router.get("")
@@ -68,8 +68,7 @@ async def list_approvals(status: Optional[str] = None, type: Optional[str] = Non
     try:
         return approval_service.list_approvals(status=status, approval_type=type)
     except Exception as e:
-        logger.error("[APPROVAL] List failed: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise safe_500(e, logger, "approval_list_failed") from e
 
 
 @router.get("/stats")
@@ -78,8 +77,7 @@ async def get_stats():
     try:
         return approval_service.get_stats()
     except Exception as e:
-        logger.error("[APPROVAL] Stats failed: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise safe_500(e, logger, "approval_stats_failed") from e
 
 
 @router.get("/{approval_id}")
@@ -99,8 +97,7 @@ async def resolve_approval(approval_id: str, req: ResolveApprovalRequest):
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error("[APPROVAL] Resolve failed: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise safe_500(e, logger, "approval_resolve_failed") from e
 
 
 @router.post("/{approval_id}/comments", status_code=201)
@@ -114,8 +111,7 @@ async def add_comment(approval_id: str, req: AddCommentRequest):
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-        logger.error("[APPROVAL] Add comment failed: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise safe_500(e, logger, "approval_add_comment_failed") from e
 
 
 @router.put("/comments/{comment_id}")
@@ -126,8 +122,7 @@ async def update_comment(comment_id: str, req: UpdateCommentRequest):
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-        logger.error("[APPROVAL] Update comment failed: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise safe_500(e, logger, "approval_update_comment_failed") from e
 
 
 @router.delete("/comments/{comment_id}")
@@ -138,5 +133,4 @@ async def delete_comment(comment_id: str):
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-        logger.error("[APPROVAL] Delete comment failed: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise safe_500(e, logger, "approval_delete_comment_failed") from e

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -34,6 +34,7 @@ fields.
 """
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 from typing import Optional
@@ -147,7 +148,7 @@ async def login(payload: LoginRequest, request: Request, response: Response) -> 
             detail={"error": "not_configured", "reason": "auth_key_unset"},
         )
 
-    if payload.api_key.strip() != expected:
+    if not hmac.compare_digest(payload.api_key.strip(), expected):
         logger.warning("[AUTH] Login failed from %s — wrong api_key", client_ip)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/routes/mcp.py
+++ b/backend/routes/mcp.py
@@ -21,6 +21,7 @@ from sqlalchemy import desc, select
 
 from core.auth import verify_api_key
 from core.database import McpEventLogModel, SessionLocal
+from helpers.http_errors import safe_500
 from services import mcp_attachments, mcp_catalog
 from services.activity_stream import activity_stream_manager
 from services.mcp_runtime import audit
@@ -230,7 +231,7 @@ async def attach_to_agent(name: str, agent: str) -> dict[str, Any]:
     except LookupError as e:
         raise HTTPException(status_code=404, detail={"message": str(e)})
     except Exception as e:
-        raise HTTPException(status_code=500, detail={"message": f"{type(e).__name__}: {e}"})
+        raise safe_500(e, logger, "mcp_attach_failed") from e
 
 
 @router.delete("/servers/{name}/agents/{agent}", dependencies=[Depends(verify_api_key)])

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -41,6 +41,7 @@ without a round-trip.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -173,13 +174,13 @@ def _ws_authenticated(ws: WebSocket, expected_api_key: str) -> bool:
     auth_header = ws.headers.get("authorization", "")
     if auth_header.lower().startswith("bearer "):
         token = auth_header.split(" ", 1)[1].strip()
-        if token == expected_api_key:
+        if token and hmac.compare_digest(token, expected_api_key):
             logger.debug("[WS-AUTH] accepted via Bearer header")
             return True
 
     # 3) ?api_key= query param (legacy — Xiaozhi device).
     token = ws.query_params.get("api_key", "")
-    if token and token == expected_api_key:
+    if token and hmac.compare_digest(token, expected_api_key):
         logger.debug("[WS-AUTH] accepted via ?api_key= query")
         return True
 

--- a/backend/services/approval_gate.py
+++ b/backend/services/approval_gate.py
@@ -119,6 +119,21 @@ async def gate(
     Returns:
         (approved, reason) — ``reason`` is a short string for logging /
         propagating back to the caller's error envelope.
+
+    Trade-off:
+        Timeout persists the row as ``rejected`` (see ``except
+        asyncio.TimeoutError`` below). Combined with the
+        ``_find_prior_decision`` short-circuit at the top of this
+        function, that means a single missed approval window — eg
+        the operator was AFK for the full ``timeout_s`` — permanently
+        blocks this exact ``(approval_type, scope_key, content_hash)``
+        triple. Every later call returns ``(False, "previously
+        rejected ...")``` without re-prompting. This is intentional:
+        a never-answered cron should not re-spawn a fresh approval
+        every 5 minutes forever. If the operator wants to revisit a
+        timed-out decision, they delete the rejected row (or change
+        the payload so the content_hash differs) and the next call
+        will create a fresh prompt.
     """
     # Local import keeps services/__init__.py free of an import cycle —
     # approval_service depends on activity_stream_manager which depends on

--- a/backend/services/approval_gate.py
+++ b/backend/services/approval_gate.py
@@ -1,0 +1,184 @@
+"""Human-approval gate for high-blast-radius server-side actions.
+
+Used by:
+* :func:`services.mcp_admin_service.install_dependencies` — block
+  ``pip install`` against an LLM-editable ``requirements.txt`` until the
+  user OKs the package list.
+* :func:`services.cron_scheduler.CronScheduler._execute_agent_turn` —
+  block the first execution of any new ``exec_payload`` so a poisoned
+  cron entry can't fire unsupervised at 03:00.
+
+The gate piggybacks on the existing approval pipeline
+(:mod:`approval_service`): create an ApprovalRequestModel, wait for the
+user to decide via the dashboard. Decisions are remembered by
+``(approval_type, scope_key, content_hash)`` so a repeat run with the
+same content auto-proceeds without prompting again. A rejected hash
+stays rejected — re-asking on every cron fire would be noise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Default: wait up to 1 hour for user. After that, treat as rejected so the
+# caller (cron tick, tool call) returns control rather than hanging forever.
+DEFAULT_GATE_TIMEOUT_S = 3600.0
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+
+
+def _matches_scope(row, scope_key: str, content_hash: str) -> bool:
+    try:
+        meta = json.loads(row.metadata_json or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return meta.get("scope_key") == scope_key and meta.get("content_hash") == content_hash
+
+
+def _find_prior_decision(
+    approval_type: str, scope_key: str, content_hash: str
+) -> Optional[str]:
+    """Return ``'approved'`` / ``'rejected'`` if a *resolved* approval for
+    this exact (type, scope_key, content_hash) exists. ``None`` otherwise."""
+    from core.database import ApprovalRequestModel, SessionLocal
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(ApprovalRequestModel)
+            .filter(
+                ApprovalRequestModel.approval_type == approval_type,
+                ApprovalRequestModel.status.in_(("approved", "rejected")),
+            )
+            .order_by(ApprovalRequestModel.resolved_at.desc())
+            .all()
+        )
+        for row in rows:
+            if _matches_scope(row, scope_key, content_hash):
+                return row.status
+    finally:
+        db.close()
+    return None
+
+
+def _find_pending_match(
+    approval_type: str, scope_key: str, content_hash: str
+) -> Optional[str]:
+    """Return the approval_id of an existing *pending* approval that
+    matches the (type, scope_key, content_hash) — so concurrent cron fires
+    coalesce onto a single user prompt instead of stacking duplicates."""
+    from core.database import ApprovalRequestModel, SessionLocal
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(ApprovalRequestModel)
+            .filter(
+                ApprovalRequestModel.approval_type == approval_type,
+                ApprovalRequestModel.status == "pending",
+            )
+            .all()
+        )
+        for row in rows:
+            if _matches_scope(row, scope_key, content_hash):
+                return row.id
+    finally:
+        db.close()
+    return None
+
+
+async def gate(
+    *,
+    approval_type: str,
+    scope_key: str,
+    content_md: str,
+    title: str,
+    agent_name: str = "Jarvis",
+    timeout_s: float = DEFAULT_GATE_TIMEOUT_S,
+) -> tuple[bool, str]:
+    """Block until the user approves (or rejects) the gated action.
+
+    Args:
+        approval_type: discriminator stored on the row, e.g. ``"mcp_install"``.
+        scope_key:     stable subject identity, e.g. ``"mcp:server_foo"`` or
+                       ``"cron:abcd1234"``.
+        content_md:    markdown shown in the approval modal — should include
+                       the exact payload + a "use at your own risk" warning.
+        title:         short header for the approval card.
+        agent_name:    affects auto-pause + UI attribution. Default Jarvis.
+        timeout_s:     max wait. On timeout, return as rejected.
+
+    Returns:
+        (approved, reason) — ``reason`` is a short string for logging /
+        propagating back to the caller's error envelope.
+    """
+    # Local import keeps services/__init__.py free of an import cycle —
+    # approval_service depends on activity_stream_manager which depends on
+    # other services that import this gate.
+    from services.approval_service import approval_service
+
+    h = _content_hash(content_md)
+
+    prior = _find_prior_decision(approval_type, scope_key, h)
+    if prior == "approved":
+        logger.info(
+            "[GATE] %s/%s — prior approval for hash=%s; proceeding without prompt",
+            approval_type, scope_key, h,
+        )
+        return True, "previously approved (same content hash)"
+    if prior == "rejected":
+        logger.info(
+            "[GATE] %s/%s — prior rejection for hash=%s; refusing",
+            approval_type, scope_key, h,
+        )
+        return False, "previously rejected (same content hash)"
+
+    existing_id = _find_pending_match(approval_type, scope_key, h)
+    if existing_id:
+        logger.info(
+            "[GATE] %s/%s — joining existing pending approval %s",
+            approval_type, scope_key, existing_id,
+        )
+        approval_id = existing_id
+    else:
+        record = approval_service.create_approval({
+            "agent_name": agent_name,
+            "approval_type": approval_type,
+            "title": title,
+            "content": content_md,
+            "content_format": "markdown",
+            "urgency": "normal",
+            "metadata": {
+                "scope_key": scope_key,
+                "content_hash": h,
+            },
+        })
+        approval_id = record["id"]
+        logger.info(
+            "[GATE] %s/%s — created approval %s; awaiting user",
+            approval_type, scope_key, approval_id,
+        )
+
+    try:
+        resolved = await asyncio.wait_for(
+            approval_service.wait_for_resolution(approval_id),
+            timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[GATE] %s/%s — timeout after %.0fs",
+            approval_type, scope_key, timeout_s,
+        )
+        return False, f"approval timeout ({timeout_s:.0f}s)"
+
+    if resolved.get("user_decision") == "approve":
+        return True, "user approved"
+    return False, f"user rejected: {resolved.get('user_comment') or 'no comment'}"

--- a/backend/services/approval_gate.py
+++ b/backend/services/approval_gate.py
@@ -174,9 +174,28 @@ async def gate(
         )
     except asyncio.TimeoutError:
         logger.warning(
-            "[GATE] %s/%s — timeout after %.0fs",
-            approval_type, scope_key, timeout_s,
+            "[GATE] %s/%s — timeout after %.0fs", approval_type, scope_key, timeout_s,
         )
+        # Persist the timeout as a rejection so subsequent gate() calls for
+        # the same (type, scope_key, content_hash) fast-skip via
+        # _find_prior_decision instead of re-creating a fresh pending row
+        # and waiting another full timeout window. Without this, a
+        # never-answered cron payload re-blocks the scheduler on every
+        # fire (and stale pending rows pile up forever).
+        try:
+            approval_service.resolve_approval(
+                approval_id,
+                decision="reject",
+                comment=f"auto-rejected after {timeout_s:.0f}s timeout",
+            )
+        except Exception as resolve_exc:
+            # Race: the user might have just resolved it manually between
+            # the timeout firing and our persist call. Log but don't mask
+            # the actual timeout reason returned to the caller.
+            logger.warning(
+                "[GATE] %s/%s — failed to persist timeout rejection: %s",
+                approval_type, scope_key, resolve_exc,
+            )
         return False, f"approval timeout ({timeout_s:.0f}s)"
 
     if resolved.get("user_decision") == "approve":

--- a/backend/services/crawl_poller.py
+++ b/backend/services/crawl_poller.py
@@ -18,7 +18,10 @@ import re
 import threading
 import time
 from datetime import datetime
+from pathlib import Path
 from urllib.parse import urljoin
+
+from helpers.path_safety import safe_story_path
 
 import requests
 from bs4 import BeautifulSoup
@@ -260,9 +263,17 @@ class CrawlPoller:
             story_folder = re.sub(r'[\\/*?:"<>|]', "", story_name).strip()
             if not story_folder:
                 story_folder = "Untitled_Story"
-            
-            save_dir = os.path.join(DATA_DIR, "stories", story_folder)
-            os.makedirs(save_dir, exist_ok=True)
+            try:
+                save_dir = safe_story_path(Path(DATA_DIR) / "stories", story_folder)
+            except ValueError as e:
+                # Scraped <title> produced a traversal-like value (eg "..").
+                # Don't write outside the sandbox — fall back to a timestamped
+                # name and log the rejection so a future debug has evidence.
+                _dbg(job_id, f"Unsafe story folder {story_folder!r} rejected: {e}; using timestamped fallback")
+                story_folder = f"Untitled_Story_{int(time.time())}"
+                save_dir = safe_story_path(Path(DATA_DIR) / "stories", story_folder)
+            save_dir.mkdir(parents=True, exist_ok=True)
+            save_dir = str(save_dir)  # downstream os.path.join() callers expect str
             
             # Register story metadata in DB (replaces legacy metadata.json)
             try:

--- a/backend/services/crawl_poller.py
+++ b/backend/services/crawl_poller.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from urllib.parse import urljoin
 
+from helpers.http_safety import get_capped_text
 from helpers.path_safety import safe_story_path
 
 import requests
@@ -336,31 +337,35 @@ class CrawlPoller:
                 
                 _dbg(job_id, f"Fetching #{count+1}: {current_url[:80]}")
                 
-                # Fetch with retry on 429
-                resp = None
+                # Fetch with retry on 429. Body is streamed + capped at
+                # MAX_CHAPTER_BYTES so a hostile/oversized chapter page
+                # can't fill RAM or disk on its own.
+                resp_status: int | None = None
+                resp_text = ""
                 for attempt in range(4):
                     try:
-                        resp = requests.get(current_url, headers=headers, timeout=10)
-                        if resp.status_code == 429:
-                            if attempt < 3:
-                                _dbg(job_id, f"429 Too Many Requests, retry {attempt+1}/3 in 5s")
-                                time.sleep(5)
-                                continue
+                        resp_status, resp_text = get_capped_text(
+                            current_url, headers=headers, timeout=10,
+                        )
+                        if resp_status == 429 and attempt < 3:
+                            _dbg(job_id, f"429 Too Many Requests, retry {attempt+1}/3 in 5s")
+                            time.sleep(5)
+                            continue
                         break
                     except Exception as e:
                         _dbg(job_id, f"Request failed: {e}")
-                        resp = None
+                        resp_status = None
                         break
-                
-                if not resp:
+
+                if resp_status is None:
                     break
-                if resp.status_code != 200:
-                    _dbg(job_id, f"HTTP {resp.status_code} for {current_url[:60]}")
+                if resp_status != 200:
+                    _dbg(job_id, f"HTTP {resp_status} for {current_url[:60]}")
                     if chapter_iterator:
                         continue
                     break
-                
-                soup = BeautifulSoup(resp.text, "html.parser")
+
+                soup = BeautifulSoup(resp_text, "html.parser")
                 
                 # Extract content
                 content_div = soup.select_one(content_selector) if content_selector else None

--- a/backend/services/crawl_poller.py
+++ b/backend/services/crawl_poller.py
@@ -198,8 +198,10 @@ class CrawlPoller:
                         sels = provider.get("selectors", {})
                         c_sel = sels.get("content")
                         if c_sel:
-                            test_resp = requests.get(start_url, headers=headers, timeout=10)
-                            test_soup = BeautifulSoup(test_resp.text, "html.parser")
+                            _vs, test_text = get_capped_text(
+                                start_url, headers=headers, timeout=10,
+                            )
+                            test_soup = BeautifulSoup(test_text, "html.parser")
                             test_div = test_soup.select_one(c_sel)
                             if test_div and len(test_div.get_text(strip=True)) > 200:
                                 provider["trust_level"] = "verified"
@@ -250,8 +252,8 @@ class CrawlPoller:
                 return
             
             # --- Determine story name ---
-            resp = requests.get(start_url, headers=headers, timeout=10)
-            soup = BeautifulSoup(resp.text, "html.parser")
+            _ts, resp_text = get_capped_text(start_url, headers=headers, timeout=10)
+            soup = BeautifulSoup(resp_text, "html.parser")
             title_tag = soup.select_one(title_selector)
             full_title = title_tag.get_text(strip=True) if title_tag else "Unknown Story"
             

--- a/backend/services/cron_scheduler.py
+++ b/backend/services/cron_scheduler.py
@@ -355,7 +355,15 @@ class CronScheduler:
         return msg
 
     async def _execute_agent_turn(self, job: CronJobModel) -> str:
-        """Execute agent turn — send message to specified agent via session."""
+        """Execute agent turn — send message to specified agent via session.
+
+        Human-approval gate: cron payloads are LLM-supplied (the agent calls
+        ``cron_create(exec_payload=...)``) and run unsupervised at fire time
+        with the configured agent's full tool set — including terminal exec.
+        Block the first fire of every (job_id, hash(payload)) pair so the
+        operator sees the prompt before it goes live. Same hash on repeat
+        fires auto-proceeds.
+        """
         if not self._agent_app or not self._session_service:
             raise RuntimeError("Agent references not set — cannot execute agent_turn")
 
@@ -363,6 +371,38 @@ class CronScheduler:
         payload = job.exec_payload
 
         logger.info("[CRON] Agent turn: '%s' → agent=%s payload='%s'", job.name, agent_name, payload[:80])
+
+        # Approval gate. Coalesces on (job_id, payload_hash) so re-runs of
+        # an already-approved cron skip the prompt.
+        from services.approval_gate import gate as _gate
+        content_md = (
+            f"## Cron job: `{job.name}`\n\n"
+            f"**Schedule:** `{job.schedule_cron}` ({job.calendar_type})\n"
+            f"**Target agent:** `{agent_name}`\n\n"
+            f"**Payload to run:**\n\n```text\n{(payload or '').rstrip()}\n```\n\n"
+            f"---\n\n"
+            f"⚠️ **Use at your own risk.** Approving lets this exact payload "
+            f"run on the schedule above, unsupervised. The target agent has "
+            f"its full tool set available — including any that touch the "
+            f"filesystem, shell, network, or external accounts.\n\n"
+            f"Approve only if you recognise the payload and trust the source "
+            f"that created this job."
+        )
+        approved, reason = await _gate(
+            approval_type="cron_first_fire",
+            scope_key=f"cron:{job.id}",
+            content_md=content_md,
+            title=f"Cron first run: {job.name}",
+            agent_name=agent_name,
+        )
+        if not approved:
+            logger.warning("[CRON] Job %s blocked by approval gate: %s", job.id, reason)
+            self._broadcast_event("agent_turn_blocked", {
+                "job_id": job.id,
+                "job_name": job.name,
+                "reason": reason,
+            })
+            return f"Approval gate blocked execution: {reason}"
 
         # Tag every LLM call this turn makes with a deterministic run_id
         # so the dashboard can correlate ``token_usage`` rows back to the

--- a/backend/services/cron_scheduler.py
+++ b/backend/services/cron_scheduler.py
@@ -119,12 +119,26 @@ class CronScheduler:
                         "[CRON] Job %s still in flight (likely awaiting approval) — "
                         "skipping this fire", job_id,
                     )
+                    # MUST yield here too — without an `await` between this
+                    # `continue` and the next `_get_next_due()` call we'd hit
+                    # a 100% CPU spin (overdue job + sleep_seconds==0 + no
+                    # other await on the path). `_get_next_due` itself filters
+                    # in-flight ids so it won't keep returning the same job,
+                    # but the yield is the safety net.
+                    await asyncio.sleep(0)
                 else:
                     task = asyncio.create_task(self._run_job_isolated(job_id))
                     self._inflight_tasks[job_id] = task
                     task.add_done_callback(
                         lambda _t, jid=job_id: self._inflight_tasks.pop(jid, None)
                     )
+                    # Yield so the freshly spawned task actually runs (and
+                    # flips its job's status to "running" inside _execute_job)
+                    # before the next iteration's _get_next_due. Without
+                    # this, `create_task` only *schedules* the coroutine and
+                    # the next loop sees the same job in status="active" with
+                    # next_run_at<=now — busy-spin instead of executing.
+                    await asyncio.sleep(0)
 
             except asyncio.CancelledError:
                 logger.info("[CRON] Scheduler shutdown")
@@ -174,18 +188,26 @@ class CronScheduler:
             db.close()
 
     def _get_next_due(self) -> tuple[Optional[CronJobModel], float]:
-        """Find the next job to execute and how long to sleep."""
+        """Find the next job to execute and how long to sleep.
+
+        Excludes any job currently in :attr:`_inflight_tasks` — those have
+        already been dispatched as a background task (eg waiting on
+        human approval) and must not be picked up again until they
+        resolve, even though their DB row may still read ``status="active"``
+        for the brief window between dispatch and ``_execute_job``'s status
+        flip. Without this filter the loop tight-spins on an overdue job
+        whose task is queued but not yet scheduled.
+        """
         db = get_db_session()
         try:
-            job = (
-                db.query(CronJobModel)
-                .filter(
-                    CronJobModel.status == "active",
-                    CronJobModel.next_run_at.isnot(None),
-                )
-                .order_by(CronJobModel.next_run_at.asc())
-                .first()
+            q = db.query(CronJobModel).filter(
+                CronJobModel.status == "active",
+                CronJobModel.next_run_at.isnot(None),
             )
+            inflight_ids = [jid for jid, t in self._inflight_tasks.items() if not t.done()]
+            if inflight_ids:
+                q = q.filter(~CronJobModel.id.in_(inflight_ids))
+            job = q.order_by(CronJobModel.next_run_at.asc()).first()
             if not job:
                 return None, 0
 
@@ -679,7 +701,14 @@ class CronScheduler:
 
     async def _catch_up_missed(self):
         """On startup, check for jobs whose next_run_at is in the past.
-        Execute each at most once (catch-up policy)."""
+        Execute each at most once (catch-up policy).
+
+        Dispatches each missed run through :meth:`_run_job_isolated` —
+        same pattern as the steady-state loop — so a single missed
+        ``agent_turn`` waiting on human approval doesn't freeze the
+        rest of the catch-up batch (each gets its own DB session and
+        its own approval window).
+        """
         db = get_db_session()
         try:
             now = time.time()
@@ -692,15 +721,26 @@ class CronScheduler:
                 )
                 .all()
             )
-            if missed_jobs:
-                logger.info("[CRON] Catching up %d missed jobs", len(missed_jobs))
-                for job in missed_jobs:
-                    try:
-                        await self._execute_job(job, db)
-                    except Exception as e:
-                        logger.error("[CRON] Catch-up failed for '%s': %s", job.name, e)
+            missed_ids = [j.id for j in missed_jobs]
         finally:
             db.close()
+
+        if not missed_ids:
+            return
+
+        logger.info("[CRON] Catching up %d missed jobs", len(missed_ids))
+        for job_id in missed_ids:
+            if job_id in self._inflight_tasks and not self._inflight_tasks[job_id].done():
+                logger.info("[CRON] Catch-up: %s already in flight, skipping", job_id)
+                continue
+            task = asyncio.create_task(self._run_job_isolated(job_id))
+            self._inflight_tasks[job_id] = task
+            task.add_done_callback(
+                lambda _t, jid=job_id: self._inflight_tasks.pop(jid, None)
+            )
+        # Yield once so all the spawned tasks at least register status="running"
+        # before the steady-state loop picks them up.
+        await asyncio.sleep(0)
 
     # ─── SSE Broadcast ────────────────────────────────────
 

--- a/backend/services/cron_scheduler.py
+++ b/backend/services/cron_scheduler.py
@@ -27,6 +27,20 @@ from services.background_jobs import BackgroundJobRunner
 logger = logging.getLogger("cron_scheduler")
 
 
+class ApprovalBlocked(Exception):
+    """Raised by ``_execute_agent_turn`` when the approval gate refuses to run.
+
+    Caught by ``_execute_job`` and recorded as ``status="blocked"`` on the
+    run row — *not* counted as a failure. This is the difference between
+    "user said no / didn't respond in time" (no fail-count bump,
+    no auto-disable) and "code crashed" (counts toward 5-strike disable).
+    """
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
 class CronScheduler:
     """Core scheduler engine — sleep-until-next pattern."""
 
@@ -36,6 +50,11 @@ class CronScheduler:
         self._sse_broadcast = None  # set by server.py
         self._agent_app = None  # set by server.py
         self._session_service = None  # set by server.py
+        # Track in-flight per job so a long-running run (eg awaiting human
+        # approval) doesn't get re-spawned on its next scheduled fire. The
+        # scheduler loop itself stays non-blocking — each fire spawns a
+        # task and immediately returns to evaluating the next due job.
+        self._inflight_tasks: dict[str, asyncio.Task] = {}
 
     def set_sse_broadcast(self, broadcast_fn):
         """Set SSE broadcast function for realtime updates."""
@@ -89,17 +108,23 @@ class CronScheduler:
                         # Timer expired — time to execute
                         pass
 
-                # Re-fetch job (it may have been modified/deleted while sleeping)
-                db = get_db_session()
-                try:
-                    job = db.query(CronJobModel).filter(
-                        CronJobModel.id == next_job.id,
-                        CronJobModel.status == "active",
-                    ).first()
-                    if job:
-                        await self._execute_job(job, db)
-                finally:
-                    db.close()
+                # Spawn the job execution as a background task so a blocking
+                # call (eg awaiting human approval, which can take an hour by
+                # design) doesn't freeze the rest of the schedule. The loop
+                # immediately re-evaluates the next due job. Same-job double-
+                # fires are prevented by `_inflight_tasks`.
+                job_id = next_job.id
+                if job_id in self._inflight_tasks and not self._inflight_tasks[job_id].done():
+                    logger.info(
+                        "[CRON] Job %s still in flight (likely awaiting approval) — "
+                        "skipping this fire", job_id,
+                    )
+                else:
+                    task = asyncio.create_task(self._run_job_isolated(job_id))
+                    self._inflight_tasks[job_id] = task
+                    task.add_done_callback(
+                        lambda _t, jid=job_id: self._inflight_tasks.pop(jid, None)
+                    )
 
             except asyncio.CancelledError:
                 logger.info("[CRON] Scheduler shutdown")
@@ -115,6 +140,38 @@ class CronScheduler:
         logger.info("[CRON] Scheduler stopped")
 
     # ─── Core Logic ───────────────────────────────────────
+
+    async def _run_job_isolated(self, job_id: str) -> None:
+        """Open a fresh DB session and run one job to completion.
+
+        Used by ``start()`` to dispatch each fire as its own task so the
+        scheduler loop stays non-blocking. The session opened here is
+        owned by this task — ``_execute_job`` does not share state with
+        the scheduler loop's own DB lifetimes.
+        """
+        db = get_db_session()
+        try:
+            job = (
+                db.query(CronJobModel)
+                .filter(
+                    CronJobModel.id == job_id,
+                    CronJobModel.status.in_(("active", "running")),
+                )
+                .first()
+            )
+            if job:
+                await self._execute_job(job, db)
+        except Exception:
+            # _execute_job already handles its own errors and persists them
+            # to the run row. Anything that escapes here is a bug in the
+            # error-handling path itself — log loudly but don't crash the
+            # scheduler.
+            logger.error(
+                "[CRON] Isolated run for job %s crashed in dispatcher",
+                job_id, exc_info=True,
+            )
+        finally:
+            db.close()
 
     def _get_next_due(self) -> tuple[Optional[CronJobModel], float]:
         """Find the next job to execute and how long to sleep."""
@@ -260,6 +317,81 @@ class CronScheduler:
                 datetime.fromtimestamp(job.next_run_at).strftime("%Y-%m-%d %H:%M") if job.next_run_at else "none",
             )
 
+        except ApprovalBlocked as exc:
+            # Gate refused / timed out. NOT a failure — the user simply
+            # hasn't approved this payload yet (or rejected it). Record
+            # the run as `blocked`, do NOT bump fail_count, and let the
+            # job stay `active` for its next scheduled fire.
+            completed_at = time.time()
+            duration_ms = int((completed_at - started_at) * 1000)
+            block_reason = exc.reason[:500]
+
+            if run_id:
+                run = db.query(CronRunModel).filter(CronRunModel.id == run_id).first()
+                if run:
+                    run.status = "blocked"
+                    run.completed_at = completed_at
+                    run.duration_ms = duration_ms
+                    run.error = f"approval gate: {block_reason}"
+
+            job.last_run_at = completed_at
+            job.last_result = "blocked"
+            job.last_error = block_reason
+            # run_count counts attempts including blocked ones so the dashboard
+            # shows the job *did* tick. fail_count stays put — no auto-disable
+            # for blocked runs.
+            job.run_count = (job.run_count or 0) + 1
+
+            job.status = "active"  # Restore from 'running'
+            if not job.one_shot:
+                job.next_run_at = self.compute_next_run(
+                    job.schedule_cron, job.calendar_type, job.schedule_timezone, job.lunar_leap
+                )
+
+            job.updated_at = time.time()
+            db.commit()
+
+            self._broadcast_event("job_blocked", {
+                "job_id": job.id,
+                "job_name": job.name,
+                "run_id": run_id,
+                "reason": block_reason,
+            })
+
+            # Blocked notification — distinct from `error` so the dashboard
+            # can colour-code it (amber) vs failed (red).
+            notif = NotificationModel(
+                run_id=run_id,
+                job_id=job.id,
+                type="blocked",
+                title=job.name,
+                preview=f"Blocked: {block_reason[:180]}",
+                content=f"## Job blocked: {job.name}\n\n```\n{block_reason}\n```",
+                content_type="markdown",
+                is_read=0,
+                created_at=completed_at,
+                metadata_json=json.dumps({
+                    "agent": job.exec_agent or "system",
+                    "exec_mode": job.exec_mode,
+                    "duration_ms": duration_ms,
+                    "status": "blocked",
+                }),
+            )
+            db.add(notif)
+            db.commit()
+            db.refresh(notif)
+
+            self._broadcast_event("new_notification", {
+                "id": notif.id,
+                "notif_type": "blocked",
+                "title": job.name,
+                "preview": f"Blocked: {block_reason[:150]}",
+                "created_at": completed_at,
+            })
+
+            logger.warning("[CRON] Job '%s' blocked: %s", job.name, block_reason)
+            return
+
         except Exception as e:
             # Failure
             completed_at = time.time()
@@ -402,7 +534,11 @@ class CronScheduler:
                 "job_name": job.name,
                 "reason": reason,
             })
-            return f"Approval gate blocked execution: {reason}"
+            # Raise so _execute_job records this as `blocked` rather than
+            # success. Different from failure: no fail_count bump, no
+            # auto-disable — the user simply hasn't approved this payload
+            # yet (or rejected it).
+            raise ApprovalBlocked(reason)
 
         # Tag every LLM call this turn makes with a deterministic run_id
         # so the dashboard can correlate ``token_usage`` rows back to the

--- a/backend/services/mcp_admin_service.py
+++ b/backend/services/mcp_admin_service.py
@@ -623,12 +623,50 @@ async def static_check(name: str) -> dict[str, Any]:
 
 async def install_dependencies(name: str) -> dict[str, Any]:
     """Create `.venv` (uv preferred, fall back to stdlib venv) and install
-    requirements.txt into it. Per-server isolation per user policy."""
+    requirements.txt into it. Per-server isolation per user policy.
+
+    Human-approval gate: the agent can scaffold an MCP server, edit
+    ``requirements.txt`` via filesystem tools, then trigger pip install.
+    pip executes setup.py / build hooks of every package with backend
+    privileges — so a prompt-injected agent could land arbitrary code
+    via this path. We block on user approval per ``(server, content_hash)``
+    so the operator sees the package list before any install fires.
+    """
     sdir = _server_dir(name)
     req = sdir / "requirements.txt"
     if not req.exists():
         raise LookupError(f"requirements.txt missing for {name!r}")
     venv = sdir / ".venv"
+
+    # Approval gate — see services/approval_gate.py. Once a (server, hash)
+    # pair is approved, identical requirements.txt re-installs (re-runs of
+    # smoke tests etc.) auto-proceed without prompting.
+    req_text = req.read_text(encoding="utf-8")
+    from services.approval_gate import gate as _gate
+    warning_md = (
+        "\n\n---\n\n"
+        "⚠️ **Use at your own risk.** Approving runs `pip install` against the "
+        "package list above. pip executes `setup.py` / build hooks of every "
+        "package with the backend process's privileges.\n\n"
+        "Before approving:\n"
+        "- Verify each package name matches its **official** source on PyPI "
+        "(typo-squatting and package-name confusion are common attack vectors).\n"
+        "- Prefer packages from reputable, well-known publishers.\n"
+        "- Consider scanning the dependency tree with `pip-audit` or `safety`.\n"
+    )
+    content_md = (
+        f"## Install dependencies for MCP server `{name}`\n\n"
+        f"```text\n{req_text.rstrip()}\n```"
+        f"{warning_md}"
+    )
+    approved, reason = await _gate(
+        approval_type="mcp_install",
+        scope_key=f"mcp:{name}",
+        content_md=content_md,
+        title=f"Install dependencies for MCP server: {name}",
+    )
+    if not approved:
+        return {"ok": False, "error": f"install_dependencies blocked by approval gate: {reason}"}
 
     async with audit("install_deps", server=name, actor="jarvis") as a:
         uv = shutil.which("uv")

--- a/backend/services/tts_pregen_job.py
+++ b/backend/services/tts_pregen_job.py
@@ -14,7 +14,10 @@ import logging
 import os
 import re
 import time
+from pathlib import Path
 from typing import Optional
+
+from helpers.path_safety import safe_story_path
 
 import edge_tts
 
@@ -584,9 +587,15 @@ class TTSPreGenJob(BackgroundJobRunner):
     
     def _read_chapter_text(self, story_title: str, chapter_file: str) -> Optional[str]:
         """Read chapter text file content."""
-        path = os.path.join(STORIES_DIR, story_title, chapter_file)
+        # StoryProgress rows can carry attacker-controlled fields (LLM tool
+        # write path). Reject `..` / separator components before touching FS.
         try:
-            if os.path.exists(path):
+            path = safe_story_path(STORIES_DIR, story_title, chapter_file)
+        except ValueError as e:
+            logger.warning(f"[PRE-GEN] Rejected unsafe path for {story_title!r}/{chapter_file!r}: {e}")
+            return None
+        try:
+            if path.exists():
                 with open(path, "r", encoding="utf-8") as f:
                     return f.read().strip()
         except Exception as e:

--- a/backend/services/voice_engine_registry.py
+++ b/backend/services/voice_engine_registry.py
@@ -238,8 +238,10 @@ STT_BACKENDS: dict[str, STTBackendSpec] = {
     },
     "gipformer_vi": {
         "label": "Gipformer 65M (Vietnamese only)",
-        "description": "Vietnamese-optimised Zipformer-RNNT via sherpa-onnx. ~73 MB int8. MIT-licensed.",
-        "badges": ["free", "local", "vi-only", "MIT"],
+        # The Gipformer MODEL weights are MIT. The sherpa-onnx RUNTIME
+        # that loads them is Apache-2.0 (see root NOTICE). Both are local.
+        "description": "Vietnamese-optimised Zipformer-RNNT via sherpa-onnx. ~73 MB int8. Model: MIT · Runtime: Apache-2.0.",
+        "badges": ["free", "local", "vi-only", "model:MIT", "runtime:Apache-2.0"],
         "language_locked": "vi",
         "params": [
             {"key": "quantize", "type": "select", "label": "Quantization", "default": "int8", "options": ["int8", "fp32"]},

--- a/backend/tests/test_helpers/test_http_safety.py
+++ b/backend/tests/test_helpers/test_http_safety.py
@@ -1,0 +1,72 @@
+"""Unit tests for helpers.http_safety.get_capped_text.
+
+Locks in the cap behaviour so chapter crawls can't be tricked into
+unbounded reads. Uses a mocked Response with iter_content so we don't
+need a network roundtrip.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from helpers.http_safety import get_capped_text
+
+
+def _mock_response(chunks: list[bytes], status: int = 200, encoding: str = "utf-8"):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.encoding = encoding
+    resp.apparent_encoding = encoding
+    resp.iter_content = MagicMock(return_value=iter(chunks))
+    resp.close = MagicMock()
+    return resp
+
+
+def test_returns_status_and_text_under_cap():
+    chunks = [b"hello ", b"world"]
+    with patch("helpers.http_safety.requests.get", return_value=_mock_response(chunks)):
+        status, text = get_capped_text("http://example.com/x")
+    assert status == 200
+    assert text == "hello world"
+
+
+def test_passes_non_200_status_through():
+    with patch("helpers.http_safety.requests.get", return_value=_mock_response([b"err"], status=429)):
+        status, text = get_capped_text("http://example.com/x")
+    assert status == 429
+    assert text == "err"
+
+
+def test_caps_oversized_body(caplog):
+    # 3 chunks of 8 bytes each = 24 bytes total; cap at 16 bytes → truncate.
+    chunks = [b"a" * 8, b"b" * 8, b"c" * 8]
+    with patch("helpers.http_safety.requests.get", return_value=_mock_response(chunks)):
+        with caplog.at_level("WARNING"):
+            status, text = get_capped_text(
+                "http://example.com/big", max_bytes=16, warn_bytes=4,
+            )
+    assert status == 200
+    # First two chunks (16 bytes) fit; third pushes over → break before append.
+    assert text == "a" * 8 + "b" * 8
+    # Warning emitted for both the warn threshold AND the truncation.
+    assert any("exceeded 4 bytes" in r.getMessage() for r in caplog.records)
+    assert any("truncated at 16 bytes" in r.getMessage() for r in caplog.records)
+
+
+def test_warn_threshold_does_not_truncate(caplog):
+    # 12 bytes total, warn at 4, cap at 100 → warns once but returns full body.
+    chunks = [b"hello", b"world!", b"!"]
+    with patch("helpers.http_safety.requests.get", return_value=_mock_response(chunks)):
+        with caplog.at_level("WARNING"):
+            status, text = get_capped_text(
+                "http://example.com/medium", max_bytes=100, warn_bytes=4,
+            )
+    assert status == 200
+    assert text == "helloworld!!"
+    warn_msgs = [r.getMessage() for r in caplog.records if "exceeded" in r.getMessage()]
+    assert len(warn_msgs) == 1
+
+
+def test_close_called_on_exit():
+    resp = _mock_response([b"x"])
+    with patch("helpers.http_safety.requests.get", return_value=resp):
+        get_capped_text("http://example.com/x")
+    resp.close.assert_called_once()

--- a/backend/tests/test_helpers/test_logging_filters.py
+++ b/backend/tests/test_helpers/test_logging_filters.py
@@ -9,7 +9,7 @@ import logging
 
 import pytest
 
-from helpers.logging_filters import RedactSecretsFilter, redact_secrets
+from helpers.logging_filters import RedactingFormatter, RedactSecretsFilter, redact_secrets
 
 
 # ---------- redact_secrets ----------
@@ -98,3 +98,45 @@ def test_filter_never_raises():
     )
     # Must not raise — record passes through.
     assert RedactSecretsFilter().filter(rec) is True
+
+
+# ---------- RedactingFormatter (exc_info traceback scrub) ----------
+
+def test_formatter_scrubs_exception_message():
+    fmt = RedactingFormatter("%(message)s")
+    try:
+        # Stuff a secret into the exception message — simulates a third-
+        # party lib that prints the full request body on error.
+        raise RuntimeError("call failed: api_key=verysecret_abc123")
+    except RuntimeError:
+        import sys
+        rec = logging.LogRecord(
+            name="t", level=logging.ERROR, pathname=__file__, lineno=1,
+            msg="upstream failed", args=None, exc_info=sys.exc_info(),
+        )
+    rendered = fmt.format(rec)
+    # The traceback text appended by formatException contains the
+    # exception message — that's where the secret lives. Must be scrubbed.
+    assert "verysecret_abc123" not in rendered
+    assert "api_key=***" in rendered
+
+
+def test_formatter_scrubs_record_message():
+    fmt = RedactingFormatter("%(message)s")
+    rec = logging.LogRecord(
+        name="t", level=logging.INFO, pathname=__file__, lineno=1,
+        msg='request headers: {"Authorization": "Bearer eyJxxx"}',
+        args=None, exc_info=None,
+    )
+    rendered = fmt.format(rec)
+    assert "eyJxxx" not in rendered
+    assert "***" in rendered
+
+
+def test_formatter_passes_clean_log_unchanged():
+    fmt = RedactingFormatter("%(message)s")
+    rec = logging.LogRecord(
+        name="t", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="user signed in", args=None, exc_info=None,
+    )
+    assert fmt.format(rec) == "user signed in"

--- a/backend/tests/test_helpers/test_logging_filters.py
+++ b/backend/tests/test_helpers/test_logging_filters.py
@@ -1,0 +1,100 @@
+"""Unit tests for helpers.logging_filters.
+
+Locks in the redaction behaviour so a future contributor changing the
+patterns doesn't silently re-open a key-leak path. Covers the formats we
+actually see in this codebase (env-style, JSON-style, Bearer headers).
+"""
+
+import logging
+
+import pytest
+
+from helpers.logging_filters import RedactSecretsFilter, redact_secrets
+
+
+# ---------- redact_secrets ----------
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Env-style
+        ("API_KEY=abc123",         "API_KEY=***"),
+        ("api-key=xyz_789",        "api-key=***"),
+        # JSON-style (single + double quotes)
+        ('{"api_key": "abc123"}',  '{"api_key": "***"}'),
+        ("{'api_key': 'abc123'}",  "{'api_key': '***'}"),
+        # YAML-style
+        ("api_key: abc123",        "api_key: ***"),
+        # Bearer header
+        ("Authorization: Bearer eyJhbGc.payload.sig",
+                                   "Authorization: ***"),
+        ("authorization=Bearer xyz",
+                                   "authorization=***"),
+        # Mixed key/value lines (only the value is redacted)
+        ("user=alice password=p@ss",
+                                   "user=alice password=***"),
+        # Tokens / secrets
+        ("token: foo.bar.baz",     "token: ***"),
+        ("secret_key: shhh",       "secret_key: ***"),
+        # Multiple keys in one line — each value redacted independently
+        ('api_key="A" token="B"',  'api_key="***" token="***"'),
+    ],
+)
+def test_redacts(raw, expected):
+    assert redact_secrets(raw) == expected
+
+
+def test_non_secret_text_unchanged():
+    # Common false-positive shapes must NOT be mangled.
+    samples = [
+        "User signed in successfully",
+        "GET /api/status 200",
+        "Loaded 42 records",
+    ]
+    for s in samples:
+        assert redact_secrets(s) == s
+
+
+def test_idempotent():
+    once = redact_secrets("api_key=abc")
+    twice = redact_secrets(once)
+    assert once == twice == "api_key=***"
+
+
+def test_empty_input_safe():
+    assert redact_secrets("") == ""
+    assert redact_secrets(None) is None  # type: ignore[arg-type]
+
+
+# ---------- RedactSecretsFilter ----------
+
+def test_filter_redacts_message():
+    rec = logging.LogRecord(
+        name="t", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="config={'api_key': 'abc123'}", args=None, exc_info=None,
+    )
+    RedactSecretsFilter().filter(rec)
+    assert rec.getMessage() == "config={'api_key': '***'}"
+
+
+def test_filter_handles_percent_args():
+    # logger.info("config=%s", {"api_key": "abc"}) shape — args is a tuple.
+    rec = logging.LogRecord(
+        name="t", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="config=%s", args=({"api_key": "abc"},), exc_info=None,
+    )
+    RedactSecretsFilter().filter(rec)
+    # Args cleared after redaction; the final message text was already merged
+    # and scrubbed.
+    assert rec.args is None
+    assert rec.getMessage() == "config={'api_key': '***'}"
+
+
+def test_filter_never_raises():
+    # Pathological record that would normally raise on getMessage().
+    rec = logging.LogRecord(
+        name="t", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="%s %s", args=("only-one-arg",), exc_info=None,
+    )
+    # Must not raise — record passes through.
+    assert RedactSecretsFilter().filter(rec) is True

--- a/backend/tests/test_helpers/test_path_safety.py
+++ b/backend/tests/test_helpers/test_path_safety.py
@@ -1,0 +1,68 @@
+"""Unit tests for helpers.path_safety.
+
+Pins the rejection set so regressions are caught loudly. Real traversal
+attempts at the four call sites (crawl_poller, story_server, story_reader,
+tts_pregen_job) feed through this helper; the integration assertions live
+near those call sites.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from helpers.path_safety import safe_story_path
+
+
+def test_happy_path(tmp_path):
+    base = tmp_path / "stories"
+    base.mkdir()
+    p = safe_story_path(base, "MyStory", "chapter1.txt")
+    assert p == (base / "MyStory" / "chapter1.txt").resolve()
+
+
+def test_preserves_vietnamese_unicode(tmp_path):
+    base = tmp_path / "stories"
+    base.mkdir()
+    p = safe_story_path(base, "Truyện Hay", "Chương 1.txt")
+    assert "Truyện Hay" in str(p)
+    assert "Chương 1.txt" in str(p)
+
+
+@pytest.mark.parametrize("bad", [".", "..", "", "/", "\\", "a/b", "a\\b", "\x00"])
+def test_rejects_separators_and_traversal(tmp_path, bad):
+    base = tmp_path / "stories"
+    base.mkdir()
+    with pytest.raises(ValueError):
+        safe_story_path(base, bad)
+
+
+def test_rejects_traversal_via_join(tmp_path):
+    # Two valid-looking parts that, when joined, escape the sandbox via "..".
+    base = tmp_path / "stories"
+    base.mkdir()
+    # ".." is caught at the per-part check, not at the realpath check —
+    # both layers exist; this asserts the per-part layer fires first.
+    with pytest.raises(ValueError):
+        safe_story_path(base, "story", "..")
+
+
+def test_rejects_symlink_escape(tmp_path):
+    base = tmp_path / "stories"
+    base.mkdir()
+    secret = tmp_path / "secret"
+    secret.mkdir()
+    # Plant a symlink that goes outside the sandbox.
+    link = base / "evil"
+    os.symlink(secret, link)
+    with pytest.raises(ValueError):
+        safe_story_path(base, "evil")
+
+
+def test_returns_resolved_path(tmp_path):
+    # base supplied as str → still returns a resolved Path.
+    base = tmp_path / "stories"
+    base.mkdir()
+    p = safe_story_path(str(base), "OK")
+    assert isinstance(p, Path)
+    assert p.is_absolute()

--- a/backend/tests/test_services/test_approval_gate.py
+++ b/backend/tests/test_services/test_approval_gate.py
@@ -26,17 +26,36 @@ from services.approval_gate import (
 
 
 @pytest.fixture
-def isolated_db(tmp_path, monkeypatch):
-    """Point SessionLocal at a throwaway SQLite file for the test."""
-    db_file = tmp_path / "approval_gate_test.db"
-    monkeypatch.setenv("JARVIS_DB_PATH", str(db_file))
+def isolated_db():
+    """Ensure the ``approval_requests`` table exists on the shared test DB
+    (conftest already points ``JARVIS_DB_PATH`` at ``data/jarvis.test.db``)
+    and clear any rows this test inserted before yielding control to the
+    next test.
 
-    # Reset the module-level engine so the env var takes effect.
-    import importlib
+    We deliberately do NOT ``importlib.reload(database)`` — that would
+    rebuild ``SessionLocal`` / ``Base`` / engine in the live module, while
+    other modules still hold references to the originals. The mixed state
+    surfaced as UNIQUE-constraint / team_name failures across unrelated
+    test suites in CI.
+    """
     from core import database
-    importlib.reload(database)
-    database.init_db()
+    database.init_db()  # idempotent — CREATE TABLE IF NOT EXISTS
+    # Clean slate so prior tests' rows don't leak into _find_* lookups.
+    db = database.SessionLocal()
+    try:
+        db.query(database.ApprovalRequestModel).delete()
+        db.commit()
+    finally:
+        db.close()
     yield database
+    # Tear down: drop the rows this test inserted so the next test sees a
+    # clean approval_requests table.
+    db = database.SessionLocal()
+    try:
+        db.query(database.ApprovalRequestModel).delete()
+        db.commit()
+    finally:
+        db.close()
 
 
 def _insert_approval(database, *, approval_type, scope_key, content_hash, status, **extra):

--- a/backend/tests/test_services/test_approval_gate.py
+++ b/backend/tests/test_services/test_approval_gate.py
@@ -1,0 +1,210 @@
+"""Unit tests for services.approval_gate.
+
+Three behaviours we MUST keep:
+
+1. Hash-keyed decision memory — once approved, identical content auto-
+   proceeds; once rejected, identical content stays rejected (so a
+   recurring cron doesn't re-prompt every 5 min after rejection).
+2. Pending-coalescing — concurrent gate calls for the same hash join
+   the same pending approval instead of stacking duplicates.
+3. Timeout — caller never hangs forever; treat timeout as rejection.
+"""
+
+import asyncio
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from services.approval_gate import (
+    _content_hash,
+    _find_prior_decision,
+    _find_pending_match,
+    gate,
+)
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    """Point SessionLocal at a throwaway SQLite file for the test."""
+    db_file = tmp_path / "approval_gate_test.db"
+    monkeypatch.setenv("JARVIS_DB_PATH", str(db_file))
+
+    # Reset the module-level engine so the env var takes effect.
+    import importlib
+    from core import database
+    importlib.reload(database)
+    database.init_db()
+    yield database
+
+
+def _insert_approval(database, *, approval_type, scope_key, content_hash, status, **extra):
+    import json
+    db = database.SessionLocal()
+    try:
+        approval_id = str(uuid.uuid4())
+        now = time.time()
+        row = database.ApprovalRequestModel(
+            id=approval_id,
+            agent_name=extra.get("agent_name", "Jarvis"),
+            team_name=None,
+            run_id="",
+            conversation_id=None,
+            approval_type=approval_type,
+            title="test",
+            content="payload",
+            content_format="markdown",
+            urgency="normal",
+            status=status,
+            paused_agents="[]",
+            created_at=now,
+            resolved_at=now if status != "pending" else None,
+            user_decision="approve" if status == "approved" else ("reject" if status == "rejected" else None),
+            metadata_json=json.dumps({
+                "scope_key": scope_key,
+                "content_hash": content_hash,
+            }),
+        )
+        db.add(row)
+        db.commit()
+        return approval_id
+    finally:
+        db.close()
+
+
+def test_hash_is_deterministic_short():
+    h1 = _content_hash("hello")
+    h2 = _content_hash("hello")
+    h3 = _content_hash("hello2")
+    assert h1 == h2
+    assert h1 != h3
+    assert len(h1) == 16
+
+
+def test_find_prior_decision_returns_approved(isolated_db):
+    _insert_approval(
+        isolated_db,
+        approval_type="mcp_install", scope_key="mcp:foo",
+        content_hash="deadbeef", status="approved",
+    )
+    assert _find_prior_decision("mcp_install", "mcp:foo", "deadbeef") == "approved"
+
+
+def test_find_prior_decision_returns_rejected(isolated_db):
+    _insert_approval(
+        isolated_db,
+        approval_type="cron_first_fire", scope_key="cron:abc",
+        content_hash="cafebabe", status="rejected",
+    )
+    assert _find_prior_decision("cron_first_fire", "cron:abc", "cafebabe") == "rejected"
+
+
+def test_find_prior_decision_ignores_pending(isolated_db):
+    # Pending approvals are NOT prior decisions — they are still ambiguous.
+    _insert_approval(
+        isolated_db,
+        approval_type="mcp_install", scope_key="mcp:bar",
+        content_hash="1111", status="pending",
+    )
+    assert _find_prior_decision("mcp_install", "mcp:bar", "1111") is None
+
+
+def test_find_pending_match_coalesces(isolated_db):
+    pending_id = _insert_approval(
+        isolated_db,
+        approval_type="mcp_install", scope_key="mcp:baz",
+        content_hash="2222", status="pending",
+    )
+    assert _find_pending_match("mcp_install", "mcp:baz", "2222") == pending_id
+
+
+def test_find_pending_match_ignores_resolved(isolated_db):
+    _insert_approval(
+        isolated_db,
+        approval_type="mcp_install", scope_key="mcp:qux",
+        content_hash="3333", status="approved",
+    )
+    assert _find_pending_match("mcp_install", "mcp:qux", "3333") is None
+
+
+@pytest.mark.asyncio
+async def test_gate_short_circuits_on_prior_approval(isolated_db):
+    _insert_approval(
+        isolated_db,
+        approval_type="mcp_install", scope_key="mcp:auto",
+        content_hash=_content_hash("payload"), status="approved",
+    )
+    # No prompt should reach approval_service — patch to detect.
+    with patch("services.approval_service.approval_service.create_approval") as mock_create:
+        ok, reason = await gate(
+            approval_type="mcp_install",
+            scope_key="mcp:auto",
+            content_md="payload",
+            title="t",
+        )
+    assert ok is True
+    assert "previously approved" in reason
+    mock_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gate_short_circuits_on_prior_rejection(isolated_db):
+    _insert_approval(
+        isolated_db,
+        approval_type="cron_first_fire", scope_key="cron:bad",
+        content_hash=_content_hash("evil payload"), status="rejected",
+    )
+    with patch("services.approval_service.approval_service.create_approval") as mock_create:
+        ok, reason = await gate(
+            approval_type="cron_first_fire",
+            scope_key="cron:bad",
+            content_md="evil payload",
+            title="t",
+        )
+    assert ok is False
+    assert "previously rejected" in reason
+    mock_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gate_creates_and_awaits_when_no_prior(isolated_db):
+    fake_resolved = {"id": "x", "user_decision": "approve", "user_comment": None}
+
+    async def _fake_wait(approval_id):
+        return fake_resolved
+
+    with patch("services.approval_service.approval_service.create_approval",
+               return_value={"id": "x"}) as mock_create, \
+         patch("services.approval_service.approval_service.wait_for_resolution",
+               side_effect=_fake_wait) as mock_wait:
+        ok, reason = await gate(
+            approval_type="mcp_install",
+            scope_key="mcp:new",
+            content_md="fresh payload",
+            title="t",
+        )
+    assert ok is True
+    assert reason == "user approved"
+    mock_create.assert_called_once()
+    mock_wait.assert_called_once_with("x")
+
+
+@pytest.mark.asyncio
+async def test_gate_timeout_returns_rejected(isolated_db):
+    async def _hang(approval_id):
+        await asyncio.sleep(10)  # longer than gate timeout
+
+    with patch("services.approval_service.approval_service.create_approval",
+               return_value={"id": "x"}), \
+         patch("services.approval_service.approval_service.wait_for_resolution",
+               side_effect=_hang):
+        ok, reason = await gate(
+            approval_type="mcp_install",
+            scope_key="mcp:slow",
+            content_md="fresh payload",
+            title="t",
+            timeout_s=0.1,
+        )
+    assert ok is False
+    assert "timeout" in reason

--- a/backend/tests/test_services/test_approval_gate.py
+++ b/backend/tests/test_services/test_approval_gate.py
@@ -208,3 +208,64 @@ async def test_gate_timeout_returns_rejected(isolated_db):
         )
     assert ok is False
     assert "timeout" in reason
+
+
+@pytest.mark.asyncio
+async def test_gate_timeout_persists_rejection(isolated_db):
+    """Reviewer's MEDIUM finding: on timeout we MUST call resolve_approval
+    so the row no longer sits `pending`. Otherwise every subsequent fire
+    re-attaches to the same stale pending row via _find_pending_match and
+    re-blocks for another full timeout window."""
+
+    async def _hang(approval_id):
+        await asyncio.sleep(10)
+
+    with patch("services.approval_service.approval_service.create_approval",
+               return_value={"id": "x"}), \
+         patch("services.approval_service.approval_service.wait_for_resolution",
+               side_effect=_hang), \
+         patch("services.approval_service.approval_service.resolve_approval") as mock_resolve:
+        await gate(
+            approval_type="cron_first_fire",
+            scope_key="cron:hang",
+            content_md="payload",
+            title="t",
+            timeout_s=0.05,
+        )
+    # The timeout path must persist the row as rejected so _find_prior_decision
+    # short-circuits future calls.
+    mock_resolve.assert_called_once()
+    args, kwargs = mock_resolve.call_args
+    assert args[0] == "x"
+    assert kwargs.get("decision") == "reject"
+    assert "timeout" in (kwargs.get("comment") or "")
+
+
+@pytest.mark.asyncio
+async def test_gate_timeout_persist_failure_does_not_mask_timeout(isolated_db):
+    """If resolve_approval itself raises (e.g. user resolved manually in
+    the race window), the gate should still return the timeout reason —
+    don't swallow it behind a 'persist failed' string."""
+
+    async def _hang(approval_id):
+        await asyncio.sleep(10)
+
+    def _resolve_fails(*a, **kw):
+        raise RuntimeError("already resolved")
+
+    with patch("services.approval_service.approval_service.create_approval",
+               return_value={"id": "x"}), \
+         patch("services.approval_service.approval_service.wait_for_resolution",
+               side_effect=_hang), \
+         patch("services.approval_service.approval_service.resolve_approval",
+               side_effect=_resolve_fails):
+        ok, reason = await gate(
+            approval_type="cron_first_fire",
+            scope_key="cron:hang2",
+            content_md="payload",
+            title="t",
+            timeout_s=0.05,
+        )
+    assert ok is False
+    assert "timeout" in reason
+    assert "persist" not in reason  # caller still sees the real reason

--- a/backend/tests/test_services/test_cron_scheduler_agent_turn.py
+++ b/backend/tests/test_services/test_cron_scheduler_agent_turn.py
@@ -15,11 +15,28 @@ this test.
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from services.cron_scheduler import CronScheduler
+from services.cron_scheduler import ApprovalBlocked, CronScheduler
+
+
+# All tests in this module exercise the *post-gate* behaviour of
+# ``_execute_agent_turn``. The approval gate itself has its own
+# coverage in test_approval_gate.py — here we patch it to auto-
+# approve so each test can focus on the resume_and_send contract
+# (originally added for the 2026-05-05 "no agent_name" regression).
+# ``_execute_agent_turn`` imports the gate locally as
+# ``from services.approval_gate import gate as _gate`` — patching
+# at the source module ``services.approval_gate.gate`` is the only
+# anchor that intercepts that local re-bind.
+@pytest.fixture(autouse=True)
+def _auto_approve_gate():
+    async def _allow(**_kw):
+        return True, "test auto-approve"
+    with patch("services.approval_gate.gate", side_effect=_allow):
+        yield
 
 
 @pytest.mark.asyncio
@@ -81,3 +98,37 @@ async def test_execute_agent_turn_logs_warning_on_empty_response(caplog):
         "EMPTY response" in r.message and "ResearchAgent" in r.message
         for r in caplog.records
     ), f"empty-response warning missing; records: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_execute_agent_turn_raises_approval_blocked_when_gate_refuses(_auto_approve_gate):
+    """When the approval gate returns ``approved=False`` the agent turn
+    MUST raise :class:`ApprovalBlocked`. This is the contract _execute_job
+    catches separately so a gate-blocked run is recorded as ``blocked``
+    rather than ``success`` (PR #57 reviewer finding, comment on
+    cron_scheduler.py:405).
+    """
+    # Replace the auto-approve fixture's gate with one that refuses.
+    async def _refuse(**_kw):
+        return False, "user rejected: not happy with payload"
+
+    sched = CronScheduler()
+    sched._agent_app = MagicMock()
+    sched._session_service = MagicMock()
+    sched._session_service.resume_and_send = AsyncMock(return_value=("should not run", "sid"))
+
+    job = MagicMock()
+    job.id = "abc123"
+    job.name = "Blocked job"
+    job.exec_agent = "Jarvis"
+    job.exec_payload = "do thing"
+    job.schedule_cron = "* * * * *"
+    job.calendar_type = "solar"
+
+    with patch("services.approval_gate.gate", side_effect=_refuse):
+        with pytest.raises(ApprovalBlocked) as excinfo:
+            await sched._execute_agent_turn(job)
+
+    assert "user rejected" in str(excinfo.value)
+    # The actual resume_and_send must NEVER be called when the gate refused.
+    sched._session_service.resume_and_send.assert_not_called()

--- a/backend/tests/test_services/test_cron_scheduler_agent_turn.py
+++ b/backend/tests/test_services/test_cron_scheduler_agent_turn.py
@@ -15,6 +15,7 @@ this test.
 """
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -98,6 +99,125 @@ async def test_execute_agent_turn_logs_warning_on_empty_response(caplog):
         "EMPTY response" in r.message and "ResearchAgent" in r.message
         for r in caplog.records
     ), f"empty-response warning missing; records: {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_get_next_due_excludes_in_flight_jobs(monkeypatch):
+    """Reviewer HIGH regression: after dispatch the loop must not re-pick
+    the in-flight job. ``_get_next_due`` filters by ``_inflight_tasks`` so
+    even with the spawn race window (status still ``active`` between
+    create_task and the task actually running), the loop sees None / next
+    job instead and avoids the 100%-CPU spin.
+    """
+    sched = CronScheduler()
+
+    # Two stub job rows — both active, both overdue, simulating the moment
+    # right after start() dispatched job "A" and is about to re-evaluate.
+    class _Row:
+        def __init__(self, jid):
+            self.id = jid
+            self.status = "active"
+            self.next_run_at = 1.0  # any past timestamp
+            self.name = f"job-{jid}"
+
+    rows = [_Row("A"), _Row("B")]
+
+    class _FakeQuery:
+        def __init__(self):
+            self._filtered = list(rows)
+
+        def filter(self, *clauses):
+            # Inspect the clause for the ~CronJobModel.id.in_(...) we added.
+            for clause in clauses:
+                txt = str(clause)
+                # Pick up the "id NOT IN (...)" produced by ~id.in_(inflight_ids)
+                if "id NOT IN" in txt or "NOT (cron_jobs.id IN" in txt:
+                    # Parameters live on the BindParameter — extract the inflight set
+                    # via the compiled clause for the test. Simpler: just exclude "A".
+                    self._filtered = [r for r in self._filtered if r.id != "A"]
+            return self
+
+        def order_by(self, *a):
+            return self
+
+        def first(self):
+            return self._filtered[0] if self._filtered else None
+
+    class _FakeDb:
+        def query(self, *a):
+            return _FakeQuery()
+
+        def expunge(self, _):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("services.cron_scheduler.get_db_session", lambda: _FakeDb())
+
+    # Mark job "A" as in-flight via a never-resolving sentinel task.
+    async def _hang():
+        await asyncio.sleep(60)
+    sched._inflight_tasks["A"] = asyncio.create_task(_hang())
+    try:
+        # Now _get_next_due should pick "B", not "A", even though "A" is in
+        # the underlying row list with an earlier next_run_at.
+        next_job, _sleep = sched._get_next_due()
+        assert next_job is not None
+        assert next_job.id == "B"
+    finally:
+        sched._inflight_tasks["A"].cancel()
+
+
+@pytest.mark.asyncio
+async def test_run_job_isolated_uses_fresh_db_session(monkeypatch):
+    """``_run_job_isolated`` must open + close its own DB session so a long-
+    running task (eg awaiting human approval) doesn't pin the scheduler-
+    loop's session for an hour. Verifies the basic plumbing: a session is
+    obtained, the job is looked up, ``_execute_job`` is called, the
+    session is closed in finally."""
+    sched = CronScheduler()
+
+    closed_sessions: list[str] = []
+
+    class _Row:
+        id = "abc"
+        status = "active"
+        name = "x"
+
+    class _Db:
+        def __init__(self, label):
+            self.label = label
+
+        def query(self, *a):
+            class _Q:
+                def filter(self, *a):
+                    return self
+
+                def first(_self):
+                    return _Row()
+            return _Q()
+
+        def close(self):
+            closed_sessions.append(self.label)
+
+    counter = {"n": 0}
+
+    def _new_session():
+        counter["n"] += 1
+        return _Db(f"sess-{counter['n']}")
+
+    monkeypatch.setattr("services.cron_scheduler.get_db_session", _new_session)
+
+    exec_calls: list[str] = []
+
+    async def _fake_execute(self, job, db):
+        exec_calls.append(getattr(db, "label", "?"))
+    monkeypatch.setattr(CronScheduler, "_execute_job", _fake_execute)
+
+    await sched._run_job_isolated("abc")
+    assert exec_calls == ["sess-1"]
+    assert closed_sessions == ["sess-1"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_services/test_token_persistence_central.py
+++ b/backend/tests/test_services/test_token_persistence_central.py
@@ -39,6 +39,20 @@ from services.sse_progress import (
 )
 
 
+# Cron agent-turn tests below call ``_execute_agent_turn`` directly. Since
+# the approval-gate fix landed in cron_scheduler, those calls would
+# otherwise reach into the real approval pipeline + DB and wait the full
+# 1h gate timeout in CI. Patch the gate at the source module so the local
+# `from services.approval_gate import gate as _gate` inside
+# `_execute_agent_turn` sees the auto-approving stub.
+@pytest.fixture(autouse=True)
+def _auto_approve_cron_gate():
+    async def _allow(**_kw):
+        return True, "test auto-approve"
+    with patch("services.approval_gate.gate", side_effect=_allow):
+        yield
+
+
 def _fake_agent_with_usage(input_tokens=100, output_tokens=20, model="gpt-5.5"):
     """Build a minimal stand-in for a fast-agent ``LlmAgent`` with a
     usage_accumulator that the hook can read like the real thing."""

--- a/backend/tools/story_server.py
+++ b/backend/tools/story_server.py
@@ -7,6 +7,7 @@ import unicodedata
 from pathlib import Path
 from bs4 import BeautifulSoup
 
+from helpers.http_safety import get_capped_text
 from helpers.path_safety import safe_story_path
 from mcp.server.fastmcp import FastMCP
 from typing import List, Dict, Optional
@@ -1305,12 +1306,17 @@ def _crawl_worker(job_id: str, start_url: str, content_selector: str, title_sele
 
             logger.info(f"[{job_id}] Step {count+1}: Fetching {current_url}")
             _dbg(f"Fetching #{count+1}: {current_url[:80]}")
-            resp = None
-            # [NEW] Retry Logic for 429: max 3 retries, 5s delay
+            resp_status: int | None = None
+            resp_text = ""
+            # [NEW] Retry Logic for 429: max 3 retries, 5s delay. Body
+            # is streamed + capped at MAX_CHAPTER_BYTES to bound disk +
+            # RAM use per chapter.
             for attempt in range(4): # Initial + 3 retries
                 try:
-                    resp = requests.get(current_url, headers=headers, timeout=(3, 10))
-                    if resp.status_code == 429:
+                    resp_status, resp_text = get_capped_text(
+                        current_url, headers=headers, timeout=(3, 10),
+                    )
+                    if resp_status == 429:
                         if attempt < 3:
                             logger.warning(f"[{job_id}] 429 Too Many Requests. Retrying in 5s... ({attempt+1}/3)")
                             time.sleep(5)
@@ -1320,21 +1326,21 @@ def _crawl_worker(job_id: str, start_url: str, content_selector: str, title_sele
                     break # Success or non-retriable status
                 except Exception as e:
                     logger.error(f"[{job_id}] Request failed: {e}")
-                    resp = None
+                    resp_status = None
                     break
-            
-            if not resp: break
-                
-            logger.info(f"[{job_id}] Status {resp.status_code} for {current_url}")
-            if resp.status_code != 200:
-                logger.error(f"[{job_id}] Failed to fetch {current_url}: {resp.status_code}")
+
+            if resp_status is None: break
+
+            logger.info(f"[{job_id}] Status {resp_status} for {current_url}")
+            if resp_status != 200:
+                logger.error(f"[{job_id}] Failed to fetch {current_url}: {resp_status}")
                 # Try next chapter if in list mode, otherwise break
                 if chapter_iterator:
                     continue
                 else:
                     break
-                
-            soup = BeautifulSoup(resp.text, "html.parser")
+
+            soup = BeautifulSoup(resp_text, "html.parser")
             logger.info(f"[{job_id}] Parsed HTML for {current_url}. Title selector: {title_selector}, Content: {content_selector}")
             
             # Content

--- a/backend/tools/story_server.py
+++ b/backend/tools/story_server.py
@@ -4,7 +4,10 @@ import json
 import os
 import re
 import unicodedata
+from pathlib import Path
 from bs4 import BeautifulSoup
+
+from helpers.path_safety import safe_story_path
 from mcp.server.fastmcp import FastMCP
 from typing import List, Dict, Optional
 import time
@@ -1230,9 +1233,16 @@ def _crawl_worker(job_id: str, start_url: str, content_selector: str, title_sele
 
         story_folder_name = re.sub(r'[\\/*?:"<>|]', "", story_name).strip()
         if not story_folder_name: story_folder_name = "Untitled_Story"
-        
-        save_dir = os.path.join(DATA_DIR, "stories", story_folder_name)
-        os.makedirs(save_dir, exist_ok=True)
+        try:
+            save_dir_path = safe_story_path(Path(DATA_DIR) / "stories", story_folder_name)
+        except ValueError as e:
+            # Scraped <title> produced a traversal-like value. Fall back to
+            # a timestamped name rather than writing outside the sandbox.
+            logger.warning(f"Unsafe story folder {story_folder_name!r} rejected: {e}; using timestamped fallback")
+            story_folder_name = f"Untitled_Story_{int(time.time())}"
+            save_dir_path = safe_story_path(Path(DATA_DIR) / "stories", story_folder_name)
+        save_dir_path.mkdir(parents=True, exist_ok=True)
+        save_dir = str(save_dir_path)  # downstream os.path.join() callers expect str
         
         meta_file = os.path.join(save_dir, "metadata.json")
         if not os.path.exists(meta_file):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,6 @@ services:
     volumes:
       - ./backend:/app
       - /app/.venv
-      - /var/run/docker.sock:/var/run/docker.sock
       # --- Secrets & Credentials ---
       # fastagent.secrets.yaml is mounted read-write from the persistent host
       # directory so Setup Wizard edits (via /api/yaml/secrets) and

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: Build Vue frontend
-FROM node:20-alpine AS build
+# Minor-pin so a rebuild a month from now picks up the same Node line.
+# Bump manually when upstream issues a new LTS minor.
+FROM node:20.18-alpine AS build
 
 WORKDIR /app
 
@@ -16,7 +18,8 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Serve with nginx
-FROM nginx:alpine AS final
+# Minor-pin so the runtime image is reproducible across rebuilds.
+FROM nginx:1.27-alpine AS final
 
 # Copy built frontend
 COPY --from=build /app/dist /usr/share/nginx/html

--- a/frontend/src/components/MarkdownRenderer.vue
+++ b/frontend/src/components/MarkdownRenderer.vue
@@ -170,8 +170,17 @@ async function renderMermaidBlocks() {
       el.innerHTML = svg
     } catch (err) {
       // Surface errors loud-but-contained: keep the original source visible
-      // so the agent (or user) can see what went wrong.
-      el.innerHTML = `<pre class="mermaid-error"><strong>Mermaid syntax error</strong>\n${(err && err.message) || err}\n\n${source.replace(/</g, '&lt;')}</pre>`
+      // so the agent (or user) can see what went wrong. Build the DOM via
+      // textContent so a Mermaid error message that echoes attacker-supplied
+      // source (or the source itself) can't break out into live markup.
+      const pre = document.createElement('pre')
+      pre.className = 'mermaid-error'
+      const strong = document.createElement('strong')
+      strong.textContent = 'Mermaid syntax error'
+      pre.appendChild(strong)
+      const errText = (err && err.message) || String(err)
+      pre.appendChild(document.createTextNode(`\n${errText}\n\n${source}`))
+      el.replaceChildren(pre)
     }
   }
 }
@@ -211,20 +220,31 @@ function decorateCodeBlocks() {
     shell.className = 'code-chrome'
     const header = document.createElement('div')
     header.className = 'code-chrome__header'
-    header.innerHTML = `
-      <span class="code-chrome__dots">
-        <span class="code-chrome__dot" style="background:#FF5F57"></span>
-        <span class="code-chrome__dot" style="background:#FEBC2E"></span>
-        <span class="code-chrome__dot" style="background:#28C840"></span>
-      </span>
-      <span class="code-chrome__label">${lang || 'code'}</span>
-      <button class="code-chrome__copy" type="button" aria-label="Copy code">Copy</button>
-    `
+    // Build header via DOM API so `lang` (derived from a className that
+    // survives DOMPurify untouched) can't smuggle markup into innerHTML.
+    const dots = document.createElement('span')
+    dots.className = 'code-chrome__dots'
+    for (const color of ['#FF5F57', '#FEBC2E', '#28C840']) {
+      const dot = document.createElement('span')
+      dot.className = 'code-chrome__dot'
+      dot.style.background = color
+      dots.appendChild(dot)
+    }
+    header.appendChild(dots)
+    const label = document.createElement('span')
+    label.className = 'code-chrome__label'
+    label.textContent = lang || 'code'  // textContent — not innerHTML
+    header.appendChild(label)
+    const btn = document.createElement('button')
+    btn.className = 'code-chrome__copy'
+    btn.type = 'button'
+    btn.setAttribute('aria-label', 'Copy code')
+    btn.textContent = 'Copy'
+    header.appendChild(btn)
     pre.parentNode.insertBefore(shell, pre)
     shell.appendChild(header)
     shell.appendChild(pre)
 
-    const btn = header.querySelector('.code-chrome__copy')
     btn.addEventListener('click', async () => {
       const text = code ? code.innerText : pre.innerText
       try {

--- a/frontend/src/views/settings/SettingsVoice.vue
+++ b/frontend/src/views/settings/SettingsVoice.vue
@@ -275,7 +275,20 @@ function reqBadgeFor(engineId) {
   return { text: missing.join(' · '), tone: 'warn' }
 }
 function badgesFor(spec) {
-  return spec?.badges || []
+  // Filter out the network badge — it's rendered separately as a coloured
+  // chip so the user can tell at a glance whether picking this engine
+  // sends audio/text off-box.
+  return (spec?.badges || []).filter((b) => b !== 'cloud' && b !== 'local')
+}
+
+// Derive the network chip (cloud vs local) from the same `badges` field.
+// Returns {label, tone} or null when the engine declares neither — UI then
+// shows nothing rather than guessing.
+function netBadgeFor(spec) {
+  const tags = spec?.badges || []
+  if (tags.includes('local')) return { label: 'Local', tone: 'local' }
+  if (tags.includes('cloud')) return { label: 'Cloud', tone: 'cloud' }
+  return null
 }
 
 // ─── Provider split summary (top-of-page glance card) ──────────────────
@@ -348,6 +361,12 @@ const chatProviderLabel = computed(() => {
             >
               <span class="provider-title">
                 {{ spec.label }}
+                <span
+                  v-if="netBadgeFor(spec)"
+                  class="net-chip"
+                  :class="`net-chip--${netBadgeFor(spec).tone}`"
+                  :title="netBadgeFor(spec).tone === 'cloud' ? 'Audio/text leaves your host' : 'Runs on-box, no network egress'"
+                >{{ netBadgeFor(spec).label }}</span>
                 <span v-if="(secretsStatus[id]?.api_key) || (spec.secrets?.length === 0)" class="mini-dot" title="Ready"></span>
               </span>
               <span class="provider-sub">{{ badgesFor(spec).join(' · ') || spec.description }}</span>
@@ -517,8 +536,16 @@ const chatProviderLabel = computed(() => {
               :class="{ selected: sttBackendId === id }"
               @click="changeSttBackend(id)"
             >
-              <span class="provider-title">{{ spec.label }}</span>
-              <span class="provider-sub">{{ (spec.badges || []).join(' · ') || spec.description }}</span>
+              <span class="provider-title">
+                {{ spec.label }}
+                <span
+                  v-if="netBadgeFor(spec)"
+                  class="net-chip"
+                  :class="`net-chip--${netBadgeFor(spec).tone}`"
+                  :title="netBadgeFor(spec).tone === 'cloud' ? 'Audio leaves your host' : 'Runs on-box, no network egress'"
+                >{{ netBadgeFor(spec).label }}</span>
+              </span>
+              <span class="provider-sub">{{ badgesFor(spec).join(' · ') || spec.description }}</span>
             </button>
           </template>
         </div>
@@ -784,6 +811,20 @@ const chatProviderLabel = computed(() => {
   width: 6px; height: 6px; border-radius: 50%;
   background: var(--success); display: inline-block;
 }
+/* Network chip — Cloud / Local — surfaces data-egress at a glance. */
+.net-chip {
+  font-size: 9.5px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid currentColor;
+  background: transparent;
+}
+.net-chip--cloud { color: #d97706; }      /* amber-700 — data leaves host */
+.net-chip--local { color: #15803d; }      /* green-700 — stays on-box */
 
 .provider-hint {
   margin: 4px 0 14px;

--- a/frontend/tests/e2e/fixtures/chat_streaming_xss.yaml
+++ b/frontend/tests/e2e/fixtures/chat_streaming_xss.yaml
@@ -1,0 +1,53 @@
+# Chat SSE streaming — agent reply tries to bypass MarkdownRenderer
+# sanitisation by stuffing HTML into a code-fence language specifier.
+#
+# Threat being regressed:
+#   The old `decorateCodeBlocks()` built its code-chrome header via
+#   `header.innerHTML = ...${lang}...`, where `lang` was derived from
+#   the `language-xxx` class on a <code> tag. marked accepts arbitrary
+#   characters in the info-string after ``` so an attacker could push
+#   `<img onerror=...>` into `lang` and have it land inside innerHTML
+#   AFTER DOMPurify had already run — a sanitiser bypass.
+#
+# The fix replaces the innerHTML template with explicit createElement
+# + textContent calls. This fixture feeds the malicious markdown; the
+# accompanying spec asserts the payload renders as text, no <img> tag
+# is materialised, and window.xssTriggered stays unset.
+
+backend_source:
+  - "frontend/src/components/MarkdownRenderer.vue::decorateCodeBlocks"
+
+responses:
+  "GET /api/conversations":
+    status: 200
+    json: []
+
+  "GET /api/agents":
+    status: 200
+    json:
+      - name: "Jarvis"
+        description: "Main orchestrator"
+        status: "idle"
+        is_default: true
+        team_name: null
+
+  "GET /api/agents/activities/recent":
+    status: 200
+    json: {}
+
+sse_streams:
+  "/api/chat-stream":
+    - data:
+        type: "start"
+        message: "Processing..."
+    - data:
+        type: "done"
+        response: |-
+          Here is a code block with a malicious language specifier.
+
+          ```javascript<img src=x onerror="window.xssTriggered=true">
+          console.log('hello')
+          ```
+        audio: null
+        conversation_id: "e2e-conv-xss-001"
+        total_tokens: { input: 10, output: 5, reasoning: 0, cache_read: 0 }

--- a/frontend/tests/e2e/flows/chat-markdown-xss.spec.ts
+++ b/frontend/tests/e2e/flows/chat-markdown-xss.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * MarkdownRenderer XSS regression.
+ *
+ * The `decorateCodeBlocks` helper used to inject the code-fence language
+ * specifier into its header via `header.innerHTML = ...${lang}...`. marked
+ * accepts arbitrary chars in the info-string after ``` so a crafted fence
+ * could smuggle `<img onerror=...>` past DOMPurify and into live markup.
+ *
+ * Fix: build the chrome header with createElement + textContent. This spec
+ * pins that fix by feeding the malicious markdown through chat and asserting:
+ *   1. No <img> with the attacker src reaches the DOM
+ *   2. window.xssTriggered remains unset (script didn't execute)
+ *   3. The literal lang string appears in .code-chrome__label as text
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+test('markdown renderer does not execute attacker JS in code-fence lang', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'chat_streaming_xss.yaml'),
+  ])
+
+  // Trip-wire: if any earlier-running script ran via innerHTML injection
+  // it would have set this flag before this initScript fires. The init
+  // ordering is safe because Playwright runs the script BEFORE the
+  // navigation happens, so the property is guaranteed false at page open.
+  await page.addInitScript(() => {
+    ;(window as any).xssTriggered = false
+  })
+
+  await page.goto('/chat')
+  const textarea = page.getByPlaceholder(/type a message/i)
+  await expect(textarea).toBeVisible()
+
+  const streamResponse = page.waitForResponse(
+    (r) => r.url().endsWith('/api/chat-stream') && r.request().method() === 'POST',
+  )
+  await textarea.fill('emit malicious markdown')
+  await textarea.press('Enter')
+  await streamResponse
+
+  const messagesArea = page.getByTestId('chat-messages')
+  // Wait for the code chrome to mount — the renderer's post-process step
+  // adds .code-chrome around every <pre><code>. That's our signal the
+  // sanitised content is on screen.
+  await expect(messagesArea.locator('.code-chrome').first()).toBeVisible()
+
+  // Trip-wire never triggered — the onerror= handler did not run.
+  await expect.poll(() => page.evaluate(() => (window as any).xssTriggered)).toBe(false)
+
+  // No <img> element with the attacker src materialised anywhere on the page.
+  // (DOMPurify already strips standalone <img onerror=> at the markdown
+  // sanitise step; this spec specifically guards the post-sanitise
+  // decorateCodeBlocks path.)
+  await expect(page.locator('img[src="x"]')).toHaveCount(0)
+
+  // The lang string lands inside .code-chrome__label as text, including the
+  // literal characters that *would* have been an HTML img tag. This is the
+  // positive signal that the textContent path is in play.
+  const label = messagesArea.locator('.code-chrome__label').first()
+  await expect(label).toHaveText(/javascript<img/)
+})


### PR DESCRIPTION
## Summary

Pre-release security + bug review produced 32 verified findings (out of 61 candidates). After per-finding discussion with the user, 14 ship in this PR; 5 were skipped with documented reasoning. Each fix lives in its own commit so reviewers can land them piecemeal if needed.

## Fixes

| # | Severity | Title | Commit |
|---|---|---|---|
| #04 | high | `hmac.compare_digest` × 5 sites | `ea87b60` |
| #10 | high | RedactSecretsFilter for all log handlers | `01ac9f2` |
| #09 | high | Drop `docker.sock` mount from both compose files | `2d4dbcf` |
| #02 | high | `safe_story_path` helper × 4 path-join sites | `360a361` |
| #06 | high | Stream + 10 MB cap per chapter (warn at 5 MB) | `8a9163b` |
| #08 | high | Close XSS in MarkdownRenderer (code-chrome + mermaid err) | `4cf7b2b` |
| #01 + #05 | crit + high | Approval gate for `mcp_install` + cron first fire | `cd6efc8` |
| #12 | high | Minor-pin frontend Dockerfile base images | `e284640` |
| #13 | high | Root `NOTICE` for Apache-2.0 attributions | `87e6d73` |
| #14 | high | `SKILL_LICENSING.md` policy for skills sans LICENSE | `3c9e385` |
| #15 | med | `safe_500` helper for 5xx routes (10 sites) | `063d71a` |
| #18 | med | Privacy section + Cloud/Local chip in Voice settings | `6249df7` |
| #19 | med | Split Gipformer (MIT) from sherpa-onnx (Apache-2.0) | `7bdf1dd` |
| submodules | — | Bump fast-agent + mcp-atlassian | `01cd401` |

## Skipped (explicit decision)

| # | Reason |
|---|---|
| #03 SSRF | crawl response → file → TTS, no exfil channel |
| #07 CORS `*`+creds | browser spec blocks the combo + CSRF middleware in place |
| #11 curl\|gpg devcontainer | fixed upstream in `omnigentx/mcp-atlassian#4`, submodule pointer bumped |
| #16 gmail draft validation | drafts only — user reviews `To:` before manual send |
| #17 nginx as root | static file server, breaking change for compose port mapping |

## New tests

* `test_helpers/test_logging_filters.py` — 17 cases pinning redaction patterns
* `test_helpers/test_path_safety.py` — 13 cases (separators, traversal, symlink escape, Vietnamese Unicode happy path)
* `test_helpers/test_http_safety.py` — 5 cases (cap / warn / status pass-through)
* `test_services/test_approval_gate.py` — 10 cases (hash memory, pending coalesce, timeout)
* `frontend/tests/e2e/flows/chat-markdown-xss.spec.ts` — Playwright regression for the lang-injection vector

All backend unit + integration tests pass locally (auth × 39, routes × 52, services full × 790).

## Submodule bumps included

* **fast-agent** → `d6a7ef01` — adds `CHANGES.md` for Apache-2.0 §4(b)
  ([omnigentx/fast-agent#7](https://github.com/omnigentx/fast-agent/pull/7))
* **mcp-atlassian** → `a038a36` — drops `.devcontainer/` curl\|gpg and 6 jira/confluence prod fixes
  ([omnigentx/mcp-atlassian#4](https://github.com/omnigentx/mcp-atlassian/pull/4))

## Test plan

- [ ] `cd backend && uv run pytest tests/test_routes/test_auth.py tests/test_routes/test_auth_session.py tests/test_routes/test_ws_voice_auth.py` — auth + WS auth (39 tests)
- [ ] `cd backend && uv run pytest tests/test_helpers/ tests/test_services/test_approval_gate.py` — new helpers + gate (45 tests)
- [ ] `cd backend && uv run pytest tests/test_routes/` — full routes regression
- [ ] `cd frontend && npm run test:unit` — frontend unit tests (142 cases)
- [ ] `cd frontend && npx playwright test chat-markdown-xss` — XSS regression (requires dev server)
- [ ] Manual: open Settings → Voice → confirm each engine card shows a Cloud (amber) or Local (green) chip
- [ ] Manual: trigger `mcp_install_dependencies` for a new MCP server — verify approval prompt appears with `requirements.txt` content + "use at your own risk" warning
- [ ] Manual: create a cron with `agent_turn` exec mode — verify first fire prompts for approval; subsequent fires of same payload skip the prompt

## Follow-ups (not in this PR)

1. `omnigentx/RealtimeSTT` / `RealtimeTTS` / `figma-ui-mcp` — MIT, no §4(b) compliance work needed.
2. Background-task `uv.lock` regeneration left untracked locally — not part of this security scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)