### PR TITLE
fix: story audio playback, crawl redesign, voice STT, interrupt, passkey login

### DIFF
--- a/backend/.fast-agent/skills/crawling/SKILL.md
+++ b/backend/.fast-agent/skills/crawling/SKILL.md
@@ -1,68 +1,72 @@
 ---
 name: crawling
 description: >
-  Crawl and download stories from the internet to local library. Use when user wants to add
-  new stories, download from web, or check crawl progress. Flow: analyze page → test → full crawl.
+  Crawl and download stories from ANY website into the local library —
+  site-agnostic, language-agnostic. Use when the user wants to add a new story,
+  download from the web, or check crawl progress. Flow: detect structure →
+  build recipe → verify 3 chapters → full crawl (worker enumerates).
 ---
 
-# STORY CRAWLING WORKFLOW
+# STORY CRAWLING WORKFLOW (recipe-based, AI-driven)
+
+You analyse page STRUCTURE and emit a small RECIPE. The backend worker enumerates
+every chapter from that recipe and downloads them — the chapter list never passes
+through you, so this scales to 1000+ chapter stories without burning tokens.
 
 ## Decision Tree
-
 ```
-What does the user want?
-├── Add new story
-│   ├── Has link? → Step 0
-│   └── No link? → Step 1
-├── Check progress → get_crawl_status(job_id)
-└── View downloaded stories → local_list_stories()
+Add new story → has URL? use it : search_stories(query)
+Check progress → get_crawl_status(job_id)
+View library  → local_list_stories()
 ```
 
-<url_handling>
-When user provides a URL:
-- If it's an index/overview page → DO NOT use it for analysis
-- ACTION: call `get_story_chapters(overview_url)` → get Chapter 1 URL + total_chapters
-- Only use the Chapter 1 URL for structure analysis
-</url_handling>
+## Step 0: GET A URL
+- User gave a URL → use it directly (skip search).
+- No URL → **serpapi** (Google search, fast) to find the story page. scrapling
+  is for fetching a known URL, not searching. (Legacy `web_search_stories` is a
+  slow per-site HTTP fallback — avoid unless serpapi is down.)
 
-## Step 1: FIND CHAPTER 1 URL
-- `search_stories(query)` → find story on web
+## Step 1: DETECT STRUCTURE
+`detect_story_structure(url)` renders the page (JS-aware) and returns, all
+LANGUAGE-AGNOSTIC:
+- `link_patterns`: same-domain links grouped by URL shape (digits→#) with counts +
+  `within_story_root` flag + `selector_hint`. A high-count within-story pattern =
+  the chapter links.
+- `content_candidates`: scored by paragraph density (pick narrative, not nav).
+- `pagination_hints`, `story_root_guess`.
 
-## Step 2: ANALYZE PAGE STRUCTURE (CRITICAL)
-- `get_story_page_structure(url)` → find CSS selectors
-- Choose selector with highest score (usually contains 'content', 'chapter', long text)
-- If "TOP NEXT LINK CANDIDATES" found → `add_story_provider` to teach the system
+## Step 2: BUILD RECIPE (JSON)
+- **LIST mode** (page lists many chapters):
+  `{mode:"list", story_root:"/slug/", overview_url, chapter_url_pattern:"<sample chapter URL>", content_selector, title_selector, next_page_selector?}`
+- **CHAIN mode** (single chapter page + a "next" link):
+  `{mode:"chain", story_root:"/slug/", first_chapter_url, next_chapter_selector, content_selector, title_selector}`
+- `story_root` is REQUIRED in both — the same-story guard that blocks drift into
+  recommended/other stories.
+- Find `content_selector` on a CHAPTER page (overview pages have no chapter body).
+  Re-run detect_story_structure on a sample chapter URL if needed.
 
-<verify_step>
-Step 3: VERIFICATION — THIS STEP IS MANDATORY
-- `test_crawl_chapter(url, content_selector=...)` → check content quality
-- You MUST verify before proceeding to full crawl
-</verify_step>
-
-<content_validation>
-❌ GARBAGE content — choose a different selector:
-- Contains "Advertisement", "Sorry", "Posted at...", "Please..."
-- Content too short (< 200 characters)
-- Repeats story title/author multiple times
-
-✅ VALID content:
-- Starts with actual story content ("Chapter 1...", "He opened his eyes...")
-- Reasonable length (> 500 characters)
-
-ACTION when garbage found: Drop selector → pick another → test again. Repeat until valid.
-</content_validation>
+## Step 3: VERIFY — MANDATORY (3 chapters)
+`verify_chapters(recipe_json)` fetches the first 3 chapters and checks length,
+that chapters differ, and URL continuity.
+- ok=false → read `issues`, fix the recipe (usually content_selector), re-verify.
+- NEVER crawl an unverified recipe.
 
 ## Step 4: FULL CRAWL
-```
-crawl_story(url, content_selector="#...", title_selector="h1", speed=1.0, max_chapters=total_chapters)
-```
-- Returns `job_id`
-- Report to user: "Started crawling..." with tag `[[[CRAWL_STARTED: job_id]]]`
+`crawl_story(recipe_json, max_chapters=..., speed=1.0)` → returns job_id.
+Report to the user ending with `[[[CRAWL_STARTED: job_id]]]`.
 
-## Step 5: TRACKING
-- User asks → `get_crawl_status(job_id)`
+## Step 5: TRACKING / SELF-HEAL
+- Progress on request → `get_crawl_status(job_id)`.
+- If a crawl gets stuck, the worker pauses and AUTO-WAKES you with a
+  `[CRAWL SELF-HEAL]` message (stuck URL + current recipe). Then:
+  detect_story_structure(stuck_url) → diagnose → verify_chapters(fixed) →
+  `resume_crawl(job_id, recipe_patch_json=<fix>)`. If it's the real end of the
+  story → `resume_crawl(job_id, mark_done=true)`. If the site is blocked / changed
+  structurally → tell the user.
 
 <violation>
-- Starting full crawl WITHOUT running test_crawl_chapter first → VIOLATION
-- Using an index/overview page URL for analysis → VIOLATION
+- Crawling WITHOUT verify_chapters first → VIOLATION.
+- A recipe without `story_root` (no same-story guard) → VIOLATION.
+- Relying on language-specific words (e.g. "Chương") for detection → use URL/DOM
+  structure instead.
 </violation>

--- a/backend/agent.py
+++ b/backend/agent.py
@@ -177,42 +177,61 @@ async def finance_agent(prompt: str):
 @fast.agent(
     name="CrawlStoriesAgent",
     instruction="""\
-You are a web story crawler specialist. Collect story data (Crawler) from the internet into the local library.
+You are a web story crawler specialist. Collect stories from ANY website into the
+local library — site-agnostic and language-agnostic. You analyse page STRUCTURE
+(not language-specific words) and produce a small "recipe"; the backend worker
+then enumerates and downloads all chapters from that recipe (the chapter list
+never passes through you, so it works for 1000+ chapter stories cheaply).
 
-CRAWL WORKFLOW (MANUAL FLOW):
+CRAWL WORKFLOW:
 
-0. SMART URL HANDLING — INDEX/OVERVIEW LINK:
-- If the user provides an Index/Overview link (Introduction page) -> DO NOT use it for Analyze.
-- ACTION:
-  1. get_story_chapters(overview_link).
-  2. Get the URL of Chapter 1 and total_chapters.
-  3. Use the Chapter 1 URL for the next steps.
+1. FIND THE STORY:
+- If the user gave a URL, use it directly — go straight to step 2 (do NOT search).
+- Otherwise use serpapi to Google the story (fast). Pick the best result URL.
+  serpapi is the primary search tool; the legacy story-server web_search_stories
+  is a slow per-site HTTP fallback — only use it if serpapi is unavailable.
+- scrapling-server is for FETCHING a known URL, not for searching.
 
-1. FIND CHAPTER 1 URL:
-- If the user has not provided a chapter link -> search_stories(query).
+2. DETECT STRUCTURE:
+- Call detect_story_structure(url). It RENDERS the page (handles JS sites) and
+  returns a language-agnostic summary: link_patterns (URL shapes + counts),
+  content_candidates, pagination_hints, story_root_guess.
+- Decide a RECIPE (JSON). Two modes:
+  • LIST mode — a within_story_root link_pattern has a high count (the page lists
+    many chapters). Recipe: {mode:"list", story_root, overview_url,
+    chapter_url_pattern (a sample chapter URL), content_selector, title_selector,
+    next_page_selector (optional)}.
+  • CHAIN mode — the page is a single chapter / no big chapter list, but a "next"
+    link exists. Recipe: {mode:"chain", story_root, first_chapter_url,
+    next_chapter_selector, content_selector, title_selector}.
+- ALWAYS set story_root (e.g. "/story-slug/") — it is the same-story guard that
+  stops the crawl drifting into recommended/other stories.
+- content_selector: detect it on a CHAPTER page (overview pages have no chapter
+  body). If detect_story_structure was called on the overview, call it again on
+  a sample chapter URL to find the real content_selector.
 
-2. ANALYZE STRUCTURE (IMPORTANT):
-- Call get_story_page_structure(url).
-- Find the highest-scoring Selector (usually contains 'content', 'chapter', long text).
-- AUTO-LEARN: If you see "TOP NEXT LINK CANDIDATES", pick the highest-scoring selector and call add_story_provider to teach the system.
-
-3. VERIFY (TEST FIRST — IMPORTANT):
-- Call test_crawl_chapter(url, content_selector=...).
-- MENTAL CHECK:
-  - If you see: "Advertisement", "Sorry", "Posted at...", "Please..." -> IT IS GARBAGE.
-  - ACTION: Skip this selector. Pick another selector. Test again until you see clean story content (e.g. "Chapter 1...", actual narrative text).
+3. VERIFY (MANDATORY — checks 3 chapters, not 1):
+- Call verify_chapters(recipe_json). It fetches the first 3 chapters and checks
+  length + that chapters differ + URL order (continuity).
+- If ok=false: read issues, fix the recipe (usually a better content_selector),
+  verify again. NEVER crawl an unverified recipe.
 
 4. CRAWL FULL:
-- Call crawl_story(url, content_selector="#...", title_selector="h1", speed=1.0, max_chapters=total_chapters).
-- Returns job_id.
-- Inform the user: "Download started..." with tag [[[CRAWL_STARTED: job_id]]].
+- Call crawl_story(recipe_json, max_chapters=..., speed=1.0). Returns job_id.
+- Tell the user it started, ending with the tag [[[CRAWL_STARTED: job_id]]].
 
-5. TRACKING:
-- If the user asks -> get_crawl_status(job_id).
+5. TRACKING / SELF-HEAL:
+- If the user asks progress -> get_crawl_status(job_id).
+- If a crawl gets STUCK, the worker pauses and AUTO-WAKES YOU with a
+  "[CRAWL SELF-HEAL]" message containing the stuck URL + current recipe. When you
+  get that: detect_story_structure on the stuck URL, diagnose, verify_chapters
+  with the fix, then resume_crawl(job_id, recipe_patch_json=<fix>). If the stuck
+  point is genuinely the end of the story, call resume_crawl(job_id, mark_done=true).
+  If the site changed structurally / is blocked, tell the user.
 
 {{agentSkills}}""",
     skills=CORE_SKILLS + get_skills("proactive-mode", "crawling", "scrape-web"),
-    servers=["story-server", "scrapling-server"],
+    servers=["story-server", "scrapling-server", "serpapi"],
 )
 async def crawl_stories_agent(prompt: str):
     pass

--- a/backend/core/csrf.py
+++ b/backend/core/csrf.py
@@ -46,10 +46,13 @@ Exemptions
 ----------
 
 * ``GET / HEAD / OPTIONS`` are always allowed.
-* The auth bootstrap endpoints (``/api/auth/login``, ``/api/setup/...``)
-  are exempt because the user has not yet been issued a CSRF cookie at
-  that point.  ``/api/auth/login`` itself is rate-limited per-IP and
-  same-origin enforced by SameSite=Lax on the response Set-Cookie.
+* The auth bootstrap endpoints (``/api/auth/login``,
+  ``/api/auth/passkey/authenticate/*``, ``/api/setup/...``) are exempt because
+  the user has not yet been issued a (valid) CSRF cookie at that point — a
+  stale cookie from an expired session must not block re-login. Passkey
+  authenticate is defended by WebAuthn's own challenge/signature; ``login`` is
+  rate-limited per-IP and same-origin enforced by SameSite=Lax. Passkey
+  REGISTER stays protected (needs an authenticated session).
 * OAuth callback endpoints (``/api/oauth/.../callback``) are exempt —
   third-party redirect cannot carry our header.  Those routes have
   their own ``state``-parameter CSRF defence.
@@ -75,6 +78,15 @@ _PROTECTED_METHODS: frozenset[str] = frozenset({"POST", "PUT", "PATCH", "DELETE"
 _EXEMPT_PREFIXES: tuple[str, ...] = (
     "/api/auth/login",       # user has no CSRF cookie yet
     "/api/auth/logout",      # safe to invoke without prior cookie (no side effect on logout)
+    # Passkey AUTHENTICATE is a LOGIN flow (same class as /api/auth/login): the
+    # user is not signed in yet, so they have no valid CSRF token to send in the
+    # header. A stale CSRF cookie left over from an expired session would
+    # otherwise make this 403 ("has cookie, header empty") and lock the user out
+    # of re-logging-in. WebAuthn's own challenge/signature is the CSRF defence
+    # here. NOTE: passkey REGISTER is intentionally NOT exempt — it requires an
+    # authenticated session + real CSRF token (don't let an attacker silently
+    # enrol a passkey).
+    "/api/auth/passkey/authenticate",
     "/api/setup",            # bootstrap surface; user has no CSRF cookie until wizard ends
     "/api/oauth/google/callback",  # third-party redirect; has its own `state` CSRF
 )

--- a/backend/helpers/story_reader.py
+++ b/backend/helpers/story_reader.py
@@ -12,6 +12,32 @@ from helpers.text_processing import clean_text_for_tts
 logger = logging.getLogger(__name__)
 
 
+def build_story_meta(story_title, chapter_file):
+    """Build the playlist metadata the chat ``done`` event hands the frontend
+    singleton player, so a story started from chat behaves exactly like one
+    started from the Stories library (chapter nav, progress, resume).
+
+    ``story_id`` is the folder name — identical to the id the ``/api/stories``
+    routes use — so the frontend replays through the same ``playChapter`` path
+    and reuses the TTS cache this request already populated.
+
+    Returns ``None`` when inputs are missing so the caller falls back to plain
+    chat-TTS playback.
+    """
+    if not story_title or not chapter_file:
+        return None
+    story_dir = os.path.join("data/stories", story_title)
+    chapter_files = []
+    if os.path.isdir(story_dir):
+        chapter_files = sorted(f for f in os.listdir(story_dir) if f.endswith(".txt"))
+    return {
+        "story_id": story_title,
+        "story_title": story_title,
+        "chapter_file": chapter_file,
+        "chapter_files": chapter_files,
+    }
+
+
 def handle_read_local(story_title: str, chapter_filename: str, library_manager, tts_cache) -> dict:
     """
     Handle [[[READ_LOCAL: story_title|chapter_filename]]] tag.
@@ -57,7 +83,15 @@ def handle_read_local(story_title: str, chapter_filename: str, library_manager, 
 
         tts_cache.save_tts_text(unique_id, text)
 
-        return {"book_id": unique_id, "tts_text": text}
+        # story_title/chapter_file let the chat route build playlist metadata
+        # (build_story_meta) so chat playback routes through the singleton
+        # story player instead of a one-off TTS clip.
+        return {
+            "book_id": unique_id,
+            "tts_text": text,
+            "story_title": story_title,
+            "chapter_file": chapter_filename,
+        }
 
     except Exception as e:
         logger.error(f"handle_read_local error: {e}", exc_info=True)
@@ -97,7 +131,12 @@ def check_pending_read(library_manager, tts_cache, get_chapter_content_fn) -> di
                 result = handle_read_local(action["story_title"], action["chapter_filename"],
                                            library_manager, tts_cache)
                 if "error" not in result:
-                    return {"book_id": result["book_id"], "tts_text": result["tts_text"]}
+                    return {
+                        "book_id": result["book_id"],
+                        "tts_text": result["tts_text"],
+                        "story_title": result.get("story_title"),
+                        "chapter_file": result.get("chapter_file"),
+                    }
                 else:
                     logger.warning(f"Pending READ_LOCAL failed: {result['error']}")
 

--- a/backend/routes/chat.py
+++ b/backend/routes/chat.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from core.auth import verify_api_key
 from helpers.text_processing import process_agent_response, clean_text_for_tts
-from helpers.story_reader import handle_read_local, check_pending_read
+from helpers.story_reader import handle_read_local, check_pending_read, build_story_meta
 from services.shared_state import (
     session_service, library_manager, tts_cache,
 )
@@ -111,11 +111,21 @@ class ChatResponse(BaseModel):
     playback_url: str | None = None
     user_text: str | None = None
     conversation_id: str | None = None
+    # Present when the reply is a local story chapter, so the frontend can
+    # route playback through the singleton story player (chapter nav, resume)
+    # instead of treating it as a one-off TTS clip.
+    story: dict | None = None
+    # Present when the reply started a web crawl, so the frontend can poll
+    # /api/stories/crawl/status/{id} for live progress + a cancel button.
+    crawl_job_id: str | None = None
 
 
-def _process_response_tags(response_text, tts_text, book_id):
-    """Process story/library/local tags in response text. Returns (response_text, tts_text, book_id)."""
-    
+def _process_response_tags(response_text, tts_text, book_id, story_meta=None):
+    """Process story/library/local tags in response text.
+
+    Returns ``(response_text, tts_text, book_id, story_meta)``.
+    """
+
     # Check READ_STORY tag
     if not book_id:
         match = re.search(r"\[\[\[READ_STORY: (.*?)\]\]\]", response_text)
@@ -180,12 +190,85 @@ def _process_response_tags(response_text, tts_text, book_id):
         if "error" not in result:
             book_id = result["book_id"]
             tts_text = result["tts_text"]
+            story_meta = build_story_meta(result.get("story_title"), result.get("chapter_file"))
             response_text = response_text.replace(match_local.group(0), "").strip()
         else:
             logger.warning(f"READ_LOCAL failed: {result['error']}")
             response_text += f"\n(Local read error: {result['error']})"
 
-    return response_text, tts_text, book_id
+    # Final sweep: strip EVERY backend marker tag so none reach the chat bubble
+    # as raw text. The per-tag branches above only strip on a successful match
+    # AND when book_id wasn't already set — but find_story_chapter sets book_id
+    # via the pending-read queue FIRST (check_pending_read runs before this), so
+    # those branches get skipped and the tag rendered verbatim (the READ_LOCAL
+    # leak, then CRAWL_STARTED, then whatever the next new tag is).
+    #
+    # Strip-all-except-PLAY instead of an allowlist: every [[[TAG: ...]]] is a
+    # backend/agent control marker the user must never see, EXCEPT [[[PLAY: id]]]
+    # which the frontend (utils/youtubeTags.js) parses for YouTube embeds. This
+    # is future-proof — a new backend tag is hidden by default, no code change.
+    response_text = re.sub(
+        r"\s*\[\[\[(?!PLAY[:\]])[A-Z_]+(?::.*?)?\]\]\]",
+        "", response_text,
+    ).strip()
+
+    return response_text, tts_text, book_id, story_meta
+
+
+def resolve_story_playback(raw_response):
+    """Single source of truth for turning a raw agent reply into playback.
+
+    Used by BOTH the typed-chat route and the voice WS route so a story plays
+    identically in either mode. Resolves the pending-read queue + any inline
+    story tags, then returns:
+
+      spoken_text  — the reply with all playback tags stripped. For a story
+                     this is just the announcement ("Đang phát ... chương 1");
+                     callers MUST NOT TTS-speak it when is_story is True (the
+                     story chapter itself is the audio).
+      tts_text     — the text to synthesise for the on-demand /api/tts audio
+                     (story chapter content, or the reply for a plain turn).
+      book_id      — TTS cache id for the chapter, or None for a plain reply.
+      story_meta   — playlist metadata for the singleton player, or None.
+      is_story     — True when this reply triggered story/library playback.
+      crawl_job_id — id of a crawl job the agent just started, or None. The
+                     [[[CRAWL_STARTED: id]]] tag is stripped from the bubble
+                     (machine noise), so we surface the id as structured data
+                     for the frontend to poll /api/stories/crawl/status/{id}.
+    """
+    response_text = process_agent_response(raw_response)
+    tts_text = response_text
+    book_id = None
+    story_meta = None
+
+    # Pull the crawl job id out of the tag BEFORE _process_response_tags strips
+    # every [[[...]]] marker. The tag is the agent's only structured handoff
+    # for "I started crawl job X"; without capturing it here the frontend has
+    # no reliable way to attach a progress poller (parsing the free-text
+    # "Job ID: ..." line is fragile).
+    crawl_job_id = None
+    _crawl_match = re.search(r"\[\[\[CRAWL_STARTED:\s*([^\]]+)\]\]\]", response_text)
+    if _crawl_match:
+        crawl_job_id = _crawl_match.group(1).strip()
+
+    pending = check_pending_read(library_manager, tts_cache, get_chapter_content)
+    if pending:
+        book_id = pending["book_id"]
+        tts_text = pending["tts_text"]
+        story_meta = build_story_meta(pending.get("story_title"), pending.get("chapter_file"))
+
+    response_text, tts_text, book_id, story_meta = _process_response_tags(
+        response_text, tts_text, book_id, story_meta
+    )
+
+    return {
+        "spoken_text": response_text,
+        "tts_text": tts_text,
+        "book_id": book_id,
+        "story_meta": story_meta,
+        "is_story": book_id is not None,
+        "crawl_job_id": crawl_job_id,
+    }
 
 
 def _prepare_audio_url(book_id, tts_text, base_url=""):
@@ -223,18 +306,14 @@ async def chat(request: ChatRequest, raw_request: Request = None, _=Depends(veri
         raw_response, cid = await session_service.resume_and_send(
             agent_app, request.message, request.conversation_id
         )
-        response_text = process_agent_response(raw_response)
-        tts_text = response_text
-        book_id = None
-
-        # Priority: Check pending read action
-        pending = check_pending_read(library_manager, tts_cache, get_chapter_content)
-        if pending:
-            book_id = pending["book_id"]
-            tts_text = pending["tts_text"]
-
-        # Process tags in response
-        response_text, tts_text, book_id = _process_response_tags(response_text, tts_text, book_id)
+        # Shared story/playback resolution (same path as voice — single source
+        # of truth). Strips tags, resolves pending-read, builds story metadata.
+        resolved = resolve_story_playback(raw_response)
+        response_text = resolved["spoken_text"]
+        tts_text = resolved["tts_text"]
+        book_id = resolved["book_id"]
+        story_meta = resolved["story_meta"]
+        crawl_job_id = resolved["crawl_job_id"]
 
         # Clean text for TTS
         if tts_text:
@@ -248,7 +327,7 @@ async def chat(request: ChatRequest, raw_request: Request = None, _=Depends(veri
 
         _duration = _time.time() - _t0
         logger.info(f"[RESPONSE] POST /chat cid={cid} duration={_duration:.1f}s status=ok")
-        return ChatResponse(response=str(response_text), audio=audio_url, playback_url=playback_url, conversation_id=cid)
+        return ChatResponse(response=str(response_text), audio=audio_url, playback_url=playback_url, conversation_id=cid, story=story_meta, crawl_job_id=crawl_job_id)
 
     except Exception as e:
         _duration = _time.time() - _t0
@@ -392,34 +471,36 @@ async def chat_stream(raw_request: Request, _=Depends(verify_api_key)):
                 )
                 _state.current_conversation_id = cid  # update with resolved cid
                 
-                # Save context window snapshot for the active agent
-                # Reuses the same centralized service as spawned agents
-                target_name = agent_name or "Jarvis"
+                # Save context window snapshots for EVERY agent that ran this
+                # turn — not just the primary one. Jarvis delegates to builtin
+                # sub-agents (e.g. AudioReaderAgent) via agent__ tool calls;
+                # those sub-agents run their own LLM turns in-process but were
+                # never snapshotted, so their "Context Window" tab stayed empty
+                # while "History" (per-agent progress hooks) showed their rows.
+                # save_agent_context() skips agents with empty message_history,
+                # so idle agents cost nothing — the message_history IS the
+                # single source of truth for "did this agent participate".
                 try:
                     from services.context_persistence import save_agent_context
-                    target_agent_obj = agent_app._agents.get(target_name)
-                    if target_agent_obj:
+                    for _name, _agent_obj in agent_app._agents.items():
                         await save_agent_context(
-                            target_agent_obj,
+                            _agent_obj,
                             request_id,
                             trigger="chat_complete",
-                            agent_name=target_name,
+                            agent_name=_name,
                             session_id=cid,
                         )
                 except Exception as _ctx_err:
                     logger.warning("[CONTEXT] Failed to save built-in agent context: %s", _ctx_err)
                 
-                response_text = process_agent_response(raw_response)
-                tts_text = response_text
-                book_id = None
-                
-                pending = check_pending_read(library_manager, tts_cache, get_chapter_content)
-                if pending:
-                    book_id = pending["book_id"]
-                    tts_text = pending["tts_text"]
-                
-                response_text, tts_text, book_id = _process_response_tags(response_text, tts_text, book_id)
-                
+                # Shared story/playback resolution (same path as voice).
+                resolved = resolve_story_playback(raw_response)
+                response_text = resolved["spoken_text"]
+                tts_text = resolved["tts_text"]
+                book_id = resolved["book_id"]
+                story_meta = resolved["story_meta"]
+                crawl_job_id = resolved["crawl_job_id"]
+
                 if tts_text:
                     tts_text = clean_text_for_tts(tts_text)
                     if _state.bg_scheduler and _state.bg_scheduler.is_running():
@@ -453,6 +534,8 @@ async def chat_stream(raw_request: Request, _=Depends(verify_api_key)):
                     "playback_url": playback_url,
                     "conversation_id": cid,
                     "total_tokens": total_tokens,
+                    "story": story_meta,
+                    "crawl_job_id": crawl_job_id,
                 })
                 
                 # Broadcast idle event to global activity stream

--- a/backend/routes/stories.py
+++ b/backend/routes/stories.py
@@ -406,7 +406,13 @@ async def play_local_chapter(story_id: str, filename: str, _=Depends(verify_api_
         else:
             if _state.bg_scheduler and _state.bg_scheduler.is_running():
                 _state.bg_scheduler.notify_tts_activity()
-                _state.bg_scheduler.request_cancel()
+                # Only cancel pre-gen if it's working a DIFFERENT chapter.
+                # Cancelling the chapter the user just clicked would delete its
+                # half-written mp3 + lock mid-stream → the live stream closes at
+                # ~11s and the player auto-advances. The .lock on this exact
+                # cache_path means pre-gen already owns it → hand over instead.
+                if not os.path.exists(cache_path + ".lock"):
+                    _state.bg_scheduler.request_cancel()
         
         return response
     except Exception as e:

--- a/backend/routes/tts.py
+++ b/backend/routes/tts.py
@@ -60,14 +60,17 @@ async def cancel_tts(request_id: str, _=Depends(verify_api_key)):
 
 @router.api_route("/{request_id}", methods=["GET", "HEAD"])
 async def tts_endpoint(request_id: str, request: Request, _auth=Depends(verify_optional_api_key)):
-    # Notify scheduler: on-demand TTS activity
+    # Notify scheduler of on-demand activity. The cancel-vs-handover decision
+    # is DEFERRED until we've resolved cache_path + lock state below. The old
+    # is_generating(request_id) check never matched — pre-gen keys its tasks by
+    # {story_title, chapter_file}, never request_id — so it ALWAYS fell through
+    # to request_cancel(), cancelling the very chapter the user just asked for.
+    # That deleted the half-written mp3 + lock mid-stream → the live stream
+    # closed at ~11s → the browser fired 'ended' → auto-advanced. The lock file
+    # on THIS cache_path (computed below) is the real source of truth for
+    # "is this exact audio already being generated".
     if _state.bg_scheduler:
         _state.bg_scheduler.notify_tts_activity()
-        if _state.bg_scheduler.is_generating(request_id):
-            logger.debug(f"[KB1] Handover: pre-gen working on {request_id}, streaming in progress")
-        elif _state.bg_scheduler.is_running():
-            logger.debug(f"[KB2] Cancel pre-gen: user requested {request_id}")
-            _state.bg_scheduler.request_cancel()
     
     # Check if this request_id belongs to the Library
     book = library_manager.get_book(request_id)
@@ -139,15 +142,32 @@ async def tts_endpoint(request_id: str, request: Request, _auth=Depends(verify_o
         file_size = 0
         if mp3_exists:
              file_size = os.path.getsize(cache_path)
-        
+
         headers = {"Accept-Ranges": "bytes", "Content-Type": "audio/mpeg"}
         if file_size > 0:
             headers["Content-Length"] = str(file_size)
+        # Tell the player whether this audio is still being generated. The
+        # frontend uses this on a premature 'ended' to tell a live-stream
+        # buffer underrun (resume) apart from a real end-of-chapter (advance).
+        if os.path.exists(cache_path + ".lock"):
+            headers["X-TTS-Generating"] = "1"
         return Response(status_code=200, headers=headers)
 
     # Check/Start Background Generation
     lock_path = cache_path + ".lock"
-    meta_path = cache_path + ".part.json" 
+    meta_path = cache_path + ".part.json"
+
+    # Handover vs cancel (deferred from the top of the handler). The .lock on
+    # THIS cache_path is the single source of truth: if it exists, something is
+    # already generating this exact audio — hand over and stream its output. If
+    # not and the scheduler is busy, it's working a DIFFERENT chapter, so cancel
+    # it to free the Edge quota for this on-demand request.
+    if _state.bg_scheduler and _state.bg_scheduler.is_running():
+        if os.path.exists(lock_path):
+            logger.debug(f"[KB1] Handover: pre-gen owns {request_id}, streaming its output")
+        else:
+            logger.debug(f"[KB2] Cancel pre-gen (different chapter): user requested {request_id}")
+            _state.bg_scheduler.request_cancel()
     
     is_generating = False
     if os.path.exists(lock_path):

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -724,27 +724,40 @@ async def voice_ws(ws: WebSocket) -> None:
             # context-history view ("context window was not being saved
             # to db after agent idle" bug). Best-effort — never
             # break the speak() path on a save failure.
+            # Snapshot EVERY agent that ran this turn, not just the primary —
+            # delegated builtin sub-agents (e.g. AudioReaderAgent) run their
+            # own in-process LLM turns and otherwise never get a Context Window
+            # snapshot. save_agent_context() skips empty histories, so idle
+            # agents are free. (Mirrors the chat-stream fix.)
             try:
                 from services.context_persistence import save_agent_context
-                target_name = agent_name or "Jarvis"
-                target_agent_obj = state.agent_app._agents.get(target_name)
-                if target_agent_obj:
+                for _name, _agent_obj in state.agent_app._agents.items():
                     await save_agent_context(
-                        target_agent_obj,
+                        _agent_obj,
                         req_id,
                         trigger="voice_turn_complete",
-                        agent_name=target_name,
+                        agent_name=_name,
                         session_id=session_id,
                     )
             except Exception:
                 logger.warning("[CONTEXT] voice turn save failed", exc_info=True)
 
-            response = (response or "").strip()
+            # Resolve story playback through the SAME path as typed chat
+            # (single source of truth): strips playback tags, runs the
+            # pending-read queue, builds story metadata. This is what makes
+            # "play a story by voice" behave like the typed flow instead of
+            # the bot reading the "[[[READ_LOCAL: ...]]]" announcement aloud.
+            from routes.chat import resolve_story_playback
+            resolved = resolve_story_playback(response)
+            spoken = (resolved["spoken_text"] or "").strip()
+            is_story = resolved["is_story"]
+            story_meta = resolved["story_meta"]
+
             logger.info(
-                "[ws_voice] turn done req=%s response_len=%d empty=%s",
-                req_id, len(response), not response,
+                "[ws_voice] turn done req=%s spoken_len=%d is_story=%s",
+                req_id, len(spoken), is_story,
             )
-            if not response:
+            if not spoken and not is_story:
                 # Empty reply — finalize placeholder with a clear message so
                 # the UI doesn't sit on an invisible streaming bubble.
                 await out_queue.put({
@@ -754,12 +767,21 @@ async def voice_ws(ws: WebSocket) -> None:
                     "empty": True,
                 })
                 return
+            # Send the (tag-stripped) announcement to the chat bubble, plus the
+            # story metadata so the frontend routes playback through the
+            # singleton player (mini-player, chapter nav, resume).
             await out_queue.put({
                 "type": "assistant_message",
-                "text": response,
+                "text": spoken,
                 "session_id": session_id,
+                "story": story_meta,
             })
-            tts_task = asyncio.create_task(speak(response))
+            if is_story:
+                # A story plays through the singleton audio player, NOT the
+                # voice TTS channel. Speaking the announcement here would talk
+                # over the chapter — so we deliberately do NOT call speak().
+                return
+            tts_task = asyncio.create_task(speak(spoken))
             try:
                 await tts_task
             except asyncio.CancelledError:

--- a/backend/services/crawl_poller.py
+++ b/backend/services/crawl_poller.py
@@ -44,6 +44,32 @@ def _dbg(job_id: str, msg: str):
         pass
 
 
+_CHAPTER_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                  "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+}
+
+
+def render_page_or_get(url: str, headers: dict) -> str | None:
+    """Fetch a CHAPTER page. Chapter bodies are usually static HTML (verified:
+    truyenfull #chapter-c served by plain requests) → try fast ``requests``
+    first, fall back to JS render only if the static fetch yields too little.
+    Keeps the common case fast while still handling JS-built chapter pages."""
+    try:
+        resp = requests.get(url, headers=headers or _CHAPTER_HEADERS, timeout=(3, 15))
+        if resp.status_code == 200 and len(resp.text) > 2000:
+            return resp.text
+    except Exception:
+        pass
+    # Fallback: JS render (handles SPA chapter pages)
+    try:
+        from tools.story_server import render_page
+        return render_page(url)
+    except Exception as e:
+        logger.warning("[CRAWL_POLLER] render fallback failed for %s: %s", url, e)
+        return None
+
+
 class CrawlPoller:
     """Background poller that picks up pending crawl jobs from DB."""
     
@@ -52,10 +78,15 @@ class CrawlPoller:
     def __init__(self):
         self._running = False
         self._active_threads: dict[str, threading.Thread] = {}
-    
+        self._loop = None  # main event loop — captured in start(), used by worker
+                           # threads to schedule async self-heal turns thread-safely
+
     async def start(self):
         """Main loop — runs forever within FastAPI lifespan."""
         self._running = True
+        # Capture the FastAPI event loop so crawl worker THREADS can hand a
+        # self-heal agent turn back to it via run_coroutine_threadsafe.
+        self._loop = asyncio.get_running_loop()
         logger.info("[CRAWL_POLLER] Started, polling every %ds", self.POLL_INTERVAL)
         
         # On startup: mark stale 'running' jobs as 'pending' for retry
@@ -137,6 +168,372 @@ class CrawlPoller:
         except Exception:
             return "unknown"
     
+    def _enumerate_list_mode(self, job_id: str, overview_url: str, recipe: dict) -> list[dict]:
+        """LIST mode: render overview (+ pagination) and collect chapter URLs that
+        match the recipe's chapter_url_pattern AND live under story_root.
+
+        Language-agnostic: filters by URL structure (path-pattern + story_root
+        prefix), NOT by chapter-title words. This is the same-story guard that
+        stops sidebar "recommended story" links (different slug) from leaking in.
+        """
+        from urllib.parse import urlparse
+        from tools.story_server import render_page, _url_path_pattern
+
+        story_root = recipe.get("story_root") or "/"
+        want_pat = recipe.get("chapter_url_pattern")
+        want_pat = _url_path_pattern(want_pat.rstrip("/")) if want_pat else None
+        next_sel = recipe.get("next_page_selector")
+        base_host = urlparse(overview_url).netloc
+
+        seen: set[str] = set()
+        chapters: list[dict] = []
+        page_url = overview_url
+        visited_pages: set[str] = set()
+        pages = 0
+        while page_url and pages < 100:
+            if page_url in visited_pages:
+                break
+            visited_pages.add(page_url)
+            html = render_page(page_url)
+            if not html:
+                break
+            soup = BeautifulSoup(html, "html.parser")
+            for a in soup.find_all("a", href=True):
+                full = urljoin(page_url, a["href"])
+                pp = urlparse(full)
+                if (pp.netloc or base_host) != base_host:
+                    continue
+                path = pp.path
+                # same-story guard: must live under the story root
+                if not path.startswith(story_root):
+                    continue
+                if path.rstrip("/") == story_root.rstrip("/"):
+                    continue
+                # structural pattern match (digits collapsed) — language-agnostic
+                if want_pat and _url_path_pattern(path.rstrip("/")) != want_pat:
+                    continue
+                if full in seen:
+                    continue
+                seen.add(full)
+                chapters.append({"url": full, "title": a.get_text(strip=True)})
+            # ── pagination (structural, language-agnostic) ──
+            # 1) recipe-supplied selector, 2) rel=next, 3) discover ALL paginated
+            #    list pages by collecting same-story links that look like page
+            #    indexes (e.g. /story/trang-2/, ?page=2) and queueing the unseen
+            #    ones. (3) survives sites whose "next" link is text-only like
+            #    "Trang tiếp"/"Next" — we don't read the words, we match the
+            #    page-URL shape under story_root.
+            nxt = None
+            if next_sel:
+                n = soup.select_one(next_sel)
+                if n and n.get("href"):
+                    nxt = urljoin(page_url, n["href"])
+            if not nxt:
+                n = soup.select_one("a[rel='next']")
+                if n and n.get("href"):
+                    nxt = urljoin(page_url, n["href"])
+            if not nxt:
+                for a in soup.find_all("a", href=True):
+                    full = urljoin(page_url, a["href"]).split("#")[0]
+                    pp = urlparse(full)
+                    if (pp.netloc or base_host) != base_host:
+                        continue
+                    if not pp.path.startswith(story_root):
+                        continue
+                    # page-index shape: .../trang-N/ , .../page/N , ?page=N , .../N/
+                    if re.search(r"(trang|page)[-/_]?\d+|[?&]page=\d+", full, re.I):
+                        if full not in visited_pages:
+                            nxt = full
+                            break
+            page_url = nxt.split("#")[0] if (nxt and nxt.split("#")[0] not in visited_pages) else None
+            pages += 1
+
+        # Natural sort by the numbers embedded in each chapter URL (quyen, chuong…)
+        def _numkey(c):
+            nums = [int(x) for x in re.findall(r"\d+", urlparse(c["url"]).path)]
+            return nums or [0]
+        chapters.sort(key=_numkey)
+        _dbg(job_id, f"LIST enumerate: {len(chapters)} chapters across {pages} page(s)")
+        return chapters
+
+    def _same_story(self, url: str, story_root: str, base_host: str) -> bool:
+        """True if url stays on the same host AND under story_root — the
+        chain-mode drift guard (stops 'next' links into a different story)."""
+        from urllib.parse import urlparse
+        p = urlparse(url)
+        if (p.netloc or base_host) != base_host:
+            return False
+        return p.path.startswith(story_root)
+
+    def _run_recipe_crawl(self, job_id: str, start_url: str, recipe: dict,
+                          speed: float, max_chapters: int, headers: dict,
+                          resume_from: int = 0):
+        """AI-driven crawl: build the chapter URL list from the recipe (LIST or
+        CHAIN mode), then fetch each chapter's content statically and save.
+
+        same_story guard (story_root) is enforced in BOTH modes so the crawl can
+        never drift into a different story. On repeated content failures it flags
+        the job 'needs_attention' and wakes CrawlStoriesAgent to self-heal.
+
+        resume_from: skip this many already-saved chapters (self-heal continues
+        from the checkpoint instead of restarting at chapter 1).
+        """
+        from urllib.parse import urlparse
+
+        mode = recipe.get("mode", "list")
+        story_root = recipe.get("story_root") or "/"
+        content_sel = recipe.get("content_selector")
+        title_sel = recipe.get("title_selector", "h1")
+        base_host = urlparse(start_url).netloc
+        story_title = recipe.get("story_title") or ""
+
+        # ── Build the chapter list (NO LLM — code enumerates) ──
+        if mode == "list":
+            chapters = self._enumerate_list_mode(job_id, start_url, recipe)
+            if not chapters:
+                self._update_job(job_id, status="needs_attention",
+                                 message="LIST mode found 0 chapters — recipe selector/pattern likely wrong")
+                _dbg(job_id, "LIST mode: 0 chapters → needs_attention")
+                return
+        else:
+            chapters = None  # CHAIN mode walks next-links lazily below
+
+        # ── Resolve story folder/title from the first chapter page ──
+        first_url = (chapters[0]["url"] if chapters
+                     else recipe.get("first_chapter_url") or start_url)
+        first_html = render_page_or_get(first_url, headers or _CHAPTER_HEADERS)
+        if not first_html:
+            self._update_job(job_id, status="needs_attention",
+                             message=f"Could not fetch first chapter {first_url}")
+            return
+        fsoup = BeautifulSoup(first_html, "html.parser")
+        if not story_title:
+            t = fsoup.select_one(title_sel)
+            raw = t.get_text(strip=True) if t else ""
+            story_title = re.sub(r'\s*(Chương|Chapter|Quyển)\s*\d+.*$', '', raw, flags=re.I).strip() or "Story"
+        story_folder = re.sub(r'[\\/*?:"<>|]', "", story_title).strip() or "Untitled_Story"
+        save_dir = os.path.join(DATA_DIR, "stories", story_folder)
+        os.makedirs(save_dir, exist_ok=True)
+        self._register_story_meta(story_folder, story_title, start_url)
+        total = len(chapters) if chapters else max_chapters
+        self._update_job(job_id, story_title=story_title, total_chapters=total,
+                         current_chapter=0, message="Starting crawl...")
+        _dbg(job_id, f"[RECIPE/{mode}] story='{story_title}' total={total}")
+
+        # ── Crawl loop ──
+        # resume_from: continue after the checkpoint. LIST mode skips that many
+        # entries; CHAIN mode can't random-access so it re-walks but only saves
+        # past the checkpoint (filenames are index-based → no dupes/gaps).
+        count = resume_from if resume_from else 0
+        empty_streak = 0
+        if chapters and resume_from:
+            chapter_iter = iter(chapters[resume_from:])
+            _dbg(job_id, f"[RECIPE] resuming LIST from chapter {resume_from+1}")
+        else:
+            chapter_iter = iter(chapters) if chapters else None
+        current_url = first_url
+        while count < max_chapters:
+            if self._get_job_status(job_id) == "cancelled":
+                self._update_job(job_id, message="Cancelled by user.")
+                _dbg(job_id, "Cancelled by user")
+                return
+
+            if chapter_iter is not None:
+                try:
+                    current_url = next(chapter_iter)["url"]
+                except StopIteration:
+                    break
+            # CHAIN drift guard: never follow a link outside the story
+            if not self._same_story(current_url, story_root, base_host):
+                _dbg(job_id, f"[RECIPE] drift blocked: {current_url[:70]} not under {story_root}")
+                break
+
+            html = render_page_or_get(current_url, headers)
+            if not html:
+                empty_streak += 1
+                if empty_streak >= 3:
+                    self._update_job(job_id, status="needs_attention",
+                                     message=f"3 fetch failures in a row near chapter {count+1} ({current_url})")
+                    _dbg(job_id, "3 fetch failures → needs_attention")
+                    return
+                if chapter_iter is not None:
+                    continue
+                break
+            soup = BeautifulSoup(html, "html.parser")
+            cdiv = soup.select_one(content_sel) if content_sel else None
+            text = ""
+            if cdiv:
+                for s in cdiv(["script", "style", "iframe"]):
+                    s.decompose()
+                text = cdiv.get_text(separator="\n\n").strip()
+
+            if len(text) < 100:
+                empty_streak += 1
+                _dbg(job_id, f"[RECIPE] empty/short content #{count+1} (streak={empty_streak})")
+                if empty_streak >= 3:
+                    # Self-heal trigger (Phase 4): selector likely broke mid-crawl
+                    self._flag_needs_attention(job_id, current_url, recipe, count,
+                                               "content_selector returned empty for 3 chapters in a row")
+                    return
+                if chapter_iter is not None:
+                    continue
+                break
+            empty_streak = 0
+
+            t_tag = soup.select_one(title_sel)
+            chap_title = t_tag.get_text(strip=True) if t_tag else f"Chapter {count+1}"
+            filename = f"{count+1:03d}_{re.sub(r'[\\/*?:\"<>|]', '', chap_title)[:50]}.txt"
+            with open(os.path.join(save_dir, filename), "w", encoding="utf-8") as f:
+                f.write(text)
+            count += 1
+            self._update_job(job_id, current_chapter=count, message=f"Crawled: {chap_title}")
+            _dbg(job_id, f"[RECIPE] saved #{count}: {chap_title[:40]}")
+
+            # CHAIN mode: find next chapter link, validate same-story
+            if chapter_iter is None:
+                nxt = None
+                nsel = recipe.get("next_chapter_selector")
+                if nsel:
+                    n = soup.select_one(nsel)
+                    if n and n.get("href"):
+                        nxt = urljoin(current_url, n["href"])
+                if not nxt or not self._same_story(nxt, story_root, base_host):
+                    _dbg(job_id, "[RECIPE/chain] no valid same-story next link → stop")
+                    break
+                current_url = nxt
+            time.sleep(speed)
+
+        self._update_job(job_id, status="completed",
+                         message=f"Completed. Saved {count} chapters.")
+        self._finalize_story_meta(story_folder, count)
+        _dbg(job_id, f"[RECIPE] Completed. {count} chapters.")
+
+    def _register_story_meta(self, story_folder: str, story_title: str, src: str):
+        try:
+            from core.database import StoryMeta
+            db = get_db_session()
+            try:
+                if not db.query(StoryMeta).filter(StoryMeta.story_id == story_folder).first():
+                    db.add(StoryMeta(story_id=story_folder, title=story_title,
+                                     source_url=src, chapter_count=0))
+                    db.commit()
+            finally:
+                db.close()
+        except Exception as e:
+            logger.warning("[CRAWL_POLLER] register meta failed: %s", e)
+
+    def _finalize_story_meta(self, story_folder: str, count: int):
+        try:
+            from core.database import StoryMeta
+            db = get_db_session()
+            try:
+                m = db.query(StoryMeta).filter(StoryMeta.story_id == story_folder).first()
+                if m:
+                    m.chapter_count = count
+                    m.updated_at = datetime.now().timestamp()
+                    db.commit()
+            finally:
+                db.close()
+        except Exception as e:
+            logger.warning("[CRAWL_POLLER] finalize meta failed: %s", e)
+
+    def _flag_needs_attention(self, job_id, url, recipe, count, reason):
+        """Self-heal trigger: worker hit an anomaly it can't resolve by itself.
+
+        1. Persist checkpoint (chapter index, current recipe, stuck URL) so a
+           later resume continues instead of restarting.
+        2. Mark status='needs_attention' + a human-readable message → the crawl
+           banner (useCrawlStatus) turns to a warning state.
+        3. Push an activity_stream event so the UI updates instantly (no poll
+           wait) — the user SEES the problem.
+        4. Schedule a CrawlStoriesAgent turn on the main loop to diagnose + fix
+           the recipe (event-driven, agent_lock auto-queues if Jarvis is busy).
+        """
+        checkpoint = {
+            "stuck_url": url,
+            "stuck_index": count,          # 0-based: chapters 0..count-1 are saved
+            "recipe": recipe,
+            "reason": reason,
+        }
+        # 1 + 2: persist checkpoint into params.checkpoint + flip status
+        self._update_job(
+            job_id,
+            status="needs_attention",
+            message=f"Kẹt ở chương {count+1}: {reason}",
+            **self._merge_checkpoint(job_id, checkpoint),
+        )
+        _dbg(job_id, f"needs_attention @ ch{count+1}: {reason}")
+
+        # 3: instant UI notify (activity_stream is sync → safe from this thread)
+        try:
+            from services.activity_stream import activity_stream_manager
+            activity_stream_manager.broadcast({
+                "agent_name": "CrawlStoriesAgent",
+                "event_type": "crawl_anomaly",
+                "message": f"Crawl gặp vấn đề ở chương {count+1}: {reason}",
+                "run_id": job_id,
+                "timestamp": time.time(),
+                "data": {"job_id": job_id, "stuck_index": count, "reason": reason},
+            })
+        except Exception as e:
+            logger.warning("[CRAWL_POLLER] activity broadcast failed: %s", e)
+
+        # 4: wake CrawlStoriesAgent to self-heal (thread → main loop)
+        self._schedule_self_heal(job_id, checkpoint)
+
+    def _merge_checkpoint(self, job_id: str, checkpoint: dict) -> dict:
+        """Return a {'params': <json>} update that preserves existing params and
+        adds the checkpoint, for _update_job(**...)."""
+        try:
+            db = get_db_session()
+            try:
+                job = db.query(CrawlJob).filter(CrawlJob.job_id == job_id).first()
+                params = json.loads(job.params) if (job and job.params) else {}
+            finally:
+                db.close()
+        except Exception:
+            params = {}
+        params["checkpoint"] = checkpoint
+        return {"params": json.dumps(params, ensure_ascii=False)}
+
+    def _schedule_self_heal(self, job_id: str, checkpoint: dict):
+        """Hand a self-heal agent turn to the main event loop from this worker
+        thread. CrawlStoriesAgent wakes, diagnoses, and (via verify_chapters +
+        resume_crawl tools) fixes the recipe. _agent_lock serialises it behind
+        any in-flight user turn — no race, no lost work."""
+        if self._loop is None:
+            _dbg(job_id, "self-heal skipped: no event loop ref")
+            return
+        reason = checkpoint.get("reason", "unknown")
+        stuck_idx = checkpoint.get("stuck_index", 0)
+        stuck_url = checkpoint.get("stuck_url", "")
+        recipe = checkpoint.get("recipe", {})
+        payload = (
+            f"[CRAWL SELF-HEAL] Crawl job {job_id} bị kẹt ở chương {stuck_idx+1}: {reason}\n"
+            f"URL kẹt: {stuck_url}\n"
+            f"Recipe hiện tại: {json.dumps(recipe, ensure_ascii=False)}\n\n"
+            f"HÃY: render lại trang kẹt (detect_story_structure), chẩn đoán selector/pattern sai, "
+            f"chạy verify_chapters với recipe đã sửa. Nếu OK → gọi resume_crawl(job_id='{job_id}', "
+            f"recipe_patch=<phần sửa>). Nếu thật sự đã hết truyện ở chương {stuck_idx} → "
+            f"gọi resume_crawl(job_id='{job_id}', recipe_patch={{}}, mark_done=true). "
+            f"Nếu site đổi cấu trúc hẳn / bị chặn → báo người dùng."
+        )
+
+        async def _run():
+            try:
+                from services.shared_state import session_service, agent_app
+                await session_service.resume_and_send(
+                    agent_app, payload, session_id=None, agent_name="CrawlStoriesAgent",
+                )
+            except Exception as e:
+                logger.error("[CRAWL_POLLER] self-heal turn failed for %s: %s", job_id[:8], e)
+
+        try:
+            asyncio.run_coroutine_threadsafe(_run(), self._loop)
+            _dbg(job_id, "self-heal agent turn scheduled")
+        except Exception as e:
+            logger.error("[CRAWL_POLLER] failed to schedule self-heal: %s", e)
+
     def _crawl_worker(self, job_id: str, start_url: str, params: dict):
         """Main crawl logic — runs in a thread within FastAPI process."""
         content_selector = params.get("content_selector")
@@ -144,8 +541,10 @@ class CrawlPoller:
         next_selector = params.get("next_selector")
         speed = params.get("speed", 2.0)
         max_chapters = params.get("max_chapters", 2000)
-        
-        _dbg(job_id, f"Worker started: {start_url}")
+        recipe = params.get("recipe")  # AI-generated crawl recipe (new path)
+        resume_from = params.get("resume_from", 0)  # self-heal: skip already-saved
+
+        _dbg(job_id, f"Worker started: {start_url}" + (" [RECIPE]" if recipe else " [legacy]"))
         
         try:
             headers = {
@@ -157,7 +556,14 @@ class CrawlPoller:
             if self._get_job_status(job_id) == "cancelled":
                 _dbg(job_id, "Cancelled before start")
                 return
-            
+
+            # ── AI-driven path: a recipe was supplied → enumerate + crawl by it,
+            #    bypassing the legacy provider-autodetect / regex chapter-1 logic.
+            if recipe:
+                self._run_recipe_crawl(job_id, start_url, recipe, speed, max_chapters, headers,
+                                       resume_from=resume_from)
+                return
+
             # --- Provider auto-detection ---
             # Import StoryConfigManager from tools module (safe, no MCP dependency)
             try:

--- a/backend/services/pause_controller.py
+++ b/backend/services/pause_controller.py
@@ -152,11 +152,19 @@ class PauseController:
         # needs to emit the terminal event itself (idle agent) or wait
         # for the hook to do it (active agent).
         self._active: dict[str, bool] = {}
-        # Task ref of the in-flight LLM call. Set by the ``before_llm_call``
-        # hook (captures ``asyncio.current_task()``), cleared by
-        # ``after_llm_call``. ``pause()`` cancels this task to interrupt
-        # long-running LLM streams — see module docstring "Instant pause".
+        # Task ref of the in-flight LLM call ONLY. Set by ``before_llm_call``,
+        # cleared by ``after_llm_call``. ``pause()`` uses this (cooperative:
+        # cancel mid-LLM, but let an in-flight TOOL call finish — strategy B).
         self._current_tasks: dict[str, asyncio.Task] = {}
+        # Task ref for the WHOLE turn (LLM + tool/delegate phases). Set on the
+        # first ``before_llm_call`` of a turn, cleared at ``after_turn_complete``
+        # (or on a genuine cancel). ``interrupt()`` (hard Stop) uses this so it
+        # can cancel even while the agent is mid-tool / delegating to a
+        # sub-agent — the previous bug: interrupt read ``_current_tasks`` which
+        # is empty during the tool phase, so "Stop" while delegating was a
+        # NO-OP, the turn kept running and held session_service._agent_lock,
+        # and every later chat message blocked forever (reload didn't help).
+        self._turn_tasks: dict[str, asyncio.Task] = {}
 
     def _get_event(self, agent_name: str) -> asyncio.Event:
         """Get or create an asyncio.Event for the given agent (default: set = not paused)."""
@@ -503,7 +511,12 @@ class PauseController:
             # than wrapping the LLM call) because hooks are already in
             # the call site and we don't have to touch tool_runner.
             try:
-                self._current_tasks[agent_name] = asyncio.current_task()
+                cur = asyncio.current_task()
+                self._current_tasks[agent_name] = cur
+                # Track the turn-level task too (first LLM call of the turn).
+                # interrupt() uses this so a hard Stop works during the tool/
+                # delegate phase, when _current_tasks is empty.
+                self._turn_tasks.setdefault(agent_name, cur)
             except RuntimeError:
                 pass  # not in a task context — skip cancel support
             if not event.is_set():
@@ -533,6 +546,7 @@ class PauseController:
         async def on_after_turn_complete(runner: Any, message: Any) -> None:
             self._active[agent_name] = False
             self._current_tasks.pop(agent_name, None)
+            self._turn_tasks.pop(agent_name, None)
 
         async def on_pause_cancel(runner: Any) -> bool:
             """Called by tool_runner when a CancelledError surfaces inside
@@ -638,6 +652,7 @@ class PauseController:
         if name:
             self._active.pop(name, None)
             self._current_tasks.pop(name, None)
+            self._turn_tasks.pop(name, None)
 
     def interrupt(self, scope: str) -> list[str]:
         """Soft interrupt: cancel in-flight LLM call WITHOUT entering paused state.
@@ -660,11 +675,15 @@ class PauseController:
         agents, _ = self._resolve_scope(scope)
         cancelled: list[str] = []
         for agent in agents:
-            task = self._current_tasks.get(agent)
+            # Use the TURN task (covers LLM + tool/delegate phases), not just
+            # the LLM-window task. Fall back to _current_tasks for safety.
+            task = self._turn_tasks.get(agent) or self._current_tasks.get(agent)
             if task is not None and not task.done():
                 task.cancel()
                 cancelled.append(agent)
-                logger.info("[INTERRUPT] Cancelled in-flight LLM task for %s", agent)
+                self._turn_tasks.pop(agent, None)
+                self._current_tasks.pop(agent, None)
+                logger.info("[INTERRUPT] Cancelled in-flight turn task for %s", agent)
         return cancelled
 
     def hard_kill(self, scope: str) -> dict:
@@ -700,14 +719,18 @@ class PauseController:
 
         Returns ``{cancelled_tasks: [name], killed_pids: [{name, pid}]}``.
         """
-        # 1. Cancel parent in-flight task (in-process Jarvis).
+        # 1. Cancel parent in-flight task (in-process Jarvis). Use the TURN
+        # task so a hard Stop works during the tool/delegate phase too (same
+        # fix as interrupt() — _current_tasks is empty mid-tool).
         agents, _ = self._resolve_scope(scope)
         cancelled: list[str] = []
         for agent in agents:
-            task = self._current_tasks.get(agent)
+            task = self._turn_tasks.get(agent) or self._current_tasks.get(agent)
             if task is not None and not task.done():
                 task.cancel()
                 cancelled.append(agent)
+                self._turn_tasks.pop(agent, None)
+                self._current_tasks.pop(agent, None)
 
         # 2. SIGTERM every running subprocess subagent.
         killed: list[dict] = []

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -682,10 +682,19 @@ class SessionService:
                 except Exception:
                     logger.debug("[SESSION] cancellation rollback: history pop failed", exc_info=True)
                 logger.info(
-                    f"[SESSION] turn cancelled — skipping save_history for "
-                    f"session={session_id} (rolled back agent.message_history)"
+                    f"[SESSION] turn cancelled for session={session_id} — "
+                    f"rolled back phantom turn, still stamping primary + saving "
+                    f"so the conversation stays visible in the list"
                 )
-                return response, session_id
+                # IMPORTANT: do NOT return early here. We still fall through to
+                # stamp the primary agent + save_history below. Returning early
+                # (the previous behaviour) skipped the primary-agent stamp, so a
+                # session whose FIRST turn was cancelled (e.g. user starts a long
+                # crawl turn then navigates away / hits Stop) was left with no
+                # primary_agent metadata → _resolve_primary_agent() returns None
+                # → list_sessions HIDES it → "the conversation disappeared" bug.
+                # History was already rolled back above, so the save below
+                # persists clean state (no phantom turn) + the metadata.
 
             # Stamp the primary agent on first send so list_sessions /
             # get_display_history can route follow-up reads without the caller

--- a/backend/services/stt_backends/_ws_streaming.py
+++ b/backend/services/stt_backends/_ws_streaming.py
@@ -81,6 +81,13 @@ class WSStreamingSTT:
     #: Override in subclass — logging tag, e.g. ``"Soniox STT"``.
     LOG_TAG: ClassVar[str] = "WS STT"
 
+    #: How often (seconds) to send a keepalive while no audio is flowing.
+    #: Cloud STT WebSockets drop the connection after an idle window (Soniox:
+    #: ">20s with no keepalive or audio" → 408 Request timeout). Sending under
+    #: that window keeps the session alive through user silence. 10s gives a
+    #: comfortable margin under the typical 20s server idle timeout.
+    KEEPALIVE_INTERVAL: ClassVar[float] = 10.0
+
     def __init__(self, *, sample_rate: int = 16000) -> None:
         if not self.WS_URL:
             raise NotImplementedError(f"{type(self).__name__} must set WS_URL")
@@ -89,6 +96,9 @@ class WSStreamingSTT:
         self._hook: Optional[EventHook] = None
         self._lock = threading.Lock()
         self._closed = False
+        # Set by a subclass on an unrecoverable error (bad API key, bad config)
+        # so the reconnect loop gives up instead of hammering a doomed endpoint.
+        self._fatal = False
 
         self._audio_queue: Optional[asyncio.Queue[bytes]] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -264,6 +274,18 @@ class WSStreamingSTT:
         (re)connect. Called once after the config message is sent.
         """
 
+    def _keepalive_message(self) -> Optional[str]:
+        """Return the keepalive frame to send during audio silence, or None
+        if this provider needs none. Sent every ``KEEPALIVE_INTERVAL`` seconds
+        while the audio queue is idle."""
+        return None
+
+    def mark_fatal(self) -> None:
+        """Subclasses call this from ``_handle_event`` when an inbound error is
+        unrecoverable (bad key / bad config) — stops the reconnect loop so we
+        don't spin against an endpoint that will reject us every time."""
+        self._fatal = True
+
     # ---- emit helpers (subclass convenience) -------------------------
 
     def _emit(self, event: str, payload: dict[str, Any]) -> None:
@@ -359,7 +381,7 @@ class WSStreamingSTT:
 
         backoff = BACKOFF_INITIAL
 
-        while not self._closed:
+        while not self._closed and not self._fatal:
             # ── Step 1: wait for mic-on (resume()) ──
             if not self._active_event.is_set():
                 # Only emit IDLE if we're transitioning back to it after a
@@ -438,7 +460,10 @@ class WSStreamingSTT:
                 # gather returned normally → server closed (idle timeout
                 # or pause() forced close). Outer while re-enters.
                 self._current_ws_holder["ws"] = None
-                if self._closed:
+                if self._closed or self._fatal:
+                    # _fatal: a subclass flagged an unrecoverable inbound error
+                    # (bad key/config) — stop the loop instead of reconnecting
+                    # into a guaranteed rejection.
                     return
                 if not self._active_event.is_set():
                     # pause() forced close — silent IDLE, no reconnect noise.
@@ -479,8 +504,25 @@ class WSStreamingSTT:
 
     async def _sender(self, ws) -> None:
         assert self._audio_queue is not None
+        keepalive = self._keepalive_message()
         while True:
-            chunk = await self._audio_queue.get()
+            # Wait for the next audio chunk, but wake up every KEEPALIVE_INTERVAL
+            # to send a keepalive when the user is silent. Cloud STT closes the
+            # socket after a short idle window (Soniox >20s → 408); a keepalive
+            # under that window holds the session open through silence.
+            try:
+                chunk = await asyncio.wait_for(
+                    self._audio_queue.get(), timeout=self.KEEPALIVE_INTERVAL,
+                )
+            except asyncio.TimeoutError:
+                if self._closed:
+                    return
+                if keepalive is not None:
+                    try:
+                        await ws.send(keepalive)
+                    except Exception:
+                        return
+                continue
             if self._closed or chunk == b"":
                 try:
                     await self._send_end_of_audio(ws)

--- a/backend/services/stt_backends/soniox.py
+++ b/backend/services/stt_backends/soniox.py
@@ -17,6 +17,7 @@ the next ``final_transcript`` and reset.
 """
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, ClassVar
 
@@ -26,6 +27,14 @@ logger = logging.getLogger(__name__)
 
 SONIOX_STT_WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket"
 ENDPOINT_TOKEN_TEXT = "<end>"
+
+# Error codes that mean "this request config will NEVER work" → stop the
+# reconnect loop. Everything else (timeouts, transient server errors) is
+# recoverable by opening a fresh request, per Soniox's error-handling guide
+# ("Immediately start a new request to continue streaming").
+#   401 unauthorized / 403 forbidden — bad or missing API key
+#   400 bad request — malformed config (wrong model, unsupported format)
+_SONIOX_FATAL_ERROR_CODES = frozenset({400, 401, 403})
 
 
 class SonioxSTTService(WSStreamingSTT):
@@ -83,13 +92,31 @@ class SonioxSTTService(WSStreamingSTT):
         self._provisional_tail = ""
         self._in_utterance = False
 
+    def _keepalive_message(self) -> str:
+        # Soniox closes the socket after >20s of no audio/keepalive (408).
+        # The base sender emits this every KEEPALIVE_INTERVAL during silence.
+        return json.dumps({"type": "keepalive"})
+
     def _handle_event(self, data: dict[str, Any]) -> None:
         err_code = data.get("error_code")
         if err_code:
             logger.error("[Soniox STT] error %s: %s", err_code, data.get("error_message"))
-            self._emit("error", {
-                "detail": data.get("error_message") or f"soniox error {err_code}",
-            })
+            # Transient errors (e.g. 408 idle timeout) are recoverable — the
+            # base loop reconnects. Only bad-key/bad-config codes are fatal.
+            try:
+                fatal = int(err_code) in _SONIOX_FATAL_ERROR_CODES
+            except (TypeError, ValueError):
+                fatal = False
+            if fatal:
+                self.mark_fatal()
+                self._emit("error", {
+                    "detail": data.get("error_message") or f"soniox error {err_code}",
+                })
+            else:
+                # Recoverable: log + let the socket close & reconnect. Don't
+                # emit a user-facing 'error' (that would flip the UI to a
+                # failed state for a blip the reconnect already heals).
+                logger.info("[Soniox STT] transient error %s — will reconnect", err_code)
             return
 
         # Soniox packs *all* current non-final tokens into every frame —

--- a/backend/tests/e2e/test_audio_reader_flow.py
+++ b/backend/tests/e2e/test_audio_reader_flow.py
@@ -2,7 +2,8 @@
 
 What this guards:
  * `find_story_chapter` keeps returning the `response` + `source` JSON shape
-   AudioReaderAgent depends on (tags like [[[AUDIO_URL:...]]] parsed by server.py).
+   AudioReaderAgent depends on (the [[[READ_LOCAL:title|file]]] tag parsed by
+   routes/chat.py + routes/ws_voice.py via check_pending_read / _process_response_tags).
  * Local-priority search (data/stories/{title}/{NNN}_{...}.txt) keeps working.
  * AudioReaderAgent still calls find_story_chapter with (story_name, chapter_number)
    — if any code change alters the LLM-facing tool contract, this fails.

--- a/backend/tests/e2e/test_tag_relay_hook.py
+++ b/backend/tests/e2e/test_tag_relay_hook.py
@@ -73,8 +73,12 @@ async def test_tag_relay_hook_injects_reminder(seeded_stories):
         f"Hook fired too early — no tool result yet:\n{turn1_text}"
     )
 
-    # Turn 2: after find_story_chapter returned with [[[AUDIO_URL:...]]] tag
+    # Turn 2: after find_story_chapter returned with a [[[READ_LOCAL:...]]] tag
     # in its response field, the hook must have appended a SYSTEM reminder.
+    # (The tool now emits ONE canonical [[[READ_LOCAL]]] tag — the old extra
+    # [[[AUDIO_URL]]] was redundant and leaked into the chat bubble, so it was
+    # dropped. The hook is tag-agnostic; it relays whatever [[[TAG:value]]] the
+    # tool result carries.)
     assert len(llm.observed_messages) >= 2, (
         "Expected at least 2 LLM calls (initial + post-tool); "
         f"got {len(llm.observed_messages)}"
@@ -86,7 +90,7 @@ async def test_tag_relay_hook_injects_reminder(seeded_stories):
     )
     # The actual tag value should be present too — proves the regex extracted
     # the tag from the tool result's `response` field.
-    assert "[[[AUDIO_URL:" in turn2_text, (
+    assert "[[[READ_LOCAL:" in turn2_text, (
         "Hook injected reminder but tag value missing — regex may have "
         f"drifted from [[[TAG:value]]] pattern.\nTurn 2:\n{turn2_text}"
     )

--- a/backend/tests/test_core/test_csrf.py
+++ b/backend/tests/test_core/test_csrf.py
@@ -57,6 +57,20 @@ def client() -> TestClient:
     async def oauth_callback() -> dict:
         return {"ok": True}
 
+    # Passkey AUTHENTICATE is a login flow → exempt. REGISTER is NOT (needs
+    # an authenticated session + real CSRF token).
+    @app.post("/api/auth/passkey/authenticate/begin")
+    async def passkey_auth_begin() -> dict:
+        return {"ok": True}
+
+    @app.post("/api/auth/passkey/authenticate/finish")
+    async def passkey_auth_finish() -> dict:
+        return {"ok": True}
+
+    @app.post("/api/auth/passkey/register/begin")
+    async def passkey_register_begin() -> dict:
+        return {"ok": True}
+
     # Non-API mutation — should never be guarded by us
     @app.post("/upload")
     async def upload_static() -> dict:
@@ -152,6 +166,48 @@ class TestExemptPaths:
         """Third-party redirects can't carry our header."""
         client.cookies.set(CSRF_COOKIE_NAME, "stale")
         resp = client.post("/api/oauth/google/callback")
+        assert resp.status_code == 200
+
+
+class TestPasskeyCsrfBoundary:
+    """Passkey AUTHENTICATE is a login flow — the user has no valid CSRF token
+    yet, and a STALE cookie from an expired session must not lock them out of
+    re-logging-in. WebAuthn's own challenge/signature is the CSRF defence here.
+    REGISTER must STAY protected: it requires an authenticated session, so a
+    missing/invalid token must 403 (don't let an attacker silently enrol a
+    passkey). Pins both halves of the security boundary.
+    """
+
+    def test_authenticate_begin_exempt_with_stale_cookie(self, client):
+        # Reproduces the reported bug: expired session left a stale CSRF cookie,
+        # login flow sends no header → must NOT 403.
+        client.cookies.set(CSRF_COOKIE_NAME, "stale-from-expired-session")
+        resp = client.post("/api/auth/passkey/authenticate/begin")
+        assert resp.status_code == 200
+
+    def test_authenticate_finish_exempt_with_stale_cookie(self, client):
+        client.cookies.set(CSRF_COOKIE_NAME, "stale-from-expired-session")
+        resp = client.post("/api/auth/passkey/authenticate/finish")
+        assert resp.status_code == 200
+
+    def test_authenticate_exempt_with_no_cookie(self, client):
+        # First-ever login: no cookie at all → also fine.
+        resp = client.post("/api/auth/passkey/authenticate/begin")
+        assert resp.status_code == 200
+
+    def test_register_still_protected(self, client):
+        # REGISTER must keep CSRF: cookie present + no header → 403.
+        client.cookies.set(CSRF_COOKIE_NAME, "abc123")
+        resp = client.post("/api/auth/passkey/register/begin")
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "csrf_failed"
+
+    def test_register_passes_with_matching_header(self, client):
+        client.cookies.set(CSRF_COOKIE_NAME, "abc123")
+        resp = client.post(
+            "/api/auth/passkey/register/begin",
+            headers={"X-CSRF-Token": "abc123"},
+        )
         assert resp.status_code == 200
 
 

--- a/backend/tests/test_services/test_pause_controller.py
+++ b/backend/tests/test_services/test_pause_controller.py
@@ -486,6 +486,101 @@ def test_after_llm_call_clears_task_ref_so_pause_during_tool_does_not_cancel():
         act.activity_stream_manager = original
 
 
+def test_interrupt_cancels_turn_even_mid_delegate():
+    """Regression: hard Stop while the agent is mid-tool/mid-delegate.
+
+    The deadlock this guards against: after_llm_call clears ``_current_tasks``
+    (Strategy B — don't cancel a running tool), so during a delegate to a
+    sub-agent there is NO entry in ``_current_tasks``. ``interrupt()`` used to
+    read only ``_current_tasks`` → found nothing → cancelled nothing → the turn
+    kept running and held ``session_service._agent_lock`` → every later chat
+    blocked forever (reload didn't help).
+
+    ``_turn_tasks`` tracks the WHOLE turn, so ``interrupt()`` must still cancel
+    the running turn task even though ``_current_tasks`` is empty.
+    """
+    from services.pause_controller import PauseController
+    import services.activity_stream as act
+
+    class FakeMgr:
+        def broadcast(self, p): pass
+
+    original = act.activity_stream_manager
+    act.activity_stream_manager = FakeMgr()
+
+    async def run():
+        ctrl = PauseController()
+        hooks = ctrl.create_pause_hooks("Delegator")
+
+        async def turn_task():
+            await asyncio.sleep(60)  # stands in for a long delegate/tool phase
+
+        task = asyncio.create_task(turn_task())
+        await asyncio.sleep(0)
+
+        # before_llm_call captured the task into BOTH refs.
+        ctrl._current_tasks["Delegator"] = task
+        ctrl._turn_tasks["Delegator"] = task
+        ctrl._active["Delegator"] = True
+
+        # LLM call finished, tool/delegate phase begins → after_llm_call clears
+        # _current_tasks but the turn task is still running.
+        await hooks.after_llm_call(runner=None, message=None)
+        assert "Delegator" not in ctrl._current_tasks
+        assert "Delegator" in ctrl._turn_tasks  # turn-level ref survives
+
+        # Hard Stop mid-delegate.
+        cancelled = ctrl.interrupt("Delegator")
+        assert cancelled == ["Delegator"], (
+            "interrupt() must cancel the turn even when _current_tasks is empty "
+            "(mid-delegate) — else the turn holds _agent_lock and freezes chat"
+        )
+
+        # The actual asyncio task must receive the cancellation.
+        try:
+            await task
+            was_cancelled = False
+        except asyncio.CancelledError:
+            was_cancelled = True
+        assert was_cancelled, "the running turn task must actually be cancelled"
+
+    try:
+        asyncio.run(run())
+    finally:
+        act.activity_stream_manager = original
+
+
+def test_after_turn_complete_clears_turn_task_ref():
+    """``_turn_tasks`` must be released at turn end so a later ``interrupt()``
+    can't cancel a stale/done task from a previous turn."""
+    from services.pause_controller import PauseController
+    import services.activity_stream as act
+
+    class FakeMgr:
+        def broadcast(self, p): pass
+
+    original = act.activity_stream_manager
+    act.activity_stream_manager = FakeMgr()
+
+    async def run():
+        ctrl = PauseController()
+        hooks = ctrl.create_pause_hooks("Finisher")
+        ctrl._turn_tasks["Finisher"] = asyncio.current_task()
+        ctrl._current_tasks["Finisher"] = asyncio.current_task()
+
+        await hooks.after_turn_complete(runner=None, message=None)
+
+        assert "Finisher" not in ctrl._turn_tasks
+        assert "Finisher" not in ctrl._current_tasks
+        # interrupt() on a finished turn cancels nothing.
+        assert ctrl.interrupt("Finisher") == []
+
+    try:
+        asyncio.run(run())
+    finally:
+        act.activity_stream_manager = original
+
+
 # ─── Phase 4: team-wide pause + scope resolution ────────────────────
 
 

--- a/backend/tests/test_services/test_session_service.py
+++ b/backend/tests/test_services/test_session_service.py
@@ -91,14 +91,19 @@ class TestResumeAndSendCancellationRollback:
     """When a turn is cancelled mid-LLM, fast-agent's OpenAI provider
     catches CancelledError and returns an empty Prompt rather than
     re-raising. The agent has already pushed the user message + a
-    placeholder assistant message into ``message_history``; if we let
-    ``save_history`` run, the disk session ends up with a phantom
-    user/blank-assistant pair the next reload renders as a real
-    exchange. The rollback path must:
+    placeholder assistant message into ``message_history``; that phantom
+    pair must not survive. The rollback path must:
 
-      * skip ``save_history`` for the cancelled call
-      * pop the half-turn entries from ``agent.message_history`` so the
-        in-memory state matches what we'd want on disk
+      * POP the half-turn entries from ``agent.message_history`` BEFORE
+        saving, so neither the phantom user nor the blank assistant lands
+        on disk.
+      * STILL stamp ``primary_agent`` metadata + ``save_history`` — the
+        history is already clean (popped) so nothing phantom is persisted,
+        and the metadata is required for the session to remain VISIBLE in
+        list_sessions. (Regression 2026-06-01: returning early here skipped
+        the stamp, so a session whose first turn was cancelled — e.g. a long
+        crawl turn the user navigated away from — got no primary_agent and
+        was hidden → "conversation disappeared".)
     """
 
     @pytest.mark.asyncio
@@ -155,16 +160,22 @@ class TestResumeAndSendCancellationRollback:
             )
 
         assert response == ""
-        # The fix must have popped both stale entries:
+        # The fix must have popped both stale entries BEFORE save:
         assert fake_agent.message_history == [], (
             "agent.message_history retained the cancelled half-turn — "
             "the rollback should pop both the user and the empty "
             "assistant entries"
         )
-        # And save_history must NOT have been called for the cancelled
-        # turn — otherwise the phantom pair lands on disk.
-        assert save_history_calls == [], (
-            f"save_history was called {len(save_history_calls)} time(s) "
-            "for a cancelled turn — the on-disk session would surface a "
-            "ghost user/blank-assistant pair on reload"
+        # save_history IS called now — but on the already-cleaned history,
+        # so no phantom pair lands on disk. The call is what persists the
+        # primary_agent metadata that keeps the session visible.
+        assert len(save_history_calls) == 1, (
+            "save_history must run once on a cancelled first turn so the "
+            "primary_agent stamp is persisted (else the session is hidden "
+            "from list_sessions — the 'conversation disappeared' bug)"
+        )
+        # The stamp itself must be present.
+        assert fake_session.info.metadata.get("primary_agent") == "Jarvis", (
+            "primary_agent was not stamped on the cancelled turn — the "
+            "session would be hidden from the conversation list"
         )

--- a/backend/tools/story_server.py
+++ b/backend/tools/story_server.py
@@ -12,7 +12,7 @@ from helpers.path_safety import safe_story_path
 from mcp.server.fastmcp import FastMCP
 from typing import List, Dict, Optional
 import time
-from urllib.parse import urljoin, quote
+from urllib.parse import urljoin
 import uuid
 import threading
 from dotenv import load_dotenv
@@ -574,67 +574,6 @@ def _get_story_chapters_impl(story_url: str) -> list:
 
 
 @mcp.tool()
-def test_crawl_chapter(chapter_url: str, content_selector: str = None, title_selector: str = "h1") -> str:
-    """
-    Test crawling a single chapter to verify selectors.
-    If selectors are provided, uses them. Otherwise checks saved config or heuristics.
-    Returns preview of Title + Start/End content.
-    """
-    logger.info(f"Testing crawl for: {chapter_url} with sel={content_selector}")
-    try:
-        headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"}
-        resp = requests.get(chapter_url, headers=headers, timeout=(3, 15))
-        resp.raise_for_status()
-        
-        soup = BeautifulSoup(resp.text, 'html.parser')
-        
-        # Determine Selectors
-        c_sel = content_selector
-        t_sel = title_selector
-        
-        # If not provided, try to find from config
-        if not c_sel:
-             provider = StoryConfigManager.get_provider_for_url(chapter_url)
-             if provider and provider.get('selectors'):
-                 c_sel = provider['selectors'].get('content')
-                 t_sel = provider['selectors'].get('title', 'h1')
-        
-        # Extraction
-        title_text = "Unknown Title"
-        if t_sel:
-            t_tag = soup.select_one(t_sel)
-            if t_tag: title_text = t_tag.get_text(strip=True)
-            
-        content_text = ""
-        if c_sel:
-            c_tag = soup.select_one(c_sel)
-            if c_tag:
-                # Clean before extraction
-                _clean_dom(c_tag) 
-                content_text = c_tag.get_text(separator="\n", strip=True)
-        else:
-            # Fallback to heuristic
-            content_text, _ = heuristic_extract(resp.text)
-            title_text = "Heuristic Title"
-
-        if not content_text:
-            return f"Error: No content found with selector '{c_sel}'"
-            
-        len_txt = len(content_text)
-        preview_start = content_text[:200].replace("\n", " ")
-        preview_end = content_text[-200:].replace("\n", " ")
-        
-        return (f"SUCCESS: Found {len_txt} chars.\n"
-                f"TITLE: {title_text}\n"
-                f"SELECTOR: {c_sel}\n"
-                f"START: {preview_start}\n"
-                f"...\n"
-                f"END: {preview_end}")
-                
-    except Exception as e:
-        return f"Error testing crawl: {e}"   
-
-@mcp.tool()
 def get_chapter_content(chapter_url: str) -> str:
     """
     Get text content of a chapter. 
@@ -812,6 +751,236 @@ def _find_best_next_selector(soup: BeautifulSoup) -> list[dict]:
     next_candidates.sort(key=lambda x: x["score"], reverse=True)
     return next_candidates
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AI-DRIVEN CRAWL (redesign — see docs/crawl-redesign-spec.md)
+#
+# Principle: render the page (JS-aware), hand the LLM a compact, LANGUAGE-AGNOSTIC
+# structural summary, let the LLM produce a small "recipe". Code (the worker) then
+# enumerates the full chapter list from that recipe — the 1000 URLs never touch
+# the LLM context, so token cost is fixed regardless of chapter count.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def render_page(url: str, timeout_ms: int = 45000) -> Optional[str]:
+    """Fetch a page WITH JS rendering via Scrapling StealthyFetcher.
+
+    Falls back to plain ``requests`` if rendering is unavailable/fails — many
+    chapter pages are static HTML (verified: truyenfull chapter content is
+    static), so the fallback is fine for content; rendering matters mainly for
+    JS-built chapter-list/overview pages (verified: truyencom needs it).
+
+    Returns HTML string, or None on total failure.
+    """
+    try:
+        from scrapling.fetchers import StealthyFetcher
+        page = StealthyFetcher.fetch(
+            url, headless=True, network_idle=True, timeout=timeout_ms,
+        )
+        html = getattr(page, "html_content", None)
+        if html:
+            return html
+        # Some Scrapling versions expose body differently
+        return str(page) if page is not None else None
+    except Exception as e:
+        logger.warning(f"[render_page] StealthyFetcher failed ({e}); falling back to requests")
+        try:
+            headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                       "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"}
+            resp = requests.get(url, headers=headers, timeout=(3, 20))
+            return resp.text if resp.status_code == 200 else None
+        except Exception as e2:
+            logger.error(f"[render_page] requests fallback also failed: {e2}")
+            return None
+
+
+def _url_path_pattern(path: str) -> str:
+    """Collapse digits to '#' so chapter URLs of one story share one pattern.
+    Language-agnostic: works on URL structure, not on words.
+    e.g. /thien-anh/quyen-1-chuong-12/ -> /thien-anh/quyen-#-chuong-#/"""
+    return re.sub(r"\d+", "#", path)
+
+
+@mcp.tool()
+def detect_story_structure(url: str) -> str:
+    """Render a story page (overview OR chapter URL) and return a compact,
+    language-agnostic STRUCTURAL summary for the LLM to build a crawl recipe.
+
+    The LLM uses the output to decide a recipe:
+      { "mode": "list" | "chain",
+        "story_root": "/story-slug/",              # same-story guard (path prefix)
+        "chapter_link_selector": "...",            # list mode: CSS for chapter <a>
+        "chapter_url_pattern": "/slug/...-#...",    # digits→# template the worker matches
+        "next_page_selector": "...",               # list mode: pagination link (optional)
+        "first_chapter_url": "https://...",         # chain mode: where to start
+        "next_chapter_selector": "...",            # chain mode: 'next chapter' link
+        "content_selector": "#chapter-c",          # chapter body
+        "title_selector": "h1" }
+
+    Output groups same-domain links by URL path-pattern (digits collapsed to #)
+    with counts + a sample, so the LLM sees "this pattern appears 53x → likely
+    chapter links" vs "this 1x → nav" WITHOUT reading 1000 URLs or any words.
+    """
+    from urllib.parse import urlparse
+    html = render_page(url)
+    if not html:
+        return json.dumps({"error": f"Could not fetch/render {url}"}, ensure_ascii=False)
+
+    soup = BeautifulSoup(html, "html.parser")
+    base = urlparse(url)
+    base_host = base.netloc
+    segs = [s for s in base.path.split("/") if s]
+
+    # story_root candidates — the same-story guard prefix. NOT always the first
+    # path segment: e.g. truyenfull /thien-anh/<ch> → root /thien-anh/, but
+    # webnovel /book/<slug>_id/<ch> → root must be /book/<slug>_id/ (just /book/
+    # would match EVERY story). We surface multiple candidates and let the LLM
+    # pick — language-agnostic, no per-site rule.
+    root_candidates = []
+    if segs:
+        root_candidates.append(f"/{segs[0]}/")                    # segment-1
+    # If the CURRENT url is a chapter, the prefix before the chapter segment is
+    # a strong story_root candidate (handles /book/<slug>_id/chapter-N).
+    cur_path = base.path.rstrip("/")
+    m = re.search(r"^(.*?)/(chuong|chapter|chap|ch|episode|quyen|c)[-_/]?\d", cur_path, re.I)
+    if m and m.group(1):
+        root_candidates.append(m.group(1) + "/")
+    if len(segs) >= 2:
+        root_candidates.append(f"/{segs[0]}/{segs[1]}/")          # segment-1+2
+    # de-dup preserve order
+    seen_r = set(); root_candidates = [r for r in root_candidates if not (r in seen_r or seen_r.add(r))]
+    story_root = root_candidates[0] if root_candidates else "/"
+
+    # 1. Group same-domain links by path-pattern (structural, language-agnostic)
+    import collections
+    pat_count = collections.Counter()
+    pat_sample = {}
+    pat_samples = collections.defaultdict(list)  # up to a few real URLs per pattern
+    pat_selector = {}  # representative CSS-ish hint (parent class) per pattern
+    for a in soup.find_all("a", href=True):
+        p = urlparse(a["href"])
+        host = p.netloc or base_host
+        if host != base_host:
+            continue
+        if not p.path or p.path == "/":
+            continue
+        key = _url_path_pattern(p.path)
+        pat_count[key] += 1
+        full = a["href"] if a["href"].startswith("http") else urljoin(url, a["href"])
+        if len(pat_samples[key]) < 4:
+            pat_samples[key].append(full)
+        if key not in pat_sample:
+            pat_sample[key] = full
+            # capture a structural hint: nearest ancestor with class/id
+            hint = None
+            for anc in [a] + list(a.parents)[:3]:
+                if getattr(anc, "get", None):
+                    cls = anc.get("class"); aid = anc.get("id")
+                    if aid:
+                        hint = f"#{aid} a"; break
+                    if cls:
+                        hint = f".{'.'.join(cls)} a"; break
+            pat_selector[key] = hint
+
+    def _common_path_prefix(urls: list) -> str:
+        """Longest shared path prefix (segment-wise) of chapter URLs → a precise
+        story_root candidate even when site nests under /book/<slug>_id/."""
+        paths = [urlparse(u).path for u in urls]
+        if not paths:
+            return ""
+        split = [p.strip("/").split("/") for p in paths]
+        pref = []
+        for parts in zip(*split):
+            if len(set(parts)) == 1:
+                pref.append(parts[0])
+            else:
+                break
+        return "/" + "/".join(pref) + "/" if pref else "/"
+
+    # Sort patterns by count desc; the chapter-link pattern usually dominates
+    link_patterns = []
+    for key, cnt in pat_count.most_common(20):
+        same_story = any(key.startswith(_url_path_pattern(r).rstrip("/")) for r in root_candidates)
+        # For a high-count pattern, the common prefix of its samples is a great
+        # story_root candidate (e.g. /book/<slug>_id/).
+        cp = _common_path_prefix(pat_samples[key]) if cnt >= 2 else ""
+        if cp and cp not in root_candidates and cp != "/":
+            root_candidates.append(cp)
+        link_patterns.append({
+            "path_pattern": key,
+            "count": cnt,
+            "sample_url": pat_sample[key],
+            "common_prefix": cp,
+            "selector_hint": pat_selector.get(key),
+            "within_story_root": same_story,
+        })
+
+    # 2. Content candidates (density-based; selector only, no language words)
+    content_candidates = []
+    for tag in soup.find_all(["div", "article", "section", "main"]):
+        text = tag.get_text(separator=" ", strip=True)
+        if len(text) < 300:
+            continue
+        p_count = len(tag.find_all("p"))
+        sel = None
+        if tag.get("id"):
+            sel = f"#{tag['id']}"
+        elif tag.get("class"):
+            sel = f".{'.'.join(tag.get('class'))}"
+        content_candidates.append({
+            "selector": sel,
+            "tag": tag.name,
+            "p_count": p_count,
+            "text_len": len(text),
+            "text_head": text[:120],
+        })
+    content_candidates.sort(key=lambda c: (c["p_count"], c["text_len"]), reverse=True)
+    content_candidates = content_candidates[:5]
+
+    # 3. Pagination / next-page hints (structural attrs only)
+    pagination_hints = []
+    for a in soup.select("a[rel='next'], .pagination a, .paging a, nav a"):
+        href = a.get("href")
+        if not href:
+            continue
+        pagination_hints.append({
+            "rel": a.get("rel"),
+            "class": a.get("class"),
+            "href": href if href.startswith("http") else urljoin(url, href),
+            "text_len": len(a.get_text(strip=True)),
+        })
+
+    # de-dup root candidates, keep order
+    seen_r = set()
+    story_root_candidates = [r for r in root_candidates if not (r in seen_r or seen_r.add(r))]
+
+    out = {
+        "url": url,
+        "host": base_host,
+        "story_root_candidates": story_root_candidates,
+        "story_root_guess": story_root,
+        "rendered": True,
+        "link_patterns": link_patterns,
+        "content_candidates": content_candidates,
+        "pagination_hints": pagination_hints[:8],
+        "guidance": (
+            "Build a recipe (language-agnostic — use URL/DOM structure, never words). "
+            "STORY_ROOT: pick from story_root_candidates the prefix that uniquely "
+            "identifies THIS story. WARNING: the first candidate (first path segment) "
+            "is often TOO BROAD — e.g. '/book/' matches every story on the site. Prefer "
+            "the 'common_prefix' of the high-count chapter link_pattern (e.g. "
+            "'/book/<slug>_<id>/') which is unique to this story. "
+            "MODE: if a within_story_root link_pattern has a high count (chapters listed "
+            "here) → mode='list' with its selector_hint + a chapter sample as "
+            "chapter_url_pattern + a pagination_hint as next_page_selector. If the page "
+            "is a single chapter (no high-count chapter pattern; a 'next' link exists) → "
+            "mode='chain' with first_chapter_url + next_chapter_selector. "
+            "CONTENT: pick content_selector from content_candidates (highest p_count, "
+            "text_head reads like narrative). Then call verify_chapters before crawling."
+        ),
+    }
+    return json.dumps(out, ensure_ascii=False)
+
+
 @mcp.tool()
 def get_story_page_structure(url: str) -> str:
     """
@@ -970,88 +1139,247 @@ def test_crawl_chapter(url: str, content_selector: str, title_selector: str = "h
     except Exception as e:
         return f"Test failed: {e}"
 
-# Global Crawl State — DB-backed for cross-process visibility
-_crawl_db_initialized = False
 
-def _save_crawl_status():
-    """Persist crawl_jobs to DB so FastAPI can read it."""
-    global _crawl_db_initialized
-    try:
-        from core.database import get_db_session, CrawlJob, init_db
-        if not _crawl_db_initialized:
-            init_db()
-            _crawl_db_initialized = True
-        from datetime import datetime
-        db = get_db_session()
+def _recipe_first_chapters(recipe: dict, n: int = 3) -> list[str]:
+    """Resolve the first N chapter URLs from a recipe (LIST: enumerate page 1;
+    CHAIN: follow next_chapter_selector from first_chapter_url). Used by
+    verify_chapters — only N pages fetched, so this is cheap."""
+    from urllib.parse import urlparse
+    mode = recipe.get("mode", "list")
+    story_root = recipe.get("story_root") or "/"
+    if mode == "list":
+        # Reuse the poller's enumerator for parity with the real crawl.
         try:
-            for job_id, job in crawl_jobs.items():
-                existing = db.query(CrawlJob).filter(CrawlJob.job_id == job_id).first()
-                if existing:
-                    existing.status = job.get("status", "unknown")
-                    existing.story_title = job.get("story_title")
-                    existing.current_chapter = job.get("current", 0)
-                    existing.total_chapters = job.get("total", 0)
-                    existing.message = job.get("message")
-                    existing.updated_at = datetime.now().timestamp()
-                else:
-                    db.add(CrawlJob(
-                        job_id=job_id,
-                        status=job.get("status", "pending"),
-                        story_title=job.get("story_title"),
-                        current_chapter=job.get("current", 0),
-                        total_chapters=job.get("total", 0),
-                        message=job.get("message"),
-                        start_url=job.get("start_url"),
-                    ))
-            db.commit()
-        finally:
-            db.close()
-    except Exception as e:
-        logger.warning(f"Failed to save crawl status to DB: {e}")
+            from services.crawl_poller import CrawlPoller
+            chs = CrawlPoller()._enumerate_list_mode("verify", recipe.get("overview_url") or recipe.get("first_chapter_url") or "", recipe)
+            return [c["url"] for c in chs[:n]]
+        except Exception as e:
+            logger.warning(f"[verify] list enumerate failed: {e}")
+            return []
+    # CHAIN: walk next links
+    urls = []
+    cur = recipe.get("first_chapter_url")
+    nsel = recipe.get("next_chapter_selector")
+    base_host = urlparse(cur).netloc if cur else ""
+    for _ in range(n):
+        if not cur:
+            break
+        urls.append(cur)
+        html = render_page(cur)
+        if not html or not nsel:
+            break
+        nx = BeautifulSoup(html, "html.parser").select_one(nsel)
+        nxt = urljoin(cur, nx["href"]) if (nx and nx.get("href")) else None
+        # same-story guard
+        if not nxt or urlparse(nxt).netloc not in ("", base_host) or not urlparse(nxt).path.startswith(story_root):
+            break
+        cur = nxt
+    return urls
 
-crawl_jobs = {}
+
+@mcp.tool()
+def verify_chapters(recipe_json: str) -> str:
+    """Verify a crawl recipe on the FIRST 3 CHAPTERS before a full crawl.
+
+    Stronger than testing one chapter: fetches 3 consecutive chapters, returns
+    a longer preview of each, and runs language-agnostic CONTINUITY checks so
+    the agent can catch a wrong/garbage selector OR a drift into another story
+    BEFORE committing to 1000 chapters.
+
+    Pass the recipe as JSON (from detect_story_structure analysis). Returns a
+    verdict {ok, chapters:[{url,len,head,tail}], issues:[...]} for the agent to
+    decide: crawl, or fix the recipe and re-verify.
+    """
+    try:
+        recipe = json.loads(recipe_json) if isinstance(recipe_json, str) else recipe_json
+    except Exception as e:
+        return json.dumps({"ok": False, "issues": [f"recipe_json parse error: {e}"]}, ensure_ascii=False)
+
+    content_sel = recipe.get("content_selector")
+    title_sel = recipe.get("title_selector", "h1")
+    if not content_sel:
+        return json.dumps({"ok": False, "issues": ["recipe missing content_selector"]}, ensure_ascii=False)
+
+    urls = _recipe_first_chapters(recipe, n=3)
+    if not urls:
+        return json.dumps({"ok": False, "issues": ["could not resolve first chapters from recipe (mode/selectors likely wrong)"]}, ensure_ascii=False)
+
+    chapters = []
+    issues = []
+    headers = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+               "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"}
+    for i, u in enumerate(urls):
+        html = None
+        try:
+            r = requests.get(u, headers=headers, timeout=(3, 15))
+            html = r.text if r.status_code == 200 and len(r.text) > 2000 else None
+        except Exception:
+            pass
+        if not html:
+            html = render_page(u)
+        if not html:
+            issues.append(f"ch{i+1}: could not fetch {u}")
+            continue
+        soup = BeautifulSoup(html, "html.parser")
+        cdiv = soup.select_one(content_sel)
+        text = ""
+        if cdiv:
+            for s in cdiv(["script", "style", "iframe"]):
+                s.decompose()
+            text = cdiv.get_text(separator="\n\n").strip()
+        t = soup.select_one(title_sel)
+        chapters.append({
+            "url": u,
+            "title": t.get_text(strip=True) if t else None,
+            "len": len(text),
+            "head": text[:1000],
+            "tail": text[-500:] if len(text) > 500 else "",
+        })
+
+    # ── Continuity / sanity checks (language-agnostic) ──
+    if len(chapters) < 3:
+        issues.append(f"only resolved {len(chapters)}/3 chapters")
+    for c in chapters:
+        if c["len"] < 500:
+            issues.append(f"{c['url']}: content too short ({c['len']} chars) — selector likely wrong/garbage")
+    # distinct content: 3 chapters must not be identical (selector grabbing a static block)
+    heads = [c["head"] for c in chapters if c["head"]]
+    if len(heads) >= 2 and len(set(heads)) == 1:
+        issues.append("all chapters returned identical content — selector grabs a non-chapter block")
+    # URL monotonic (numbers increase) — drift / wrong order guard
+    nums = []
+    from urllib.parse import urlparse
+    for c in chapters:
+        ns = [int(x) for x in re.findall(r"\d+", urlparse(c["url"]).path)]
+        nums.append(ns)
+    if len(nums) >= 2 and not all(nums[i] <= nums[i+1] for i in range(len(nums)-1)):
+        issues.append("chapter URLs not in increasing order — list/sort may be wrong")
+
+    return json.dumps({
+        "ok": len(issues) == 0,
+        "chapter_count_checked": len(chapters),
+        "chapters": chapters,
+        "issues": issues,
+        "guidance": "If ok=false, inspect issues. Common fix: choose a different content_selector "
+                    "(longer narrative text, not nav/sidebar) and re-run verify_chapters. "
+                    "If chapters are short or identical, the selector is wrong.",
+    }, ensure_ascii=False)
 
 
 
 @mcp.tool()
-def crawl_story(url: str, content_selector: str = None, title_selector: str = "h1", next_selector: str = None, speed: float = 2.0, max_chapters: int = 2000) -> str:
+def crawl_story(recipe_json: str, max_chapters: int = 2000, speed: float = 2.0) -> str:
     """
-    Start a background job to crawl a story.
-    The job is inserted as 'pending' into DB. FastAPI CrawlPoller picks it up.
-    
+    Start a background crawl job from a VERIFIED recipe (preferred path).
+
+    Call this AFTER detect_story_structure + verify_chapters confirm the recipe
+    is good. The CrawlPoller (FastAPI process) enumerates the full chapter list
+    from the recipe (the 1000 URLs never pass through the LLM) and fetches each
+    chapter — so token cost is independent of chapter count.
+
     Args:
-        url: The starting chapter URL.
-        content_selector: CSS selector for chapter text (Required if not saved).
-        title_selector: CSS selector for chapter title.
-        next_selector: CSS selector for 'next chapter' link.
-        speed: Delay between requests (seconds).
-        max_chapters: Limit number of chapters.
+        recipe_json: JSON recipe. Required keys depend on mode:
+          { "mode": "list" | "chain",
+            "story_root": "/story-slug/",         # same-story guard (REQUIRED)
+            "content_selector": "#chapter-c",      # chapter body (REQUIRED)
+            "title_selector": "h1",
+            # list mode:
+            "overview_url": "https://.../story/",  # page that lists chapters
+            "chapter_url_pattern": "/story/chuong-1/",  # a sample chapter URL (digits→# template)
+            "next_page_selector": "...",           # optional pagination link
+            # chain mode:
+            "first_chapter_url": "https://.../chuong-1/",
+            "next_chapter_selector": "a.next",
+            "story_title": "..."                    # optional; else derived from page
+          }
+        max_chapters: safety cap.
+        speed: delay between chapter fetches (seconds).
     """
+    try:
+        recipe = json.loads(recipe_json) if isinstance(recipe_json, str) else recipe_json
+    except Exception as e:
+        return f"Error: recipe_json is not valid JSON: {e}"
+    if not recipe.get("content_selector"):
+        return "Error: recipe missing required 'content_selector'."
+    if not recipe.get("story_root"):
+        return "Error: recipe missing required 'story_root' (same-story guard)."
+    start_url = (recipe.get("overview_url") or recipe.get("first_chapter_url")
+                 or recipe.get("chapter_url_pattern"))
+    if not start_url:
+        return "Error: recipe needs overview_url (list mode) or first_chapter_url (chain mode)."
+
     job_id = str(uuid.uuid4())
     params = json.dumps({
-        "content_selector": content_selector,
-        "title_selector": title_selector,
-        "next_selector": next_selector,
+        "recipe": recipe,
         "speed": speed,
         "max_chapters": max_chapters,
-    })
+    }, ensure_ascii=False)
     try:
         from core.database import get_db_session, CrawlJob, init_db
         init_db()
         db = get_db_session()
-        db.add(CrawlJob(
-            job_id=job_id,
-            status="pending",
-            start_url=url,
-            params=params,
-        ))
+        db.add(CrawlJob(job_id=job_id, status="pending", start_url=start_url, params=params))
         db.commit()
         db.close()
     except Exception as e:
         logger.error(f"Failed to create crawl job: {e}")
         return f"Error creating crawl job: {e}"
 
-    return f"Started crawl job {job_id}. Report this job_id to the user. The crawl runs in the background. Do NOT poll get_crawl_status repeatedly."
+    return (f"Started crawl job {job_id}. The crawl runs in the background. "
+            f"Report this job_id to the user with the tag [[[CRAWL_STARTED: {job_id}]]]. "
+            f"Do NOT poll get_crawl_status repeatedly.")
+
+
+@mcp.tool()
+def resume_crawl(job_id: str, recipe_patch_json: str = "{}", mark_done: bool = False) -> str:
+    """Resume a crawl job that flagged 'needs_attention' (self-heal path).
+
+    The crawl worker pauses and wakes CrawlStoriesAgent when it gets stuck
+    (selector broke mid-crawl, drift, etc). After diagnosing (detect_story_
+    structure + verify_chapters), call this to fix the recipe and continue
+    FROM THE CHECKPOINT (not from chapter 1).
+
+    Args:
+        job_id: the stuck job.
+        recipe_patch_json: JSON of recipe keys to override (e.g.
+            {"content_selector": ".reading-content"}). Merged onto the saved recipe.
+        mark_done: pass true if the "stuck" point is actually the real end of
+            the story (no fix needed) — marks the job completed as-is.
+    """
+    try:
+        from core.database import get_db_session, CrawlJob
+        db = get_db_session()
+        job = db.query(CrawlJob).filter(CrawlJob.job_id == job_id).first()
+        if not job:
+            db.close()
+            return json.dumps({"status": "not_found"})
+        params = json.loads(job.params) if job.params else {}
+        if mark_done:
+            job.status = "completed"
+            job.message = f"Marked done by agent at chapter {job.current_chapter}."
+            db.commit(); db.close()
+            return json.dumps({"status": "completed", "job_id": job_id})
+        try:
+            patch = json.loads(recipe_patch_json) if isinstance(recipe_patch_json, str) else (recipe_patch_json or {})
+        except Exception as e:
+            db.close()
+            return json.dumps({"status": "error", "message": f"recipe_patch_json invalid: {e}"})
+        recipe = params.get("recipe") or {}
+        recipe.update(patch)
+        params["recipe"] = recipe
+        # resume_from: checkpoint stuck_index → worker skips already-saved chapters
+        cp = params.get("checkpoint") or {}
+        params["resume_from"] = cp.get("stuck_index", 0)
+        job.params = json.dumps(params, ensure_ascii=False)
+        job.status = "pending"   # CrawlPoller re-picks it up
+        job.message = "Resuming after recipe fix..."
+        db.commit(); db.close()
+        return json.dumps({"status": "resuming", "job_id": job_id,
+                           "resume_from_chapter": params["resume_from"] + 1,
+                           "patched_keys": list(patch.keys())}, ensure_ascii=False)
+    except Exception as e:
+        return json.dumps({"status": "error", "message": str(e)})
+
 
 @mcp.tool()
 def get_crawl_status(job_id: str) -> str:
@@ -1078,422 +1406,6 @@ def get_crawl_status(job_id: str) -> str:
     except Exception as e:
         return json.dumps({"status": "error", "message": str(e)})
 
-def _crawl_worker(job_id: str, start_url: str, content_selector: str, title_selector: str, next_selector: str, speed: float, max_chapters: int):
-    import traceback as _tb
-    _log_path = os.path.join(DATA_DIR, "crawl_debug.log")
-    def _dbg(msg):
-        line = f"[{time.strftime('%H:%M:%S')}][{job_id[:8]}] {msg}"
-        print(line, flush=True)
-        try:
-            with open(_log_path, "a") as _f:
-                _f.write(line + "\n")
-        except: pass
-    _dbg(f"Worker started: {start_url}")
-    try:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-        }
-        
-        # 1. Check Cancellation Early
-        if crawl_jobs[job_id].get("status") == "cancelled":
-             logger.info(f"[{job_id}] Cancelled before start.")
-             return
-
-        # 2. Determine Story Name & Chapter 1
-        logger.info(f"[{job_id}] Initializing crawl for: {start_url}")
-
-        # [NEW] Check for Saved Provider Overrides OR Auto-Discover
-        provider = StoryConfigManager.get_provider_for_url(start_url)
-        
-        if not provider:
-            logger.info(f"[{job_id}] No known provider for {start_url}. Initiating Auto-Discovery...")
-            try:
-                # 1. Analyze
-                analysis_json = _analyze_story_pattern_impl(start_url)
-                analysis = json.loads(analysis_json)
-                
-                if analysis and analysis.get("content"):
-                    # 2. Extract Domain
-                    from urllib.parse import urlparse
-                    domain_obj = urlparse(start_url)
-                    domain = domain_obj.netloc
-                    name = domain.split(':')[0]
-                    
-                    # 3. Create Provider
-                    new_provider = {
-                        "domain": domain,
-                        "name": name.capitalize(),
-                        "selectors": {
-                            "content": analysis.get("content"),
-                            "title": analysis.get("title", "h1"),
-                            "next_chapter": analysis.get("next_chapter")
-                        },
-                        "trust_level": "auto-learned"
-                    }
-                    
-                    # 4. Save and Use
-                    StoryConfigManager.save_provider(new_provider)
-                    logger.info(f"[{job_id}] Auto-Discovery Successful! Registered provider: {name} ({domain})")
-                    provider = new_provider
-                else:
-                    logger.warning(f"[{job_id}] Auto-Discovery failed to find reliable selectors.")
-            except Exception as e:
-                logger.error(f"[{job_id}] Auto-Discovery failed: {e}")
-
-        if provider:
-            logger.info(f"[{job_id}] Found provider: {provider.get('name')} ({provider.get('trust_level')})")
-            
-            # [NEW] Pipeline Step 2: Verification
-            if provider.get("trust_level") != "verified":
-                logger.info(f"[{job_id}] Verifying provider '{provider.get('name')}'...")
-                
-                # Use current selectors
-                sels = provider.get('selectors', {})
-                c_sel = sels.get('content')
-                t_sel = sels.get('title', 'h1')
-                
-                if not c_sel:
-                     logger.warning(f"[{job_id}] Verification failed: No content selector.")
-                     provider = None # Abort use
-                else:
-                    # Test extraction
-                    test_result = test_crawl_chapter(start_url, c_sel, t_sel)
-                    
-                    # Analyze test result (simple check: length > 200 and no error)
-                    if "Error:" not in test_result and len(test_result.split("START:\n")[-1]) > 200:
-                         logger.info(f"[{job_id}] Verification PASSED. Promoting to 'verified'.")
-                         provider["trust_level"] = "verified"
-                         StoryConfigManager.save_provider(provider)
-                    else:
-                         logger.warning(f"[{job_id}] Verification FAILED. Result: {test_result[:100]}...")
-                         # Do not use this provider, fallback to heuristic or fail
-                         provider = None
-            
-            if provider:
-                logger.info(f"[{job_id}] Using verified provider: {provider.get('name')}")
-                if provider.get('selectors'):
-                    sels = provider['selectors']
-                    if sels.get('content'): 
-                        content_selector = sels['content']
-                    if sels.get('title'): 
-                        title_selector = sels['title']
-                    if sels.get('next_chapter'): 
-                        next_selector = sels['next_chapter']
-        
-        # [AUTO-DETECT CHAPTER 1]
-        try:
-             # Heuristic: If URL looks like a chapter, check if we can find Chapter 1
-             domain_match = re.search(r"https?://([^/]+)", start_url)
-             if domain_match:
-                 logger.info(f"[{job_id}] checking if we should rewind to Chapter 1...")
-                 # Call implementation directly (bypassing Tool wrapper)
-                 chapters = _get_story_chapters_impl(start_url)
-                 logger.info(f"[{job_id}] Found {len(chapters)} chapters from list.")
-                 
-                 if chapters and len(chapters) > 0:
-                     # Filter for "Chapter 1"
-                     # TODO(i18n): VN literals — regex matches Vietnamese chapter-1/prologue titles
-                     c1 = next((c for c in chapters if re.search(r'(chương|chapter)\s+0*1(\s+:|$|\D)', c['title'], re.I) or re.search(r'(mở đầu|văn án)', c['title'], re.I)), None)
-                     
-                     if c1:
-                         if c1['url'] != start_url:
-                             logger.info(f"[{job_id}] Switching start URL to Found Chapter 1: {c1['url']}")
-                             start_url = c1['url']
-                     if c1:
-                         if c1['url'] != start_url:
-                             logger.info(f"[{job_id}] Switching start URL to Found Chapter 1: {c1['url']}")
-                             start_url = c1['url']
-                     else:
-                         # Fallback: If no explicit "Chapter 1" found, but list exists and has items
-                         # And start_url seems to be a Story URL (not in list)
-                         logger.info(f"[{job_id}] 'Chapter 1' not explicitly detected by regex. Defaulting to first chapter in list.")
-                         c1 = chapters[0]
-                         if c1['url'] != start_url:
-                             logger.info(f"[{job_id}] Switching start URL to First Chapter: {c1['url']}")
-                             start_url = c1['url']
-        except Exception as e:
-            logger.warning(f"[{job_id}] Chapter 1 auto-detect error: {e}")
-            chapters = [] # Retrieve failed, reset to empty for safety
-
-        # Check Cancellation Again
-        if crawl_jobs[job_id].get("status") == "cancelled":
-             logger.info(f"[{job_id}] Cancelled during setup.")
-             return
-
-        resp = requests.get(start_url, headers=headers, timeout=(3, 15))
-        soup = BeautifulSoup(resp.text, "html.parser")
-        title_tag = soup.select_one(title_selector)
-        full_title = title_tag.get_text(strip=True) if title_tag else "Unknown Story"
-        
-        story_name = full_title.split("-")[0].strip()
-        # Cleanup if title captured chapter info
-        # TODO(i18n): VN literal — strips Vietnamese chapter suffix from scraped page titles
-        story_name = re.sub(r'\s*(Chương|Chapter)\s+\d+.*$', '', story_name, flags=re.I).strip()
-        
-        if not story_name: story_name = f"Story_{int(time.time())}"
-
-        story_folder_name = re.sub(r'[\\/*?:"<>|]', "", story_name).strip()
-        if not story_folder_name: story_folder_name = "Untitled_Story"
-        try:
-            save_dir_path = safe_story_path(Path(DATA_DIR) / "stories", story_folder_name)
-        except ValueError as e:
-            # Scraped <title> produced a traversal-like value. Fall back to
-            # a timestamped name rather than writing outside the sandbox.
-            logger.warning(f"Unsafe story folder {story_folder_name!r} rejected: {e}; using timestamped fallback")
-            story_folder_name = f"Untitled_Story_{int(time.time())}"
-            save_dir_path = safe_story_path(Path(DATA_DIR) / "stories", story_folder_name)
-        save_dir_path.mkdir(parents=True, exist_ok=True)
-        save_dir = str(save_dir_path)  # downstream os.path.join() callers expect str
-        
-        meta_file = os.path.join(save_dir, "metadata.json")
-        if not os.path.exists(meta_file):
-            with open(meta_file, "w", encoding="utf-8") as f:
-                json.dump({"title": story_name, "source": start_url}, f, ensure_ascii=False)
-        
-        crawl_jobs[job_id].update({
-            "status": "running",
-            "story_title": story_name,
-            "total": max_chapters, 
-            "current": 0,
-            "message": "Starting crawl..."
-        })
-        _save_crawl_status()
-
-        current_url = start_url
-        count = 0
-        
-        # [NEW Logic] Logic: "List Mode" vs "Chain Mode"
-        # If we have a `chapters` list and `start_url` is in it, use the list!
-        chapter_iterator = None
-        _dbg(f"chapters={len(chapters) if chapters else 0}, start_url={start_url}")
-        if chapters and len(chapters) > 0:
-            # Find index of start_url
-            start_index = -1
-            for i, c in enumerate(chapters):
-                # Loose compare URLs (sometimes http vs https or trailing slash)
-                if c['url'].strip('/') == start_url.strip('/'):
-                    start_index = i
-                    break
-            
-            if start_index != -1:
-                _dbg(f"LIST MODE from index {start_index}/{len(chapters)}")
-                logger.info(f"[{job_id}] Engaging 'List Mode' crawling starting from index {start_index} (total {len(chapters)}).")
-                chapter_iterator = iter(chapters[start_index:])
-            else:
-                 _dbg(f"start_url NOT in chapter list, CHAIN MODE. first_url={chapters[0]['url'][:80]}")
-                 logger.info(f"[{job_id}] Start URL not found in chapter list. Falling back to chain mode.")
-        
-        _dbg(f"Entering loop. chapter_iterator={'yes' if chapter_iterator else 'no'}, max={max_chapters}")
-        while count < max_chapters:
-            _dbg(f"Loop top: count={count}, status={crawl_jobs[job_id].get('status')}")
-            # Check for stop signal
-            if crawl_jobs[job_id].get("status") == "cancelled":
-                logger.info(f"[{job_id}] Job cancelled by user.")
-                crawl_jobs[job_id]["message"] = "Cancelled by user."
-                _save_crawl_status()
-                break
-            
-            if chapter_iterator:
-                try:
-                    chapter_node = next(chapter_iterator)
-                    current_url = chapter_node['url']
-                    # We could also use chapter_node['title'] to assume title, but fetching content confirms existence.
-                except StopIteration:
-                    logger.info(f"[{job_id}] End of chapter list reached.")
-                    break
-            
-            # ... rest of fetch log ...
-
-            logger.info(f"[{job_id}] Step {count+1}: Fetching {current_url}")
-            _dbg(f"Fetching #{count+1}: {current_url[:80]}")
-            resp_status: int | None = None
-            resp_text = ""
-            # [NEW] Retry Logic for 429: max 3 retries, 5s delay. Body
-            # is streamed + capped at MAX_CHAPTER_BYTES to bound disk +
-            # RAM use per chapter.
-            for attempt in range(4): # Initial + 3 retries
-                try:
-                    resp_status, resp_text = get_capped_text(
-                        current_url, headers=headers, timeout=(3, 10),
-                    )
-                    if resp_status == 429:
-                        if attempt < 3:
-                            logger.warning(f"[{job_id}] 429 Too Many Requests. Retrying in 5s... ({attempt+1}/3)")
-                            time.sleep(5)
-                            continue
-                        else:
-                            logger.error(f"[{job_id}] Max retries exceeded for 429.")
-                    break # Success or non-retriable status
-                except Exception as e:
-                    logger.error(f"[{job_id}] Request failed: {e}")
-                    resp_status = None
-                    break
-
-            if resp_status is None: break
-
-            logger.info(f"[{job_id}] Status {resp_status} for {current_url}")
-            if resp_status != 200:
-                logger.error(f"[{job_id}] Failed to fetch {current_url}: {resp_status}")
-                # Try next chapter if in list mode, otherwise break
-                if chapter_iterator:
-                    continue
-                else:
-                    break
-
-            soup = BeautifulSoup(resp_text, "html.parser")
-            logger.info(f"[{job_id}] Parsed HTML for {current_url}. Title selector: {title_selector}, Content: {content_selector}")
-            
-            # Content
-            content_div = soup.select_one(content_selector)
-            if not content_div:
-                logger.warning(f"[{job_id}] Content selector '{content_selector}' not found in {current_url}. Trying fallbacks...")
-                # Try simpler selectors?
-                # ...
-                # Fallback handled later in loop? 
-                
-            if not content_div:
-                crawl_jobs[job_id]["message"] = f"No content found at {current_url}"
-                # DO NOT BREAK yet, Try next chapter if list mode!
-                if chapter_iterator:
-                    logger.info(f"[{job_id}] skipping {current_url} due to no content.")
-                    continue
-                else:
-                     break
-                
-            for s in content_div(["script", "style", "iframe"]):
-                s.decompose()
-            text = content_div.get_text(separator="\n\n").strip()
-            logger.info(f"[{job_id}] Extracted content length: {len(text)}")
-            
-            # Title
-            t_tag = soup.select_one(title_selector)
-            chap_title = t_tag.get_text(strip=True) if t_tag else f"Chapter {count+1}"
-            
-            # Save
-            filename = f"{count+1:03d}_{re.sub(r'[\\\\/*?:\"<>|]', '', chap_title)[:50]}.txt"
-            with open(os.path.join(save_dir, filename), "w", encoding="utf-8") as f:
-                f.write(text)
-                
-            count += 1
-            crawl_jobs[job_id].update({
-                "current": count,
-                "message": f"Crawled: {chap_title}"
-            })
-            _save_crawl_status()
-            _dbg(f"Saved #{count}: {chap_title}")
-            
-            # Next chapter: chain mode only (list mode uses iterator at top of loop)
-            if not chapter_iterator:
-                next_url = None
-                if next_selector:
-                    n = soup.select_one(next_selector)
-                    if n and n.get("href"):
-                        next_url = n.get("href")
-                
-                # Smart next detection if explicit selector failed or wasn't provided
-                if not next_url:
-                    # 1. Search for typical "Next" buttons by class/id
-                    next_candidates = soup.select("a.next, a.chap-next, a#next_chap, a.btn-next, a[title*='sau'], a[title*='next']")
-                    if next_candidates:
-                        next_url = next_candidates[0]["href"]
-                    else:
-                        # 2. Look for keywords in text
-                        for a in soup.find_all("a"):
-                            t = a.get_text(strip=True).lower()
-                            # TODO(i18n): VN literals — matches Vietnamese "next chapter" link text
-                            if "chương sau" in t or "tiếp" in t or "next" in t or "chap sau" in t:
-                                next_url = a.get("href")
-                                logger.info(f"[{job_id}] Auto-detected next link: {t} -> {next_url}")
-                                break
-                
-                if next_url:
-                    if not next_url.startswith("http"):
-                        next_url = urljoin(current_url, next_url)
-                    logger.info(f"[{job_id}] Next URL found: {next_url}")
-                else:
-                    _dbg("CHAIN MODE: No next URL found. Stopping.")
-                    logger.info(f"[{job_id}] No next URL found. Stopping.")
-                
-                if not next_url:
-                    break
-                    
-                current_url = next_url
-            # else: In List Mode, loop continues to `next(chapter_iterator)` at top
-                
-            _dbg(f"Sleeping {speed}s before next chapter...")
-            time.sleep(speed)
-            _dbg(f"Woke up, looping back")
-            
-        _dbg(f"Loop exited. count={count}, status={crawl_jobs[job_id].get('status')}")
-        crawl_jobs[job_id]["status"] = "completed"
-        crawl_jobs[job_id]["message"] = f"Completed. Saved {count} chapters."
-        _save_crawl_status()
-        logger.info(f"[{job_id}] Crawl completed. Total chapters: {count}")
-        
-    except Exception as e:
-        _dbg(f"EXCEPTION: {e}\n{_tb.format_exc()}")
-        logger.error(f"Crawl job {job_id} failed: {e}")
-        crawl_jobs[job_id].update({
-            "status": "failed",
-            "message": str(e)
-        })
-        _save_crawl_status()
-
-@mcp.tool()
-def crawl_story_full(start_url: str, content_selector: str, title_selector: str = "h1", next_selector: str = None, speed: float = 1.0, max_chapters: int = 1000) -> str:
-    """
-    Start a background crawl job for a story.
-    
-    This tool crawls multiple chapters starting from `start_url`.
-    It automatically detects if `start_url` is a Chapter or a Story page.
-    
-    Args:
-        start_url: The URL to start crawling from. Can be a Chapter URL (e.g., .../chapter-1) or a Story URL (e.g., .../story-name).
-                   If a Story URL is provided, it will attempt to find the chapter list and start from Chapter 1.
-        content_selector: CSS selector to find the chapter content (e.g., 'div.chapter-c').
-        title_selector: CSS selector for the chapter title. Defaults to 'h1'.
-        next_selector: (Optional) CSS selector for the 'Next Chapter' link. 
-                       If not provided, the crawler uses heuristics to find the next link.
-        speed: Delay in seconds between requests to avoid blocking. Default is 1.0s.
-        max_chapters: Maximum number of chapters to crawl. Default is 1000. 
-                      Increase this if you expect the story to be longer.
-
-    Returns:
-        JSON string containing the `job_id` to track progress via `get_crawl_status(job_id)`.
-    """
-    import threading
-    import uuid
-    
-    job_id = str(uuid.uuid4())
-    crawl_jobs[job_id] = {
-        "status": "pending",
-        "story_title": "Initializing...",
-        "current": 0,
-        "total": max_chapters,
-        "message": "Starting..."
-    }
-    _save_crawl_status()
-    
-    thread = threading.Thread(
-        target=_crawl_worker,
-        args=(job_id, start_url, content_selector, title_selector, next_selector, speed, max_chapters),
-        daemon=True
-    )
-    thread.start()
-    
-    return json.dumps({"job_id": job_id})
-
-@mcp.tool()
-def cancel_crawl(job_id: str) -> str:
-    """Cancel a running crawl job."""
-    logger.info(f"Received cancel request for job: {job_id}")
-    if job_id in crawl_jobs:
-        crawl_jobs[job_id]["status"] = "cancelled"
-        _save_crawl_status()
-        logger.info(f"Job {job_id} marked as cancelled. Current Status: {crawl_jobs[job_id]}")
-        return json.dumps({"status": "cancelled", "job_id": job_id})
-    logger.warning(f"Cancel failed: Job {job_id} not found in {list(crawl_jobs.keys())}")
-    return json.dumps({"status": "not_found", "job_id": job_id})
 
 def delete_local_story(story_id: str) -> dict:
     """Delete a story and all its chapters from local storage."""
@@ -1620,11 +1532,6 @@ def _find_chapter_in_list(chapters: list, chapter_number: int) -> Optional[str]:
     return None
 
 
-def _build_audio_url(book_id: str) -> Optional[str]:
-    """Build relative audio URL for a given book_id."""
-    return f"/api/tts/{quote(book_id, safe='')}"
-
-
 def _save_pending_read(action: dict):
     """Write pending read action to DB for FastAPI process to pick up.
     Replaces file-based pending_read.json — atomic, crash-safe."""
@@ -1675,13 +1582,15 @@ def find_story_chapter(story_name: str, chapter_number: int) -> str:
                         filename = files[0]
                         logger.info(f"find_story_chapter: Found local: {dir_name}/{filename}")
                         _save_pending_read({"type": "READ_LOCAL", "story_title": dir_name, "chapter_filename": filename})
-                        # Compute book_id (same pattern as handle_read_local in server.py)
-                        safe_fname = re.sub(r'[^\w\-\.]', '_', filename)
-                        book_id = f"story_{dir_name}_{safe_fname}"
-                        audio_url = _build_audio_url(book_id)
-                        response_text = f"Now playing {dir_name} chapter {chapter_number}."
-                        if audio_url:
-                            response_text += f" [[[AUDIO_URL: {audio_url}]]]"
+                        # ONE canonical tag for local playback: [[[READ_LOCAL: title|file]]].
+                        # The chat/voice routes resolve playback via the pending-read queue
+                        # above (check_pending_read → handle_read_local). The old extra
+                        # [[[AUDIO_URL: ...]]] tag was redundant — same mechanism, two
+                        # surface strings — and leaked into the chat bubble. Dropped.
+                        response_text = (
+                            f"Now playing {dir_name} chapter {chapter_number}. "
+                            f"[[[READ_LOCAL: {dir_name}|{filename}]]]"
+                        )
                         return json.dumps({
                             "response": response_text,
                             "source": "local"

--- a/docs/crawl-redesign-spec.md
+++ b/docs/crawl-redesign-spec.md
@@ -1,0 +1,186 @@
+# Crawl Redesign Spec — site-agnostic, AI-driven
+
+> Status: **DRAFT for review** (chưa code). Mục tiêu: crawl truyện từ **trang bất kỳ**,
+> không phụ thuộc ngôn ngữ / không hardcode selector từng site. Cho Jarvis OSS.
+
+## 1. Vì sao thiết kế cũ không phổ quát (đã verify bằng dữ liệu thật)
+
+| # | Vấn đề | Bằng chứng (chạy thật, không đoán) |
+|---|--------|-----|
+| 1 | `requests.get` không render JS | 10/10 chỗ fetch dùng `requests`. `truyencom.com` overview render bằng JS → same-slug scan = **0 link**. `StealthyFetcher` import OK in-process. |
+| 2 | Resolve overview bằng regex `chuong/quyen` mong manh | `story_server.py:465` `/(chuong\|chapter\|hoi\|c)[-_]?\d+.*$` KHÔNG khớp `/quyen-1-chuong-1/`. Chạy thật: chương-URL → **6 link rác (sidebar)**, overview-URL → **128 đúng**. |
+| 3 | Chapter list lọc bằng regex text tiếng Việt + selector hardcode | `:494` container `.list-chapter,#list-chapter,...` → fallback `container=soup` (cả trang). `:509` lọc `(chương\|chapter\|hồi)\s+\d+` → nuốt link "truyện đề xuất". Không đa ngôn ngữ. |
+| 4 | CHAIN MODE drift sang truyện khác | `:1378-1391` follow `next` link KHÔNG validate cùng domain/slug; `:1234,1357` mọi chương lưu chung 1 folder, số thứ tự nối tiếp → "đống chapter của truyện khác". |
+| 5 | Provider match substring | `:132` `p['domain'] in url`; 1 selector/domain cho mọi truyện. |
+
+**Đã chứng minh same-slug KHÔNG phổ quát:** truyenfull overview → 53 link/trang (tốt); truyencom → 0 (JS). ⇒ không thể đắp rule tĩnh.
+
+## 2. Nguyên lý (chốt với user)
+
+> Phải **lấy được cấu trúc trang đã render** → **AI phân tích** tìm chapter-list + next-page,
+> không rule cứng. Verify **3 chương đầu** (không phải 1), preview dài hơn, và **continuity check**:
+> cuối chương X phải nối mạch đầu chương X+1.
+
+## 3. Kiến trúc: AI ra RECIPE (nhỏ), CODE enumerate LIST (không token)
+
+> **Nguyên tắc token (user nêu):** truyện 1000+ chương ⇒ 1000 URL. LLM **KHÔNG ĐƯỢC**
+> nhìn thấy 1000 URL đó. LLM chỉ phân tích **cấu trúc 1 trang** → output một **recipe**
+> nhỏ (selectors + url-pattern + pagination rule). **Worker (code, no-LLM)** dùng recipe
+> để enumerate đủ N chương. Token gần như **cố định**, không scale theo số chương.
+>
+> ⚠️ Sửa lỗi spec v1: KHÔNG truyền `chapter_urls=[...1000 url]` qua context agent
+> (sẽ nổ token). Code hiện tại đã đúng phần này — worker tự enumerate; ta giữ nguyên ý đó,
+> chỉ thay phần detect tĩnh bằng recipe do AI sinh.
+
+```
+CrawlStoriesAgent (LLM)                         _crawl_worker (code, no-LLM)
+──────────────────────                          ────────────────────────────
+1. render(overview_url) → DOM structure   ┐
+   của 1 TRANG (vài KB, không phải list)  │ DETECT      6. enumerate full list bằng recipe
+2. LLM đọc structure → output RECIPE nhỏ: │ (1 lần,        (pagination, same-story filter)
+   { chapter_link_selector,               │  token nhỏ)    → LLM KHÔNG thấy 1000 URL → 0 token
+     next_page_selector,                  │             7. fetch content từng chương theo recipe
+     same_story_pattern,                  │             8. heuristic continuity (toàn bộ):
+     content_selector }                   │                URL tuần tự + dedup nội dung
+3. verify 3 chương đầu (LLM đọc 3 đoạn) ──┘             9. lưu vào folder story_title
+4. continuity 3 chương (LLM judge nhẹ)
+5. crawl_story(recipe, overview_url, story_title, max_chapters)
+   → truyền RECIPE (nhỏ), KHÔNG truyền list
+```
+
+**LLM chỉ chạm:** structure 1 trang + 3 đoạn chương verify. Bất kể 50 hay 5000 chương.
+
+**Lý do tách:** `_crawl_worker` chạy trong FastAPI process, **không có LLM**. Recipe phải
+sinh xong ở agent TRƯỚC khi gọi `crawl_story`; worker chỉ thực thi recipe (deterministic).
+
+## 3bis. Recipe phải hỗ trợ 2 MODE (verify bằng 2 site thật)
+
+| Site | Mode | Bằng chứng (chạy thật, render JS) |
+|------|------|-----------------------------------|
+| truyenfull.today | **LIST** | overview nhúng 53 link/trang cùng slug (×3 trang=128) |
+| truyencom.com | **CHAIN** | overview KHÔNG có link chương của chính nó (29 link "chương" đều là truyện KHÁC ở sidebar); list chương lấy bằng follow next-link từ chương 1 |
+
+⇒ Recipe có field `mode: "list" | "chain"`. AI tự nhận diện khi detect:
+- `list`: `{mode:list, chapter_link_selector, next_page_selector, same_story_pattern}` — worker enumerate từ overview + pagination.
+- `chain`: `{mode:chain, first_chapter_url, next_chapter_selector, same_story_pattern}` — worker follow next từ chương 1.
+- **`same_story_pattern` BẮT BUỘC ở cả 2 mode** (vd path-prefix `/dao-gioi-thien-ha-convert/` hoặc regex slug). Worker loại mọi link không khớp → chặn 29-link-truyện-khác bằng code, không cần LLM duyệt từng link. Đây là chốt chặn drift cốt lõi.
+
+## 4. Thay đổi cụ thể
+
+### 4.1 Fetch layer — render JS
+- Thêm helper `render_page(url)` dùng `scrapling.fetchers.StealthyFetcher` (in-process, đã verify import).
+  Trả HTML đã render. Thay `requests.get` ở các bước **detect** (page-structure, chapter-list, verify).
+- Worker fetch content: render nếu site cần JS cho nội dung chương (thường chương là HTML tĩnh — đo thực tế).
+
+### 4.2 DETECT tools (agent gọi)
+- `get_story_page_structure(url)` (đổi): render → trả **DOM signals** cho LLM tự quyết, không tự chấm điểm bằng regex ngôn ngữ. Trả: danh sách container ứng viên (tag, #id, .class, p-count, text-len, link-count, link-href-pattern mẫu) + ứng viên next-page. LLM đọc → chọn.
+- `get_chapter_list(overview_url, list_selector, link_pattern)` (mới/đổi): render từng trang pagination, lấy link trong `list_selector` khớp `link_pattern` (LLM cung cấp, structural — vd "href chứa story-slug"), validate cùng domain+slug. Trả full list URL.
+
+### 4.3 VERIFY mạnh hơn (theo ý user)
+- `verify_chapters(urls[0:3], content_selector, title_selector)`:
+  - Fetch **3 chương đầu**, preview mỗi chương **dài hơn** (vd 800–1500 ký tự, không phải 200).
+  - **Continuity check**: kiểm tra mạch nội dung chương X → X+1. Cách (cần thử thật, chưa chốt):
+    - rẻ: chương phải khác nhau (không trùng), title tăng dần theo số; HOẶC
+    - mạnh: LLM judge "đoạn cuối X và đầu X+1 có liền mạch / cùng truyện không".
+  - Trả verdict + lý do để agent quyết định crawl hay đổi selector.
+
+### 4.4 EXECUTE — crawl_story nhận RECIPE (không phải list)
+- `crawl_story(overview_url, recipe: dict, story_title, max_chapters, speed)`.
+  `recipe = {chapter_link_selector, next_page_selector, same_story_pattern, content_selector, title_selector}`.
+  Bỏ CHAIN-mode-tự-detect. Worker **enumerate list bằng recipe** (pagination + same-story filter)
+  → 1000 URL sinh trong code, **không qua LLM**.
+- `CrawlJob.params` (Text/JSON, đã có) chứa **recipe nhỏ** (vài trăm byte), KHÔNG chứa 1000 URL.
+- Folder = `story_title` do agent cung cấp (đã validate), không suy từ title scrape từng trang (tránh drift đổi tên).
+- `same_story_pattern` (recipe) là chốt chặn drift: worker chỉ nhận link khớp pattern (vd cùng path-prefix story-slug) → loại sidebar/truyện khác **bằng code**, không cần LLM duyệt từng link.
+
+### 4.5 Skill / agent prompt
+- `crawling/SKILL.md` + agent: viết lại workflow theo DETECT→VERIFY(3 chương+continuity)→EXECUTE.
+  Bỏ ngôn từ giả định selector tiếng Việt. Nhấn: luôn render, luôn validate cùng story.
+
+## 4bis. SELF-HEAL: worker gặp lỗi → LLM sửa (event-driven, KHÔNG polling)
+
+> Yêu cầu cốt lõi (user): LLM phải **verify + sửa sai khi gặp vấn đề**, không stuck.
+> Cơ chế: **event-driven** — worker push event đánh thức LLM, không polling.
+
+**Sự thật kiến trúc (đã verify, file:line):**
+- KHÔNG wake được agent **giữa turn**. Inbox chỉ inject giữa các tool-loop của turn đang chạy
+  (`inbox_watcher_hook.py:54-105`).
+- NHƯNG wake được agent **đang idle** bằng `services/inject_resume.py:resume_with_inject()`
+  (chính là code path "Send message to agent" của dashboard — đã có test, dùng thật).
+- Worker crawl chạy nền trong FastAPI process; agent crawl lúc đó **đã idle** (đã trả lời user
+  "đã bắt đầu crawl"). ⇒ đúng điều kiện để `resume_with_inject` đánh thức.
+
+**Vòng self-heal:**
+```
+Worker phát hiện anomaly (selector fail N chương liên tiếp / nội dung rỗng /
+  drift khác slug / pagination đứt sớm so với total)
+  │
+  ├─ status='needs_attention', LƯU checkpoint (chương đang dở, recipe hiện tại, sample HTML lỗi)
+  │
+  └─ PUSH event: resume_with_inject(CrawlStoriesAgent, inject=
+        "Crawl job X kẹt ở chương 47: <triệu chứng> + <sample HTML đã render>.
+         Recipe hiện tại: {...}. Chẩn đoán và sửa recipe, hoặc xác nhận đã hết truyện.")
+        ↓ (event-driven, KHÔNG poll)
+     LLM thức dậy → render lại trang lỗi → chẩn đoán → 1 trong:
+        (a) sửa recipe (selector/pattern mới) → gọi resume_crawl(job_id, new_recipe)
+        (b) xác nhận "hết truyện thật" (47 = chương cuối) → mark completed
+        (c) báo user nếu bất khả (site đổi cấu trúc hẳn / bị chặn)
+        ↓
+     Worker resume từ checkpoint với recipe mới (KHÔNG crawl lại từ đầu)
+```
+
+**LLM chỉ thức khi có lỗi** → token thấp. Không lỗi thì worker chạy hết im lặng.
+
+**Cần thêm:**
+- `CrawlJob.status` thêm giá trị `needs_attention`; cột/JSON checkpoint (chương dở + recipe + sample).
+- Worker: bộ phát hiện anomaly (ngưỡng: K chương rỗng liên tiếp, drift slug, total mismatch).
+- Tool mới `resume_crawl(job_id, recipe_patch)` cho LLM gọi sau khi sửa.
+
+**NOTIFY UI (user yêu cầu) — user PHẢI biết khi có vấn đề, không self-heal ngầm:**
+Mỗi mốc của vòng self-heal đẩy event ra UI (dùng kênh đã có, KHÔNG polling):
+- Worker phát hiện anomaly → cập nhật `CrawlJob.status='needs_attention'` + message cụ thể
+  ("Kẹt ở chương 47: selector nội dung không khớp"). Banner crawl (`useCrawlStatus`, đã wire)
+  poll status sẽ đổi sang trạng thái cảnh báo vàng "⚠ Crawl gặp vấn đề — Jarvis đang xử lý…".
+- Đẩy event qua `activity_stream` (SSE → browser, đã có) để hiện ngay không chờ poll-tick:
+  `{type:'crawl_anomaly', job_id, message}`.
+- Khi LLM sửa xong → status về `running` + message "Đã sửa, tiếp tục từ chương 47" → banner xanh lại.
+- Nếu LLM bó tay (site đổi hẳn / bị chặn) → status `failed` + message rõ lý do cho user.
+- Mọi mốc cũng nên xuất hiện ở chat (assistant message ngắn) khi LLM thức xử lý, để user
+  có ngữ cảnh: "Crawl Thiên Ảnh gặp vấn đề ở ch.47, mình đang thử selector khác…".
+- Frontend `useCrawlStatus`: thêm xử lý status `needs_attention` (màu cảnh báo + message) và
+  lắng nghe event `crawl_anomaly` để cập nhật tức thì.
+
+## 4ter. DỌN DEAD CODE + UPDATE SKILL (user yêu cầu)
+
+Sau redesign, các tool sau **thành mồ côi / trùng** — xoá, không maintain:
+- `test_crawl_chapter` **định nghĩa 2 lần** (`story_server.py:572` VÀ `:933`) → `@mcp.tool()` sau
+  override trước ⇒ **L572 là dead code chắc chắn**. Xoá 1.
+- `crawl_story` (`:1012`) vs `crawl_story_full` (`:1426`) → kiểm tra trùng vai trò, gộp còn 1.
+- `analyze_story_pattern`(`:879`)/`_analyze_story_pattern_impl` + `get_story_page_structure`(`:811`):
+  redesign gộp thành 1 tool detect "render → structure cho LLM". Bỏ scoring regex tiếng Việt
+  (`_find_best_next_selector` text-based scoring) nếu LLM tự chọn từ structure.
+- `add_story_provider` + `StoryConfigManager` substring-match: giữ làm **cache recipe** (tối ưu)
+  hay bỏ — quyết theo phase. Nếu giữ: sửa match đúng host, lưu recipe thay selector rời.
+- `find_story_chapter`(`:1631`): của AudioReaderAgent (đọc truyện), KHÁC luồng crawl — **giữ**.
+
+**Quy tắc:** trước khi xoá mỗi tool → `grep` callers (agent whitelist trong `agent.py`, skill,
+route, test). Chỉ xoá khi 0 caller thật. Cập nhật `agent.py` tools whitelist + `crawling/SKILL.md`
+cho khớp tool mới (DETECT→VERIFY 3 chương+continuity→EXECUTE→SELF-HEAL). Chạy test sau mỗi lần xoá.
+
+## 5. Điểm CHƯA chắc — phải verify khi code (không đoán)
+- [ ] `StealthyFetcher` render: tốc độ với truyện 1000+ chương (pagination nhiều trang)? Có cần cache/parallel?
+- [ ] Worker fetch content: site nào cần render JS cho **nội dung chương** (không chỉ list)? Đo thực tế.
+- [ ] Continuity check: dùng heuristic (overlap/dedup/title-seq) hay LLM judge? Token cost vs độ chính xác.
+- [ ] Provider cache: còn giữ `add_story_provider` để lần sau khỏi detect lại không? (tối ưu, không bắt buộc)
+- [ ] `crawl_story` đổi signature → ai gọi cũ bị vỡ? grep callers + cập nhật.
+
+## 6. Test plan (đa site, không chỉ 1 trang)
+- truyenfull.today (static list, pagination, URL `/quyen-N-chuong-M/`)
+- truyencom.com (JS list — phải render mới thấy)
+- ≥1 site tiếng Anh (chứng minh đa ngôn ngữ)
+- Mỗi site: detect → verify 3 chương → crawl 5 chương → assert: đúng số chương, cùng story (slug), nội dung liền mạch, không lẫn truyện khác.
+
+## 7. Blast radius
+`tools/story_server.py` (fetch layer, detect tools, crawl_story signature, worker), `core/database.py`
+(params shape — đã đủ), `.fast-agent/skills/crawling/SKILL.md`, `agent.py` (CrawlStoriesAgent prompt),
+callers của `crawl_story`. **Lớn** — nên làm theo phase, test từng phase.

--- a/frontend/src/components/AuthGate.vue
+++ b/frontend/src/components/AuthGate.vue
@@ -337,8 +337,14 @@ function onKeydown(event) {
   inset: 0;
   z-index: 9999;
   display: flex;
+  /* Stack brand + card in one column with a real gap so the "Jarvis"
+     wordmark can never overlap the card's top edge. Previously the brand
+     was position:absolute (out of flow) while the card was flex-centered,
+     so on tall viewports the two collided. */
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 28px;
   background: radial-gradient(ellipse at center, var(--bg-1), var(--bg-0) 80%);
   font-family: var(--font-body);
   color: var(--text);
@@ -354,10 +360,8 @@ function onKeydown(event) {
 }
 
 .auth-gate-brand {
-  position: absolute;
-  top: 60px;
-  left: 50%;
-  transform: translateX(-50%);
+  position: relative;
+  z-index: 2;
   text-align: center;
 }
 .auth-gate-brand__mark {

--- a/frontend/src/components/global/FloatingChatDock.vue
+++ b/frontend/src/components/global/FloatingChatDock.vue
@@ -19,10 +19,14 @@ import { ref, computed, watch, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useChatStore } from '../../stores/chat.js'
 import { useChatStream } from '../../composables/useChatStream.js'
+import { useAudioPlayerStore } from '../../stores/audioPlayer.js'
+import { useCrawlStatus } from '../../composables/useCrawlStatus.js'
 import MarkdownRenderer from '../MarkdownRenderer.vue'
 
 const chatStore = useChatStore()
 const { send, isStreaming } = useChatStream()
+const audioStore = useAudioPlayerStore()
+const crawl = useCrawlStatus()
 const route = useRoute()
 const router = useRouter()
 
@@ -141,6 +145,13 @@ async function handleSend() {
             audio: event.audio,
             total_tokens: event.total_tokens,
           })
+          // Same unified playback path as ChatView — story replies become
+          // full story playback in the singleton player; plain replies are
+          // chat-TTS, gated by the read-aloud preference.
+          audioStore.playFromChat(event, chatStore.ttsEnabled)
+          // Track a crawl started from the dock so its progress shows when the
+          // user opens the full /chat view (shared singleton composable).
+          if (event.crawl_job_id) crawl.track(event.crawl_job_id)
           break
         case 'error':
           chatStore.setMessageError(msgId, event.message || 'Unknown error')

--- a/frontend/src/components/stories/ChapterList.vue
+++ b/frontend/src/components/stories/ChapterList.vue
@@ -47,6 +47,16 @@ async function fetchChapters() {
 }
 
 async function handlePlay(filename) {
+  // If this chapter is already the one loaded in the player, the button acts
+  // as play/pause toggle instead of restarting from the top — clicking the
+  // pause icon while it's playing previously re-fired playChapter() and
+  // restarted the chapter from 0s. Only a different chapter starts fresh.
+  const isCurrent = audioStore.currentStoryId === props.storyId
+    && audioStore.currentChapterFile === filename
+  if (isCurrent) {
+    audioStore.togglePlayPause()
+    return
+  }
   try {
     await audioStore.playChapter(
       props.storyId,
@@ -66,10 +76,14 @@ function handleRead(filename) {
   })
 }
 
-function isChapterPlaying(filename) {
+function isChapterCurrent(filename) {
   return audioStore.currentStoryId === props.storyId
     && audioStore.currentChapterFile === filename
-    && (audioStore.isPlaying || audioStore.isPaused)
+}
+// Actively playing (not paused) — drives the pause icon. A paused current
+// chapter shows the play icon so the button reads "resume", not "restart".
+function isChapterPlaying(filename) {
+  return isChapterCurrent(filename) && audioStore.isPlaying
 }
 
 function chapterPreload(ch) {
@@ -137,6 +151,7 @@ watch(
           :chapter="ch"
           :index="idx"
           :is-playing="isChapterPlaying(ch.file)"
+          :is-current="isChapterCurrent(ch.file)"
           :effective-preload="chapterPreload(ch)"
           :queue-position="chapterQueuePos(ch.file)"
           @play="handlePlay"

--- a/frontend/src/components/stories/ChapterRow.vue
+++ b/frontend/src/components/stories/ChapterRow.vue
@@ -8,7 +8,11 @@ import { computed } from 'vue'
 
 const props = defineProps({
   chapter: { type: Object, required: true },
+  // Actively playing (not paused) — drives the pause icon + eq animation.
   isPlaying: { type: Boolean, default: false },
+  // This chapter is the one loaded in the player (playing OR paused) — drives
+  // the row highlight so a paused chapter stays visually selected.
+  isCurrent: { type: Boolean, default: false },
   index: { type: Number, required: true },
   effectivePreload: { type: String, default: null },
   queuePosition: { type: Number, default: -1 },
@@ -29,7 +33,7 @@ const chapterTitle = computed(() => {
 })
 
 const statusType = computed(() => {
-  if (props.isPlaying) return 'playing'
+  if (props.isCurrent) return 'playing'
   return props.effectivePreload || props.chapter.preload || 'none'
 })
 </script>
@@ -37,7 +41,7 @@ const statusType = computed(() => {
 <template>
   <div
     class="ch-row"
-    :class="{ 'ch-row--playing': isPlaying }"
+    :class="{ 'ch-row--playing': isCurrent }"
     @click="emit('play', chapter.file)"
   >
     <span class="ch-row__num">Ch.{{ String(chapterNum).padStart(2, '0') }}</span>

--- a/frontend/src/composables/useAudioPlayer.js
+++ b/frontend/src/composables/useAudioPlayer.js
@@ -22,6 +22,10 @@ let _audio = null
 let _progressInterval = null
 let _broadcastChannel = null
 const BROADCAST_CHANNEL_NAME = 'jarvis-audio'
+// Network-error retry budget per playback. Reset on each successful play.
+// Without a cap, a permanently-failing URL retries every 2s forever.
+let _networkRetries = 0
+const MAX_NETWORK_RETRIES = 3
 
 export function useAudioPlayer() {
   const store = useAudioPlayerStore()
@@ -128,6 +132,7 @@ export function useAudioPlayer() {
     _audio.src = fullUrl
     _audio.playbackRate = store.playbackSpeed
     _audio.play().then(() => {
+      _networkRetries = 0 // fresh successful start → reset the retry budget
       store.setPlayingState(true)
       _setupMediaSession()
       _startProgressSaver()
@@ -140,6 +145,43 @@ export function useAudioPlayer() {
         store.isPaused = true
       }
     })
+  }
+
+  // Probe whether a story's TTS audio is still being generated server-side.
+  // A premature 'ended' on a live stream (buffer underrun) is NOT a real
+  // end-of-chapter — the backend signals in-progress generation via the
+  // X-TTS-Generating header on a HEAD. Returns true = still generating.
+  async function _isStillGenerating(url) {
+    try {
+      const res = await fetch(url, { method: 'HEAD', credentials: 'include', cache: 'no-store' })
+      return res.headers.get('X-TTS-Generating') === '1'
+    } catch (_) {
+      // Network blip — assume NOT generating so we don't loop forever; the
+      // 'ended' path's real-end branch will then advance/stop normally.
+      return false
+    }
+  }
+
+  // A live-stream chapter underran (played all bytes written so far, but the
+  // server is still generating). Resume from the current position once more
+  // bytes — eventually the full file — are available, WITHOUT replaying from
+  // the start. Re-probes until generation completes.
+  async function _resumeAfterUnderrun() {
+    const url = store.currentAudioUrl
+    const resumeAt = store.currentTime
+    store.setBuffering(true)
+    // Poll HEAD every 500ms until generation finishes (≈60s ceiling), letting
+    // the next chunks land before we reload.
+    for (let i = 0; i < 120; i++) {
+      await new Promise(r => setTimeout(r, 500))
+      if (store.currentAudioUrl !== url) return // user moved on (next/prev/close)
+      if (!(await _isStillGenerating(url))) break
+    }
+    if (store.currentAudioUrl !== url) return
+    // Reload the now-complete file and seek back to where we left off, so the
+    // user hears the continuation — not a replay from the start.
+    store.pendingSeekPosition = resumeAt
+    _playUrl(url)
   }
 
   // ─── Core: Play notifTts URL (shares _audio singleton, doesn't touch story store state) ───
@@ -222,6 +264,24 @@ export function useAudioPlayer() {
         store.onNotifTtsEnded()
         return
       }
+      // A story chapter can fire 'ended' prematurely while its TTS is still
+      // streaming live — the player simply ran out of buffered bytes (the
+      // ~11s "plays then jumps to next chapter" bug). Probe the server: if
+      // generation is still in progress, this is an underrun → resume from
+      // here, DON'T advance. Only a true end (generation finished) advances.
+      if (store.playbackType === 'story' && store.currentAudioUrl) {
+        _isStillGenerating(store.currentAudioUrl).then(generating => {
+          if (generating && store.currentAudioUrl) {
+            _resumeAfterUnderrun()
+          } else {
+            store.isPlaying = false
+            store.isPaused = false
+            store.saveProgress()
+            nextTick(() => store.nextChapter())
+          }
+        })
+        return
+      }
       store.isPlaying = false
       store.isPaused = false
       store.saveProgress()
@@ -239,13 +299,20 @@ export function useAudioPlayer() {
       const err = audio.error
       console.error('[AudioPlayer] Audio error:', err?.code, err?.message)
       store.setBuffering(false)
-      // Retry once after 2s for network errors
-      if (err?.code === MediaError.MEDIA_ERR_NETWORK) {
+      // Retry on network errors, but cap it — a permanently-broken URL must
+      // not retry every 2s forever. After the budget is spent, surface the
+      // failure (pause) instead of silently looping.
+      if (err?.code === MediaError.MEDIA_ERR_NETWORK && _networkRetries < MAX_NETWORK_RETRIES) {
+        _networkRetries++
         setTimeout(() => {
           if (store.currentAudioUrl) {
             _playUrl(store.currentAudioUrl)
           }
         }, 2000)
+      } else if (err?.code === MediaError.MEDIA_ERR_NETWORK) {
+        console.error('[AudioPlayer] Network retries exhausted — stopping playback')
+        store.isPlaying = false
+        store.isPaused = true
       }
     })
   }

--- a/frontend/src/composables/useCrawlStatus.js
+++ b/frontend/src/composables/useCrawlStatus.js
@@ -1,0 +1,89 @@
+/**
+ * useCrawlStatus — track a background story-crawl job's progress.
+ *
+ * There is NO crawl SSE stream (only TTS pre-gen has one), so we POLL
+ * GET /api/stories/crawl/status/{job_id} on a timer until the job reaches a
+ * terminal state. The job_id arrives as a structured field on the chat 'done'
+ * event (chat.py → resolve_story_playback extracts it from the
+ * [[[CRAWL_STARTED: id]]] tag before that tag is stripped from the bubble).
+ *
+ * Shared singleton: a crawl started from chat should keep updating even if the
+ * user navigates away, and only one crawl banner makes sense at a time.
+ */
+import { ref, computed } from 'vue'
+import { apiFetch } from '../api.js'
+
+const TERMINAL = new Set(['completed', 'failed', 'cancelled', 'not_found', 'error'])
+// 'needs_attention' is NOT terminal — the worker paused and woke the agent to
+// self-heal; we keep polling so the banner flips back to running once fixed.
+const POLL_MS = 3000
+
+const jobId = ref(null)
+const status = ref(null)        // pending | running | completed | failed | cancelled | error
+const storyTitle = ref('')
+const current = ref(0)
+const total = ref(0)
+const message = ref('')
+let _timer = null
+
+const isActive = computed(() => !!jobId.value && !TERMINAL.has(status.value))
+// Worker paused on an anomaly and is being self-healed by the agent.
+const needsAttention = computed(() => status.value === 'needs_attention')
+const percent = computed(() =>
+  total.value > 0 ? Math.min(Math.round((current.value / total.value) * 100), 100) : 0,
+)
+
+function _stopTimer() {
+  if (_timer) { clearInterval(_timer); _timer = null }
+}
+
+async function _poll() {
+  if (!jobId.value) return
+  try {
+    const data = await apiFetch(`/api/stories/crawl/status/${encodeURIComponent(jobId.value)}`)
+    status.value = data.status || 'error'
+    storyTitle.value = data.story_title || storyTitle.value
+    current.value = data.current || 0
+    total.value = data.total || 0
+    message.value = data.message || ''
+    if (TERMINAL.has(status.value)) _stopTimer()
+  } catch (_) {
+    // Transient network blip — keep polling; a persistent failure just leaves
+    // the banner on its last known state, which the user can dismiss.
+  }
+}
+
+/** Begin tracking a crawl job. Replaces any currently-tracked job. */
+function track(id) {
+  if (!id || id === jobId.value) return
+  _stopTimer()
+  jobId.value = id
+  status.value = 'pending'
+  storyTitle.value = ''
+  current.value = 0
+  total.value = 0
+  message.value = ''
+  _poll()
+  _timer = setInterval(_poll, POLL_MS)
+}
+
+/** Ask the backend to cancel the tracked crawl, then stop polling. */
+async function cancel() {
+  if (!jobId.value) return
+  try {
+    await apiFetch(`/api/stories/crawl/cancel/${encodeURIComponent(jobId.value)}`, { method: 'POST' })
+  } catch (_) { /* best-effort */ }
+  status.value = 'cancelled'
+  _stopTimer()
+}
+
+/** Hide the banner (clears tracking state). */
+function dismiss() {
+  _stopTimer()
+  jobId.value = null
+  status.value = null
+}
+
+export function useCrawlStatus() {
+  return { jobId, status, storyTitle, current, total, message, isActive, needsAttention, percent, track, cancel, dismiss }
+}

--- a/frontend/src/composables/useVoiceSession.js
+++ b/frontend/src/composables/useVoiceSession.js
@@ -21,6 +21,7 @@
  */
 import { ref, reactive, shallowRef, onScopeDispose } from 'vue'
 import { useChatStore } from '../stores/chat.js'
+import { useAudioPlayerStore } from '../stores/audioPlayer.js'
 import { EVENTS, on } from '../auth/bus.js'
 import { expandToolRequest, expandToolDone } from '../utils/toolEvents.js'
 
@@ -276,6 +277,14 @@ function _createVoiceSession() {
             const id = chatStore.addAgentMessagePlaceholder?.()
             if (id) chatStore.finalizeAgentMessage?.(id, text, meta)
           }
+          // Story playback by voice routes through the SAME singleton player as
+          // typed chat (mini-player, chapter nav, resume). The story plays via
+          // the audio player, NOT the voice TTS channel — the backend already
+          // suppressed speaking the announcement. Pass ttsEnabled=true because
+          // the user explicitly asked to listen (voice has no read-aloud toggle).
+          if (msg.story) {
+            useAudioPlayerStore().playFromChat({ story: msg.story }, true)
+          }
           pendingAgentMsgId = null
           wasInterrupted.value = false
           // Status will flip to 'speaking' when the next tts_start arrives;
@@ -342,6 +351,12 @@ function _createVoiceSession() {
         case 'error':
           _failPending(msg.detail || 'agent error')
           error.value = msg.detail || 'server error'
+          // Flip status to 'error' so the header/VoiceBar stop showing a green
+          // "connected" chip while STT is actually dead. Without this the chip
+          // stayed green on a Soniox 408 (transient errors no longer reach here
+          // — only fatal ones do — so this means STT genuinely failed). The
+          // user sees the mic is off and can re-toggle to reconnect.
+          status.value = 'error'
           break
       }
     } else if (ev.data instanceof Blob) {
@@ -404,7 +419,13 @@ function _createVoiceSession() {
   }
 
   async function start() {
-    if (status.value !== 'idle') return
+    // Allow (re)start from idle OR error — a failed session must be
+    // recoverable by re-toggling the mic. Any other state (connecting/
+    // listening/…) means a session is already live, so guard against re-entry.
+    if (status.value !== 'idle' && status.value !== 'error') return
+    // Clean up any half-torn-down previous session before opening a new one,
+    // so an errored session doesn't leak its old socket/mic/worklet.
+    if (status.value === 'error') await stop()
     error.value = ''
     status.value = 'connecting'
     torn = false

--- a/frontend/src/stores/audioPlayer.js
+++ b/frontend/src/stores/audioPlayer.js
@@ -10,7 +10,7 @@
  */
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
-import { apiFetch } from '../api'
+import { apiFetch } from '../api.js'
 
 const STORAGE_KEY = 'jarvis_audio_progress'
 const SPEED_STORAGE_KEY = 'jarvis_audio_speed'
@@ -137,6 +137,52 @@ export const useAudioPlayerStore = defineStore('audioPlayer', () => {
       isBuffering.value = false
       console.error('[AudioStore] playChapter error:', err)
       throw err
+    }
+  }
+
+  /**
+   * Play a one-off chat-TTS reply through the singleton element.
+   *
+   * Unlike playChapter this is ephemeral: no playlist, no chapter nav, and
+   * no progress persistence (currentRequestId stays null so the save timer
+   * is never armed and saveProgress() no-ops). It still funnels through the
+   * one audio element so a reply can never overlap a story.
+   *
+   * @param {string} audioUrl - /api/tts/{id} url from the chat 'done' event
+   */
+  function playChatTts(audioUrl) {
+    playbackType.value = 'chatTts'
+    currentStoryId.value = null
+    currentStoryTitle.value = 'Chat'
+    currentChapterFile.value = null
+    chapterFiles.value = []
+    currentIndex.value = -1
+    currentRequestId.value = null
+    currentTime.value = 0
+    duration.value = 0
+    isBuffering.value = true
+    isMiniPlayerVisible.value = true
+    // Setting the url triggers the useAudioPlayer watcher → playback.
+    currentAudioUrl.value = audioUrl
+  }
+
+  /**
+   * Single entry point for audio coming from a chat 'done' event — the one
+   * place that decides story vs plain reply, shared by every chat surface.
+   *
+   * Story replies (event.story present) become full story playback: the user
+   * explicitly asked to listen, so they play regardless of the read-aloud
+   * toggle. Plain replies are chat-TTS, gated by that toggle.
+   *
+   * @param {{audio?: string, story?: object}} event
+   * @param {boolean} ttsEnabled - user's "read replies aloud" preference
+   */
+  function playFromChat(event, ttsEnabled) {
+    const s = event?.story
+    if (s && s.story_id && s.chapter_file) {
+      playChapter(s.story_id, s.story_title || s.story_id, s.chapter_file, s.chapter_files || [])
+    } else if (ttsEnabled && event?.audio) {
+      playChatTts(event.audio)
     }
   }
 
@@ -268,7 +314,12 @@ export const useAudioPlayerStore = defineStore('audioPlayer', () => {
   function updateDuration(dur) {
     duration.value = dur
     isBuffering.value = false
-    generationStatus.value = { ...generationStatus.value, [currentChapterFile.value]: 'ready' }
+    // NOTE: do NOT mark the chapter 'ready' here. While a chapter streams
+    // live, the browser reports a duration from the bytes received so far —
+    // marking 'ready' on that would flip the chapter-list badge to green
+    // before generation actually finishes. The authoritative 'ready' signal
+    // is the pregen SSE 'chapter_ready' event (usePregenStream) / the play
+    // API's status:'ready'. Leave generationStatus untouched here.
   }
 
   function setPlayingState(playing) {
@@ -564,6 +615,8 @@ export const useAudioPlayerStore = defineStore('audioPlayer', () => {
 
     // Actions
     playChapter,
+    playChatTts,
+    playFromChat,
     nextChapter,
     prevChapter,
     togglePlayPause,

--- a/frontend/src/stores/audioPlayer.test.js
+++ b/frontend/src/stores/audioPlayer.test.js
@@ -1,0 +1,79 @@
+/**
+ * audioPlayer store — chat playback routing (single source of truth).
+ *
+ * Covers playFromChat()/playChatTts(): the ONE decision point that funnels
+ * every chat surface's audio into the singleton player, so a story started
+ * from chat behaves like one started from the library, and a plain TTS reply
+ * can never overlap a story (only one audio element exists).
+ */
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createPinia, setActivePinia } from 'pinia'
+
+// The store reads localStorage at setup (_loadSpeed) — shim it for node.
+globalThis.localStorage = {
+  _m: {},
+  getItem(k) { return k in this._m ? this._m[k] : null },
+  setItem(k, v) { this._m[k] = String(v) },
+  removeItem(k) { delete this._m[k] },
+}
+
+// playChapter() POSTs /api/stories/{id}/{file}/play — stub the response so
+// the story branch resolves without a live backend.
+globalThis.fetch = async () =>
+  new Response(
+    JSON.stringify({ audio_url: '/api/tts/story_X_001_X.txt', status: 'ready', duration: 12 }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  )
+
+const { useAudioPlayerStore } = await import('./audioPlayer.js')
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+// A story reply must become full story playback — and play even when the
+// "read replies aloud" toggle is OFF, because the user explicitly asked to
+// listen. (playChapter sets the playlist state synchronously, before its
+// await, so we can assert it immediately.)
+test('playFromChat: story reply → story playback, ignores read-aloud toggle', () => {
+  const store = useAudioPlayerStore()
+  store.playFromChat(
+    {
+      audio: '/api/tts/story_X_001_X.txt',
+      story: { story_id: 'X', story_title: 'X', chapter_file: '001_X.txt', chapter_files: ['001_X.txt', '002_X.txt'] },
+    },
+    false, // read-aloud OFF
+  )
+  assert.equal(store.playbackType, 'story')
+  assert.equal(store.currentStoryId, 'X')
+  assert.equal(store.currentChapterFile, '001_X.txt')
+  assert.deepEqual(store.chapterFiles, ['001_X.txt', '002_X.txt'])
+  assert.equal(store.canPlayNext, true)
+  assert.equal(store.isMiniPlayerVisible, true)
+})
+
+// A plain reply plays as ephemeral chatTts only when read-aloud is ON.
+test('playFromChat: plain reply → chatTts when read-aloud is ON', () => {
+  const store = useAudioPlayerStore()
+  store.playFromChat({ audio: '/api/tts/abc' }, true)
+  assert.equal(store.playbackType, 'chatTts')
+  assert.equal(store.currentAudioUrl, '/api/tts/abc')
+  assert.equal(store.currentRequestId, null) // ephemeral — no progress persistence
+  assert.equal(store.isMiniPlayerVisible, true)
+})
+
+// Plain reply must stay silent when the user has read-aloud OFF.
+test('playFromChat: plain reply is silent when read-aloud is OFF', () => {
+  const store = useAudioPlayerStore()
+  store.playFromChat({ audio: '/api/tts/abc' }, false)
+  assert.equal(store.playbackType, 'none')
+  assert.equal(store.isMiniPlayerVisible, false)
+})
+
+// Neither audio nor story → nothing happens.
+test('playFromChat: no audio and no story → no-op', () => {
+  const store = useAudioPlayerStore()
+  store.playFromChat({}, true)
+  assert.equal(store.playbackType, 'none')
+})

--- a/frontend/src/stores/chat.js
+++ b/frontend/src/stores/chat.js
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { apiFetch } from '../api'
+import { useAudioPlayerStore } from './audioPlayer'
 
 const META_STORAGE_KEY = 'jarvis_chat_meta'
 const TTS_STORAGE_KEY = 'jarvis_tts_enabled'
@@ -13,8 +14,13 @@ export const useChatStore = defineStore('chat', () => {
   const isStreaming = ref(false)
   const isLoadingHistory = ref(false)
   const ttsEnabled = ref(localStorage.getItem(TTS_STORAGE_KEY) === 'true')
-  const ttsPlaying = ref(false)
-  const _ttsAudioRef = ref(null) // internal ref, set by ChatView
+  // Chat TTS plays through the singleton audio player (single source of
+  // truth) — ttsPlaying just mirrors it so chat UI reacts without owning
+  // an audio element of its own. See audioPlayer.playFromChat().
+  const ttsPlaying = computed(() => {
+    const audio = useAudioPlayerStore()
+    return audio.playbackType === 'chatTts' && audio.isPlaying
+  })
 
   // --- Computed ---
   const activeConversation = computed(() =>
@@ -147,10 +153,17 @@ export const useChatStore = defineStore('chat', () => {
   // --- Actions ---
   function createConversation(agentName) {
     const id = crypto.randomUUID()
+    // Resolve the agent ONCE, then make it the single source of truth for both
+    // the conversation record AND the active-agent header. Previously only
+    // conv.agentName got the 'Jarvis' fallback while activeAgentName was left
+    // as-is — so if you hit "+" before the agent roster finished loading
+    // (activeAgentName still null), the new conversation belonged to Jarvis but
+    // the header read the null activeAgentName and rendered "No Agent".
+    const resolvedAgent = agentName || activeAgentName.value || 'Jarvis'
     const conv = {
       id,
       title: 'New Conversation',
-      agentName: agentName || activeAgentName.value || 'Jarvis',
+      agentName: resolvedAgent,
       backendConversationId: null, // Set by backend on first response
       messages: [],
       createdAt: Date.now(),
@@ -158,6 +171,7 @@ export const useChatStore = defineStore('chat', () => {
     }
     conversations.value.unshift(conv)
     activeConversationId.value = id
+    activeAgentName.value = resolvedAgent
     _saveMeta()
     return conv
   }
@@ -190,7 +204,15 @@ export const useChatStore = defineStore('chat', () => {
 
     conversations.value = conversations.value.filter(c => c.id !== id)
     if (activeConversationId.value === id) {
-      activeConversationId.value = conversations.value[0]?.id || null
+      // Re-point to the next conversation AND sync the active agent to it.
+      // Previously only activeConversationId moved; activeAgentName kept the
+      // deleted conversation's agent (or went stale), so the two truths
+      // diverged — and deleting the LAST conversation left activeConversationId
+      // null while the header still read a now-orphaned agent. Keep both in
+      // lockstep: the next conversation's agent, or fall back to Jarvis.
+      const next = conversations.value[0] || null
+      activeConversationId.value = next?.id || null
+      activeAgentName.value = next?.agentName || 'Jarvis'
     }
     _saveMeta()
   }
@@ -213,15 +235,11 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   function stopTts() {
-    if (_ttsAudioRef.value) {
-      _ttsAudioRef.value.pause()
-      _ttsAudioRef.value.currentTime = 0
+    // Chat TTS now plays through the singleton player; stop it there.
+    const audio = useAudioPlayerStore()
+    if (audio.playbackType === 'chatTts') {
+      audio.stopAndReset()
     }
-    ttsPlaying.value = false
-  }
-
-  function setTtsAudioRef(el) {
-    _ttsAudioRef.value = el
   }
 
   /**
@@ -386,7 +404,6 @@ export const useChatStore = defineStore('chat', () => {
     setActiveAgent,
     toggleTts,
     stopTts,
-    setTtsAudioRef,
     addUserMessage,
     addAgentMessagePlaceholder,
     pushToolCall,

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -14,9 +14,12 @@
  *       - ChatInput
  *       - hidden TTS audio element
  */
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useChatStore } from '../stores/chat'
+import { useAudioPlayerStore } from '../stores/audioPlayer'
 import { useAgentsStore } from '../stores/agents'
+import { useCrawlStatus } from '../composables/useCrawlStatus'
+import { EVENTS, on } from '../auth/bus.js'
 import { useChatStream } from '../composables/useChatStream'
 import { useConfirm } from '../composables/useConfirm'
 import { useToast } from '../composables/useToast'
@@ -36,25 +39,38 @@ const { isMobile } = useBreakpoint()
 const showMobileConversations = ref(false)
 
 const chatStore = useChatStore()
+const audioStore = useAudioPlayerStore()
 const agentsStore = useAgentsStore()
+const crawl = useCrawlStatus()
 const { isStreaming, send, cancel } = useChatStream()
 const { confirm } = useConfirm()
 const toast = useToast()
 const voice = useVoiceSession()
 
-const ttsAudio = ref(null)
+// Load the conversation list + agent roster. Both hit auth-gated APIs, so
+// they must (re-)run whenever auth becomes valid — not just on first mount.
+function loadWorkspace() {
+  chatStore.fetchConversations()
+  if (!agentsStore.agentsList.length) agentsStore.fetchAgents()
+}
 
-onMounted(async () => {
-  if (ttsAudio.value) {
-    chatStore.setTtsAudioRef(ttsAudio.value)
-    ttsAudio.value.addEventListener('play',  () => { chatStore.ttsPlaying = true })
-    ttsAudio.value.addEventListener('ended', () => { chatStore.ttsPlaying = false })
-    ttsAudio.value.addEventListener('pause', () => { chatStore.ttsPlaying = false })
-  }
-  await chatStore.fetchConversations()
+onMounted(() => {
+  loadWorkspace()
 })
 
-if (!agentsStore.agentsList.length) agentsStore.fetchAgents()
+// Post-passkey-login race: this view is kept-alive (AppLayout's
+// <keep-alive include="['Chat']">) and AuthGate is an overlay, NOT a route
+// guard — so ChatView mounts ONCE while still unauthenticated. Its onMounted
+// fetch 401s silently → empty list + "No Agent", and nothing remounts it
+// after login, so only a full page refresh recovered. The auth store emits
+// EVENTS.RESTORED the moment login succeeds (same signal SSE/meeting/pregen
+// streams already reconnect on) — re-fetch the workspace then.
+const offRestored = on(EVENTS.RESTORED, () => {
+  loadWorkspace()
+})
+onUnmounted(() => {
+  offRestored()
+})
 
 watch(
   () => agentsStore.agentsList,
@@ -157,10 +173,15 @@ async function handleSend(payload) {
             audio: event.audio,
             total_tokens: event.total_tokens,
           })
-          if (chatStore.ttsEnabled && event.audio && ttsAudio.value) {
-            ttsAudio.value.src = event.audio
-            ttsAudio.value.play().catch(err => console.warn('[TTS] Auto-play blocked:', err))
-          }
+          // Route playback through the singleton audio player (single source
+          // of truth) so it persists across navigation and shows in the
+          // global mini-player. Story replies become full story playback;
+          // plain replies are chat-TTS, gated by the read-aloud preference.
+          audioStore.playFromChat(event, chatStore.ttsEnabled)
+          // If the agent started a web crawl, attach the live-progress poller
+          // (the [[[CRAWL_STARTED]]] tag is stripped from the bubble — the id
+          // arrives here as structured data instead).
+          if (event.crawl_job_id) crawl.track(event.crawl_job_id)
           break
         case 'error':
           chatStore.setMessageError(msgId, event.message || 'Unknown error')
@@ -237,13 +258,47 @@ function handleSwitchAgent(name) {
         </button>
       </div>
 
+      <!-- Crawl progress strip — live chapter X/Y + cancel/dismiss -->
+      <div
+        v-if="crawl.jobId.value"
+        class="crawl-strip"
+        :class="{ done: !crawl.isActive.value, warn: crawl.needsAttention.value }"
+      >
+        <span class="crawl-spinner" v-if="crawl.isActive.value" />
+        <span class="crawl-label">
+          <template v-if="crawl.status.value === 'completed'">
+            ✓ Tải xong{{ crawl.storyTitle.value ? ` "${crawl.storyTitle.value}"` : '' }} — {{ crawl.current.value }}/{{ crawl.total.value }} chương
+          </template>
+          <template v-else-if="crawl.status.value === 'failed' || crawl.status.value === 'error'">
+            ⚠ Tải truyện thất bại{{ crawl.message.value ? `: ${crawl.message.value}` : '' }}
+          </template>
+          <template v-else-if="crawl.status.value === 'cancelled'">
+            Đã huỷ tải truyện
+          </template>
+          <template v-else-if="crawl.needsAttention.value">
+            ⚠ Crawl gặp vấn đề — Jarvis đang xử lý… {{ crawl.message.value ? `(${crawl.message.value})` : '' }}
+          </template>
+          <template v-else>
+            Đang tải{{ crawl.storyTitle.value ? ` "${crawl.storyTitle.value}"` : ' truyện' }}…
+            {{ crawl.current.value }}/{{ crawl.total.value || '?' }} chương
+            <span v-if="crawl.total.value" class="crawl-pct">{{ crawl.percent.value }}%</span>
+          </template>
+        </span>
+        <button v-if="crawl.isActive.value" class="crawl-btn" @click="crawl.cancel()">Huỷ</button>
+        <button v-else class="crawl-btn" @click="crawl.dismiss()">Ẩn</button>
+      </div>
+
+      <!-- Status footer (above input) -->
+      <div v-if="statusFooter" class="status-footer">
+        <span class="status-footer-dot" :class="{ pulse: statusFooterActive }" />
+        <span class="status-footer-text">{{ statusFooter }}</span>
+      </div>
+
       <ChatInput
         :isStreaming="isStreaming"
         @send="handleSend"
         @stop="handleStop"
       />
-
-      <audio ref="ttsAudio" style="display: none;" />
     </main>
   </div>
 </template>
@@ -299,6 +354,70 @@ function handleSwitchAgent(name) {
 .conv-overlay-enter-from, .conv-overlay-leave-to { opacity: 0; }
 .conv-overlay-enter-from .conv-slide-panel,
 .conv-overlay-leave-to .conv-slide-panel { transform: translateX(-100%); }
+
+/* Crawl progress strip */
+.crawl-strip {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 24px;
+  background: var(--primary-bg);
+  border-top: 1px solid var(--primary-bg-strong);
+  font-size: 12px;
+  color: var(--text);
+}
+.crawl-strip.done { background: var(--bg-2); border-top-color: var(--border); }
+.crawl-strip.warn { background: var(--warning-bg); border-top-color: rgba(245,158,11,0.30); }
+.crawl-label { flex: 1; }
+.crawl-pct { color: var(--primary-hover); font-weight: 600; margin-left: 4px; }
+.crawl-spinner {
+  width: 14px; height: 14px; flex-shrink: 0;
+  border: 2px solid var(--primary-bg-strong);
+  border-top-color: var(--primary-hover);
+  border-radius: 50%;
+  animation: crawl-spin 0.8s linear infinite;
+}
+@keyframes crawl-spin { to { transform: rotate(360deg); } }
+.crawl-btn {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  color: var(--text-dim);
+  font-size: 11px;
+  cursor: pointer;
+}
+.crawl-btn:hover { color: var(--text); background: var(--bg-4); }
+
+/* Status footer */
+.status-footer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 24px;
+  background: var(--bg-1);
+  border-top: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+}
+.status-footer-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+.status-footer-dot.pulse {
+  background: var(--accent);
+  animation: status-pulse 1.2s ease-in-out infinite;
+}
+@keyframes status-pulse {
+  0%, 100% { opacity: 1;    transform: scale(1);    }
+  50%      { opacity: 0.45; transform: scale(1.4);  }
+}
 
 /* TTS Now Playing */
 .tts-now-playing {


### PR DESCRIPTION
Bundles the bug fixes + crawl rework from this session. Each is its own commit; all verified on top of latest `main` (backend 51 tests pass, frontend build + 77 unit tests pass).

## Commits
1. **feat(crawl): site-agnostic AI-driven story crawl + serpapi + dead-code cleanup**
   Rewrite crawling to work on ANY site/language: `detect_story_structure` renders JS + hands the LLM a language-agnostic structural summary → a small "recipe"; the worker enumerates the full chapter list from it (1000s of URLs never touch the LLM → fixed token cost). LIST + CHAIN modes with a same-story guard (no drift into other stories). `verify_chapters` checks the first 3 chapters. Self-heal: a stuck crawl wakes CrawlStoriesAgent to fix the recipe + `resume_crawl` from checkpoint. Added serpapi to the agent (fast search). Removed ~500 lines of dead crawl code. Verified e2e on truyenfull.today (LIST/VN), truyencom.com (CHAIN/VN/JS), webnovel.com (EN/JS). Preserves main's `get_capped_text` security fix.
2. **fix(audio): unify story playback on the singleton player + stop ~11s false-end**
   Chat/story audio routes through the one audioPlayer (persists across nav, mini-player). Backend no longer cancels the chapter being listened to; player treats a premature `ended` during live TTS as an underrun (resume) not end-of-chapter. Capped network retries.
3. **fix(chat/voice): one story-playback path, no leaked tags, no lost conversations**
   Shared `resolve_story_playback` for typed + voice; strip all backend marker tags before the bubble (except `[[[PLAY]]]`); one canonical READ_LOCAL tag; structured `crawl_job_id`; fix "No Agent" on create/delete; cancelled first turn still stamps `primary_agent` (was hiding the conversation); re-fetch on auth RESTORED.
4. **fix(interrupt): Stop while delegating a sub-agent no longer dead-locks chat**
   Track the whole-turn task (`_turn_tasks`) so interrupt/hard_kill cancel even mid-delegate, instead of leaking `_agent_lock` and freezing all later chats.
5. **fix(stt): Soniox keepalive + reconnect so voice doesn't silently die**
   Send keepalive every 10s during silence; classify fatal (400/401/403) vs transient (408 etc → reconnect). Layered on top of main's STT lifecycle/state-machine.
6. **fix(auth): passkey login no longer 403s on a stale CSRF cookie**
   Exempt `/api/auth/passkey/authenticate` from CSRF (login flow, no token yet); REGISTER stays protected.
7. **fix(ui): AuthGate spacing + chapter play/pause button**
   Wordmark no longer overlaps the login card; chapter button pauses/resumes the current chapter instead of restarting.

## Verification
- backend: `pytest` session/soniox/tag-relay/audio-reader → 51 passed
- frontend: `npm run build` ✓, `npm run test:unit` → 77 passed / 0 failed
- crawl e2e on 3 real sites (LIST, CHAIN, EN/JS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)