### PR TITLE
fix(passkey): works on any domain — infer https origin instead of trusting proxy

### DIFF
--- a/backend/core/webauthn.py
+++ b/backend/core/webauthn.py
@@ -117,10 +117,35 @@ def rp_id_from_request(request: Request) -> str:
     return host
 
 
+# Hosts the WebAuthn spec allows to run over plaintext http (the secure-
+# context dev exception). Every other host is necessarily https in a browser.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _is_loopback_host(rp_id: str) -> bool:
+    """True for the hosts a browser will run WebAuthn on over plain http."""
+    return rp_id in _LOOPBACK_HOSTS
+
+
 def origin_from_request(request: Request) -> str:
-    """Origin = full scheme + host + port, used to verify the
-    ``clientDataJSON.origin`` field the authenticator signs."""
-    return f"{_request_scheme(request)}://{_request_host(request)}"
+    """Origin = scheme://host, used to verify the ``clientDataJSON.origin``
+    field the authenticator signs.
+
+    The scheme is INFERRED from the host, not trusted from the proxy.
+    WebAuthn only runs in a secure context, so the browser-signed origin is
+    ``https`` for every host except loopback (localhost/127.0.0.1/::1 — the
+    spec's one plaintext dev exception). A reverse-proxy chain that
+    terminates TLS upstream and speaks plain http internally (Cloudflare
+    tunnel → nginx → app) reports scheme=http / X-Forwarded-Proto=http;
+    trusting that builds ``http://<domain>`` and fails verification with
+    InvalidRegistrationResponse. Host-based inference is proxy-independent,
+    so passkeys work on any domain with zero proxy config — the user never
+    configures an RP ID, origin, or X-Forwarded-* header.
+    """
+    host = _request_host(request)
+    if _is_loopback_host(rp_id_from_request(request)):
+        return f"{_request_scheme(request)}://{host}"
+    return f"https://{host}"
 
 
 # ---- Ceremony storage (in-process, TTL-bounded) ----------------------------

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -54,6 +54,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from core.session import SESSION_COOKIE_NAME, SessionVerifyError, verify_session_token
+from core.webauthn import _is_loopback_host
 from services import shared_state as state
 from services.sse_progress import (
     create_progress_hooks,
@@ -94,11 +95,27 @@ def _expected_ws_origin(ws: WebSocket) -> str:
         forwarded_host.split(",")[0].strip() if forwarded_host else ""
     ) or ws.headers.get("host", "")
 
-    forwarded_proto = ws.headers.get("x-forwarded-proto", "")
-    if "https" in forwarded_proto.lower() or ws.url.scheme in ("wss", "https"):
-        scheme = "https"
+    # hostname only (strip port / IPv6 brackets) for the loopback check
+    if host.startswith("[") and "]" in host:
+        hostname = host[1 : host.find("]")]
+    elif ":" in host:
+        hostname = host.rsplit(":", 1)[0]
     else:
-        scheme = "http"
+        hostname = host
+
+    # Scheme inferred from the host, not trusted from the proxy — same rule
+    # as core.webauthn.origin_from_request (loopback may be plaintext dev;
+    # every other host is https in a browser). Keeps this mirror honest so a
+    # TLS-terminating proxy (Cloudflare tunnel → nginx → app) doesn't make us
+    # expect http:// while the browser declares https:// and the WS is rejected.
+    if _is_loopback_host(hostname):
+        forwarded_proto = ws.headers.get("x-forwarded-proto", "")
+        if "https" in forwarded_proto.lower() or ws.url.scheme in ("wss", "https"):
+            scheme = "https"
+        else:
+            scheme = "http"
+    else:
+        scheme = "https"
     return f"{scheme}://{host}"
 
 

--- a/backend/tests/test_core/test_webauthn.py
+++ b/backend/tests/test_core/test_webauthn.py
@@ -115,6 +115,22 @@ class TestOriginFromRequest:
         )
         assert wa.origin_from_request(req) == "https://jarvis.alice.com"
 
+    def test_https_inferred_for_public_host_with_no_proto_hint(self):
+        # Regression: Cloudflare tunnel → nginx → app terminates TLS upstream
+        # and speaks plain http internally, so both request.url.scheme AND the
+        # forwarded proto arrive as http. A public host is still https in the
+        # browser, so we must infer https from the host, not trust the proxy —
+        # otherwise verify_registration_response raised InvalidRegistrationResponse
+        # ("Attestation rejected") on app.omnigentx.com.
+        req = _make_request(host="app.omnigentx.com", scheme="http")
+        assert wa.origin_from_request(req) == "https://app.omnigentx.com"
+
+    def test_loopback_stays_http_for_dev(self):
+        # The one plaintext exception WebAuthn allows: loopback dev keeps http.
+        for h in ("localhost:3001", "127.0.0.1:8001", "[::1]:8000"):
+            req = _make_request(host=h, scheme="http")
+            assert wa.origin_from_request(req).startswith("http://")
+
 
 # ---- Ceremony store --------------------------------------------------------
 

--- a/backend/tests/test_routes/test_ws_voice_auth.py
+++ b/backend/tests/test_routes/test_ws_voice_auth.py
@@ -37,6 +37,18 @@ def _assert_rejected(client: TestClient, **connect_kwargs) -> None:
         assert exc_info.value.code == 4401
 
 
+def _assert_accepted(client: TestClient, **connect_kwargs) -> None:
+    """Open the WS and *receive* — an accepted socket emits a real event
+    (the STT pipeline's ``stt_loading`` status fires on connect), while a
+    rejected one closes 4401 which surfaces as ``WebSocketDisconnect`` on
+    the first receive. Receiving (not just ``send_json``) is what makes
+    this assertion "feel pain": a regression that flips accept→reject
+    turns into a 4401 disconnect here instead of passing silently."""
+    with client.websocket_connect("/ws/voice", **connect_kwargs) as ws:
+        msg = ws.receive_json()  # raises WebSocketDisconnect(4401) if rejected
+        assert msg.get("type"), f"expected a status event on accept, got {msg!r}"
+
+
 @pytest.fixture(autouse=True)
 def _stable_secrets(monkeypatch):
     monkeypatch.setenv("JWT_SECRET", "test-jwt-secret-xxxxxxxxxxxxxxxxxxxx")
@@ -90,14 +102,27 @@ class TestWsVoiceAuth:
     def test_session_cookie_accepted_with_matching_origin(self, client):
         """Cookie path requires Origin to match the deployment (CSWSH
         defence — see H2). Browser-issued WS upgrades carry Origin;
-        the TestClient simulates one explicitly."""
+        the TestClient simulates one explicitly.
+
+        The expected origin is ``https://testserver`` because
+        ``_expected_ws_origin`` infers https for any non-loopback host
+        (it no longer trusts the proxy's X-Forwarded-Proto). A plain
+        ``http://testserver`` Origin is now (correctly) rejected — see
+        ``test_session_cookie_http_origin_rejected_on_public_host``."""
         session_token, _payload = create_session_token()
         client.cookies.set(SESSION_COOKIE_NAME, session_token)
-        with client.websocket_connect(
-            "/ws/voice",
-            headers={"Origin": "http://testserver"},
-        ) as ws:
-            ws.send_json({"type": "noop"})
+        _assert_accepted(client, headers={"Origin": "https://testserver"})
+
+    def test_session_cookie_http_origin_rejected_on_public_host(self, client):
+        """The flip side of the matching-origin test: a cookie-auth WS
+        whose Origin is plain ``http://`` on a public host is rejected,
+        because the browser would have signed ``https://`` there. This
+        is the regression the matching-origin test was silently masking
+        before it learned to ``receive`` (it sent http and never noticed
+        the 4401 close)."""
+        session_token, _payload = create_session_token()
+        client.cookies.set(SESSION_COOKIE_NAME, session_token)
+        _assert_rejected(client, headers={"Origin": "http://testserver"})
 
     def test_session_cookie_with_missing_origin_falls_through(self, client):
         """No Origin header on the cookie path → rejection. Falls
@@ -195,3 +220,52 @@ class TestWsVoiceAuth:
         # No credentials supplied → still gets through.
         with client.websocket_connect("/ws/voice") as ws:
             ws.send_json({"type": "noop"})
+
+
+# ---- _expected_ws_origin (host-based https inference) ----------------------
+
+
+def _make_ws(*, host: str = "", forwarded_host: str = "", scheme: str = "http"):
+    """Stub matching the ``WebSocket`` surface ``_expected_ws_origin``
+    touches: ``.headers.get(...)`` and ``.url.scheme``. Mirrors the
+    ``_make_request`` stub in ``test_core/test_webauthn.py`` so the two
+    origin derivations are tested with the same shapes."""
+    from types import SimpleNamespace
+
+    headers = {}
+    if host:
+        headers["host"] = host
+    if forwarded_host:
+        headers["x-forwarded-host"] = forwarded_host
+    return SimpleNamespace(headers=headers, url=SimpleNamespace(scheme=scheme))
+
+
+class TestExpectedWsOrigin:
+    """Locks the http→https inference for the WS path — the mirror of
+    ``core.webauthn.origin_from_request``. Before this was tested, the
+    only coverage was the integration test above, which masked a 4401
+    because it never received."""
+
+    def test_loopback_stays_http_for_dev(self):
+        from routes.ws_voice import _expected_ws_origin
+
+        ws = _make_ws(host="localhost:3001", scheme="http")
+        assert _expected_ws_origin(ws) == "http://localhost:3001"
+
+    def test_https_inferred_for_public_host_despite_plaintext_backend(self):
+        from routes.ws_voice import _expected_ws_origin
+
+        # Proxy terminates TLS and talks http to the app, but the browser
+        # signed https — so we must expect https, not the backend's scheme.
+        ws = _make_ws(host="app.omnigentx.com", scheme="http")
+        assert _expected_ws_origin(ws) == "https://app.omnigentx.com"
+
+    def test_forwarded_host_drives_origin_with_https(self):
+        from routes.ws_voice import _expected_ws_origin
+
+        ws = _make_ws(
+            host="localhost:8001",
+            forwarded_host="app.omnigentx.com",
+            scheme="http",
+        )
+        assert _expected_ws_origin(ws) == "https://app.omnigentx.com"


### PR DESCRIPTION
## Triệu chứng
Đăng ký passkey trên `app.omnigentx.com` báo **\"Attestation rejected (verification_error)\"**. Log backend: `InvalidRegistrationResponse`.

## Root cause (đã verify từ code + log + nginx.conf + cloudflared)
Chuỗi deploy: **Cloudflare (HTTPS) → cloudflared → `http://localhost:80` (nginx) → backend**. TLS kết thúc ở Cloudflare, nội bộ chạy http. Nên cả `request.url.scheme` lẫn `X-Forwarded-Proto` (nginx đè `$scheme`) đều = **http**.
→ `origin_from_request` dựng `http://app.omnigentx.com`, browser ký `https://app.omnigentx.com` → **origin mismatch** → verify ném `InvalidRegistrationResponse`.
RP ID (host) đã đúng; chỉ **scheme** sai.

## Fix — suy scheme từ HOST, không tin proxy (zero-config, mọi domain)
WebAuthn chỉ chạy trong secure context → origin browser ký luôn là **https** trừ loopback (localhost/127.0.0.1/::1 — ngoại lệ dev plaintext duy nhất của spec). Suy từ host là **proxy-independent**: user deploy domain nào cũng tự khớp, không cần cấu hình origin / X-Forwarded-* / RP ID.

- `core/webauthn.py`: `origin_from_request` → loopback dùng scheme thật (dev http), còn lại `https://`. Thêm helper `_is_loopback_host`.
- `routes/ws_voice.py`: `_expected_ws_origin` (mirror cùng logic cho WS origin/CSWSH check, dính y hệt bug trên public domain) dùng chung `_is_loopback_host` → **một nguồn chân lý**.

## Security (đã cân nhắc — câu hỏi của reviewer trước)
- Credential **isolate theo rp_id** sẵn → không cross-domain takeover; browser tự ràng origin↔rp_id.
- Suy https-cho-non-loopback **chặt hơn** việc tin `X-Forwarded-Proto` (header có thể bị giả nếu backend lộ trực tiếp). Yêu cầu vận hành: **backend chỉ truy cập qua proxy** (cổng 8000 không expose ra ngoài).

## Test
- Regression: public host + proxy http → `https://...` (đúng kịch bản app.omnigentx.com).
- Loopback giữ http (dev).
- ✅ webauthn 29 / passkey routes 31 / ws_voice auth 13 đều pass.

## Impact (gitnexus)
LOW cho cả `origin_from_request`, `_request_scheme`, `_expected_ws_origin` — chỉ chạm passkey register/authenticate + voice_ws origin check; không HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)