### PR TITLE
fix(frontend): Docker build fails — rolldown native binding (alpine/musl + node 20.18)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,19 @@
 # Stage 1: Build Vue frontend
-# Minor-pin so a rebuild a month from now picks up the same Node line.
-# Bump manually when upstream issues a new LTS minor.
+# Track the active LTS line (22.x) on glibc — NOT a frozen minor and NOT
+# alpine. Major-pin (not minor-pin) so the build stage keeps receiving
+# 22.x security patches automatically; Node 20 went EOL ~2026-04.
 #
-# MUST be glibc (slim) + Node >= 20.19, NOT alpine and NOT 20.18:
-# Vite 8 bundles with rolldown, whose native binding is an optional,
-# platform-specific dep (@rolldown/binding-linux-*). `npm ci` fails to
-# install that binding on (a) alpine/musl (any npm) and (b) Node 20.18
-# even on glibc, so `npm run build` dies with
-# `MODULE_NOT_FOUND ... rolldown/dist/shared/binding-*.mjs`. Node 20.19
-# (which enables require(esm)) on glibc resolves it. Verified by building
-# the real context locally across alpine/slim × node 20.18/20.19/20.20.
-FROM node:20.19-slim AS build
+# MUST be glibc (slim) + Node 22, for two reasons:
+#  1. Vite 8 bundles with rolldown, whose native binding is an optional,
+#     platform-specific dep (@rolldown/binding-linux-*). `npm ci` fails to
+#     install it on alpine/musl (any npm) -> `npm run build` dies with
+#     `MODULE_NOT_FOUND ... rolldown/dist/shared/binding-*.mjs`. glibc fixes it.
+#  2. vite + rolldown need Node >= 20.19; @babel/generator (via
+#     @vitejs/plugin-vue) wants >= 22.18 — Node 22 satisfies all three with
+#     no EBADENGINE warnings, where 20.19 only just cleared the binding.
+# Verified by building the real context locally (linux/amd64) across
+# alpine/slim x node 20.18/20.19/20.20/22.
+FROM node:22-slim AS build
 
 WORKDIR /app
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,16 @@
 # Stage 1: Build Vue frontend
 # Minor-pin so a rebuild a month from now picks up the same Node line.
 # Bump manually when upstream issues a new LTS minor.
-FROM node:20.18-alpine AS build
+#
+# MUST be glibc (slim) + Node >= 20.19, NOT alpine and NOT 20.18:
+# Vite 8 bundles with rolldown, whose native binding is an optional,
+# platform-specific dep (@rolldown/binding-linux-*). `npm ci` fails to
+# install that binding on (a) alpine/musl (any npm) and (b) Node 20.18
+# even on glibc, so `npm run build` dies with
+# `MODULE_NOT_FOUND ... rolldown/dist/shared/binding-*.mjs`. Node 20.19
+# (which enables require(esm)) on glibc resolves it. Verified by building
+# the real context locally across alpine/slim × node 20.18/20.19/20.20.
+FROM node:20.19-slim AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Vấn đề
Deploy `v2.0.0` (PR #68 đã merge) fail ở target **jarvis-web**:
```
npm run build → code: 'MODULE_NOT_FOUND'
requireStack: [ '/app/node_modules/rolldown/dist/shared/binding-CXquf8ay.mjs' ]
```
Lỗi có sẵn từ trước (run 03:52 cùng ngày cũng fail), chặn cả backend (compose build abort).

## Root cause (đã verify, không đoán)
Vite 8 bundle bằng **rolldown** → native binding là optional dep theo platform (`@rolldown/binding-linux-*`). Build stage dùng `node:20.18-alpine`; `npm ci` **không cài binding** trên alpine/musl → `node_modules/@rolldown/` chỉ có `pluginutils`.

Build context thật (linux/amd64) theo ma trận:
| Base | npm | Kết quả |
|------|-----|---------|
| alpine 20.18 | 10.8.2 | ❌ MODULE_NOT_FOUND |
| alpine 20-latest | 11.16 | ❌ (musl) |
| slim 20.18 | 10.8 / 11 | ❌ (node < 20.19) |
| **slim 20.19 / 20.20** | 10.8.2 | ✅ build OK |

⇒ Cần **glibc (slim) + Node ≥ 20.19** (node 20.19 bật `require(esm)`, rolldown mới load được binding ESM).

## Fix
`frontend/Dockerfile` build stage: `node:20.18-alpine` → **`node:20.19-slim`** (kèm comment giải thích). Final stage giữ `nginx:1.27-alpine` (build stage bị bỏ → không ảnh hưởng size image runtime).

## Verify
Build `frontend/Dockerfile` thật end-to-end (cả stage nginx) trên linux/amd64 → ✅ `dist/` sinh ra, image export thành công.

🤖 Generated with [Claude Code](https://claude.com/claude-code)