### PR TITLE
chore(mcp): remove git MCP server, agents use gh/git CLI instead

### DIFF
--- a/backend/.fast-agent/skills/self-audit-tools/SKILL.md
+++ b/backend/.fast-agent/skills/self-audit-tools/SKILL.md
@@ -109,7 +109,7 @@ inbox)?
 |---|---|---|
 | **READ** | Returns data, no side effect | `*__list_*`, `*__get_*`, `*__search_*`, `*__read_*`, `*__status`, `*_info`, `execute(git log/status/diff)`, `execute(gh pr view/list)`, `jira_get_issue`, `confluence_search`, `github__list_commits` |
 | **WRITE** | Creates/modifies state | `*__create_*`, `*__update_*`, `*__edit_*`, `*__write_*`, `*__send_*`, `jira_transition_issue`, `github__create_pull_request` |
-| **DESTRUCTIVE** | Deletes or otherwise non-reversible | `*__delete_*`, `git_reset --hard`, `execute(rm ...)`, `jira_delete_issue` |
+| **DESTRUCTIVE** | Deletes or otherwise non-reversible | `*__delete_*`, `execute(git reset --hard)`, `execute(rm ...)`, `jira_delete_issue` |
 
 If the schema description is ambiguous, default to **WRITE** (safer).
 Tools named `get_*` / `list_*` / `status` are strong READ signals even

--- a/backend/.fast-agent/skills/self-audit-tools/SKILL.md
+++ b/backend/.fast-agent/skills/self-audit-tools/SKILL.md
@@ -107,7 +107,7 @@ inbox)?
 
 | Class | Definition | Examples |
 |---|---|---|
-| **READ** | Returns data, no side effect | `*__list_*`, `*__get_*`, `*__search_*`, `*__read_*`, `*__status`, `*_info`, `git_log`, `git_diff`, `jira_get_issue`, `confluence_search`, `github__list_commits` |
+| **READ** | Returns data, no side effect | `*__list_*`, `*__get_*`, `*__search_*`, `*__read_*`, `*__status`, `*_info`, `execute(git log/status/diff)`, `execute(gh pr view/list)`, `jira_get_issue`, `confluence_search`, `github__list_commits` |
 | **WRITE** | Creates/modifies state | `*__create_*`, `*__update_*`, `*__edit_*`, `*__write_*`, `*__send_*`, `jira_transition_issue`, `github__create_pull_request` |
 | **DESTRUCTIVE** | Deletes or otherwise non-reversible | `*__delete_*`, `git_reset --hard`, `execute(rm ...)`, `jira_delete_issue` |
 

--- a/backend/fastagent.config.yaml
+++ b/backend/fastagent.config.yaml
@@ -180,9 +180,6 @@ mcp:
       args: ["-m", "fast_agent.spawn.servers.email_server"]
       env:
          PYTHONUNBUFFERED: "1"
-    git:
-      command: "uvx"
-      args: ["mcp-server-git", "--repository", ".."]
     # GitNexus — code-graph intelligence (impact analysis, call graph, rename).
     # Server reads registered repos from ~/.gitnexus/registry.json (populated
     # by `gitnexus analyze` in each target repo). Docker image pre-installs

--- a/backend/team_templates/agile_team.yaml
+++ b/backend/team_templates/agile_team.yaml
@@ -296,7 +296,6 @@ roles:
         meeting_room,
         email,
         github,
-        git,
         gitnexus,
         mcp-atlassian,
         scrapling-server,
@@ -312,8 +311,6 @@ roles:
             "{workspace_dir}",
             "{project_dir}/.fast-agent/skills",
           ]
-      git:
-        args: ["mcp-server-git", "--repository", "{workspace_dir}"]
 
     model: ""
 
@@ -458,7 +455,6 @@ roles:
         meeting_room,
         email,
         github,
-        git,
         mcp-atlassian,
         scrapling-server,
       ]
@@ -471,6 +467,4 @@ roles:
             "{workspace_dir}",
             "{project_dir}/.fast-agent/skills",
           ]
-      git:
-        args: ["mcp-server-git", "--repository", "{workspace_dir}"]
     model: ""

--- a/backend/tests/test_services/test_git_mcp_removed.py
+++ b/backend/tests/test_services/test_git_mcp_removed.py
@@ -1,0 +1,63 @@
+"""Regression guard: the `git` MCP server stays removed.
+
+We dropped the built-in `git` MCP server (`uvx mcp-server-git`) because it
+is redundant — agents have shell `execute`, the `github` MCP server, and the
+Docker image (`Dockerfile.base`) ships both `git` and `gh` so agents shell out
+for git/PR/CI ops. See PR #71.
+
+`seed_from_yaml` only inserts and never deletes, and built-in catalog rows
+can't be removed via the UI, so the ONLY thing keeping `git` out of fresh
+installs is its absence from these two source files. Without a guard, a
+well-intentioned future edit could re-add it and nothing would go red.
+
+These tests parse the REAL config + template (not synthetic fixtures) and
+fail BEFORE a re-add lands.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent.parent
+CONFIG_FILE = BACKEND_DIR / "fastagent.config.yaml"
+AGILE_TEAM_FILE = BACKEND_DIR / "team_templates" / "agile_team.yaml"
+
+
+def test_git_mcp_server_absent_from_seed_catalog():
+    """The real fastagent.config.yaml must not declare a `git` MCP server.
+
+    `github` and `gitnexus` are the legitimate git-adjacent servers and MUST
+    remain — asserting their presence also proves this test is reading a
+    populated config, not an empty/misparsed one.
+    """
+    config = yaml.safe_load(CONFIG_FILE.read_text(encoding="utf-8"))
+    servers = config.get("mcp", {}).get("servers", {})
+
+    assert "git" not in servers, (
+        "fastagent.config.yaml re-introduced the `git` MCP server. It was "
+        "removed in PR #71 — agents use `git`/`gh` CLI via the execute tool "
+        "instead. If you genuinely need it back, update this guard too."
+    )
+    assert {"github", "gitnexus"} <= set(servers), (
+        "expected `github` and `gitnexus` MCP servers in the catalog — their "
+        "absence means this test is reading the wrong/empty config."
+    )
+
+
+def test_no_agile_team_role_uses_git_mcp_server():
+    """No role in the real agile_team.yaml may list the bare `git` server.
+
+    Distinct from `github`/`gitnexus`: this checks the exact token `git` in
+    each role's `servers` list, mirroring how fast-agent resolves server names.
+    """
+    template = yaml.safe_load(AGILE_TEAM_FILE.read_text(encoding="utf-8"))
+    roles = template.get("roles", {})
+    assert roles, "agile_team.yaml has no roles — wrong/empty template parsed."
+
+    offenders = [name for name, role in roles.items() if "git" in (role.get("servers") or [])]
+    assert not offenders, (
+        f"agile_team.yaml roles {offenders} list the `git` MCP server, removed "
+        f"in PR #71. Roles use `git`/`gh` CLI via the execute tool instead. "
+        f"Also drop any `server_overrides.git` block for these roles."
+    )


### PR DESCRIPTION
## What

Removes the built-in **`git` MCP server** (`uvx mcp-server-git`). Agents now use `git`/`gh` CLI via the `execute` shell tool for git/PR/CI ops.

## Why

The `git` MCP server is redundant:
- Agents already have shell `execute` + the `github` MCP server.
- `Dockerfile.base` ships both **`git`** and **`gh=2.92.0`** (with `GH_CONFIG_DIR=/app/.gh-config`) *specifically* so agents can shell out for git/PR/CI ops — the infra was already designed for this.
- Agents already clone via `git clone` through `execute` (agile_team.yaml line ~259).

## Changes (3 files, −10/+1)

| File | Change |
|---|---|
| `backend/fastagent.config.yaml` | Remove `git:` from `mcp.servers` (seed catalog) |
| `backend/team_templates/agile_team.yaml` | Drop `git` from `servers:` + `server_overrides` of the 2 roles that used it (`dev`, `dso`) |
| `backend/.fast-agent/skills/self-audit-tools/SKILL.md` | READ examples `git_log`/`git_diff` (MCP) → `execute(git log/status/diff)`, `execute(gh pr view/list)` |

`github` and `gitnexus` MCP servers are untouched. No Dockerfile change needed (git + gh already present).

## ⚠️ Scope: factory-default only

`seed_from_yaml()` never deletes, and built-in catalog rows can't be removed via the UI/service (`mcp_catalog.py` raises `PermissionError` on built-in delete). Team templates are factory defaults applied **only at team creation** (running teams' SSoT is `team_sessions.data_json.template`). So:

- ✅ Fresh installs / newly-created teams: no `git` MCP server.
- ❗ Already-deployed catalogs + running teams: keep `git` until a separate **runtime cleanup** (delete the DB row + patch running team templates). Not included here.

## Test

`uv run pytest` on the affected suites — **108 passed**:
`test_git_mcp_removed` (new), `test_mcp_catalog`, `test_team_templates_factory`, `test_fastagent_config_defaults`, `test_team_template_service`, `test_team_template_routes`.

**Regression guard** (`tests/test_services/test_git_mcp_removed.py`, added per review): parses the **real** `fastagent.config.yaml` + `team_templates/agile_team.yaml` and asserts `git` is absent from the catalog and from every role's `servers` list, while `github`/`gitnexus` remain. Verified it goes **red on re-add** (temporarily re-injected `git` → catalog assertion failed → restored). The other suites pass but do **not** guard this — they were run only to confirm the removal broke nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
