### PR TITLE
fix(team-template): address PR #58 ultrareview backlog (path-traversal + data-loss + nits)

### DIFF
--- a/backend/routes/team_template.py
+++ b/backend/routes/team_template.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import Session
 
 from core.auth import verify_api_key
 from core.database import get_db
+from services import team_template_factory_service as factory_svc
 from services import team_template_service as svc
 from services.team_reload import reload_roles
 
@@ -38,23 +39,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/team-sessions", tags=["team-template"])
 
-# Yaml templates dir — used by /reset/{role} to look up the factory default.
-_YAML_DIR = Path(__file__).resolve().parent.parent / "team_templates"
-
 
 def _resolve_yaml_for_session(session_id: str) -> Path:
     """Locate the yaml template for a team session.
 
     Reads ``team_sessions.template.name`` to find which yaml the team was
-    created from (e.g. 'agile-team' → 'agile_team.yaml').
+    created from (e.g. 'agile-team' → 'agile_team.yaml'). Delegates to the
+    guarded ``factory_svc.resolve_factory_path`` so a malicious template name
+    can't escape ``team_templates/`` (raises ``PathTraversalError``).
     """
     template = svc.get_template(session_id)
-    name = template.get("name") or "agile-team"
-    candidate = _YAML_DIR / f"{name.replace('-', '_')}.yaml"
-    if not candidate.exists():
-        # Fallback: try literal name
-        candidate = _YAML_DIR / f"{name}.yaml"
-    return candidate
+    return factory_svc.resolve_factory_path(template.get("name") or "agile-team")
 
 
 class PatchRoleBody(BaseModel):
@@ -241,7 +236,10 @@ async def reset_role(
     Writes audit rows for every field that diverged. Other roles untouched.
     """
     edited_by = _principal(request)
-    yaml_path = _resolve_yaml_for_session(session_id)
+    try:
+        yaml_path = _resolve_yaml_for_session(session_id)
+    except factory_svc.PathTraversalError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     try:
         result = svc.reset_role_to_yaml(
             db,
@@ -284,7 +282,10 @@ async def yaml_diff(session_id: str):
     except svc.NotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
-    yaml_path = _resolve_yaml_for_session(session_id)
+    try:
+        yaml_path = _resolve_yaml_for_session(session_id)
+    except factory_svc.PathTraversalError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     if not yaml_path.exists():
         raise HTTPException(
             status_code=404,
@@ -293,7 +294,16 @@ async def yaml_diff(session_id: str):
 
     with yaml_path.open(encoding="utf-8") as f:
         yaml_doc = yaml_lib.safe_load(f) or {}
-    yaml_template = yaml_doc.get("team") or yaml_doc
+    # Guard the shape before calling .get — a top-level list/scalar yaml, or a
+    # truthy non-dict ``team:`` (``team: [pm, dev]``), would otherwise raise
+    # AttributeError → unhandled 500.
+    if not isinstance(yaml_doc, dict):
+        raise HTTPException(
+            status_code=400,
+            detail=f"factory yaml at {yaml_path} is not a mapping",
+        )
+    team = yaml_doc.get("team")
+    yaml_template = team if isinstance(team, dict) else yaml_doc
     yaml_roles = yaml_template.get("roles") or {}
     current_roles = current_template.get("roles") or {}
 

--- a/backend/routes/team_template.py
+++ b/backend/routes/team_template.py
@@ -275,8 +275,6 @@ async def yaml_diff(session_id: str):
     Decision 2026-05-17: yaml is FACTORY DEFAULT, not continuous source.
     This endpoint lets the user *see* drift without enforcing convergence.
     """
-    import yaml as yaml_lib
-
     try:
         current_template = svc.get_template(session_id)
     except svc.NotFoundError as e:
@@ -292,19 +290,12 @@ async def yaml_diff(session_id: str):
             detail=f"factory yaml not found at {yaml_path}",
         )
 
-    with yaml_path.open(encoding="utf-8") as f:
-        yaml_doc = yaml_lib.safe_load(f) or {}
-    # Guard the shape before calling .get — a top-level list/scalar yaml, or a
-    # truthy non-dict ``team:`` (``team: [pm, dev]``), would otherwise raise
-    # AttributeError → unhandled 500.
-    if not isinstance(yaml_doc, dict):
-        raise HTTPException(
-            status_code=400,
-            detail=f"factory yaml at {yaml_path} is not a mapping",
-        )
-    team = yaml_doc.get("team")
-    yaml_template = team if isinstance(team, dict) else yaml_doc
-    yaml_roles = yaml_template.get("roles") or {}
+    # Open + unwrap roles via the shared helper so this and the RPC handler's
+    # copy stay in lockstep. ValidationError = non-mapping yaml → 400.
+    try:
+        yaml_roles = factory_svc.load_factory_roles(yaml_path)
+    except factory_svc.ValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     current_roles = current_template.get("roles") or {}
 
     per_role: dict[str, dict] = {}

--- a/backend/services/team_template_factory_service.py
+++ b/backend/services/team_template_factory_service.py
@@ -105,6 +105,32 @@ def resolve_factory_path(name: str) -> Path:
     return candidate
 
 
+def load_factory_roles(path: Path) -> dict[str, Any]:
+    """Read a factory yaml and return its ``roles`` mapping.
+
+    Single source for the "open + unwrap roles" step the yaml-diff callers
+    (REST route + RPC handler) both need — kept here so the shape-guard can't
+    drift between the two layers.
+
+    Accepts the two layouts the spawner supports: top-level ``roles:`` or
+    nested ``team.roles:``. Only a NON-EMPTY ``team:`` mapping overrides the
+    top level — an empty ``team: {}`` or a non-dict ``team: [..]`` falls back
+    to the top-level ``roles:`` (an unusable ``team`` should not blank out the
+    diff). Returns ``{}`` when no roles are defined.
+
+    Raises ``ValidationError`` if the file isn't a mapping at all (a top-level
+    list/scalar), which would otherwise crash the caller with AttributeError.
+    """
+    with path.open(encoding="utf-8") as f:
+        doc = yaml.safe_load(f) or {}
+    if not isinstance(doc, dict):
+        raise ValidationError(f"factory yaml at {path} is not a mapping")
+    team = doc.get("team")
+    container = team if (isinstance(team, dict) and team) else doc
+    roles = container.get("roles")
+    return roles if isinstance(roles, dict) else {}
+
+
 def list_factory_templates() -> list[dict[str, Any]]:
     """Return every yaml in ``team_templates/`` with size + parsed display name.
 

--- a/backend/services/team_template_factory_service.py
+++ b/backend/services/team_template_factory_service.py
@@ -85,6 +85,26 @@ def _resolve(name: str) -> Path:
     return candidate
 
 
+def resolve_factory_path(name: str) -> Path:
+    """Map a running template's ``name`` to its factory yaml path — GUARDED.
+
+    Tries the hyphen→underscore form first (``agile-team`` → ``agile_team.yaml``),
+    then the literal name. BOTH forms go through :func:`_resolve`, so a
+    malicious template name (e.g. ``../../secrets`` — the ``name`` field is
+    LLM-writable via ``team_template_write_factory`` and is NOT structurally
+    validated) is refused with ``PathTraversalError`` instead of being opened.
+
+    Returns the underscored candidate when it exists, else the literal-name
+    candidate (existence is the caller's concern). Raises ``PathTraversalError``
+    if neither form is a safe name.
+    """
+    underscored = (name or "agile-team").replace("-", "_")
+    candidate = _resolve(underscored)
+    if not candidate.exists() and name and name != underscored:
+        candidate = _resolve(name)
+    return candidate
+
+
 def list_factory_templates() -> list[dict[str, Any]]:
     """Return every yaml in ``team_templates/`` with size + parsed display name.
 

--- a/backend/services/team_template_rpc_handlers.py
+++ b/backend/services/team_template_rpc_handlers.py
@@ -47,13 +47,13 @@ def _session_scope():
 def _factory_yaml_path_for(name: str) -> Path:
     """Resolve the yaml path the running template was instantiated from.
 
-    Mirrors ``_resolve_yaml_for_session`` in ``routes/team_template.py``: maps
-    e.g. ``agile-team`` → ``agile_team.yaml``. Caller is the reset/diff handler.
+    Delegates to ``factory_svc.resolve_factory_path`` so the path-traversal
+    guard applies — ``name`` comes from the (LLM-writable, unvalidated)
+    template ``name`` field, so raw interpolation here would let it escape
+    ``team_templates/``. Raises ``factory_svc.PathTraversalError`` on a bad
+    name; callers translate it to a 400.
     """
-    candidate = factory_svc.factory_dir() / f"{(name or 'agile-team').replace('-', '_')}.yaml"
-    if not candidate.exists():
-        candidate = factory_svc.factory_dir() / f"{name}.yaml"
-    return candidate
+    return factory_svc.resolve_factory_path(name)
 
 
 # ── factory yaml (file-level) ──────────────────────────────────────────────
@@ -180,7 +180,10 @@ def _running_reset_role(
         template = svc.get_template(session_id)
     except svc.NotFoundError as exc:
         return _err(str(exc), 404)
-    yaml_path = _factory_yaml_path_for(template.get("name") or "agile-team")
+    try:
+        yaml_path = _factory_yaml_path_for(template.get("name") or "agile-team")
+    except factory_svc.PathTraversalError as exc:
+        return _err(str(exc), 400)
     db = _session_scope()
     try:
         try:
@@ -214,13 +217,22 @@ def _running_yaml_diff(*, session_id: str) -> dict:
     except svc.NotFoundError as exc:
         return _err(str(exc), 404)
 
-    yaml_path = _factory_yaml_path_for(current_template.get("name") or "agile-team")
+    try:
+        yaml_path = _factory_yaml_path_for(current_template.get("name") or "agile-team")
+    except factory_svc.PathTraversalError as exc:
+        return _err(str(exc), 400)
     if not yaml_path.exists():
         return _err(f"factory yaml not found at {yaml_path}", 404)
 
     with yaml_path.open(encoding="utf-8") as f:
         yaml_doc = yaml_lib.safe_load(f) or {}
-    yaml_template = yaml_doc.get("team") or yaml_doc
+    # Guard the shape before calling .get — a top-level list/scalar yaml, or a
+    # truthy non-dict ``team:`` (``team: [pm, dev]``), would otherwise raise
+    # AttributeError → unhandled 500. Mirror list_factory_templates.
+    if not isinstance(yaml_doc, dict):
+        return _err(f"factory yaml at {yaml_path} is not a mapping", 400)
+    team = yaml_doc.get("team")
+    yaml_template = team if isinstance(team, dict) else yaml_doc
     yaml_roles = yaml_template.get("roles") or {}
     current_roles = current_template.get("roles") or {}
 

--- a/backend/services/team_template_rpc_handlers.py
+++ b/backend/services/team_template_rpc_handlers.py
@@ -210,8 +210,6 @@ def _running_reset_role(
 
 
 def _running_yaml_diff(*, session_id: str) -> dict:
-    import yaml as yaml_lib
-
     try:
         current_template = svc.get_template(session_id)
     except svc.NotFoundError as exc:
@@ -224,16 +222,12 @@ def _running_yaml_diff(*, session_id: str) -> dict:
     if not yaml_path.exists():
         return _err(f"factory yaml not found at {yaml_path}", 404)
 
-    with yaml_path.open(encoding="utf-8") as f:
-        yaml_doc = yaml_lib.safe_load(f) or {}
-    # Guard the shape before calling .get — a top-level list/scalar yaml, or a
-    # truthy non-dict ``team:`` (``team: [pm, dev]``), would otherwise raise
-    # AttributeError → unhandled 500. Mirror list_factory_templates.
-    if not isinstance(yaml_doc, dict):
-        return _err(f"factory yaml at {yaml_path} is not a mapping", 400)
-    team = yaml_doc.get("team")
-    yaml_template = team if isinstance(team, dict) else yaml_doc
-    yaml_roles = yaml_template.get("roles") or {}
+    # Open + unwrap roles via the shared helper so the shape-guard can't drift
+    # from the REST route's copy. ValidationError = non-mapping yaml → 400.
+    try:
+        yaml_roles = factory_svc.load_factory_roles(yaml_path)
+    except factory_svc.ValidationError as exc:
+        return _err(str(exc), 400)
     current_roles = current_template.get("roles") or {}
 
     per_role: dict[str, dict] = {}

--- a/backend/tests/test_routes/test_team_template_routes.py
+++ b/backend/tests/test_routes/test_team_template_routes.py
@@ -372,6 +372,16 @@ class TestYamlDiff:
         )
         assert r.status_code == 404
 
+    def test_path_traversal_name_400(self, client, fake_store):
+        # Real _resolve_yaml_for_session (NOT monkeypatched): a traversal
+        # template name must be refused at the HTTP layer with 400, never
+        # used to open() a file outside team_templates/.
+        fake_store["ses-1"]["template"]["name"] = "../../secrets"
+        r = client.get(
+            "/api/team-sessions/ses-1/template/yaml-diff", headers=_h(),
+        )
+        assert r.status_code == 400
+
 
 class TestResetRole:
     def test_reset_writes_audit_and_replaces_role(self, client, fake_store, tmp_path, monkeypatch):
@@ -404,3 +414,13 @@ class TestResetRole:
             "/api/team-sessions/ses-1/template/history?role=qe", headers=_h(),
         ).json()["rows"]
         assert any(row["source"] == "yaml-reset" for row in rows)
+
+    def test_path_traversal_name_400(self, client, fake_store):
+        # Reset must reject a traversal template name with 400 (same guard as
+        # yaml-diff) — the name is the only attacker-influenced input here.
+        fake_store["ses-1"]["template"]["name"] = "../../secrets"
+        r = client.post(
+            "/api/team-sessions/ses-1/template/reset/qe",
+            json={"comment": "x"}, headers=_h(),
+        )
+        assert r.status_code == 400

--- a/backend/tests/test_services/test_team_template_rpc_handlers.py
+++ b/backend/tests/test_services/test_team_template_rpc_handlers.py
@@ -240,6 +240,57 @@ class TestRunningSurface:
         out = asyncio.run(_running_reload(session_id="ses-1", roles=[]))
         assert out["status"] == 400
 
+    def test_yaml_diff_path_traversal_blocked(
+        self, session_factory, fake_store, factory_dir
+    ):
+        # The template ``name`` is LLM-writable and NOT structurally validated.
+        # A traversal name must be refused (400), not used to open() a file
+        # outside team_templates/.
+        from services.team_template_rpc_handlers import _running_yaml_diff
+
+        fake_store["ses-1"]["template"]["name"] = "../../secrets"
+        out = _running_yaml_diff(session_id="ses-1")
+        assert out["status"] == 400
+
+    def test_reset_role_path_traversal_blocked(
+        self, session_factory, fake_store, factory_dir
+    ):
+        from services.team_template_rpc_handlers import _running_reset_role
+
+        fake_store["ses-1"]["template"]["name"] = "../../secrets"
+        out = _running_reset_role(session_id="ses-1", role="qe")
+        assert out["status"] == 400
+
+    def test_yaml_diff_non_dict_team_does_not_crash(
+        self, session_factory, fake_store, factory_dir
+    ):
+        # ``team:`` as a list used to crash with AttributeError → 500. It must
+        # now fall back to the top-level ``roles:`` and diff normally.
+        (factory_dir / "listy.yaml").write_text(
+            "team:\n  - pm\n  - dev\n"
+            "roles:\n"
+            "  qe:\n"
+            "    servers: [filesystem]\n",
+            encoding="utf-8",
+        )
+        fake_store["ses-1"]["template"]["name"] = "listy"
+        from services.team_template_rpc_handlers import _running_yaml_diff
+
+        out = _running_yaml_diff(session_id="ses-1")
+        assert "error" not in out
+        assert "qe" in out["per_role"]
+
+    def test_yaml_diff_top_level_list_yaml_400(
+        self, session_factory, fake_store, factory_dir
+    ):
+        # A top-level non-mapping yaml is rejected cleanly (400), not a 500.
+        (factory_dir / "scalar.yaml").write_text("- a\n- b\n", encoding="utf-8")
+        fake_store["ses-1"]["template"]["name"] = "scalar"
+        from services.team_template_rpc_handlers import _running_yaml_diff
+
+        out = _running_yaml_diff(session_id="ses-1")
+        assert out["status"] == 400
+
 
 # ── Registration ──────────────────────────────────────────────────────────
 

--- a/backend/tests/test_services/test_team_template_rpc_handlers.py
+++ b/backend/tests/test_services/test_team_template_rpc_handlers.py
@@ -292,6 +292,59 @@ class TestRunningSurface:
         assert out["status"] == 400
 
 
+# ── load_factory_roles helper (shared shape-guard, SSoT) ──────────────────
+
+
+class TestLoadFactoryRoles:
+    def test_top_level_roles(self, factory_dir):
+        from services.team_template_factory_service import load_factory_roles
+
+        roles = load_factory_roles(factory_dir / "agile_team.yaml")
+        assert "qe" in roles
+
+    def test_nested_team_roles(self, factory_dir):
+        from services.team_template_factory_service import load_factory_roles
+
+        (factory_dir / "nested.yaml").write_text(
+            "team:\n  name: nested\n  roles:\n    pm:\n      instruction: hi\n",
+            encoding="utf-8",
+        )
+        roles = load_factory_roles(factory_dir / "nested.yaml")
+        assert "pm" in roles
+
+    def test_empty_team_falls_back_to_top_level(self, factory_dir):
+        # An empty ``team: {}`` is unusable → must fall back to top-level
+        # ``roles:`` (not blank out the diff). Regression for the semantics
+        # gap flagged in PR #61 review.
+        from services.team_template_factory_service import load_factory_roles
+
+        (factory_dir / "emptyteam.yaml").write_text(
+            "team: {}\nroles:\n  qe:\n    instruction: top-level\n",
+            encoding="utf-8",
+        )
+        roles = load_factory_roles(factory_dir / "emptyteam.yaml")
+        assert "qe" in roles
+
+    def test_non_dict_team_falls_back_to_top_level(self, factory_dir):
+        from services.team_template_factory_service import load_factory_roles
+
+        (factory_dir / "listteam.yaml").write_text(
+            "team:\n  - pm\nroles:\n  qe: {}\n", encoding="utf-8",
+        )
+        roles = load_factory_roles(factory_dir / "listteam.yaml")
+        assert "qe" in roles
+
+    def test_top_level_list_raises_validation(self, factory_dir):
+        from services.team_template_factory_service import (
+            ValidationError,
+            load_factory_roles,
+        )
+
+        (factory_dir / "scalar.yaml").write_text("- a\n- b\n", encoding="utf-8")
+        with pytest.raises(ValidationError):
+            load_factory_roles(factory_dir / "scalar.yaml")
+
+
 # ── Registration ──────────────────────────────────────────────────────────
 
 

--- a/frontend/src/views/settings/SettingsRunningTemplates.vue
+++ b/frontend/src/views/settings/SettingsRunningTemplates.vue
@@ -83,12 +83,22 @@ const dirty = computed(() => {
     // Unparseable text is definitively dirty — Save will surface the error.
     draftOverrides = draft.value.server_overrides_text
   }
+  // servers/skills are unordered sets server-side (compute_role_diff), and
+  // _buildPatch sorts before diffing — so a pure reorder produces an EMPTY
+  // patch. Mirror that normalization here, else the UNSAVED pill lights up on
+  // a reorder but Save reports "No changes" and the pill never clears (stuck).
+  const serversDirty =
+    JSON.stringify(_splitLines(draft.value.servers_text).sort()) !==
+    JSON.stringify([...(live.servers || [])].sort())
+  const skillsDirty =
+    JSON.stringify(_splitLines(draft.value.skills_text).sort()) !==
+    JSON.stringify([...(live.skills || [])].sort())
   return (
     draft.value.instruction !== (live.instruction || '') ||
     draft.value.role_display !== (live.role_display || '') ||
     draft.value.model !== (live.model || '') ||
-    draft.value.servers_text !== (live.servers || []).join('\n') ||
-    draft.value.skills_text !== (live.skills || []).join('\n') ||
+    serversDirty ||
+    skillsDirty ||
     draftOverrides !== liveOverrides
   )
 })
@@ -281,26 +291,43 @@ async function onResetModalConfirm(mode) {
   successMsg.value = ''
   try {
     const r = await _doResetCall()
+    // From here the DB write has landed. A reload failure below is a PARTIAL
+    // success — catch it locally so we still refetch and converge the UI to
+    // the new DB truth. If we let it bubble to the outer catch (old behaviour),
+    // the UI kept showing pre-reset values; the user would re-edit them and
+    // Save, silently overwriting the just-synced fields.
     let respawned = 0
+    let reloadError = null
     if (mode === 'sync-and-reload') {
       reloading.value = true
       try {
         const rl = await _doReloadCall()
         respawned = Object.values(rl.results || {}).flat().length
+      } catch (rlErr) {
+        reloadError = rlErr
       } finally {
         reloading.value = false
       }
     }
     const fields = r.audit_ids?.length || 0
-    successMsg.value =
-      mode === 'sync-and-reload'
-        ? `Reset · ${fields} field(s) synced from yaml · ${respawned} agent(s) respawned.`
-        : `Reset · ${fields} field(s) synced from yaml. Running agents will pick up the change on next restart — click "Force reload" to apply now.`
     resetModal.value = { visible: false, busy: false, mode: null }
     await loadTemplate(activeSessionId.value)
+    if (reloadError) {
+      error.value =
+        `Synced ${fields} field(s) to DB, but force-reload failed — agents are ` +
+        `still running the old template: ${_friendly(reloadError)}`
+    } else {
+      successMsg.value =
+        mode === 'sync-and-reload'
+          ? `Reset · ${fields} field(s) synced from yaml · ${respawned} agent(s) respawned.`
+          : `Reset · ${fields} field(s) synced from yaml. Running agents will pick up the change on next restart — click "Force reload" to apply now.`
+    }
   } catch (err) {
+    // Reset itself failed (or the refetch threw). Still refetch so the UI
+    // reflects whatever the DB actually holds rather than a stale draft.
     error.value = _friendly(err)
     resetModal.value = { ...resetModal.value, busy: false }
+    loadTemplate(activeSessionId.value).catch(() => {})
   } finally {
     resetting.value = false
   }
@@ -309,6 +336,40 @@ async function onResetModalConfirm(mode) {
 function onResetModalCancel() {
   if (resetModal.value.busy) return
   resetModal.value = { visible: false, busy: false, mode: null }
+}
+
+// Switching role/session or refreshing re-seeds the draft from live data,
+// silently discarding in-progress edits. Confirm first (mirrors
+// SettingsYaml.selectFile) so a glance at a sibling role can't lose work.
+async function _confirmDiscardIfDirty() {
+  if (!dirty.value) return true
+  return await confirm({
+    title: 'Discard unsaved changes',
+    message: `You have unsaved edits to "${activeRole.value}". Discard and switch?`,
+    confirmText: 'Discard & Switch',
+    variant: 'warning',
+  })
+}
+
+async function onSelectRole(role) {
+  if (role === activeRole.value) return
+  if (!(await _confirmDiscardIfDirty())) return
+  activeRole.value = role
+}
+
+async function onSelectSession(evt) {
+  const sid = evt.target.value
+  if (sid === activeSessionId.value) return
+  if (!(await _confirmDiscardIfDirty())) {
+    evt.target.value = activeSessionId.value // revert the <select> on cancel
+    return
+  }
+  activeSessionId.value = sid
+}
+
+async function onRefresh() {
+  if (!(await _confirmDiscardIfDirty())) return
+  loadTemplate(activeSessionId.value)
 }
 
 function onShowDiff() {
@@ -462,7 +523,7 @@ onMounted(() => loadSessions())
     <!-- Session selector -->
     <div class="session-bar">
       <label class="session-label">Team session</label>
-      <select v-model="activeSessionId" class="session-select" :disabled="!sessions.length">
+      <select :value="activeSessionId" @change="onSelectSession" class="session-select" :disabled="!sessions.length">
         <option v-if="!sessions.length" :value="null">No active team sessions</option>
         <option v-for="s in sessions" :key="s.session_id" :value="s.session_id">
           {{ s.team_name }} · {{ s.session_id.slice(0, 8) }} · {{ s.agents_count }} agent{{ s.agents_count === 1 ? '' : 's' }}
@@ -471,7 +532,7 @@ onMounted(() => loadSessions())
       <span v-if="yamlDiff" class="drift-pill" :class="{ insync: yamlDiff.in_sync }">
         {{ yamlDiff.in_sync ? '✓ in sync with yaml' : `△ ${yamlDiff.diverged_count} role(s) diverged from yaml` }}
       </span>
-      <button class="btn ghost" type="button" :disabled="loading" @click="loadTemplate(activeSessionId)">
+      <button class="btn ghost" type="button" :disabled="loading" @click="onRefresh">
         Refresh
       </button>
     </div>
@@ -486,7 +547,7 @@ onMounted(() => loadSessions())
           type="button"
           class="role-item"
           :class="{ active: activeRole === role }"
-          @click="activeRole = role"
+          @click="onSelectRole(role)"
         >
           <span class="role-name">{{ cfg.role_display || role }}</span>
           <span class="role-key"><code>{{ role }}</code></span>
@@ -704,7 +765,7 @@ onMounted(() => loadSessions())
             <h3 class="reset-title">Reset <code>{{ activeRole }}</code> to factory yaml?</h3>
             <p class="reset-body">
               Pulls every editable field of <strong>{{ activeRole }}</strong> from
-              <code>team_templates/{{ template?.name?.replace('-', '_') || 'agile_team' }}.yaml</code>
+              <code>team_templates/{{ template?.name?.replaceAll('-', '_') || 'agile_team' }}.yaml</code>
               into this team's DB. Other roles are untouched and audited.
             </p>
             <p class="reset-body muted">

--- a/frontend/src/views/settings/SettingsYaml.vue
+++ b/frontend/src/views/settings/SettingsYaml.vue
@@ -283,7 +283,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown))
           </svg>
           <code class="name">{{ f.filename }}</code>
           <span v-if="f.is_secret_file" class="lock-icon" title="Contains secrets">🔒</span>
-          <span v-if="activeName === f.name && dirty" class="dirty-dot">●</span>
+          <span v-if="activeName === f.name && activeKind === f.kind && dirty" class="dirty-dot">●</span>
           <span v-if="!f.exists" class="new-tag">NEW</span>
         </button>
       </template>

--- a/frontend/tests/e2e/flows/settings-running-templates.spec.ts
+++ b/frontend/tests/e2e/flows/settings-running-templates.spec.ts
@@ -143,3 +143,43 @@ test('happy path: pick session → edit role → save → audit appears → roll
   // enforce strict consumption either.
   expect(backend.unexpected).toEqual([])
 })
+
+test('switching role with unsaved edits prompts to discard (bug_006)', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'settings_running_templates.yaml')])
+
+  await page.goto('/settings')
+  await page.getByRole('button', { name: 'Running Templates', exact: true }).click()
+  await expect(page.locator('.role-item.active').filter({ hasText: 'PM' })).toBeVisible()
+
+  const instructionEditor = page.locator(
+    'label:has(span.fl:text("Instruction")) textarea',
+  )
+  await expect(instructionEditor).toHaveValue('You are the orchestrator.')
+
+  // Make the role dirty, then try to switch to QE.
+  await instructionEditor.fill('half-typed edit, not saved')
+  await expect(page.locator('.pill.dirty')).toBeVisible()
+  await page.locator('.role-item').filter({ hasText: 'QE' }).click()
+
+  // A confirm dialog must appear — switching would otherwise silently
+  // discard the edit.
+  const modalCard = page.locator('.cm-card')
+  await expect(
+    modalCard.getByRole('heading', { name: /discard unsaved changes/i }),
+  ).toBeVisible()
+
+  // Cancel → stay on PM, edit + dirty pill preserved.
+  await modalCard.locator('.cm-btn-cancel').click()
+  await expect(page.locator('.role-item.active').filter({ hasText: 'PM' })).toBeVisible()
+  await expect(instructionEditor).toHaveValue('half-typed edit, not saved')
+  await expect(page.locator('.pill.dirty')).toBeVisible()
+
+  // Try again, this time confirm → switch to QE, edit discarded.
+  await page.locator('.role-item').filter({ hasText: 'QE' }).click()
+  await modalCard.getByRole('button', { name: /discard & switch/i }).click()
+  await expect(page.locator('.role-item.active').filter({ hasText: 'QE' })).toBeVisible()
+  await expect(instructionEditor).toHaveValue('You are QE.')
+})


### PR DESCRIPTION
## Summary

Resolves all **7 findings** from the PR #58 ultrareview (tracked in #60). PR #58 merged at `5efa46e` before these were addressed, so they landed on `main`.

## Findings fixed

### 🔴 Backend (the dangerous class)
- **bug_004 — path traversal.** `_factory_yaml_path_for` (rpc) and `_resolve_yaml_for_session` (route) built the yaml path by raw string interpolation, bypassing `_resolve()`. The template `name` is LLM-writable via `team_template_write_factory` and is **not** structurally validated, so `name: ../../x` could `open()` files outside `team_templates/`. Both now route through the new guarded `factory_svc.resolve_factory_path` → `PathTraversalError` → 400. Removed the orphaned `_YAML_DIR`.
- **bug_003 — `yaml_diff` 500.** A top-level list/scalar yaml or a non-dict `team:` made `.get()` raise `AttributeError` → unhandled 500. Both yaml_diff paths now guard the shape and 400 cleanly; a list `team:` falls back to top-level `roles:`.

### 🔴 Frontend (data-loss)
- **bug_011 — sync+reload partial failure.** Reset succeeded but reload threw → UI stayed stale → a re-edit+Save overwrote the just-synced DB. Reload failure is now a *partial success*: always refetch, distinct "synced to DB but reload failed" message.
- **bug_006 — discard unsaved edits.** Switching role/session or Refresh silently dropped in-progress edits. Added a `useConfirm` dirty-guard (mirrors `SettingsYaml.selectFile`) on role-click, session-select, and Refresh.

### 🟡 Nits
- **bug_008** — `dirty` was order-sensitive while `_buildPatch` sorts → reorder lit UNSAVED but Save said "No changes" (stuck pill). `dirty` now sort-normalizes servers/skills.
- **bug_001** — `.replace('-','_')` → `.replaceAll` so multi-hyphen template names show the correct factory filename.
- **bug_005** — dirty-dot `v-if` now checks `activeKind === f.kind` so a same-named team template doesn't light the ● on the fastagent row.

## Tests
- **Backend: 60 pass** (+4 new: path-traversal blocked on reset & yaml_diff; non-dict `team:` doesn't crash; top-level-list yaml → 400).
- **Frontend: `vite build` clean.** Added an e2e covering the bug_006 confirm-on-switch flow (cancel keeps the edit, confirm discards).

## Click-flow (bug_006 e2e)
Open Settings → Running Templates → edit a role's instruction → click another role → **"Discard unsaved changes?"** dialog → Cancel keeps the edit + UNSAVED pill → click again → Discard & Switch → switches, edit gone.

## Known gap
Frontend e2e could not run in the local sandbox (the app-boot harness fails for **unrelated** specs too, e.g. `chat-markdown-xss`); the new + existing specs are validated by CI.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)
