### PR TITLE
chore(gitignore): cover frontend test artifacts + untrack stray .last-run.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,5 +89,10 @@ dashboard/playwright-report/
 dashboard/test-results/
 backend/test-results/
 
+# ─── Frontend Playwright E2E + Vite cache ────────
+frontend/playwright-report/
+frontend/test-results/
+frontend/.vite/
+
 # ─── Skill auto-backups (.bak siblings created on edit) ──
 backend/.fast-agent/skills/**/*.bak

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## What

- Add ignore rules for frontend Playwright/Vite outputs that were slipping through as untracked: `frontend/playwright-report/`, `frontend/test-results/`, `frontend/.vite/`.
- Untrack `frontend/test-results/.last-run.json` — a Playwright run-state artifact accidentally committed in the initial frontend commit (`fdb6be5`). File stays on disk, now ignored.

## Why

`.gitignore` only ignored test artifacts under `dashboard/` (old dir name) and `backend/`. When the frontend was added, the matching rules were never created, so every Playwright/Vite run left untracked junk in `git status` and one run-state file got committed.

## Scope

Config only — no application code touched, so no test suite applies. Verified `git check-ignore` now matches all three frontend paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)