### PR TITLE
feat(team-template): edit factory yaml + running team via UI + MCP

### DIFF
--- a/backend/fastagent.config.yaml
+++ b/backend/fastagent.config.yaml
@@ -233,6 +233,17 @@ mcp:
       env:
         PYTHONUNBUFFERED: "1"
         JARVIS_RUNTIME_RPC_SOCKET: "${JARVIS_RUNTIME_RPC_SOCKET}"
+    # Edit team-template factory yamls + per-session running templates.
+    # Same RPC bridge as mcp_admin: every tool delegates to
+    # team_template_rpc_handlers in the main backend so audit rows, DB SSoT
+    # updates, and force-reload all land in the live process. No HTTP, no
+    # API key — trust is fs permissions on the UDS socket.
+    team_template:
+      command: "python"
+      args: ["tools/team_template_server.py"]
+      env:
+        PYTHONUNBUFFERED: "1"
+        JARVIS_RUNTIME_RPC_SOCKET: "${JARVIS_RUNTIME_RPC_SOCKET}"
     mcp-atlassian:
       command: "uv"
       args: ["run", "--directory", "mcp-atlassian", "mcp-atlassian"]

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -25,6 +25,7 @@ from routes.system import router as system_router
 from routes.voice import router as voice_router
 from routes.ws_voice import router as ws_voice_router
 from routes.team_template import router as team_template_router
+from routes.team_templates_factory import router as team_templates_factory_router
 
 all_routers: list[APIRouter] = [
     auth_router,
@@ -51,4 +52,5 @@ all_routers: list[APIRouter] = [
     voice_router,
     ws_voice_router,
     team_template_router,
+    team_templates_factory_router,
 ]

--- a/backend/routes/team_template.py
+++ b/backend/routes/team_template.py
@@ -96,9 +96,15 @@ async def list_sessions():
     Used by the Settings → Running templates dropdown so the UI never has to
     pull the full template dict for every team just to render a selector.
     """
+    # Narrow the catch to ImportError so we degrade gracefully only when the
+    # fast_agent package is genuinely absent (e.g. a stripped test harness).
+    # Any runtime failure inside list_team_sessions() (DB down, corrupted
+    # row, etc.) must propagate as a 500 — silently returning an empty list
+    # would render the Settings dropdown blank with no signal that
+    # enumeration failed.
     try:
         from fast_agent.spawn.team_spawner import list_team_sessions
-    except Exception as exc:
+    except ImportError as exc:
         logger.warning("[team-template] team_spawner unavailable: %s", exc)
         return {"sessions": []}
     out = []

--- a/backend/routes/team_template.py
+++ b/backend/routes/team_template.py
@@ -86,6 +86,34 @@ class ResetBody(BaseModel):
 
 
 @router.get(
+    "",
+    dependencies=[Depends(verify_api_key)],
+)
+async def list_sessions():
+    """Lightweight enumeration of every team session.
+
+    Returns ``{"sessions": [{session_id, team_name, template_name, agents_count}]}``.
+    Used by the Settings → Running templates dropdown so the UI never has to
+    pull the full template dict for every team just to render a selector.
+    """
+    try:
+        from fast_agent.spawn.team_spawner import list_team_sessions
+    except Exception as exc:
+        logger.warning("[team-template] team_spawner unavailable: %s", exc)
+        return {"sessions": []}
+    out = []
+    for sess in list_team_sessions():
+        template = sess.get("template") or {}
+        out.append({
+            "session_id": sess.get("session_id"),
+            "team_name": sess.get("team_name"),
+            "template_name": template.get("name"),
+            "agents_count": len(sess.get("agents") or {}),
+        })
+    return {"sessions": out}
+
+
+@router.get(
     "/{session_id}/template",
     dependencies=[Depends(verify_api_key)],
 )

--- a/backend/routes/team_templates_factory.py
+++ b/backend/routes/team_templates_factory.py
@@ -1,0 +1,63 @@
+"""Factory team-template yaml REST API.
+
+Endpoints (all gated by ``verify_api_key``):
+
+  GET  /api/team-templates                → list yaml factory files
+  GET  /api/team-templates/{name}         → read raw + parsed yaml
+  PUT  /api/team-templates/{name}         → write yaml (validates + .bak)
+
+Pairs with the running-team API at ``/api/team-sessions/{id}/template/*`` —
+see ``routes/team_template.py``. Factory edits do NOT touch running teams;
+drift is surfaced through the running-team ``yaml-diff`` endpoint and the
+user clicks Reload-from-yaml manually.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from core.auth import verify_api_key
+from services import team_template_factory_service as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/team-templates", tags=["team-template-factory"])
+
+
+class TemplatePutBody(BaseModel):
+    content: str = Field(..., max_length=svc.MAX_BYTES)
+
+
+@router.get("", dependencies=[Depends(verify_api_key)])
+async def list_templates():
+    """Return every yaml file in the factory directory."""
+    return {"templates": svc.list_factory_templates()}
+
+
+@router.get("/{name}", dependencies=[Depends(verify_api_key)])
+async def read_template(name: str):
+    try:
+        return svc.read_factory_template(name)
+    except svc.NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except svc.PathTraversalError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except svc.FactoryTemplateError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.put("/{name}", dependencies=[Depends(verify_api_key)])
+async def write_template(name: str, body: TemplatePutBody):
+    try:
+        return svc.write_factory_template(name, body.content)
+    except svc.ValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": str(exc), "name": name},
+        )
+    except svc.PathTraversalError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except svc.FactoryTemplateError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/server.py
+++ b/backend/server.py
@@ -186,13 +186,19 @@ async def lifespan(app: FastAPI):
     runtime_rpc_server = None
     try:
         from services.runtime_rpc import RuntimeRpcServer
-        from services import skill_rpc_handlers, mcp_rpc_handlers, approval_rpc_handlers
+        from services import (
+            skill_rpc_handlers,
+            mcp_rpc_handlers,
+            approval_rpc_handlers,
+            team_template_rpc_handlers,
+        )
 
         rpc_socket_path = os.environ["JARVIS_RUNTIME_RPC_SOCKET"]
         runtime_rpc_server = RuntimeRpcServer(rpc_socket_path)
         skill_rpc_handlers.register(runtime_rpc_server)
         mcp_rpc_handlers.register(runtime_rpc_server)
         approval_rpc_handlers.register(runtime_rpc_server)
+        team_template_rpc_handlers.register(runtime_rpc_server)
         await runtime_rpc_server.start()
         state.runtime_rpc_server = runtime_rpc_server
         logger.info(

--- a/backend/services/team_template_factory_service.py
+++ b/backend/services/team_template_factory_service.py
@@ -1,0 +1,195 @@
+"""Factory-yaml team template service — read/write ``backend/team_templates/*.yaml``.
+
+Companion to :mod:`services.team_template_service`, which edits the running
+team's DB SSoT. This module edits the **factory default** the spawner reads
+at team creation. Per user decision 2026-05-17 the two paths are kept
+deliberately separate: editing a factory yaml does NOT mutate running teams.
+Drift is surfaced via ``/api/team-sessions/{id}/template/yaml-diff`` and the
+user clicks Reload-from-yaml manually.
+
+Safety properties (mirrors :mod:`routes.yaml_config`):
+
+* Only files directly inside the ``team_templates`` directory may be touched;
+  path-traversal (``..``) is refused.
+* Writes are ``yaml.safe_load``-validated before they hit disk so a broken
+  edit never bricks the next spawn.
+* Atomic write via ``tmp → os.replace`` with ``EBUSY`` fallback for bind-mounted
+  files (Docker compose dev loop).
+* Previous content rotates into a ``.bak`` sibling so a bad edit is recoverable.
+"""
+from __future__ import annotations
+
+import errno
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Resolved once at import — same hardening as yaml_config: even if cwd flips
+# mid-request we never escape the factory directory.
+_FACTORY_DIR = (Path(__file__).resolve().parent.parent / "team_templates").resolve()
+
+# Same cap as yaml_config.py; team templates are typically a few KB.
+MAX_BYTES = 256 * 1024
+
+
+class FactoryTemplateError(Exception):
+    """Base class for factory-yaml errors. Subclasses map to HTTP statuses."""
+
+    status: int = 500
+
+
+class NotFoundError(FactoryTemplateError):
+    status = 404
+
+
+class ValidationError(FactoryTemplateError):
+    status = 400
+
+
+class PathTraversalError(FactoryTemplateError):
+    status = 400
+
+
+def factory_dir() -> Path:
+    """Return the resolved team_templates directory. Mostly for tests."""
+    return _FACTORY_DIR
+
+
+def _resolve(name: str) -> Path:
+    """Map a logical template name (``agile_team``) to its yaml path.
+
+    Refuses any name that resolves outside ``_FACTORY_DIR`` — this is the
+    only allowlist we maintain. Adding a new template = dropping a yaml in
+    the directory; no service-side enum to keep in sync.
+    """
+    if not name or "/" in name or "\\" in name or name.startswith("."):
+        raise PathTraversalError(f"invalid template name: {name!r}")
+    candidate = (_FACTORY_DIR / f"{name}.yaml").resolve()
+    if _FACTORY_DIR not in candidate.parents:
+        raise PathTraversalError(f"path traversal blocked: {name!r}")
+    return candidate
+
+
+def list_factory_templates() -> list[dict[str, Any]]:
+    """Return every yaml in ``team_templates/`` with size + parsed display name.
+
+    Display name comes from the yaml's top-level ``name:`` field when it
+    exists (e.g. ``agile-team``). Falls back to the filename stem when the
+    file is empty or malformed so the UI can still show + offer to fix it.
+    """
+    if not _FACTORY_DIR.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for p in sorted(_FACTORY_DIR.glob("*.yaml")):
+        try:
+            text = p.read_text(encoding="utf-8")
+            doc = yaml.safe_load(text) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            logger.warning("[factory-yaml] %s: %s", p.name, exc)
+            doc, text = {}, ""
+        team = doc.get("team") if isinstance(doc, dict) and isinstance(doc.get("team"), dict) else doc
+        display = (team.get("name") if isinstance(team, dict) else None) or p.stem
+        out.append({
+            "name": p.stem,
+            "filename": p.name,
+            "display_name": display,
+            "description": (team.get("description") if isinstance(team, dict) else None) or "",
+            "size": len(text.encode("utf-8")),
+            "exists": True,
+        })
+    return out
+
+
+def read_factory_template(name: str) -> dict[str, Any]:
+    """Return ``{name, filename, content, parsed, exists, size}``.
+
+    ``parsed`` is the safe-loaded dict (or ``None`` if file is empty or
+    invalid) so the UI can render a structural view without re-parsing.
+    """
+    path = _resolve(name)
+    if not path.exists():
+        raise NotFoundError(f"template not found: {name}")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise FactoryTemplateError(f"read failed: {exc}") from exc
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        # Return content so the UI can still show it for hand-editing,
+        # but flag the parse failure so the UI can warn before save.
+        return {
+            "name": name,
+            "filename": path.name,
+            "content": text,
+            "parsed": None,
+            "parse_error": str(exc),
+            "exists": True,
+            "size": len(text.encode("utf-8")),
+        }
+    return {
+        "name": name,
+        "filename": path.name,
+        "content": text,
+        "parsed": parsed,
+        "exists": True,
+        "size": len(text.encode("utf-8")),
+    }
+
+
+def write_factory_template(name: str, content: str) -> dict[str, Any]:
+    """Validate + atomically write yaml. Rotates previous content to ``.bak``.
+
+    Returns ``{name, filename, size, saved: True}``. Raises:
+      * ValidationError — content fails ``yaml.safe_load`` or exceeds cap.
+      * PathTraversalError — name escapes the factory dir.
+      * FactoryTemplateError — underlying OSError.
+    """
+    if len(content.encode("utf-8")) > MAX_BYTES:
+        raise ValidationError(f"content exceeds {MAX_BYTES} bytes")
+
+    path = _resolve(name)
+    try:
+        yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        raise ValidationError(f"invalid YAML — file not saved: {exc}") from exc
+
+    if path.exists():
+        backup = path.with_suffix(path.suffix + ".bak")
+        try:
+            backup.write_bytes(path.read_bytes())
+        except OSError as exc:
+            logger.warning("[factory-yaml] could not write backup for %s: %s", path, exc)
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        try:
+            os.replace(tmp, path)
+        except OSError as exc:
+            # Docker bind-mounts a single file by inode — rename-over-mount
+            # fails with EBUSY on Linux. Fall back to truncate + in-place write;
+            # the .bak from above is still our rollback option.
+            if exc.errno != errno.EBUSY:
+                raise
+            path.write_text(content, encoding="utf-8")
+            try: tmp.unlink()
+            except OSError: pass
+    except OSError as exc:
+        if tmp.exists():
+            try: tmp.unlink()
+            except OSError: pass
+        raise FactoryTemplateError(f"write failed: {exc}") from exc
+
+    logger.info("[factory-yaml] %s saved (%d bytes)", path.name, len(content))
+    return {
+        "name": name,
+        "filename": path.name,
+        "size": len(content.encode("utf-8")),
+        "saved": True,
+    }

--- a/backend/services/team_template_factory_service.py
+++ b/backend/services/team_template_factory_service.py
@@ -11,11 +11,21 @@ Safety properties (mirrors :mod:`routes.yaml_config`):
 
 * Only files directly inside the ``team_templates`` directory may be touched;
   path-traversal (``..``) is refused.
-* Writes are ``yaml.safe_load``-validated before they hit disk so a broken
-  edit never bricks the next spawn.
+* Writes are validated for BOTH syntax (``yaml.safe_load``) and the minimal
+  template structure (top-level dict with a ``roles`` mapping, either at
+  the root or under ``team:``). The structural check is deliberately strict
+  because the MCP tool lets an unattended LLM write these — a syntactically
+  valid but structurally wrong yaml would brick every subsequent
+  ``spawn_team`` call.
 * Atomic write via ``tmp → os.replace`` with ``EBUSY`` fallback for bind-mounted
   files (Docker compose dev loop).
 * Previous content rotates into a ``.bak`` sibling so a bad edit is recoverable.
+
+Concurrency: writes are single-writer (no file lock). The MCP tool plus the
+UI can in principle race on the same file, but the only realistic concurrent
+caller pair is "human in the UI" + "human-driven LLM", which is implicitly
+serialised by the human. If true concurrent automated writers ever land,
+gate this module behind a per-path lock.
 """
 from __future__ import annotations
 
@@ -142,11 +152,52 @@ def read_factory_template(name: str) -> dict[str, Any]:
     }
 
 
+def _validate_template_structure(parsed: Any) -> None:
+    """Reject yaml that parses but is shaped wrong for the spawner.
+
+    Minimal contract enforced here:
+      * Top-level must be a mapping.
+      * Either the top-level OR a ``team:`` child must contain a ``roles``
+        mapping (the two layouts the spawner accepts today).
+      * ``roles`` itself must be a mapping (``role_name → role_config``).
+      * Each role config must be a mapping (an empty dict ``{}`` is OK —
+        the spawner falls back to whole-team defaults).
+
+    Wider checks (per-field types, allowed servers, ...) live in
+    :mod:`services.team_template_service.validate_patch`; we don't duplicate
+    them here because the factory file is read once at spawn time and any
+    silly value will surface immediately. The point of this check is solely
+    to keep a malformed top-level (missing ``roles``, ``roles`` is a list,
+    etc.) from saving and bricking ``spawn_team``.
+    """
+    if not isinstance(parsed, dict):
+        raise ValidationError(
+            "template must be a YAML mapping at top level (got "
+            f"{type(parsed).__name__})"
+        )
+    team = parsed.get("team") if isinstance(parsed.get("team"), dict) else None
+    roles = (team or parsed).get("roles")
+    if not isinstance(roles, dict):
+        raise ValidationError(
+            "template must have a 'roles' mapping (at top level or under 'team:')"
+        )
+    if not roles:
+        raise ValidationError("template 'roles' mapping must define at least one role")
+    for role_name, role_cfg in roles.items():
+        if not isinstance(role_name, str) or not role_name:
+            raise ValidationError(f"role name must be a non-empty string (got {role_name!r})")
+        if not isinstance(role_cfg, dict):
+            raise ValidationError(
+                f"role '{role_name}' config must be a mapping (got {type(role_cfg).__name__})"
+            )
+
+
 def write_factory_template(name: str, content: str) -> dict[str, Any]:
     """Validate + atomically write yaml. Rotates previous content to ``.bak``.
 
     Returns ``{name, filename, size, saved: True}``. Raises:
-      * ValidationError — content fails ``yaml.safe_load`` or exceeds cap.
+      * ValidationError — content fails ``yaml.safe_load``, is structurally
+        invalid (missing ``roles``, etc.), or exceeds cap.
       * PathTraversalError — name escapes the factory dir.
       * FactoryTemplateError — underlying OSError.
     """
@@ -155,9 +206,15 @@ def write_factory_template(name: str, content: str) -> dict[str, Any]:
 
     path = _resolve(name)
     try:
-        yaml.safe_load(content)
+        parsed = yaml.safe_load(content)
     except yaml.YAMLError as exc:
         raise ValidationError(f"invalid YAML — file not saved: {exc}") from exc
+
+    # Structural check — refuses syntactically valid but shape-wrong yaml
+    # (e.g. ``roles:`` missing) that would brick the next spawn_team call.
+    # Critical because team_template_write_factory MCP tool lets the LLM
+    # write here without a human review step.
+    _validate_template_structure(parsed)
 
     if path.exists():
         backup = path.with_suffix(path.suffix + ".bak")

--- a/backend/services/team_template_rpc_handlers.py
+++ b/backend/services/team_template_rpc_handlers.py
@@ -1,0 +1,303 @@
+"""RPC handlers for team-template editing — registered with RuntimeRpcServer.
+
+Lets the in-process MCP tool subprocess (``tools/team_template_server.py``)
+call into the live backend without HTTP / API-key round-trip. Trust model
+is filesystem permissions on the UDS socket — same as ``skill_rpc_handlers``
+and ``mcp_rpc_handlers``.
+
+Two surfaces:
+
+* **Running team** (``team_template.running.*``) — wraps
+  :mod:`services.team_template_service` (DB SSoT, per-session, with audit).
+* **Factory yaml** (``team_template.factory.*``) — wraps
+  :mod:`services.team_template_factory_service` (yaml files under
+  ``backend/team_templates/``).
+
+Errors raised by service-layer ``LookupError`` / ``ValueError`` /
+``RuntimeError`` are translated into the structured ``{"error", "status"}``
+envelope that ``runtime_rpc_client.call`` forwards to MCP tools.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from services import team_template_factory_service as factory_svc
+from services import team_template_service as svc
+from services.runtime_rpc import RuntimeRpcServer
+
+logger = logging.getLogger("team_template_rpc")
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _err(message: str, status: int) -> dict:
+    return {"error": message, "status": status}
+
+
+def _session_scope():
+    """Open a DB session for one RPC call. Use as ``with _session_scope() as db:``."""
+    from core.database import SessionLocal
+
+    return SessionLocal()
+
+
+def _factory_yaml_path_for(name: str) -> Path:
+    """Resolve the yaml path the running template was instantiated from.
+
+    Mirrors ``_resolve_yaml_for_session`` in ``routes/team_template.py``: maps
+    e.g. ``agile-team`` → ``agile_team.yaml``. Caller is the reset/diff handler.
+    """
+    candidate = factory_svc.factory_dir() / f"{(name or 'agile-team').replace('-', '_')}.yaml"
+    if not candidate.exists():
+        candidate = factory_svc.factory_dir() / f"{name}.yaml"
+    return candidate
+
+
+# ── factory yaml (file-level) ──────────────────────────────────────────────
+
+
+def _factory_list() -> dict:
+    return {"templates": factory_svc.list_factory_templates()}
+
+
+def _factory_read(*, name: str) -> dict:
+    try:
+        return factory_svc.read_factory_template(name)
+    except factory_svc.NotFoundError as exc:
+        return _err(str(exc), 404)
+    except factory_svc.PathTraversalError as exc:
+        return _err(str(exc), 400)
+    except factory_svc.FactoryTemplateError as exc:
+        return _err(str(exc), 500)
+
+
+def _factory_write(*, name: str, content: str) -> dict:
+    try:
+        return factory_svc.write_factory_template(name, content)
+    except factory_svc.ValidationError as exc:
+        return _err(str(exc), 400)
+    except factory_svc.PathTraversalError as exc:
+        return _err(str(exc), 400)
+    except factory_svc.FactoryTemplateError as exc:
+        return _err(str(exc), 500)
+
+
+# ── running team (DB-level) ────────────────────────────────────────────────
+
+
+def _running_get(*, session_id: str) -> dict:
+    try:
+        return {"session_id": session_id, "template": svc.get_template(session_id)}
+    except svc.NotFoundError as exc:
+        return _err(str(exc), 404)
+
+
+def _running_patch_role(
+    *,
+    session_id: str,
+    role: str,
+    patch: dict[str, Any],
+    edited_by: str = "jarvis",
+    comment: str = "",
+) -> dict:
+    db = _session_scope()
+    try:
+        try:
+            result = svc.apply_role_patch(
+                db,
+                session_id,
+                role,
+                patch,
+                edited_by=edited_by,
+                source="mcp",
+                comment=comment,
+            )
+        except svc.ValidationError as exc:
+            return _err(str(exc), 400)
+        except svc.NotFoundError as exc:
+            return _err(str(exc), 404)
+        except svc.ConflictError as exc:
+            return _err(str(exc), 409)
+        return {"session_id": session_id, "role": role, **result}
+    finally:
+        db.close()
+
+
+def _running_history(
+    *,
+    session_id: str,
+    role: str | None = None,
+    limit: int = 50,
+) -> dict:
+    db = _session_scope()
+    try:
+        rows = svc.get_history(db, session_id, role=role, limit=limit)
+        return {
+            "session_id": session_id,
+            "role": role,
+            "count": len(rows),
+            "rows": rows,
+        }
+    finally:
+        db.close()
+
+
+def _running_rollback(
+    *,
+    session_id: str,
+    audit_id: int,
+    edited_by: str = "jarvis",
+    comment: str = "",
+) -> dict:
+    db = _session_scope()
+    try:
+        try:
+            result = svc.rollback_to(
+                db, session_id, audit_id, edited_by=edited_by, comment=comment,
+            )
+        except svc.NotFoundError as exc:
+            return _err(str(exc), 404)
+        except svc.ValidationError as exc:
+            return _err(str(exc), 400)
+        except svc.ConflictError as exc:
+            return _err(str(exc), 409)
+        return {"session_id": session_id, "audit_id": audit_id, **result}
+    finally:
+        db.close()
+
+
+def _running_reset_role(
+    *,
+    session_id: str,
+    role: str,
+    edited_by: str = "jarvis",
+    comment: str = "",
+) -> dict:
+    try:
+        template = svc.get_template(session_id)
+    except svc.NotFoundError as exc:
+        return _err(str(exc), 404)
+    yaml_path = _factory_yaml_path_for(template.get("name") or "agile-team")
+    db = _session_scope()
+    try:
+        try:
+            result = svc.reset_role_to_yaml(
+                db,
+                session_id,
+                role,
+                yaml_path,
+                edited_by=edited_by,
+                comment=comment,
+            )
+        except svc.NotFoundError as exc:
+            return _err(str(exc), 404)
+        except svc.ConflictError as exc:
+            return _err(str(exc), 409)
+        return {
+            "session_id": session_id,
+            "role": role,
+            "yaml_path": str(yaml_path),
+            **result,
+        }
+    finally:
+        db.close()
+
+
+def _running_yaml_diff(*, session_id: str) -> dict:
+    import yaml as yaml_lib
+
+    try:
+        current_template = svc.get_template(session_id)
+    except svc.NotFoundError as exc:
+        return _err(str(exc), 404)
+
+    yaml_path = _factory_yaml_path_for(current_template.get("name") or "agile-team")
+    if not yaml_path.exists():
+        return _err(f"factory yaml not found at {yaml_path}", 404)
+
+    with yaml_path.open(encoding="utf-8") as f:
+        yaml_doc = yaml_lib.safe_load(f) or {}
+    yaml_template = yaml_doc.get("team") or yaml_doc
+    yaml_roles = yaml_template.get("roles") or {}
+    current_roles = current_template.get("roles") or {}
+
+    per_role: dict[str, dict] = {}
+    for role in set(yaml_roles) | set(current_roles):
+        before = yaml_roles.get(role)
+        after = current_roles.get(role)
+        if before is None:
+            per_role[role] = {"status": "added_in_db", "yaml": None, "current": after}
+            continue
+        if after is None:
+            per_role[role] = {"status": "removed_from_db", "yaml": before, "current": None}
+            continue
+        diff = svc.compute_role_diff(before, after)
+        per_role[role] = (
+            {"status": "diverged", "fields": diff} if diff else {"status": "in_sync"}
+        )
+
+    diverged = {r: v for r, v in per_role.items() if v["status"] != "in_sync"}
+    return {
+        "session_id": session_id,
+        "yaml_path": str(yaml_path),
+        "in_sync": not diverged,
+        "diverged_count": len(diverged),
+        "per_role": per_role,
+    }
+
+
+async def _running_reload(
+    *,
+    session_id: str,
+    roles: list[str],
+    edited_by: str = "jarvis",
+    inject_message: str | None = None,
+) -> dict:
+    """Force-kill + respawn agents. Async — reload_roles awaits inject_resume."""
+    from services.team_reload import reload_roles
+
+    if not roles:
+        return _err("'roles' must be non-empty", 400)
+    try:
+        results = await reload_roles(
+            session_id=session_id,
+            roles=roles,
+            edited_by=edited_by,
+            inject_message=inject_message,
+        )
+    except LookupError as exc:
+        return _err(str(exc), 404)
+    return {"session_id": session_id, "results": results}
+
+
+# ── registration ───────────────────────────────────────────────────────────
+
+
+_METHODS: dict[str, Any] = {
+    # Factory yaml
+    "team_template.factory.list": _factory_list,
+    "team_template.factory.read": _factory_read,
+    "team_template.factory.write": _factory_write,
+    # Running team
+    "team_template.running.get": _running_get,
+    "team_template.running.patch_role": _running_patch_role,
+    "team_template.running.history": _running_history,
+    "team_template.running.rollback": _running_rollback,
+    "team_template.running.reset_role": _running_reset_role,
+    "team_template.running.yaml_diff": _running_yaml_diff,
+    "team_template.running.reload": _running_reload,
+}
+
+
+def register(server: RuntimeRpcServer) -> None:
+    """Register every team-template method on the given RPC server.
+
+    Call once at boot from ``server.py`` lifespan, next to the other
+    ``*_rpc_handlers.register`` calls.
+    """
+    for name, handler in _METHODS.items():
+        server.register(name, handler)
+    logger.info("[team_template_rpc] registered %d methods", len(_METHODS))

--- a/backend/tests/test_routes/test_team_templates_factory.py
+++ b/backend/tests/test_routes/test_team_templates_factory.py
@@ -1,0 +1,215 @@
+"""Tests for routes/team_templates_factory.py + factory service.
+
+Covers the yaml-file API surface (list / read / write) plus the safety
+properties: yaml validation, path-traversal guard, .bak rotation. We point
+the service at a temp directory so the real ``backend/team_templates``
+yamls are never touched.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from core import auth as core_auth
+
+
+_API_KEY = "unit-test-master-key-team-templates-factory"
+
+
+@pytest.fixture(autouse=True)
+def _auth(monkeypatch):
+    monkeypatch.setenv("JARVIS_API_KEY", _API_KEY)
+    monkeypatch.setattr(core_auth, "JARVIS_API_KEY", _API_KEY)
+
+
+@pytest.fixture()
+def factory_dir(tmp_path, monkeypatch):
+    """Redirect the factory service at a fresh temp directory and seed it
+    with two valid yamls + one malformed one for read-tolerance coverage.
+    """
+    d = tmp_path / "team_templates"
+    d.mkdir()
+    (d / "agile_team.yaml").write_text(
+        "name: agile-team\n"
+        "description: Agile crew with PM + Dev\n"
+        "orchestrator: pm\n"
+        "roles:\n"
+        "  pm: {role_display: PM, instruction: do orchestration}\n",
+        encoding="utf-8",
+    )
+    (d / "research_team.yaml").write_text(
+        "team:\n"
+        "  name: research-team\n"
+        "  description: Research crew\n"
+        "  orchestrator: lead\n"
+        "  roles:\n"
+        "    lead: {role_display: Lead, instruction: investigate}\n",
+        encoding="utf-8",
+    )
+    (d / "broken.yaml").write_text("name: broken\n: not valid yaml: [\n", encoding="utf-8")
+
+    from services import team_template_factory_service as svc
+    monkeypatch.setattr(svc, "_FACTORY_DIR", d.resolve())
+    return d
+
+
+@pytest.fixture()
+def client(factory_dir):
+    from routes.team_templates_factory import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _h() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_API_KEY}"}
+
+
+# ── Auth ───────────────────────────────────────────────────────────────────
+
+
+class TestAuth:
+    def test_list_requires_bearer(self, client):
+        assert client.get("/api/team-templates").status_code == 401
+
+    def test_read_requires_bearer(self, client):
+        assert client.get("/api/team-templates/agile_team").status_code == 401
+
+    def test_write_requires_bearer(self, client):
+        r = client.put("/api/team-templates/agile_team", json={"content": "name: x\n"})
+        assert r.status_code == 401
+
+
+# ── List ───────────────────────────────────────────────────────────────────
+
+
+class TestList:
+    def test_lists_factory_yamls(self, client):
+        r = client.get("/api/team-templates", headers=_h())
+        assert r.status_code == 200
+        names = sorted(t["name"] for t in r.json()["templates"])
+        assert names == ["agile_team", "broken", "research_team"]
+
+    def test_picks_up_display_name_from_either_layout(self, client):
+        r = client.get("/api/team-templates", headers=_h())
+        by_name = {t["name"]: t for t in r.json()["templates"]}
+        # Top-level "name:" layout
+        assert by_name["agile_team"]["display_name"] == "agile-team"
+        # "team:" nested layout
+        assert by_name["research_team"]["display_name"] == "research-team"
+        # Malformed → falls back to stem
+        assert by_name["broken"]["display_name"] == "broken"
+
+
+# ── Read ───────────────────────────────────────────────────────────────────
+
+
+class TestRead:
+    def test_returns_raw_and_parsed(self, client):
+        r = client.get("/api/team-templates/agile_team", headers=_h())
+        assert r.status_code == 200
+        body = r.json()
+        assert body["name"] == "agile_team"
+        assert body["filename"] == "agile_team.yaml"
+        assert body["parsed"]["name"] == "agile-team"
+        assert "pm" in body["parsed"]["roles"]
+        assert body["exists"] is True
+        assert body["size"] > 0
+        assert "parse_error" not in body
+
+    def test_malformed_returns_content_with_parse_error(self, client):
+        r = client.get("/api/team-templates/broken", headers=_h())
+        assert r.status_code == 200
+        body = r.json()
+        assert body["parsed"] is None
+        assert "parse_error" in body
+        assert body["content"]  # raw still returned for hand-edit recovery
+
+    def test_unknown_404(self, client):
+        r = client.get("/api/team-templates/does_not_exist", headers=_h())
+        assert r.status_code == 404
+
+    def test_dotfile_name_400(self, client):
+        # Encoded ../ is normalised away by starlette before matching the
+        # single-segment {name} converter, so the dangerous shape never
+        # reaches our handler. We assert the in-band dot-prefix guard fires
+        # for the closest thing that DOES match the route.
+        r = client.get("/api/team-templates/.evil", headers=_h())
+        assert r.status_code == 400
+
+
+# ── Write ──────────────────────────────────────────────────────────────────
+
+
+class TestWrite:
+    def test_overwrites_and_rotates_bak(self, client, factory_dir):
+        new = "name: agile-team\ndescription: updated\nroles:\n  pm: {}\n"
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": new},
+            headers=_h(),
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["saved"] is True
+        # File rewritten
+        on_disk = (factory_dir / "agile_team.yaml").read_text(encoding="utf-8")
+        assert on_disk == new
+        # .bak captured prior content
+        backup = factory_dir / "agile_team.yaml.bak"
+        assert backup.exists()
+        assert "Agile crew" in backup.read_text(encoding="utf-8")
+
+    def test_creates_new_template(self, client, factory_dir):
+        r = client.put(
+            "/api/team-templates/brand_new_team",
+            json={"content": "name: brand-new\nroles:\n  lead: {}\n"},
+            headers=_h(),
+        )
+        assert r.status_code == 200
+        assert (factory_dir / "brand_new_team.yaml").exists()
+
+    def test_invalid_yaml_400(self, client, factory_dir):
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": ": broken: [\n"},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+        # Original content must NOT have been overwritten
+        original = (factory_dir / "agile_team.yaml").read_text(encoding="utf-8")
+        assert "Agile crew" in original
+
+    def test_dotfile_name_blocked(self, client, factory_dir):
+        r = client.put(
+            "/api/team-templates/.evil",
+            json={"content": "name: x\n"},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+        assert not (factory_dir / ".evil.yaml").exists()
+
+
+# ── Service-level: dotted name + nested name rejection ────────────────────
+
+
+class TestServiceGuards:
+    def test_leading_dot_rejected(self, factory_dir):
+        from services import team_template_factory_service as svc
+        with pytest.raises(svc.PathTraversalError):
+            svc._resolve(".hidden")
+
+    def test_slash_rejected(self, factory_dir):
+        from services import team_template_factory_service as svc
+        with pytest.raises(svc.PathTraversalError):
+            svc._resolve("nested/path")
+
+    def test_oversize_rejected(self, factory_dir):
+        from services import team_template_factory_service as svc
+        too_big = "x" * (svc.MAX_BYTES + 1)
+        with pytest.raises(svc.ValidationError):
+            svc.write_factory_template("agile_team", too_big)

--- a/backend/tests/test_routes/test_team_templates_factory.py
+++ b/backend/tests/test_routes/test_team_templates_factory.py
@@ -184,6 +184,72 @@ class TestWrite:
         original = (factory_dir / "agile_team.yaml").read_text(encoding="utf-8")
         assert "Agile crew" in original
 
+    def test_structurally_invalid_no_roles_400(self, client, factory_dir):
+        # Parses cleanly but has no `roles` mapping — would brick spawn_team.
+        # Critical: this is the path team_template_write_factory MCP tool
+        # takes, so an unattended LLM must not be able to write this shape.
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": "name: agile-team\ndescription: no roles here\n"},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+        assert "roles" in r.json()["detail"]["message"].lower()
+        # Original content preserved
+        assert "Agile crew" in (factory_dir / "agile_team.yaml").read_text(encoding="utf-8")
+
+    def test_structurally_invalid_roles_is_list_400(self, client, factory_dir):
+        # `roles:` exists but is a list, not a mapping — also brick-shaped.
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": "name: agile-team\nroles:\n  - pm\n  - dev\n"},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+
+    def test_structurally_invalid_role_config_not_mapping_400(self, client, factory_dir):
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": "name: agile-team\nroles:\n  pm: not-a-mapping\n"},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+
+    def test_structurally_invalid_empty_roles_400(self, client, factory_dir):
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": "name: agile-team\nroles: {}\n"},
+            headers=_h(),
+        )
+        assert r.status_code == 400
+
+    def test_accepts_team_nested_layout(self, client, factory_dir):
+        # The other layout the spawner accepts: `team: {roles: {...}}`.
+        # Must save fine (research_team.yaml uses this shape).
+        new = (
+            "team:\n"
+            "  name: agile-team\n"
+            "  roles:\n"
+            "    pm:\n"
+            "      role_display: PM\n"
+        )
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": new},
+            headers=_h(),
+        )
+        assert r.status_code == 200
+
+    def test_accepts_empty_role_config(self, client, factory_dir):
+        # An empty role dict is valid — the spawner falls back to defaults.
+        new = "name: agile-team\nroles:\n  pm: {}\n"
+        r = client.put(
+            "/api/team-templates/agile_team",
+            json={"content": new},
+            headers=_h(),
+        )
+        assert r.status_code == 200
+
     def test_dotfile_name_blocked(self, client, factory_dir):
         r = client.put(
             "/api/team-templates/.evil",

--- a/backend/tests/test_services/test_team_template_rpc_handlers.py
+++ b/backend/tests/test_services/test_team_template_rpc_handlers.py
@@ -1,0 +1,259 @@
+"""Tests for services/team_template_rpc_handlers.py.
+
+The handlers wrap two services (factory yaml + DB-level running template).
+We mock the store + DB the same way the route tests do and assert each
+RPC method returns the documented envelope (success dict or
+``{"error", "status"}``).
+"""
+from __future__ import annotations
+
+import asyncio
+import copy
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from core.database import Base
+
+
+# ── DB fixture (shared with route tests' style) ────────────────────────────
+
+
+@pytest.fixture()
+def session_factory(tmp_path, monkeypatch):
+    db_file = tmp_path / "rpc_test.db"
+    engine = create_engine(
+        f"sqlite:///{db_file}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(bind=engine)
+    SessionFactory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    import core.database as core_db
+    monkeypatch.setattr(core_db, "SessionLocal", SessionFactory)
+    yield SessionFactory
+    engine.dispose()
+
+
+# ── Fake team-sessions store ──────────────────────────────────────────────
+
+
+@pytest.fixture()
+def fake_store(monkeypatch):
+    store_state = {
+        "ses-1": {
+            "session_id": "ses-1",
+            "template": {
+                "name": "agile-team",
+                "orchestrator": "pm",
+                "roles": {
+                    "qe": {
+                        "role_display": "QE",
+                        "instruction": "you are QE",
+                        "servers": ["filesystem"],
+                        "skills": ["qe-workflow"],
+                        "model": "",
+                        "server_overrides": {},
+                    },
+                },
+            },
+        },
+    }
+    from services import team_template_service as svc_mod
+
+    monkeypatch.setattr(
+        svc_mod, "_get_team_session_dict",
+        lambda sid: copy.deepcopy(store_state[sid]) if sid in store_state
+        else (_ for _ in ()).throw(svc_mod.NotFoundError(sid)),
+    )
+    monkeypatch.setattr(
+        svc_mod, "_put_team_session_dict",
+        lambda sid, data: store_state.__setitem__(sid, copy.deepcopy(data)),
+    )
+    return store_state
+
+
+# ── Factory yaml dir ──────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def factory_dir(tmp_path, monkeypatch):
+    d = tmp_path / "team_templates"
+    d.mkdir()
+    (d / "agile_team.yaml").write_text(
+        "name: agile-team\n"
+        "roles:\n"
+        "  qe:\n"
+        "    role_display: QE\n"
+        "    instruction: factory qe\n"
+        "    servers: [filesystem, scrapling-server]\n"
+        "    skills: [qe-workflow]\n",
+        encoding="utf-8",
+    )
+    from services import team_template_factory_service as fsvc
+    monkeypatch.setattr(fsvc, "_FACTORY_DIR", d.resolve())
+    return d
+
+
+# ── Tests: factory surface ────────────────────────────────────────────────
+
+
+class TestFactorySurface:
+    def test_list(self, factory_dir):
+        from services.team_template_rpc_handlers import _factory_list
+
+        out = _factory_list()
+        names = [t["name"] for t in out["templates"]]
+        assert "agile_team" in names
+
+    def test_read_ok(self, factory_dir):
+        from services.team_template_rpc_handlers import _factory_read
+
+        out = _factory_read(name="agile_team")
+        assert out["parsed"]["name"] == "agile-team"
+        assert "error" not in out
+
+    def test_read_404(self, factory_dir):
+        from services.team_template_rpc_handlers import _factory_read
+
+        out = _factory_read(name="missing")
+        assert out == {"error": out["error"], "status": 404}
+        assert "missing" in out["error"]
+
+    def test_write_ok_persists_to_disk(self, factory_dir):
+        from services.team_template_rpc_handlers import _factory_write
+
+        new = "name: agile-team\nroles:\n  qe: {}\n"
+        out = _factory_write(name="agile_team", content=new)
+        assert out["saved"] is True
+        assert (factory_dir / "agile_team.yaml").read_text(encoding="utf-8") == new
+
+    def test_write_invalid_yaml_400(self, factory_dir):
+        from services.team_template_rpc_handlers import _factory_write
+
+        out = _factory_write(name="agile_team", content=": broken: [\n")
+        assert out["status"] == 400
+
+
+# ── Tests: running surface ────────────────────────────────────────────────
+
+
+class TestRunningSurface:
+    def test_get_returns_template(self, session_factory, fake_store):
+        from services.team_template_rpc_handlers import _running_get
+
+        out = _running_get(session_id="ses-1")
+        assert out["template"]["roles"]["qe"]["servers"] == ["filesystem"]
+
+    def test_get_unknown_session_404(self, session_factory, fake_store):
+        from services.team_template_rpc_handlers import _running_get
+
+        out = _running_get(session_id="nope")
+        assert out["status"] == 404
+
+    def test_patch_role_writes_audit_and_persists(
+        self, session_factory, fake_store
+    ):
+        from services.team_template_rpc_handlers import _running_patch_role
+
+        out = _running_patch_role(
+            session_id="ses-1",
+            role="qe",
+            patch={"servers": ["filesystem", "playwright"]},
+            comment="add playwright",
+        )
+        assert out["session_id"] == "ses-1"
+        assert "audit_ids" in out and len(out["audit_ids"]) == 1
+        # SSoT mutated
+        assert "playwright" in fake_store["ses-1"]["template"]["roles"]["qe"]["servers"]
+
+    def test_patch_role_invalid_field_400(self, session_factory, fake_store):
+        from services.team_template_rpc_handlers import _running_patch_role
+
+        out = _running_patch_role(
+            session_id="ses-1",
+            role="qe",
+            patch={"not_a_field": True},
+        )
+        assert out["status"] == 400
+
+    def test_patch_role_unknown_role_404(self, session_factory, fake_store):
+        from services.team_template_rpc_handlers import _running_patch_role
+
+        out = _running_patch_role(
+            session_id="ses-1",
+            role="unknown",
+            patch={"servers": ["x"]},
+        )
+        assert out["status"] == 404
+
+    def test_history_then_rollback(self, session_factory, fake_store):
+        from services.team_template_rpc_handlers import (
+            _running_history,
+            _running_patch_role,
+            _running_rollback,
+        )
+
+        patch_out = _running_patch_role(
+            session_id="ses-1",
+            role="qe",
+            patch={"instruction": "edited via mcp"},
+        )
+        audit_id = patch_out["audit_ids"][0]
+
+        hist = _running_history(session_id="ses-1")
+        assert hist["count"] >= 1
+
+        rb = _running_rollback(session_id="ses-1", audit_id=audit_id)
+        assert "audit_ids" in rb
+        # Rolled back to original value
+        assert (
+            fake_store["ses-1"]["template"]["roles"]["qe"]["instruction"]
+            == "you are QE"
+        )
+
+    def test_yaml_diff_detects_drift(
+        self, session_factory, fake_store, factory_dir
+    ):
+        from services.team_template_rpc_handlers import _running_yaml_diff
+
+        out = _running_yaml_diff(session_id="ses-1")
+        # Factory yaml has servers=[filesystem, scrapling-server], DB has [filesystem]
+        assert out["in_sync"] is False
+        assert out["per_role"]["qe"]["status"] == "diverged"
+        assert "servers" in out["per_role"]["qe"]["fields"]
+
+    def test_reset_role_to_yaml_factory(
+        self, session_factory, fake_store, factory_dir
+    ):
+        from services.team_template_rpc_handlers import _running_reset_role
+
+        out = _running_reset_role(session_id="ses-1", role="qe")
+        assert "audit_ids" in out
+        # DB role now matches the factory yaml
+        assert sorted(
+            fake_store["ses-1"]["template"]["roles"]["qe"]["servers"]
+        ) == sorted(["filesystem", "scrapling-server"])
+
+    def test_reload_empty_roles_400(self, session_factory, fake_store):
+        from services.team_template_rpc_handlers import _running_reload
+
+        out = asyncio.run(_running_reload(session_id="ses-1", roles=[]))
+        assert out["status"] == 400
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+
+class TestRegistration:
+    def test_register_attaches_every_method(self):
+        from services import team_template_rpc_handlers as rpc
+
+        registered: dict[str, object] = {}
+
+        class FakeServer:
+            def register(self, name, handler, **kw):
+                registered[name] = handler
+
+        rpc.register(FakeServer())
+        for method in rpc._METHODS:
+            assert method in registered, f"missing RPC method {method}"

--- a/backend/tools/team_template_server.py
+++ b/backend/tools/team_template_server.py
@@ -1,0 +1,261 @@
+"""MCP tool server — exposes team-template edit/inspect to Jarvis agents.
+
+Two surfaces:
+
+  Factory yaml  (``backend/team_templates/*.yaml``):
+    team_template_list_factory, team_template_read_factory,
+    team_template_write_factory.
+
+  Running team  (DB SSoT per ``team_sessions``):
+    team_template_get_running, team_template_patch_role,
+    team_template_history, team_template_rollback,
+    team_template_reset_role, team_template_yaml_diff,
+    team_template_reload.
+
+Trust model: delegates to the live backend via the RuntimeRpcServer Unix
+socket. No HTTP, no API key — same pattern as ``tools/mcp_admin_server.py``.
+
+Decision 2026-05-17 (factory yaml = factory default, not continuous source):
+* ``write_factory`` mutates the yaml only. It does NOT update running teams.
+  To apply the yaml edit to a live team, call ``yaml_diff`` to confirm
+  drift, then ``reset_role`` (per role) or ``reload`` (destructive: kills
+  agents) once the user has confirmed.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.runtime_rpc_client import RuntimeRpcError, call as rpc_call  # noqa: E402
+
+logger = logging.getLogger("team_template_server")
+mcp = FastMCP("TeamTemplate")
+
+
+def _bridge_error(exc: Exception) -> dict:
+    return {
+        "error": (
+            "Could not reach the main backend RPC bridge. The team_template "
+            f"subprocess is up but the runtime socket isn't responding: {exc}"
+        ),
+        "status": 503,
+    }
+
+
+def _delegate(method: str, params: dict | None = None) -> dict:
+    """Pass through to the in-process RPC handler.
+
+    No experimental gate (per user decision 2026-05-31): team-template edit
+    is part of the standard self-management surface.
+    """
+    try:
+        return rpc_call(method, params)
+    except RuntimeRpcError as exc:
+        return _bridge_error(exc)
+
+
+# ── Factory yaml ──────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def team_template_list_factory() -> dict:
+    """List every team-template yaml in ``backend/team_templates/``.
+
+    Returns ``{"templates": [{name, filename, display_name, description, size, exists}]}``.
+    These are the **factory defaults** used at team-creation time. Editing
+    them does NOT touch already-running teams — see ``team_template_yaml_diff``
+    for the drift view.
+    """
+    return _delegate("team_template.factory.list")
+
+
+@mcp.tool()
+def team_template_read_factory(name: str) -> dict:
+    """Read one factory yaml.
+
+    Args:
+        name: filename stem (``agile_team``, ``research_team``, ...).
+
+    Returns ``{name, filename, content, parsed, exists, size}``. When the
+    yaml is malformed, ``parsed`` is ``None`` and ``parse_error`` carries
+    the parser message — useful to recover a hand-edited file.
+    """
+    return _delegate("team_template.factory.read", {"name": name})
+
+
+@mcp.tool()
+def team_template_write_factory(name: str, content: str) -> dict:
+    """Overwrite one factory yaml (creates if missing).
+
+    Args:
+        name: filename stem. New names create a new yaml.
+        content: full yaml text. Validated with ``yaml.safe_load`` before
+                 write; rejected on parse error.
+
+    Side effects: rotates previous content into ``<name>.yaml.bak``,
+    atomic write via temp + rename. Does NOT update running teams. Use
+    ``team_template_yaml_diff`` to see drift and ``team_template_reload``
+    (destructive) or ``team_template_reset_role`` to apply per running team.
+    """
+    return _delegate(
+        "team_template.factory.write",
+        {"name": name, "content": content},
+    )
+
+
+# ── Running team ──────────────────────────────────────────────────────────
+
+
+@mcp.tool()
+def team_template_get_running(session_id: str) -> dict:
+    """Return the live template for a team session (DB SSoT, no cache).
+
+    Args:
+        session_id: team-session id (e.g. ``agile-team_ccd1adb9``).
+    """
+    return _delegate("team_template.running.get", {"session_id": session_id})
+
+
+@mcp.tool()
+def team_template_patch_role(
+    session_id: str,
+    role: str,
+    patch: dict[str, Any],
+    comment: str = "",
+) -> dict:
+    """Edit one role's config in a running team. Writes an audit row per field.
+
+    Args:
+        session_id: team-session id.
+        role: role key (``pm``, ``qe``, ``dev``, ...).
+        patch: subset of {instruction, servers, skills, server_overrides, model, role_display}.
+        comment: free-text audit comment (shown in history UI).
+
+    Returns ``{audit_ids, diff, after_role, edited_at}``. Edit is
+    persisted to DB only — to survive a team recreate, also commit the
+    equivalent change to the factory yaml via ``team_template_write_factory``.
+    """
+    return _delegate(
+        "team_template.running.patch_role",
+        {"session_id": session_id, "role": role, "patch": patch, "comment": comment},
+    )
+
+
+@mcp.tool()
+def team_template_history(
+    session_id: str,
+    role: str | None = None,
+    limit: int = 50,
+) -> dict:
+    """Audit log for a team session (newest first).
+
+    Args:
+        session_id: team-session id.
+        role: filter by role (omit for all).
+        limit: max rows (1..500, default 50).
+    """
+    return _delegate(
+        "team_template.running.history",
+        {"session_id": session_id, "role": role, "limit": limit},
+    )
+
+
+@mcp.tool()
+def team_template_rollback(
+    session_id: str,
+    audit_id: int,
+    comment: str = "",
+) -> dict:
+    """Revert one field to the ``before`` value of the named audit row.
+
+    Args:
+        session_id: team-session id.
+        audit_id: id from ``team_template_history``.
+        comment: free-text reason.
+
+    Writes a NEW audit row (``source='rollback'``); the original row is kept.
+    If multiple edits touched the same field after the target, rolling back
+    will silently discard the intermediate edits — pick the right audit_id.
+    """
+    return _delegate(
+        "team_template.running.rollback",
+        {"session_id": session_id, "audit_id": audit_id, "comment": comment},
+    )
+
+
+@mcp.tool()
+def team_template_reset_role(
+    session_id: str,
+    role: str,
+    comment: str = "",
+) -> dict:
+    """Reset one role's config back to its factory yaml defaults.
+
+    Args:
+        session_id: team-session id.
+        role: role key.
+        comment: free-text audit reason.
+
+    Other roles' state (including UI edits) is preserved. Use this after
+    ``team_template_write_factory`` to pull a yaml edit into a running team
+    without killing the agents (cf. ``team_template_reload`` which does kill).
+    """
+    return _delegate(
+        "team_template.running.reset_role",
+        {"session_id": session_id, "role": role, "comment": comment},
+    )
+
+
+@mcp.tool()
+def team_template_yaml_diff(session_id: str) -> dict:
+    """Compare the running team's template with its factory yaml.
+
+    Args:
+        session_id: team-session id.
+
+    Returns ``{in_sync, diverged_count, per_role: {<role>: {status, fields}}}``.
+    READ-ONLY — never mutates the running team. Use to inspect drift after a
+    factory-yaml edit before choosing ``reset_role`` or ``reload``.
+    """
+    return _delegate(
+        "team_template.running.yaml_diff",
+        {"session_id": session_id},
+    )
+
+
+@mcp.tool()
+def team_template_reload(
+    session_id: str,
+    roles: list[str],
+    inject_message: str | None = None,
+) -> dict:
+    """DESTRUCTIVE — SIGKILL + respawn every agent in the named roles.
+
+    Args:
+        session_id: team-session id.
+        roles: role keys to reload. Must be non-empty.
+        inject_message: optional override for the sentinel message injected
+                        into respawned agents' inbox (default: generic notice).
+
+    Use only after user confirmation (the UI shows a warning before calling).
+    Agents mid-task are killed without a wait-for-idle. Respawn re-reads the
+    DB SSoT, so any patches applied to those roles take effect immediately.
+    """
+    return _delegate(
+        "team_template.running.reload",
+        {
+            "session_id": session_id,
+            "roles": roles,
+            "inject_message": inject_message,
+        },
+    )
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "marked-highlight": "^2.2.4",
         "mermaid": "^11.15.0",
         "pinia": "^3.0.4",
+        "v-code-diff": "^1.13.1",
         "vue": "^3.5.34",
         "vue-codemirror": "^6.1.1",
         "vue-router": "^5.0.7",
@@ -2840,6 +2841,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/dompurify": {
       "version": "3.4.5",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
@@ -3990,6 +4006,54 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/v-code-diff": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/v-code-diff/-/v-code-diff-1.13.1.tgz",
+      "integrity": "sha512-9LTV1dZhC1oYTntyB94vfumGgsfIX5u0fEDSI2Txx4vCE5sI5LkgeLJRRy2SsTVZmDcV+R73sBr0GpPn0TJxMw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff": "^5.2.0",
+        "diff-match-patch": "^1.0.5",
+        "highlight.js": "^11.10.0",
+        "vue-demi": "^0.14.6"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.9",
+        "vue": "^2.6.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/v-code-diff/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "marked-highlight": "^2.2.4",
     "mermaid": "^11.15.0",
     "pinia": "^3.0.4",
+    "v-code-diff": "^1.13.1",
     "vue": "^3.5.34",
     "vue-codemirror": "^6.1.1",
     "vue-router": "^5.0.7",

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -14,6 +14,7 @@ import { ref } from 'vue'
 import SettingsGeneral from './settings/SettingsGeneral.vue'
 import SettingsAuth from './settings/SettingsAuth.vue'
 import SettingsYaml from './settings/SettingsYaml.vue'
+import SettingsRunningTemplates from './settings/SettingsRunningTemplates.vue'
 import SettingsServices from './settings/SettingsServices.vue'
 import SettingsLLM from './settings/SettingsLLM.vue'
 import SettingsVoice from './settings/SettingsVoice.vue'
@@ -26,6 +27,7 @@ const TABS = [
   { id: 'voice',        label: 'Voice',          eyebrow: 'MODELS' },
   { id: 'services',     label: 'Services',       eyebrow: 'INTEGRATIONS' },
   { id: 'yaml',         label: 'YAML Config',    eyebrow: 'INTEGRATIONS' },
+  { id: 'running-tmpl', label: 'Running Templates', eyebrow: 'INTEGRATIONS' },
   { id: 'experimental', label: 'Experimental',   eyebrow: 'ADVANCED' },
 ]
 const active = ref('general')
@@ -86,6 +88,7 @@ function labelFor(id) {
         <SettingsLLM v-else-if="active === 'llm'" />
         <SettingsVoice v-else-if="active === 'voice'" />
         <SettingsYaml v-else-if="active === 'yaml'" />
+        <SettingsRunningTemplates v-else-if="active === 'running-tmpl'" />
         <SettingsServices v-else-if="active === 'services'" />
         <SettingsExperimental v-else-if="active === 'experimental'" />
       </section>

--- a/frontend/src/views/settings/SettingsRunningTemplates.vue
+++ b/frontend/src/views/settings/SettingsRunningTemplates.vue
@@ -1,0 +1,1214 @@
+<script setup>
+/**
+ * Settings → Running Templates.
+ *
+ * Per-session view of the LIVE team-template state (DB SSoT). Pairs with the
+ * YAML Config tab which edits the factory yaml files — those edits don't
+ * touch already-running teams; this tab is where you actually apply them.
+ *
+ * Three primary actions per role:
+ *   • Edit fields (instruction / servers / skills / model / server_overrides /
+ *     role_display) — PATCH /api/team-sessions/{id}/template/roles/{role}.
+ *   • Reset to yaml factory — POST .../template/reset/{role}.
+ *   • Force-reload (SIGKILL + respawn agents) — POST .../reload. Confirmed.
+ *
+ * History rail on the right: every audit row for the session, with rollback.
+ *
+ * Banner: per decision 2026-05-17, edits land in DB only. The banner makes
+ * that explicit so the user doesn't expect yaml to follow along.
+ */
+import { ref, computed, watch, onMounted } from 'vue'
+import { CodeDiff } from 'v-code-diff'
+import { apiFetch, ApiError } from '../../api'
+import { useConfirm } from '../../composables/useConfirm'
+
+const { confirm } = useConfirm()
+
+const sessions = ref([])
+const activeSessionId = ref(null)
+const template = ref(null)
+const history = ref([])
+const yamlDiff = ref(null)
+const loading = ref(false)
+const error = ref('')
+const successMsg = ref('')
+
+// Per-role draft state — keyed by role name. We start drafts from the
+// fetched template every time the user switches roles (or saves) so the
+// "dirty" indicator reflects only their pending edits.
+const activeRole = ref(null)
+const draft = ref(null)
+const saving = ref(false)
+const resetting = ref(false)
+const reloading = ref(false)
+const rollingBack = ref(null)  // audit_id while in-flight
+
+// "Reset to yaml" opens a 3-way modal (Cancel / Sync only / Sync + Force
+// reload) so the user doesn't have to remember the two-step sequence —
+// the underlying API is still two calls, but the UI hides the coupling.
+const resetModal = ref({ visible: false, busy: false, mode: null })
+
+// Per-role / per-field diff viewer — reads the yamlDiff response we
+// already fetch in loadTemplate(), so no extra round-trip.
+const diffModal = ref({ visible: false })
+
+const activeSession = computed(
+  () => sessions.value.find((s) => s.session_id === activeSessionId.value) || null,
+)
+const roles = computed(() => template.value?.roles || {})
+const roleEntries = computed(() => Object.entries(roles.value))
+const driftByRole = computed(() => {
+  const out = {}
+  if (yamlDiff.value?.per_role) {
+    for (const [k, v] of Object.entries(yamlDiff.value.per_role)) out[k] = v.status
+  }
+  return out
+})
+
+const dirty = computed(() => {
+  if (!draft.value || !activeRole.value) return false
+  const live = roles.value[activeRole.value]
+  if (!live) return false
+  return (
+    draft.value.instruction !== (live.instruction || '') ||
+    draft.value.role_display !== (live.role_display || '') ||
+    draft.value.model !== (live.model || '') ||
+    draft.value.servers_text !== (live.servers || []).join('\n') ||
+    draft.value.skills_text !== (live.skills || []).join('\n') ||
+    draft.value.server_overrides_text !==
+      JSON.stringify(live.server_overrides || {}, null, 2)
+  )
+})
+
+
+// ── Network ──────────────────────────────────────────────────────────────
+
+
+async function loadSessions() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await apiFetch('/api/team-sessions')
+    sessions.value = res?.sessions || []
+    if (!activeSessionId.value && sessions.value.length) {
+      activeSessionId.value = sessions.value[0].session_id
+    }
+  } catch (err) {
+    error.value = _friendly(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadTemplate(sid) {
+  if (!sid) return
+  loading.value = true
+  error.value = ''
+  successMsg.value = ''
+  try {
+    const [tmpl, hist, diff] = await Promise.all([
+      apiFetch(`/api/team-sessions/${encodeURIComponent(sid)}/template`),
+      apiFetch(`/api/team-sessions/${encodeURIComponent(sid)}/template/history?limit=100`),
+      apiFetch(`/api/team-sessions/${encodeURIComponent(sid)}/template/yaml-diff`).catch(() => null),
+    ])
+    template.value = tmpl?.template || null
+    history.value = hist?.rows || []
+    yamlDiff.value = diff
+    // Pick first role by default; preserves selection across reloads if
+    // the role still exists.
+    const keys = Object.keys(template.value?.roles || {})
+    if (!activeRole.value || !keys.includes(activeRole.value)) {
+      activeRole.value = keys[0] || null
+    }
+    _seedDraft()
+  } catch (err) {
+    error.value = _friendly(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+function _seedDraft() {
+  const r = activeRole.value ? roles.value[activeRole.value] : null
+  if (!r) {
+    draft.value = null
+    return
+  }
+  draft.value = {
+    instruction: r.instruction || '',
+    role_display: r.role_display || '',
+    model: r.model || '',
+    servers_text: (r.servers || []).join('\n'),
+    skills_text: (r.skills || []).join('\n'),
+    server_overrides_text: JSON.stringify(r.server_overrides || {}, null, 2),
+  }
+}
+
+function _splitLines(text) {
+  return (text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function _buildPatch() {
+  // Compute the smallest patch that reaches the desired state. Skip fields
+  // that match the current value so the audit log stays focused.
+  if (!draft.value || !activeRole.value) return {}
+  const live = roles.value[activeRole.value] || {}
+  const patch = {}
+  if (draft.value.instruction !== (live.instruction || '')) {
+    patch.instruction = draft.value.instruction
+  }
+  if (draft.value.role_display !== (live.role_display || '')) {
+    patch.role_display = draft.value.role_display
+  }
+  if (draft.value.model !== (live.model || '')) {
+    patch.model = draft.value.model
+  }
+  const servers = _splitLines(draft.value.servers_text)
+  const liveServers = [...(live.servers || [])].sort()
+  if (JSON.stringify([...servers].sort()) !== JSON.stringify(liveServers)) {
+    patch.servers = servers
+  }
+  const skills = _splitLines(draft.value.skills_text)
+  const liveSkills = [...(live.skills || [])].sort()
+  if (JSON.stringify([...skills].sort()) !== JSON.stringify(liveSkills)) {
+    patch.skills = skills
+  }
+  if (draft.value.server_overrides_text.trim()) {
+    let parsed
+    try {
+      parsed = JSON.parse(draft.value.server_overrides_text)
+    } catch {
+      throw new Error('server_overrides must be valid JSON')
+    }
+    if (
+      JSON.stringify(parsed) !==
+      JSON.stringify(live.server_overrides || {})
+    ) {
+      patch.server_overrides = parsed
+    }
+  }
+  return patch
+}
+
+async function onSaveRole() {
+  if (!activeRole.value || !activeSessionId.value) return
+  let patch
+  try {
+    patch = _buildPatch()
+  } catch (err) {
+    error.value = err.message
+    return
+  }
+  if (!Object.keys(patch).length) {
+    successMsg.value = 'No changes to save.'
+    return
+  }
+  saving.value = true
+  error.value = ''
+  successMsg.value = ''
+  try {
+    const r = await apiFetch(
+      `/api/team-sessions/${encodeURIComponent(activeSessionId.value)}/template/roles/${encodeURIComponent(activeRole.value)}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ patch, comment: 'edited from Settings UI' }),
+      },
+    )
+    successMsg.value = `Saved · ${r.audit_ids?.length || 0} audit row(s). ${r.warning || ''}`.trim()
+    await loadTemplate(activeSessionId.value)
+  } catch (err) {
+    error.value = _friendly(err)
+  } finally {
+    saving.value = false
+  }
+}
+
+function onResetRole() {
+  // Just opens the chooser — the actual API call(s) fire from the modal
+  // so the user picks "sync only" or "sync + force reload" first.
+  if (!activeRole.value || !activeSessionId.value) return
+  resetModal.value = { visible: true, busy: false, mode: null }
+}
+
+async function _doResetCall() {
+  return apiFetch(
+    `/api/team-sessions/${encodeURIComponent(activeSessionId.value)}/template/reset/${encodeURIComponent(activeRole.value)}`,
+    { method: 'POST', body: JSON.stringify({ comment: 'reset from Settings UI' }) },
+  )
+}
+
+async function _doReloadCall() {
+  return apiFetch(
+    `/api/team-sessions/${encodeURIComponent(activeSessionId.value)}/reload`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ roles: [activeRole.value], confirm: true }),
+    },
+  )
+}
+
+async function onResetModalConfirm(mode) {
+  // mode: 'sync-only' — pull yaml → DB. Running agents keep using stale
+  //                     in-memory template until the next natural restart.
+  //       'sync-and-reload' — same DB write, then SIGKILL+respawn agents
+  //                     so the new template takes effect immediately.
+  resetModal.value = { ...resetModal.value, busy: true, mode }
+  resetting.value = true
+  error.value = ''
+  successMsg.value = ''
+  try {
+    const r = await _doResetCall()
+    let respawned = 0
+    if (mode === 'sync-and-reload') {
+      reloading.value = true
+      try {
+        const rl = await _doReloadCall()
+        respawned = Object.values(rl.results || {}).flat().length
+      } finally {
+        reloading.value = false
+      }
+    }
+    const fields = r.audit_ids?.length || 0
+    successMsg.value =
+      mode === 'sync-and-reload'
+        ? `Reset · ${fields} field(s) synced from yaml · ${respawned} agent(s) respawned.`
+        : `Reset · ${fields} field(s) synced from yaml. Running agents will pick up the change on next restart — click "Force reload" to apply now.`
+    resetModal.value = { visible: false, busy: false, mode: null }
+    await loadTemplate(activeSessionId.value)
+  } catch (err) {
+    error.value = _friendly(err)
+    resetModal.value = { ...resetModal.value, busy: false }
+  } finally {
+    resetting.value = false
+  }
+}
+
+function onResetModalCancel() {
+  if (resetModal.value.busy) return
+  resetModal.value = { visible: false, busy: false, mode: null }
+}
+
+function onShowDiff() {
+  diffModal.value = { visible: true }
+}
+
+function onCloseDiff() {
+  diffModal.value = { visible: false }
+}
+
+function formatDiffValue(v) {
+  // Stable, human-readable rendering for any of: string, list-of-strings,
+  // object. v-code-diff expects strings; pretty-JSON non-strings so the
+  // structural shape is obvious in both sides.
+  if (v === null || v === undefined) return ''
+  if (typeof v === 'string') return v
+  return JSON.stringify(v, null, 2)
+}
+
+// Layout toggle for the v-code-diff component. Persisted in localStorage
+// so the user's preference sticks across tab switches / refreshes.
+const diffLayout = ref(
+  (typeof localStorage !== 'undefined' && localStorage.getItem('jv.diff.layout')) || 'unified',
+)
+watch(diffLayout, (v) => {
+  try { localStorage.setItem('jv.diff.layout', v) } catch { /* private mode */ }
+})
+
+function diffLanguageFor(field) {
+  // Hints highlight.js which grammar to use. ``instruction`` is free-form
+  // text; lists/objects are rendered as JSON above; the catch-all is yaml
+  // since the rest of these fields come from yaml originally.
+  if (field === 'instruction') return 'plaintext'
+  if (field === 'server_overrides') return 'json'
+  if (field === 'servers' || field === 'skills') return 'json'
+  return 'yaml'
+}
+
+// Roles to render in the diff modal, in this order:
+//   1. The currently-active role first (so the user lands on the role
+//      they were just editing).
+//   2. Then any other diverged roles.
+//   3. In-sync / unchanged roles are dropped — the modal title already
+//      says "diff", listing in-sync rows would just be noise.
+const diffRolesOrdered = computed(() => {
+  const per = yamlDiff.value?.per_role || {}
+  const entries = Object.entries(per).filter(([, v]) => v.status !== 'in_sync')
+  entries.sort(([a], [b]) => {
+    if (a === activeRole.value) return -1
+    if (b === activeRole.value) return 1
+    return a.localeCompare(b)
+  })
+  return entries
+})
+
+async function onReloadRole() {
+  if (!activeRole.value || !activeSessionId.value) return
+  const ok = await confirm({
+    title: `Force-reload ${activeRole.value}?`,
+    message: `SIGKILL every agent in this role mid-task and respawn with the current template. This is DESTRUCTIVE — in-progress work in those agents is lost. Continue?`,
+    confirmText: 'Force-kill & respawn',
+    variant: 'danger',
+  })
+  if (!ok) return
+  reloading.value = true
+  error.value = ''
+  successMsg.value = ''
+  try {
+    const r = await apiFetch(
+      `/api/team-sessions/${encodeURIComponent(activeSessionId.value)}/reload`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ roles: [activeRole.value], confirm: true }),
+      },
+    )
+    const respawned = Object.values(r.results || {}).flat().length
+    successMsg.value = `Reload complete · ${respawned} agent(s) respawned.`
+    await loadTemplate(activeSessionId.value)
+  } catch (err) {
+    error.value = _friendly(err)
+  } finally {
+    reloading.value = false
+  }
+}
+
+async function onRollback(auditId) {
+  const ok = await confirm({
+    title: 'Roll back this audit row?',
+    message: 'Writes a new audit row that reverts the field to its previous value. Intermediate edits to the same field will be silently overwritten.',
+    confirmText: 'Rollback',
+    variant: 'warning',
+  })
+  if (!ok) return
+  rollingBack.value = auditId
+  error.value = ''
+  try {
+    await apiFetch(
+      `/api/team-sessions/${encodeURIComponent(activeSessionId.value)}/template/rollback/${auditId}`,
+      { method: 'POST', body: JSON.stringify({ comment: 'rollback from Settings UI' }) },
+    )
+    successMsg.value = `Rolled back audit #${auditId}.`
+    await loadTemplate(activeSessionId.value)
+  } catch (err) {
+    error.value = _friendly(err)
+  } finally {
+    rollingBack.value = null
+  }
+}
+
+function _friendly(err) {
+  if (err instanceof ApiError && err.body && typeof err.body === 'object') {
+    const detail = err.body.detail
+    if (detail && typeof detail === 'object') {
+      return `${detail.message || 'Request failed'} — ${detail.error || ''}`.trim()
+    }
+    if (typeof detail === 'string') return detail
+  }
+  return err?.message || String(err)
+}
+
+function fmtTime(epoch) {
+  if (!epoch) return ''
+  return new Date(epoch * 1000).toLocaleString()
+}
+
+function jsonPreview(v) {
+  const s = JSON.stringify(v)
+  return s.length > 60 ? `${s.slice(0, 57)}…` : s
+}
+
+
+// ── Lifecycle ────────────────────────────────────────────────────────────
+
+watch(activeSessionId, (sid) => sid && loadTemplate(sid))
+watch(activeRole, () => _seedDraft())
+
+onMounted(() => loadSessions())
+</script>
+
+<template>
+  <div class="running-tmpl">
+    <header class="banner">
+      <div class="banner-icon">⚠</div>
+      <div>
+        <strong>Edits live in this team's DB only.</strong>
+        Save here to take effect now; commit the same change to <code>team_templates/&lt;team&gt;.yaml</code>
+        (YAML Config tab) to survive a recreate. Use "Reset role" to pull a yaml edit into this team.
+      </div>
+    </header>
+
+    <!-- Session selector -->
+    <div class="session-bar">
+      <label class="session-label">Team session</label>
+      <select v-model="activeSessionId" class="session-select" :disabled="!sessions.length">
+        <option v-if="!sessions.length" :value="null">No active team sessions</option>
+        <option v-for="s in sessions" :key="s.session_id" :value="s.session_id">
+          {{ s.team_name }} · {{ s.session_id.slice(0, 8) }} · {{ s.agents_count }} agent{{ s.agents_count === 1 ? '' : 's' }}
+        </option>
+      </select>
+      <span v-if="yamlDiff" class="drift-pill" :class="{ insync: yamlDiff.in_sync }">
+        {{ yamlDiff.in_sync ? '✓ in sync with yaml' : `△ ${yamlDiff.diverged_count} role(s) diverged from yaml` }}
+      </span>
+      <button class="btn ghost" type="button" :disabled="loading" @click="loadTemplate(activeSessionId)">
+        Refresh
+      </button>
+    </div>
+
+    <!-- Two-column layout: role list + editor; history rail at far right -->
+    <div class="layout">
+      <aside class="role-list">
+        <div class="tree-eyebrow">ROLES</div>
+        <button
+          v-for="[role, cfg] in roleEntries"
+          :key="role"
+          type="button"
+          class="role-item"
+          :class="{ active: activeRole === role }"
+          @click="activeRole = role"
+        >
+          <span class="role-name">{{ cfg.role_display || role }}</span>
+          <span class="role-key"><code>{{ role }}</code></span>
+          <span
+            v-if="driftByRole[role] && driftByRole[role] !== 'in_sync'"
+            class="drift-dot"
+            :title="`Drift from yaml: ${driftByRole[role]}`"
+          >△</span>
+        </button>
+        <div v-if="!roleEntries.length && !loading" class="empty">No roles in this template.</div>
+      </aside>
+
+      <section class="editor">
+        <header class="editor-head" v-if="activeRole && draft">
+          <div class="title">
+            <code>{{ activeRole }}</code>
+            <span class="muted">·</span>
+            <input v-model="draft.role_display" class="display-input" placeholder="role display name" />
+          </div>
+          <div class="actions">
+            <span v-if="dirty" class="pill dirty">● UNSAVED</span>
+            <button
+              type="button"
+              class="btn ghost"
+              :disabled="!yamlDiff || yamlDiff.in_sync"
+              :title="yamlDiff?.in_sync ? 'DB matches yaml — nothing to diff' : 'Show yaml vs DB diff'"
+              @click="onShowDiff"
+            >
+              View diff
+            </button>
+            <button type="button" class="btn ghost" :disabled="resetting || !activeRole" @click="onResetRole">
+              {{ resetting ? 'Resetting…' : 'Reset to yaml' }}
+            </button>
+            <button type="button" class="btn danger" :disabled="reloading || !activeRole" @click="onReloadRole">
+              {{ reloading ? 'Reloading…' : 'Force reload' }}
+            </button>
+            <button type="button" class="btn primary" :disabled="!dirty || saving" @click="onSaveRole">
+              {{ saving ? 'Saving…' : 'Save' }}
+            </button>
+          </div>
+        </header>
+
+        <div v-if="loading" class="overlay">Loading…</div>
+        <div v-else-if="!activeRole" class="overlay">Pick a role to edit.</div>
+        <div v-else class="editor-body">
+          <label class="field">
+            <span class="fl">Model override</span>
+            <input v-model="draft.model" class="text" placeholder="(empty = inherit team default)" />
+          </label>
+          <label class="field">
+            <span class="fl">Instruction</span>
+            <textarea v-model="draft.instruction" class="textarea" rows="8" />
+          </label>
+          <div class="field-grid">
+            <label class="field">
+              <span class="fl">Servers (one per line)</span>
+              <textarea v-model="draft.servers_text" class="textarea mono" rows="6" />
+            </label>
+            <label class="field">
+              <span class="fl">Skills (one per line)</span>
+              <textarea v-model="draft.skills_text" class="textarea mono" rows="6" />
+            </label>
+          </div>
+          <label class="field">
+            <span class="fl">server_overrides (JSON)</span>
+            <textarea v-model="draft.server_overrides_text" class="textarea mono" rows="6" />
+          </label>
+        </div>
+
+        <footer class="editor-foot">
+          <span v-if="error" class="msg error">✕ {{ error }}</span>
+          <span v-else-if="successMsg" class="msg ok">✓ {{ successMsg }}</span>
+          <span v-else class="msg muted">Allowed fields: instruction, servers, skills, server_overrides, model, role_display.</span>
+        </footer>
+      </section>
+
+      <aside class="history-rail">
+        <div class="tree-eyebrow">HISTORY</div>
+        <div v-if="!history.length" class="empty">No edits yet.</div>
+        <div
+          v-for="row in history"
+          :key="row.id"
+          class="hist-row"
+          :class="{ rollback: row.source === 'rollback', 'yaml-reset': row.source === 'yaml-reset' }"
+        >
+          <div class="hist-line">
+            <code class="hist-role">{{ row.role }}.{{ row.field }}</code>
+            <span class="hist-src">{{ row.source }}</span>
+          </div>
+          <div class="hist-meta">
+            #{{ row.id }} · {{ row.edited_by }} · {{ fmtTime(row.edited_at) }}
+          </div>
+          <div class="hist-diff">
+            <div><span class="muted">−</span> <code>{{ jsonPreview(row.before) }}</code></div>
+            <div><span class="muted">+</span> <code>{{ jsonPreview(row.after) }}</code></div>
+          </div>
+          <div v-if="row.comment" class="hist-comment">{{ row.comment }}</div>
+          <button
+            type="button"
+            class="btn-mini"
+            :disabled="rollingBack === row.id"
+            @click="onRollback(row.id)"
+          >{{ rollingBack === row.id ? '…' : 'Rollback' }}</button>
+        </div>
+      </aside>
+    </div>
+
+    <!-- yaml-vs-DB diff viewer. Per-role section, per-field before/after.
+         Reads yamlDiff (already fetched in loadTemplate) — no extra
+         round-trip. In-sync roles are filtered out — they'd just be
+         noise on a "diff" screen. -->
+    <Teleport to="body">
+      <Transition name="reset-modal">
+        <div v-if="diffModal.visible" class="reset-overlay" @click.self="onCloseDiff">
+          <div class="diff-card">
+            <header class="diff-head">
+              <div>
+                <h3 class="reset-title">Yaml vs running template</h3>
+                <p class="diff-path" v-if="yamlDiff?.yaml_path">
+                  <code>{{ yamlDiff.yaml_path }}</code>
+                </p>
+              </div>
+              <div class="diff-head-actions">
+                <div class="layout-toggle" role="tablist" aria-label="Diff layout">
+                  <button
+                    type="button"
+                    :class="{ active: diffLayout === 'unified' }"
+                    role="tab"
+                    @click="diffLayout = 'unified'"
+                  >Unified</button>
+                  <button
+                    type="button"
+                    :class="{ active: diffLayout === 'side-by-side' }"
+                    role="tab"
+                    @click="diffLayout = 'side-by-side'"
+                  >Side-by-side</button>
+                </div>
+                <button type="button" class="r-btn cancel diff-close" @click="onCloseDiff">Close</button>
+              </div>
+            </header>
+
+            <div class="diff-body">
+              <div v-if="!diffRolesOrdered.length" class="diff-empty">
+                In sync — no diverged roles.
+              </div>
+              <section
+                v-for="[role, info] in diffRolesOrdered"
+                :key="role"
+                class="diff-role"
+                :class="{ 'is-active': role === activeRole }"
+              >
+                <header class="diff-role-head">
+                  <code class="diff-role-name">{{ role }}</code>
+                  <span class="diff-role-status" :class="info.status">
+                    {{ info.status === 'diverged'
+                       ? `${Object.keys(info.fields || {}).length} field(s) drift`
+                       : info.status.replace('_', ' ') }}
+                  </span>
+                </header>
+
+                <!-- Field-level rows for diverged roles. v-code-diff
+                     renders Myers + intra-line word highlight + syntax
+                     highlight via highlight.js. Layout toggles in header. -->
+                <div v-if="info.status === 'diverged'" class="diff-fields">
+                  <div
+                    v-for="[field, change] in Object.entries(info.fields || {})"
+                    :key="field"
+                    class="diff-field"
+                  >
+                    <div class="diff-field-name">
+                      <code>{{ field }}</code>
+                    </div>
+                    <CodeDiff
+                      :old-string="formatDiffValue(change.before)"
+                      :new-string="formatDiffValue(change.after)"
+                      :output-format="diffLayout"
+                      :language="diffLanguageFor(field)"
+                      :context="3"
+                      filename="YAML (factory)"
+                      new-filename="DB (running)"
+                      theme="dark"
+                    />
+                  </div>
+                </div>
+
+                <!-- Whole-role status (added/removed) — no field-level data -->
+                <div v-else-if="info.status === 'added_in_db'" class="diff-fields">
+                  <p class="diff-note">Role exists in DB only — not present in factory yaml. Saving the yaml would lose this role on next recreate.</p>
+                  <pre class="diff-pre">{{ formatDiffValue(info.current) }}</pre>
+                </div>
+                <div v-else-if="info.status === 'removed_from_db'" class="diff-fields">
+                  <p class="diff-note">Role exists in factory yaml only — removed from DB. Reset / reload would restore it.</p>
+                  <pre class="diff-pre">{{ formatDiffValue(info.yaml) }}</pre>
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Reset-to-yaml chooser. Two-action modal: the user has to decide
+         whether running agents pick up the change immediately (force
+         reload) or only on next natural restart. Cancel returns to the
+         editor without touching DB. -->
+    <Teleport to="body">
+      <Transition name="reset-modal">
+        <div
+          v-if="resetModal.visible"
+          class="reset-overlay"
+          @click.self="onResetModalCancel"
+        >
+          <div class="reset-card">
+            <div class="reset-icon">↺</div>
+            <h3 class="reset-title">Reset <code>{{ activeRole }}</code> to factory yaml?</h3>
+            <p class="reset-body">
+              Pulls every editable field of <strong>{{ activeRole }}</strong> from
+              <code>team_templates/{{ template?.name?.replace('-', '_') || 'agile_team' }}.yaml</code>
+              into this team's DB. Other roles are untouched and audited.
+            </p>
+            <p class="reset-body muted">
+              Already-running agents keep their stale in-memory template
+              until the next restart — pick whether to force-respawn them now.
+            </p>
+            <div class="reset-actions">
+              <button
+                type="button"
+                class="r-btn cancel"
+                :disabled="resetModal.busy"
+                @click="onResetModalCancel"
+              >Cancel</button>
+              <button
+                type="button"
+                class="r-btn sync"
+                :disabled="resetModal.busy"
+                @click="onResetModalConfirm('sync-only')"
+              >
+                <span v-if="resetModal.busy && resetModal.mode === 'sync-only'" class="r-spin"></span>
+                Sync yaml only
+              </button>
+              <button
+                type="button"
+                class="r-btn reload"
+                :disabled="resetModal.busy"
+                @click="onResetModalConfirm('sync-and-reload')"
+              >
+                <span v-if="resetModal.busy && resetModal.mode === 'sync-and-reload'" class="r-spin"></span>
+                Sync + force reload
+              </button>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.running-tmpl {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  color: var(--text);
+}
+.banner {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-left: 3px solid #d4a017;
+  border-radius: 6px;
+  font-size: 12.5px;
+}
+.banner code {
+  background: var(--bg-0);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+.banner-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+.session-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.session-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  color: var(--text-dim);
+}
+.session-select {
+  flex: 1;
+  min-width: 200px;
+  padding: 6px 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 4px;
+}
+.drift-pill {
+  padding: 3px 9px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  border-radius: 999px;
+  background: rgba(212, 160, 23, 0.18);
+  color: #d4a017;
+  border: 1px solid rgba(212, 160, 23, 0.32);
+}
+.drift-pill.insync {
+  background: rgba(46, 160, 67, 0.18);
+  color: #2ea043;
+  border-color: rgba(46, 160, 67, 0.32);
+}
+.layout {
+  display: grid;
+  grid-template-columns: 200px 1fr 320px;
+  gap: 12px;
+  min-height: 0;
+  flex: 1;
+}
+.role-list, .history-rail {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+.tree-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--text-dim);
+  padding: 0 2px 6px;
+}
+.role-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  border-radius: 4px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 12.5px;
+}
+.role-item:hover { background: var(--bg-0); }
+.role-item.active {
+  background: rgba(96, 134, 199, 0.18);
+  box-shadow: inset 2px 0 0 var(--primary, #5b8def);
+}
+.role-name { flex: 1; font-weight: 500; }
+.role-key { color: var(--text-dim); font-size: 11px; }
+.drift-dot { color: #d4a017; font-weight: 700; }
+.empty { color: var(--text-dim); font-style: italic; padding: 8px; }
+.editor {
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.editor-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+.editor-head .title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13.5px;
+}
+.editor-head .title code {
+  background: var(--bg-0);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+}
+.display-input {
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--text);
+  padding: 2px 8px;
+  font-size: 12.5px;
+  border-radius: 3px;
+  min-width: 140px;
+}
+.actions { display: flex; gap: 8px; align-items: center; }
+.pill.dirty {
+  padding: 3px 10px;
+  font-size: 10.5px;
+  font-family: var(--font-mono);
+  color: #f0883e;
+  background: rgba(240, 136, 62, 0.16);
+  border-radius: 999px;
+}
+.btn {
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-1);
+  color: var(--text);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn.ghost { background: transparent; }
+.btn.primary { background: var(--primary, #5b8def); border-color: var(--primary, #5b8def); color: #fff; }
+.btn.danger { background: #b54545; border-color: #b54545; color: #fff; }
+.editor-body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  flex: 1;
+}
+.field { display: flex; flex-direction: column; gap: 4px; }
+.field-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.fl {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+}
+.text, .textarea {
+  background: var(--bg-0);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 12.5px;
+}
+.textarea { resize: vertical; }
+.textarea.mono { font-family: var(--font-mono); font-size: 11.5px; }
+.editor-foot {
+  padding: 8px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 11.5px;
+}
+.msg.error { color: #f85149; }
+.msg.ok { color: #2ea043; }
+.msg.muted { color: var(--text-dim); }
+.history-rail .hist-row {
+  border-top: 1px solid var(--border);
+  padding: 8px 6px;
+  font-size: 11.5px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.history-rail .hist-row:first-of-type { border-top: none; }
+.history-rail .hist-row.rollback { background: rgba(91, 141, 239, 0.06); }
+.history-rail .hist-row.yaml-reset { background: rgba(46, 160, 67, 0.06); }
+.hist-line { display: flex; justify-content: space-between; }
+.hist-role { font-family: var(--font-mono); color: var(--text); }
+.hist-src { font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); }
+.hist-meta { color: var(--text-dim); font-size: 10.5px; }
+.hist-diff code { font-family: var(--font-mono); font-size: 11px; }
+.hist-comment { color: var(--text-dim); font-style: italic; }
+.btn-mini {
+  align-self: flex-start;
+  padding: 2px 8px;
+  font-size: 10.5px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+.btn-mini:hover { background: var(--bg-0); }
+.overlay { padding: 30px; text-align: center; color: var(--text-dim); }
+
+/* Reset-to-yaml chooser modal — sits above all app modals (matches
+   ConfirmModal z-index policy). */
+.reset-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
+}
+.reset-card {
+  width: 480px;
+  max-width: 92vw;
+  padding: 28px;
+  background: var(--bg-2, #1a1d24);
+  border: 1px solid var(--border-bright, #3a3f4a);
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 20px 40px -10px rgba(0, 0, 0, 0.6);
+}
+.reset-icon {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  border: 1px solid rgba(91, 141, 239, 0.32);
+  border-radius: 12px;
+  color: #5b8def;
+  background: rgba(91, 141, 239, 0.12);
+}
+.reset-title {
+  margin: 0 0 10px;
+  font-size: 17px;
+  font-weight: 600;
+}
+.reset-title code {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  background: var(--bg-0);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+.reset-body {
+  margin: 0 0 10px;
+  font-size: 12.5px;
+  color: var(--text-dim);
+  line-height: 1.6;
+}
+.reset-body code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  background: var(--bg-0);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.reset-body.muted { font-size: 11.5px; }
+.reset-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+.r-btn {
+  flex: 1 1 auto;
+  min-width: 120px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.r-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.r-btn.cancel {
+  background: transparent;
+  border-color: var(--border, #2d3038);
+  color: var(--text-dim);
+}
+.r-btn.sync {
+  background: rgba(46, 160, 67, 0.12);
+  border-color: rgba(46, 160, 67, 0.32);
+  color: #2ea043;
+}
+.r-btn.reload {
+  background: rgba(181, 69, 69, 0.18);
+  border-color: rgba(181, 69, 69, 0.4);
+  color: #ff7676;
+}
+.r-btn:not(:disabled):hover { filter: brightness(1.15); }
+.r-spin {
+  width: 12px;
+  height: 12px;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: r-spin 0.6s linear infinite;
+}
+@keyframes r-spin { to { transform: rotate(360deg); } }
+.reset-modal-enter-active,
+.reset-modal-leave-active { transition: opacity 0.18s; }
+.reset-modal-enter-from,
+.reset-modal-leave-to { opacity: 0; }
+
+/* Yaml-vs-DB diff modal — wider than the chooser because it renders
+   field-level before/after side-by-side. */
+.diff-card {
+  width: 920px;
+  max-width: 94vw;
+  max-height: 86vh;
+  padding: 0;
+  background: var(--bg-2, #1a1d24);
+  border: 1px solid var(--border-bright, #3a3f4a);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px -10px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.diff-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+}
+.diff-path {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  color: var(--text-dim);
+}
+.diff-path code {
+  font-family: var(--font-mono);
+  background: var(--bg-0);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.diff-close { flex: 0 0 auto; min-width: 80px; }
+.diff-body {
+  overflow-y: auto;
+  padding: 12px 22px 22px;
+  flex: 1;
+}
+.diff-empty {
+  text-align: center;
+  padding: 40px;
+  color: var(--text-dim);
+  font-style: italic;
+}
+.diff-role {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-top: 12px;
+  background: var(--bg-1);
+}
+.diff-role.is-active { border-color: rgba(91, 141, 239, 0.45); }
+.diff-role-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.diff-role-name {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--bg-0);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+.diff-role-status {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: rgba(212, 160, 23, 0.18);
+  color: #d4a017;
+}
+.diff-role-status.added_in_db {
+  background: rgba(91, 141, 239, 0.18);
+  color: #5b8def;
+}
+.diff-role-status.removed_from_db {
+  background: rgba(181, 69, 69, 0.18);
+  color: #ff7676;
+}
+.diff-fields { padding: 12px 14px; display: flex; flex-direction: column; gap: 14px; }
+.diff-field-name {
+  margin-bottom: 5px;
+  font-size: 11.5px;
+  color: var(--text-dim);
+}
+.diff-field-name code {
+  font-family: var(--font-mono);
+  background: var(--bg-0);
+  padding: 1px 6px;
+  border-radius: 3px;
+  color: var(--text);
+}
+/* v-code-diff renders its own coloured diff; we only need to constrain
+   its max-height so a 200-line instruction doesn't blow out the modal. */
+.diff-field :deep(.d2h-wrapper),
+.diff-field :deep(.d2h-file-list-wrapper),
+.diff-field :deep(.code-diff-container),
+.diff-field :deep(table) {
+  font-size: 11.5px;
+}
+.diff-field :deep(.code-diff-container) {
+  max-height: 440px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+}
+
+/* Header layout toggle — segmented control matching the rest of the UI. */
+.diff-head-actions { display: flex; align-items: center; gap: 10px; }
+.layout-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  overflow: hidden;
+  background: var(--bg-1);
+}
+.layout-toggle button {
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  padding: 5px 12px;
+  font-size: 11.5px;
+  cursor: pointer;
+  font-family: var(--font-body);
+}
+.layout-toggle button.active {
+  background: rgba(91, 141, 239, 0.18);
+  color: #5b8def;
+}
+.diff-note {
+  margin: 0 0 8px;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  font-style: italic;
+}
+@media (max-width: 720px) {
+  .diff-grid { grid-template-columns: 1fr; }
+}
+</style>

--- a/frontend/src/views/settings/SettingsRunningTemplates.vue
+++ b/frontend/src/views/settings/SettingsRunningTemplates.vue
@@ -69,14 +69,27 @@ const dirty = computed(() => {
   if (!draft.value || !activeRole.value) return false
   const live = roles.value[activeRole.value]
   if (!live) return false
+  // Empty / whitespace server_overrides_text round-trips to `{}` (see
+  // _buildPatch). Avoid showing a UNSAVED pill in that no-op case.
+  const liveOverrides = JSON.stringify(live.server_overrides || {})
+  let draftOverrides
+  try {
+    draftOverrides = JSON.stringify(
+      draft.value.server_overrides_text.trim()
+        ? JSON.parse(draft.value.server_overrides_text)
+        : {},
+    )
+  } catch {
+    // Unparseable text is definitively dirty — Save will surface the error.
+    draftOverrides = draft.value.server_overrides_text
+  }
   return (
     draft.value.instruction !== (live.instruction || '') ||
     draft.value.role_display !== (live.role_display || '') ||
     draft.value.model !== (live.model || '') ||
     draft.value.servers_text !== (live.servers || []).join('\n') ||
     draft.value.skills_text !== (live.skills || []).join('\n') ||
-    draft.value.server_overrides_text !==
-      JSON.stringify(live.server_overrides || {}, null, 2)
+    draftOverrides !== liveOverrides
   )
 })
 
@@ -176,19 +189,26 @@ function _buildPatch() {
   if (JSON.stringify([...skills].sort()) !== JSON.stringify(liveSkills)) {
     patch.skills = skills
   }
-  if (draft.value.server_overrides_text.trim()) {
-    let parsed
+  // server_overrides has a "clear" intent that must round-trip — emptying
+  // the textarea should remove the overrides, not be a no-op. Treat empty
+  // or all-whitespace as `{}` so the same code path catches both "set to
+  // empty" and "edit a value".
+  const overridesText = draft.value.server_overrides_text.trim()
+  let parsedOverrides
+  if (overridesText) {
     try {
-      parsed = JSON.parse(draft.value.server_overrides_text)
+      parsedOverrides = JSON.parse(overridesText)
     } catch {
       throw new Error('server_overrides must be valid JSON')
     }
-    if (
-      JSON.stringify(parsed) !==
-      JSON.stringify(live.server_overrides || {})
-    ) {
-      patch.server_overrides = parsed
-    }
+  } else {
+    parsedOverrides = {}
+  }
+  if (
+    JSON.stringify(parsedOverrides) !==
+    JSON.stringify(live.server_overrides || {})
+  ) {
+    patch.server_overrides = parsedOverrides
   }
   return patch
 }

--- a/frontend/src/views/settings/SettingsYaml.vue
+++ b/frontend/src/views/settings/SettingsYaml.vue
@@ -28,6 +28,7 @@ const { confirm } = useConfirm()
 
 const files = ref([])
 const activeName = ref(null)
+const activeKind = ref('fastagent')
 const content = ref('')
 const savedContent = ref('')
 const loading = ref(false)
@@ -64,34 +65,89 @@ const dirtyLineCount = computed(() => {
   for (let i = 0; i < n; i++) if (cur[i] !== sav[i]) count++
   return count
 })
-const activeFile = computed(() => files.value.find((f) => f.name === activeName.value) || null)
+const activeFile = computed(() =>
+  files.value.find(
+    (f) => f.name === activeName.value && f.kind === activeKind.value,
+  ) || null,
+)
 
-// Group files by backend's is_secret_file flag (the only structural metadata
-// the API exposes — we don't synthesize agent_card / team_template groups
-// the backend can't actually serve).
+// Group files by kind. Two surfaces here:
+//   • fastagent — fastagent.config.yaml + fastagent.secrets.yaml (handled
+//     by /api/yaml/{name}).
+//   • team-template — backend/team_templates/*.yaml (handled by
+//     /api/team-templates/{name}; spawned teams use these as factory
+//     defaults — edits do NOT touch already-running teams, see Running
+//     Templates tab for that).
+// We keep the editor + chrome identical and just branch the load/save URLs.
 const groupedFiles = computed(() => {
   const core = []
   const secrets = []
+  const teamTemplates = []
   for (const f of files.value) {
-    if (f.is_secret_file) secrets.push(f)
+    if (f.kind === 'team-template') teamTemplates.push(f)
+    else if (f.is_secret_file) secrets.push(f)
     else core.push(f)
   }
   return [
     { label: 'FAST-AGENT', items: core },
     { label: 'SECRETS', items: secrets },
+    { label: 'TEAM TEMPLATES', items: teamTemplates },
   ].filter((g) => g.items.length)
 })
 
+function _fileKey(f) {
+  // Unique key across surfaces — both APIs use "name" as their stem so we
+  // namespace by kind to avoid a collision if a team template is ever
+  // named "config" or "secrets".
+  return `${f.kind}:${f.name}`
+}
+
 async function refreshList() {
-  const res = await apiFetch('/api/yaml/files')
-  files.value = res?.files || []
+  // Fetch both surfaces in parallel; surface a per-source failure rather
+  // than letting one outage hide the other (matches the rest of the
+  // backend's defensive listing patterns).
+  const [coreRes, tmplRes] = await Promise.allSettled([
+    apiFetch('/api/yaml/files'),
+    apiFetch('/api/team-templates'),
+  ])
+  const coreFiles = (coreRes.status === 'fulfilled' ? coreRes.value?.files : []) || []
+  const tmplFiles = (tmplRes.status === 'fulfilled' ? tmplRes.value?.templates : []) || []
+  files.value = [
+    ...coreFiles.map((f) => ({ ...f, kind: 'fastagent' })),
+    ...tmplFiles.map((f) => ({
+      ...f,
+      kind: 'team-template',
+      // Match the chrome description used by /api/yaml/files
+      description: f.description || `Team template — ${f.display_name}`,
+      // Factory templates are never secret files; surfaces the lock-icon
+      // logic that already exists in the file tree.
+      is_secret_file: false,
+    })),
+  ]
   if (!activeName.value && files.value.length) {
-    await selectFile(files.value[0].name)
+    await selectFile(files.value[0])
   }
 }
 
-async function selectFile(name) {
-  if (activeName.value === name) return
+function _endpointFor(file) {
+  if (!file) return null
+  return file.kind === 'team-template'
+    ? `/api/team-templates/${encodeURIComponent(file.name)}`
+    : `/api/yaml/${encodeURIComponent(file.name)}`
+}
+
+async function selectFile(file) {
+  // Backwards-compat: existing callers pass the bare name. Resolve it
+  // against the current list so we don't have to thread the kind through
+  // every click handler.
+  const target = typeof file === 'string'
+    ? files.value.find((f) => f.name === file && f.kind === 'fastagent')
+      || files.value.find((f) => f.name === file)
+    : file
+  if (!target) return
+  const targetKey = _fileKey(target)
+  const currentKey = activeFile.value ? _fileKey(activeFile.value) : null
+  if (targetKey === currentKey) return
   if (dirty.value) {
     const ok = await confirm({
       title: 'Discard unsaved changes',
@@ -105,8 +161,9 @@ async function selectFile(name) {
   successMsg.value = ''
   loading.value = true
   try {
-    const res = await apiFetch(`/api/yaml/${encodeURIComponent(name)}`)
-    activeName.value = name
+    const res = await apiFetch(_endpointFor(target))
+    activeName.value = target.name
+    activeKind.value = target.kind
     content.value = res.content || ''
     savedContent.value = res.content || ''
     exists.value = !!res.exists
@@ -120,20 +177,29 @@ async function selectFile(name) {
 
 async function onSave() {
   if (!activeName.value || !dirty.value) return
+  const target = activeFile.value
+  if (!target) return
   saving.value = true
   error.value = ''
   successMsg.value = ''
   try {
-    const res = await apiFetch(`/api/yaml/${encodeURIComponent(activeName.value)}`, {
+    const url = _endpointFor(target)
+    const res = await apiFetch(url, {
       method: 'PUT',
       body: JSON.stringify({ content: content.value }),
     })
-    const fresh = await apiFetch(`/api/yaml/${encodeURIComponent(activeName.value)}`)
+    const fresh = await apiFetch(url)
     content.value = fresh.content
     savedContent.value = fresh.content
     exists.value = true
     sizeBytes.value = res?.size ?? fresh.size
     successMsg.value = `${fresh.filename} saved (${sizeBytes.value} bytes).`
+    if (target.kind === 'team-template') {
+      // Surface the decision-2026-05-17 invariant inline: factory yaml edits
+      // are NEVER auto-applied to running teams. The user opens Running
+      // Templates → <session> → "Reset role to yaml" / "Reload" to apply.
+      successMsg.value += ' Edits to factory yaml do NOT touch running teams — open Running Templates to apply.'
+    }
     refreshList().catch(() => {})
   } catch (err) {
     error.value = _friendly(err)
@@ -202,11 +268,14 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
         <div class="tree-section">{{ group.label }}</div>
         <button
           v-for="f in group.items"
-          :key="f.name"
+          :key="`${f.kind}:${f.name}`"
           type="button"
           class="file-item"
-          :class="{ active: activeName === f.name, dirty: activeName === f.name && dirty }"
-          @click="selectFile(f.name)"
+          :class="{
+            active: activeName === f.name && activeKind === f.kind,
+            dirty: activeName === f.name && activeKind === f.kind && dirty,
+          }"
+          @click="selectFile(f)"
         >
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6">
             <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />

--- a/frontend/tests/e2e/fixtures/settings_running_templates.yaml
+++ b/frontend/tests/e2e/fixtures/settings_running_templates.yaml
@@ -1,0 +1,225 @@
+# Settings → Running Templates happy-path fixture.
+#
+# Drives this real click-flow through SettingsRunningTemplates.vue:
+#   1. mount: GET /api/team-sessions returns 1 active session.
+#   2. session-pick: GET /template + /history + /yaml-diff fire in parallel.
+#   3. edit role: user changes pm.instruction → click Save.
+#   4. PATCH /template/roles/pm fires; history refetches with the new audit.
+#   5. rollback: click Rollback on the new history row → POST /rollback;
+#      history refetches with both the original PATCH and the rollback row.
+#
+# Backend endpoints exercised (single source of truth — keep in sync):
+#   - backend/routes/team_template.py::list_sessions  GET /api/team-sessions
+#   - backend/routes/team_template.py::get_template
+#   - backend/routes/team_template.py::get_history
+#   - backend/routes/team_template.py::yaml_diff
+#   - backend/routes/team_template.py::patch_role
+#   - backend/routes/team_template.py::rollback
+#   - backend/routes/team_templates_factory.py::list_templates  (called by
+#     SettingsYaml tab — silenced via the noise fixture's notifications block)
+#
+# Why two sequential entries for /template/history?
+#   The Save and Rollback handlers each call loadTemplate(), which refetches
+#   history. Sequential YAML arrays let us serve the pre-edit / post-edit /
+#   post-rollback states in order.
+
+backend_source:
+  - "backend/routes/team_template.py::list_sessions"
+  - "backend/routes/team_template.py::get_template, get_history, yaml_diff"
+  - "backend/routes/team_template.py::patch_role, rollback"
+  - "frontend/src/views/settings/SettingsRunningTemplates.vue"
+
+responses:
+  # SettingsView mounts SettingsGeneral by default — its store eagerly
+  # fetches /api/settings. Stub with empty categories so it renders and
+  # leaves the rest of the surface alone.
+  "GET /api/settings":
+    status: 200
+    json:
+      categories: {}
+
+  # Boot — session enumeration. One active team so the dropdown autoselects it.
+  "GET /api/team-sessions":
+    status: 200
+    json:
+      sessions:
+        - session_id: "agile-team_e2e0test"
+          team_name: "agile-team-e2e"
+          template_name: "agile-team"
+          agents_count: 3
+
+  # Per-session template: sequenced so each loadTemplate() call returns the
+  # latest state. Vue triggers loadTemplate on activeSessionId change AND
+  # after Save / Rollback via await loadTemplate(...).
+  "GET /api/team-sessions/agile-team_e2e0test/template":
+    - status: 200
+      json:
+        session_id: "agile-team_e2e0test"
+        template:
+          name: "agile-team"
+          orchestrator: "pm"
+          roles:
+            pm:
+              role_display: "PM"
+              instruction: "You are the orchestrator."
+              servers: ["filesystem"]
+              skills: ["project-management"]
+              model: ""
+              server_overrides: {}
+            qe:
+              role_display: "QE"
+              instruction: "You are QE."
+              servers: ["filesystem", "playwright"]
+              skills: ["qe-workflow"]
+              model: ""
+              server_overrides: {}
+    - status: 200
+      json:
+        session_id: "agile-team_e2e0test"
+        template:
+          name: "agile-team"
+          orchestrator: "pm"
+          roles:
+            pm:
+              role_display: "PM"
+              instruction: "You are the new orchestrator (edited via UI)."
+              servers: ["filesystem"]
+              skills: ["project-management"]
+              model: ""
+              server_overrides: {}
+            qe:
+              role_display: "QE"
+              instruction: "You are QE."
+              servers: ["filesystem", "playwright"]
+              skills: ["qe-workflow"]
+              model: ""
+              server_overrides: {}
+    # Third call: after rollback — pm.instruction back to original.
+    - status: 200
+      json:
+        session_id: "agile-team_e2e0test"
+        template:
+          name: "agile-team"
+          orchestrator: "pm"
+          roles:
+            pm:
+              role_display: "PM"
+              instruction: "You are the orchestrator."
+              servers: ["filesystem"]
+              skills: ["project-management"]
+              model: ""
+              server_overrides: {}
+            qe:
+              role_display: "QE"
+              instruction: "You are QE."
+              servers: ["filesystem", "playwright"]
+              skills: ["qe-workflow"]
+              model: ""
+              server_overrides: {}
+
+  "GET /api/team-sessions/agile-team_e2e0test/template/history":
+    # Initial — empty audit.
+    - status: 200
+      json:
+        session_id: "agile-team_e2e0test"
+        role: null
+        count: 0
+        rows: []
+    # After PATCH — one row from the edit.
+    - status: 200
+      json:
+        session_id: "agile-team_e2e0test"
+        role: null
+        count: 1
+        rows:
+          - id: 101
+            session_id: "agile-team_e2e0test"
+            role: "pm"
+            field: "instruction"
+            before: "You are the orchestrator."
+            after: "You are the new orchestrator (edited via UI)."
+            source: "api"
+            edited_by: "system"
+            edited_at: 1827542400
+            comment: "edited from Settings UI"
+    # After rollback — original row + rollback row.
+    - status: 200
+      json:
+        session_id: "agile-team_e2e0test"
+        role: null
+        count: 2
+        rows:
+          - id: 102
+            session_id: "agile-team_e2e0test"
+            role: "pm"
+            field: "instruction"
+            before: "You are the new orchestrator (edited via UI)."
+            after: "You are the orchestrator."
+            source: "rollback"
+            edited_by: "system"
+            edited_at: 1827542460
+            comment: "rollback of audit_id=101 (instruction). rollback from Settings UI"
+          - id: 101
+            session_id: "agile-team_e2e0test"
+            role: "pm"
+            field: "instruction"
+            before: "You are the orchestrator."
+            after: "You are the new orchestrator (edited via UI)."
+            source: "api"
+            edited_by: "system"
+            edited_at: 1827542400
+            comment: "edited from Settings UI"
+
+  # yaml-diff — return in_sync so the drift pill doesn't pollute the spec.
+  # The diff-modal test is a separate concern.
+  "GET /api/team-sessions/agile-team_e2e0test/template/yaml-diff":
+    status: 200
+    json:
+      session_id: "agile-team_e2e0test"
+      yaml_path: "/srv/jarvis/backend/team_templates/agile_team.yaml"
+      in_sync: true
+      diverged_count: 0
+      per_role:
+        pm: { status: "in_sync" }
+        qe: { status: "in_sync" }
+
+  # PATCH from the Save click.
+  "PATCH /api/team-sessions/agile-team_e2e0test/template/roles/pm":
+    status: 200
+    json:
+      session_id: "agile-team_e2e0test"
+      role: "pm"
+      audit_ids: [101]
+      diff:
+        instruction:
+          before: "You are the orchestrator."
+          after: "You are the new orchestrator (edited via UI)."
+      after_role:
+        role_display: "PM"
+        instruction: "You are the new orchestrator (edited via UI)."
+        servers: ["filesystem"]
+        skills: ["project-management"]
+        model: ""
+        server_overrides: {}
+      edited_at: 1827542400
+      warning: "Edit applied to DB. To survive a team recreate / reset, also commit the equivalent change to team_templates/<team>.yaml."
+
+  # Rollback from the Rollback button click.
+  "POST /api/team-sessions/agile-team_e2e0test/template/rollback/101":
+    status: 200
+    json:
+      session_id: "agile-team_e2e0test"
+      audit_id: 101
+      audit_ids: [102]
+      diff:
+        instruction:
+          before: "You are the new orchestrator (edited via UI)."
+          after: "You are the orchestrator."
+      after_role:
+        role_display: "PM"
+        instruction: "You are the orchestrator."
+        servers: ["filesystem"]
+        skills: ["project-management"]
+        model: ""
+        server_overrides: {}
+      edited_at: 1827542460

--- a/frontend/tests/e2e/flows/settings-running-templates.spec.ts
+++ b/frontend/tests/e2e/flows/settings-running-templates.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * E2E flow: Settings → Running Templates (happy path).
+ *
+ * Drives the user-facing template-edit surface end-to-end:
+ *   1. open Settings, switch to the Running Templates tab.
+ *   2. session dropdown auto-selects the only active team.
+ *   3. PM role auto-selected (first in `roles`); editor shows the live
+ *      instruction.
+ *   4. user edits the instruction → "● UNSAVED" pill appears.
+ *   5. click Save → PATCH /template/roles/pm fires; history rail flips
+ *      from "No edits yet." to a row keyed `pm.instruction`.
+ *   6. click Rollback on that audit row → POST /rollback/101 fires; the
+ *      editor refetches and the instruction is back to the original.
+ *
+ * Why this spec exists:
+ *   PR #58 review flagged "Happy Path FIRST" as a hard requirement for
+ *   user-facing changes. The destructive reload path is reachable from
+ *   this tab — a broken click-flow kills running agents. This spec is
+ *   the first line of defence against that.
+ *
+ * Out of scope (kept narrow on purpose):
+ *   - Force-reload (destructive — covered separately if/when added)
+ *   - Reset-to-yaml chooser modal (yaml is in_sync here)
+ *   - View-diff modal (yaml is in_sync here)
+ *   - server_overrides clear case (regression-covered by unit logic in
+ *     _buildPatch; e2e for it would just duplicate the assertion)
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, NetworkRecorder, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+test('happy path: pick session → edit role → save → audit appears → rollback', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const backend = await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'settings_running_templates.yaml'),
+  ])
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+
+  await page.goto('/settings')
+
+  // Switch to Running Templates tab. General is the default mount.
+  await page.getByRole('button', { name: 'Running Templates', exact: true }).click()
+
+  // Session dropdown auto-selects the only active team. Wait for the
+  // template to render — PM role pill is the stable signal.
+  await expect(page.locator('.role-item').filter({ hasText: 'PM' })).toBeVisible()
+  await expect(page.locator('.role-item.active').filter({ hasText: 'PM' })).toBeVisible()
+
+  // Editor shows the live instruction. <textarea> value isn't text content,
+  // so hasText doesn't work — match by sibling label instead.
+  const instructionEditor = page.locator(
+    'label:has(span.fl:text("Instruction")) textarea',
+  )
+  await expect(instructionEditor).toHaveValue('You are the orchestrator.')
+
+  // Initial state: history empty, no UNSAVED pill.
+  await expect(page.getByText('No edits yet.')).toBeVisible()
+  await expect(page.locator('.pill.dirty')).not.toBeVisible()
+
+  // ── 1. Edit + Save ────────────────────────────────────────────────
+  await instructionEditor.fill('You are the new orchestrator (edited via UI).')
+
+  // Dirty pill appears once draft diverges from live.
+  await expect(page.locator('.pill.dirty')).toBeVisible()
+
+  const [patchResp] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.request().method() === 'PATCH' &&
+        new URL(r.url()).pathname ===
+          '/api/team-sessions/agile-team_e2e0test/template/roles/pm',
+    ),
+    page.getByRole('button', { name: 'Save', exact: true }).click(),
+  ])
+  expect(patchResp.status()).toBe(200)
+
+  // Assert the patch body contained only the changed field — the UI must
+  // not splatter unchanged fields (audit log would otherwise be noisy).
+  const patchCall = recorder.assertContains(
+    'PATCH',
+    '/api/team-sessions/agile-team_e2e0test/template/roles/pm',
+  )
+  const patchBody = patchCall.body as {
+    patch?: Record<string, unknown>
+    comment?: string
+  } | null
+  expect(patchBody?.patch).toEqual({
+    instruction: 'You are the new orchestrator (edited via UI).',
+  })
+  expect(patchBody?.comment).toContain('Settings UI')
+
+  // History rail flips to one row — pm.instruction edit.
+  await expect(page.locator('.hist-row')).toHaveCount(1)
+  await expect(page.locator('.hist-role').first()).toHaveText('pm.instruction')
+
+  // After loadTemplate refetch, dirty pill clears.
+  await expect(page.locator('.pill.dirty')).not.toBeVisible()
+
+  // ── 2. Rollback ──────────────────────────────────────────────────
+  // ConfirmModal pops up — assert title + click confirm.
+  const rollbackPromise = page.waitForResponse(
+    (r) =>
+      r.request().method() === 'POST' &&
+      new URL(r.url()).pathname ===
+        '/api/team-sessions/agile-team_e2e0test/template/rollback/101',
+  )
+  await page.locator('.btn-mini').first().click()
+
+  // Confirm dialog — the global ConfirmModal asks "Roll back this audit
+  // row?". There's another button with text "Rollback" in the history
+  // rail, so scope to the modal card to avoid a strict-mode collision.
+  const modalCard = page.locator('.cm-card')
+  await expect(
+    modalCard.getByRole('heading', { name: /roll back this audit row/i }),
+  ).toBeVisible()
+  await modalCard.getByRole('button', { name: /^rollback$/i }).click()
+
+  const rollbackResp = await rollbackPromise
+  expect(rollbackResp.status()).toBe(200)
+
+  // History grows to 2 rows; latest (rollback) on top.
+  await expect(page.locator('.hist-row')).toHaveCount(2)
+  await expect(page.locator('.hist-row.rollback').first()).toBeVisible()
+
+  // Editor reflects the rollback — original instruction is back.
+  await expect(instructionEditor).toHaveValue('You are the orchestrator.')
+
+  // No unknown /api/* request leaked through — unknown requests would
+  // be served as 599 by the mock backend, so we only fail-loud on those.
+  // We deliberately skip assertAllFulfilled() because the merged noise
+  // fixture declares paths (passkey, approvals stats) that an
+  // authenticated user doesn't trigger, and other Settings specs don't
+  // enforce strict consumption either.
+  expect(backend.unexpected).toEqual([])
+})


### PR DESCRIPTION
## Summary

Adds two surfaces for editing team templates and exposes them to Jarvis via a dedicated MCP tool server. Per decisions on 2026-05-17 (yaml = factory default, not continuous source) and 2026-05-31 (UI lives in Settings; MCP uses the Unix-socket RPC bridge, no HTTP/API-key).

- **Factory yaml** (`team_templates/*.yaml`) — edit the recipe used at every team spawn.
- **Running team** (DB SSoT per `team_sessions`) — edit one team's template with audit, rollback, reset-to-yaml, and force-reload.
- **MCP server `team_template`** — 10 tools mirror the two surfaces; Jarvis can curate templates itself at runtime.

## Architecture

```
                                ┌─ HTTP (verify_api_key) ── Frontend UI
                                │
service layer ─── routes ──────┤
   (factory + running)          │
                                └─ RPC handlers ── UDS bridge ── MCP tools ── Jarvis LLM
```

- `services/team_template_factory_service.py` — yaml read/write/list with path-traversal guard, `yaml.safe_load` validation, `.bak` rotation, atomic rename (EBUSY fallback for Docker bind-mounts).
- `services/team_template_rpc_handlers.py` — 10 dotted methods (`team_template.factory.*`, `team_template.running.*`) registered on the existing `RuntimeRpcServer` next to skill/mcp/approval handlers.
- `tools/team_template_server.py` — FastMCP wraps each RPC method as a tool; registered as `mcp.servers.team_template` in `fastagent.config.yaml`.

## Design invariants

| Tool | Reads | Writes | Effect |
|---|---|---|---|
| `team_template_write_factory` | — | yaml file | Yaml only. Survives recreate. |
| `team_template_patch_role` | — | DB | DB only. Audited. Lost on recreate. |
| `team_template_reset_role` | yaml | DB | Pulls yaml → DB; yaml untouched. |
| `team_template_reload` | DB | — (process) | SIGKILL+respawn agents reading current DB. |

No tool writes both yaml and DB — Jarvis chains calls for combined updates. This is deliberate per decision 2026-05-17: factory yaml is the recipe, DB is the running team, and the two never auto-sync.

## Frontend

All under `Settings`:

- **YAML Config tab** — extended with a `TEAM TEMPLATES` group surfacing factory yamls. Editor + chrome reused; load/save branches by `kind` so `fastagent.config.yaml` flow is untouched.
- **Running Templates tab** (new) — session dropdown, drift pill, per-role editor (instruction / servers / skills / server_overrides / model / role_display), history rail with rollback. Reset-to-yaml opens a 3-way chooser (Cancel / Sync only / Sync + Force reload) so the user doesn't have to remember the two-step sequence. View-diff opens a `v-code-diff` modal with unified/side-by-side toggle (localStorage-persisted) and intra-line word highlight.

## Test plan

- [x] `tests/test_routes/test_team_templates_factory.py` (16 new) — auth, list, read (raw + parsed), write (atomic + .bak), malformed-yaml tolerance, path-traversal guard, oversize rejection
- [x] `tests/test_services/test_team_template_rpc_handlers.py` (15 new) — factory list/read/write, running get/patch/history/rollback/reset/yaml-diff/reload, registration count
- [x] `tests/test_routes/test_team_template_routes.py` + `tests/test_services/test_team_template_service.py` (48 pre-existing) — still pass
- [x] MCP server smoke test — `mcp.list_tools()` returns 10 expected tool names
- [x] Frontend `vite build` clean (SettingsView bundle: 100 → 237 KB; +40 KB gzip due to `v-code-diff` + highlight.js)
- [x] Backend restarted; `GET /api/team-templates` and `GET /api/team-sessions` return 401 (route exists) instead of 404 (route missing)

## Known UX gap

- No frontend Playwright e2e for the new tab yet. Manual click-flow (open Running Templates → pick session → edit role → save → audit row appears → rollback) verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)