### PR TITLE
feat(voice): realtime barge-in + WebRTC audio (iOS echo fix)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   # against (currently 1.24.4), but faster-whisper transitively pulls
   # onnxruntime>=1.25 — so on Python 3.13 the import always fails.
   "sherpa-onnx==1.10.46",
+  "aiortc>=1.14.0",
 ]
 
 [tool.uv]

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -61,6 +61,7 @@ from services.sse_progress import (
     merge_hooks,
     progress_manager,
 )
+from services.webrtc_voice import WebRtcVoiceSession
 
 
 def _chunk_rms_peak(pcm_chunk: bytes) -> tuple[int, int]:
@@ -302,6 +303,13 @@ async def voice_ws(ws: WebSocket) -> None:
     tts_task: Optional[asyncio.Task] = None
     user_query_pending = False  # set when STT finalises text but agent task hasn't started yet
     bot_speaking = False        # True from tts_start until client playback_done / barge-in
+    # WebRTC audio transport. When the client negotiates it (``webrtc_offer``),
+    # mic audio arrives on the RTCPeerConnection track (→ feed_audio) and TTS
+    # goes out the same connection — so the browser's AEC scrubs the bot's voice
+    # out of the mic (the iOS Safari echo fix). Signalling/control/STT/barge-in
+    # stay on this WS. Falls back to the WS audio path when not negotiated.
+    webrtc_session = None
+    webrtc_active = False
     # Dictation mode: client picked the bottom mic in ChatInput (press-to-talk
     # transcription) instead of the top hands-free button. In this mode the
     # STT pipeline runs as usual but ``final_transcript`` does NOT trigger
@@ -347,6 +355,11 @@ async def voice_ws(ws: WebSocket) -> None:
         # until I stop talking and the transcript submits".
         if cancelled or bot_speaking:
             bot_speaking = False
+            # WebRTC: also drop any TTS audio still queued on the outbound track
+            # so the bot goes silent immediately (cancelling the task stops
+            # *producing* audio, but already-queued frames would keep playing).
+            if webrtc_session is not None:
+                webrtc_session.tts_track.flush()
             logger.info(
                 "[ws_voice] barge-in (%s) cancelled %s",
                 reason, ",".join(cancelled) or "playback-only",
@@ -540,25 +553,44 @@ async def voice_ws(ws: WebSocket) -> None:
         await out_queue.put({"type": "tts_start"})
         bytes_sent = 0
         chunks_sent = 0
+        # Route audio over WebRTC when the client negotiated it (the browser
+        # plays the TTS track via <audio>, which is what lets its AEC scrub the
+        # echo on iOS). Otherwise the WS binary path. tts_start/tts_end JSON
+        # still go over the WS either way so the UI updates the same.
+        use_webrtc = webrtc_active and webrtc_session is not None
+
+        async def _emit(pcm: bytes) -> None:
+            nonlocal bytes_sent, chunks_sent
+            bytes_sent += len(pcm)
+            chunks_sent += 1
+            if use_webrtc:
+                webrtc_session.send_pcm(pcm)
+            else:
+                await out_queue.put(pcm)
+
         logger.info(
-            "[ws_voice] speak() start: provider=%s path=%s text_len=%d",
-            type(provider).__name__, path, len(text),
+            "[ws_voice] speak() start: provider=%s path=%s text_len=%d transport=%s",
+            type(provider).__name__, path, len(text), "webrtc" if use_webrtc else "ws",
         )
         try:
             if stream_pcm is not None:
                 async for pcm in stream_pcm(text):
-                    bytes_sent += len(pcm)
-                    chunks_sent += 1
-                    await out_queue.put(pcm)
+                    await _emit(pcm)
             else:
                 async for pcm in _mp3_stream_to_pcm(provider.stream_audio(text)):
-                    bytes_sent += len(pcm)
-                    chunks_sent += 1
-                    await out_queue.put(pcm)
+                    await _emit(pcm)
             logger.info(
                 "[ws_voice] speak() done: chunks=%d bytes=%d",
                 chunks_sent, bytes_sent,
             )
+            if use_webrtc:
+                # WebRTC: the server paces the track, so we know exactly when the
+                # user stops hearing the bot — wait for the track to drain, then
+                # drop bot_speaking. This is the WebRTC analogue of the WS path's
+                # client ``playback_done``. tts_task stays alive for the whole
+                # playback, so an onset barge-in cancels it mid-tail for free.
+                await webrtc_session.tts_track.wait_drained()
+                bot_speaking = False
         except asyncio.CancelledError:
             await out_queue.put({"type": "barge_in_ack"})
             raise
@@ -848,6 +880,12 @@ async def voice_ws(ws: WebSocket) -> None:
             if msg["type"] == "websocket.disconnect":
                 return
             if "bytes" in msg and msg["bytes"] is not None:
+                # When WebRTC is negotiated the mic arrives on the RTCPeerConnection
+                # track (pumped into feed_audio there), so ignore any WS PCM frames
+                # to avoid feeding STT twice. The client stops sending them, but
+                # guard server-side too.
+                if webrtc_active:
+                    continue
                 # Diagnostic: classify each frame as "during bot" vs "silent
                 # baseline" so we can compare RMS distributions and confirm
                 # whether browser AEC is actually scrubbing the bot's voice
@@ -877,6 +915,40 @@ async def voice_ws(ws: WebSocket) -> None:
                     if tts_task is not None and not tts_task.done():
                         tts_task.cancel()
                     tts_task = asyncio.create_task(speak(text))
+                elif kind == "webrtc_offer":
+                    # Client wants to move audio onto a WebRTC connection (so the
+                    # browser AEC can scrub the bot's TTS — the iOS echo fix).
+                    # Answer the offer; from now on mic + TTS go over WebRTC.
+                    sdp = payload.get("sdp") or ""
+                    if not sdp:
+                        await out_queue.put({"type": "webrtc_error", "detail": "missing sdp"})
+                        continue
+                    try:
+                        if webrtc_session is not None:
+                            await webrtc_session.close()
+
+                        def _feed_webrtc(pcm: bytes) -> None:
+                            if stt_service is not None:
+                                stt_service.feed_audio(pcm)
+
+                        webrtc_session = WebRtcVoiceSession(_feed_webrtc)
+                        answer = await webrtc_session.handle_offer(
+                            sdp, payload.get("sdp_type") or "offer"
+                        )
+                        webrtc_active = True
+                        await out_queue.put({
+                            "type": "webrtc_answer",
+                            "sdp": answer["sdp"],
+                            "sdp_type": answer["type"],
+                        })
+                        logger.info("[ws_voice] WebRTC negotiated — audio over RTCPeerConnection")
+                    except Exception as exc:
+                        logger.exception("[ws_voice] webrtc_offer failed")
+                        webrtc_active = False
+                        if webrtc_session is not None:
+                            await webrtc_session.close()
+                            webrtc_session = None
+                        await out_queue.put({"type": "webrtc_error", "detail": str(exc)})
                 elif kind == "barge_in":
                     _cancel_inflight("client_barge_in")
                 elif kind == "playback_done":
@@ -931,6 +1003,12 @@ async def voice_ws(ws: WebSocket) -> None:
         for t in (agent_task, tts_task):
             if t is not None and not t.done():
                 t.cancel()
+        if webrtc_session is not None:
+            # Tear down the RTCPeerConnection + inbound pump task.
+            try:
+                await webrtc_session.close()
+            except Exception:
+                logger.exception("[ws_voice] webrtc close failed")
         await out_queue.put(None)
         writer_task.cancel()
         try:

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -61,7 +61,7 @@ from services.sse_progress import (
     merge_hooks,
     progress_manager,
 )
-from services.webrtc_voice import WebRtcVoiceSession
+from services.webrtc_voice import WebRtcVoiceSession, parse_ice_servers
 
 
 def _chunk_rms_peak(pcm_chunk: bytes) -> tuple[int, int]:
@@ -77,6 +77,18 @@ def _chunk_rms_peak(pcm_chunk: bytes) -> tuple[int, int]:
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["voice-ws"])
+
+
+@router.get("/api/voice/ice")
+def voice_ice_config() -> dict:
+    """ICE servers (STUN/TURN) for the browser's RTCPeerConnection.
+
+    Sourced from ``JARVIS_WEBRTC_ICE`` so a TURN deployment (needed for
+    symmetric-NAT / iPhone-on-cellular) is an env change, not a code change —
+    the frontend fetches this before negotiating. Not secret (TURN creds here
+    are the short-lived/shared kind); behind the same auth as the app.
+    """
+    return {"iceServers": parse_ice_servers()}
 
 
 # ─── Auth helpers (cookie / Bearer / query — with CSWSH defence) ────────────
@@ -953,13 +965,20 @@ async def voice_ws(ws: WebSocket) -> None:
                     _cancel_inflight("client_barge_in")
                 elif kind == "playback_done":
                     # Authoritative "the user has stopped hearing the bot"
-                    # signal: the client finished playing every buffered TTS
-                    # chunk. Until this lands, bot_speaking stays True (set at
-                    # tts_start, kept past synthesis end) so a barge-in during
-                    # the playback tail still flushes the client queue. This is
-                    # the SSoT fix: server ``bot_speaking`` mirrors real client
+                    # signal on the WS audio path: the client finished playing
+                    # every buffered TTS chunk. Until this lands, bot_speaking
+                    # stays True (set at tts_start, kept past synthesis end) so a
+                    # barge-in during the playback tail still flushes the client
+                    # queue. SSoT: server bot_speaking mirrors real client
                     # playback instead of server-side synthesis state.
-                    bot_speaking = False
+                    #
+                    # In WebRTC mode the server PACES the track itself, so
+                    # speak()'s wait_drained() is the authority for the drain
+                    # edge — ignore any client playback_done (a correct client
+                    # won't send one, but guard defensively so a stale/foreign
+                    # client can't clear bot_speaking mid-playback).
+                    if not webrtc_active:
+                        bot_speaking = False
                 elif kind == "set_session":
                     session_id = payload.get("id") or session_id
                 elif kind == "set_agent":

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -301,7 +301,7 @@ async def voice_ws(ws: WebSocket) -> None:
     agent_task: Optional[asyncio.Task] = None
     tts_task: Optional[asyncio.Task] = None
     user_query_pending = False  # set when STT finalises text but agent task hasn't started yet
-    bot_speaking = False        # True from tts_start to tts_end / interruption
+    bot_speaking = False        # True from tts_start until client playback_done / barge-in
     # Dictation mode: client picked the bottom mic in ChatInput (press-to-talk
     # transcription) instead of the top hands-free button. In this mode the
     # STT pipeline runs as usual but ``final_transcript`` does NOT trigger
@@ -328,7 +328,7 @@ async def voice_ws(ws: WebSocket) -> None:
 
     def _cancel_inflight(reason: str) -> None:
         """Abort agent generation + TTS playback. Idempotent."""
-        nonlocal agent_task, tts_task
+        nonlocal agent_task, tts_task, bot_speaking
         cancelled = []
         if agent_task is not None and not agent_task.done():
             agent_task.cancel()
@@ -336,8 +336,21 @@ async def voice_ws(ws: WebSocket) -> None:
         if tts_task is not None and not tts_task.done():
             tts_task.cancel()
             cancelled.append("tts")
-        if cancelled:
-            logger.info("[ws_voice] barge-in (%s) cancelled %s", reason, ",".join(cancelled))
+        # Emit the interruption if we cancelled an in-flight task OR the client
+        # is still PLAYING buffered TTS audio. ``bot_speaking`` now stays True
+        # from tts_start until the client sends ``playback_done`` (queue
+        # drained) — see speak() + the playback_done handler. During that
+        # playback tail the server's tts_task has already finished synthesising
+        # (nothing to cancel), but the user is still HEARING the bot and the
+        # frontend must flush its queue. Without this branch a barge-in during
+        # the tail was a silent no-op — the root cause of "TTS keeps playing
+        # until I stop talking and the transcript submits".
+        if cancelled or bot_speaking:
+            bot_speaking = False
+            logger.info(
+                "[ws_voice] barge-in (%s) cancelled %s",
+                reason, ",".join(cancelled) or "playback-only",
+            )
             try:
                 out_queue.put_nowait({"type": "tts_interruption", "reason": reason})
             except Exception:
@@ -412,8 +425,11 @@ async def voice_ws(ws: WebSocket) -> None:
             logger.info("[ws_voice] _dispatch_user_turn skipped (dictation mode)")
             return
         # Cancel any previous in-flight agent/tts so a barge-in mid-turn
-        # cleanly resets to the new user input.
-        if (agent_task is not None and not agent_task.done()) or (
+        # cleanly resets to the new user input. ``bot_speaking`` covers the
+        # playback-tail case where synthesis already finished but the client
+        # is still playing buffered audio — flush it so the previous reply's
+        # audio doesn't bleed past the new turn.
+        if bot_speaking or (agent_task is not None and not agent_task.done()) or (
             tts_task is not None and not tts_task.done()
         ):
             _cancel_inflight("new_user_turn")
@@ -547,7 +563,13 @@ async def voice_ws(ws: WebSocket) -> None:
             await out_queue.put({"type": "barge_in_ack"})
             raise
         finally:
-            bot_speaking = False
+            # bot_speaking is intentionally NOT reset here. It now tracks actual
+            # CLIENT PLAYBACK, not server synthesis: it stays True from tts_start
+            # until the client sends ``playback_done`` (its buffer drained) or a
+            # barge-in clears it via _cancel_inflight. Synthesis finishing is not
+            # the same as the user no longer hearing the bot — the client buffers
+            # several seconds of audio ahead, and barge-in must still work during
+            # that tail.
             # Dump the mic PCM captured during this TTS turn to /data/voice_diag
             # so we can listen to what the server saw + compare RMS vs the
             # silent baseline. This is the ground truth for "is AEC working".
@@ -857,6 +879,15 @@ async def voice_ws(ws: WebSocket) -> None:
                     tts_task = asyncio.create_task(speak(text))
                 elif kind == "barge_in":
                     _cancel_inflight("client_barge_in")
+                elif kind == "playback_done":
+                    # Authoritative "the user has stopped hearing the bot"
+                    # signal: the client finished playing every buffered TTS
+                    # chunk. Until this lands, bot_speaking stays True (set at
+                    # tts_start, kept past synthesis end) so a barge-in during
+                    # the playback tail still flushes the client queue. This is
+                    # the SSoT fix: server ``bot_speaking`` mirrors real client
+                    # playback instead of server-side synthesis state.
+                    bot_speaking = False
                 elif kind == "set_session":
                     session_id = payload.get("id") or session_id
                 elif kind == "set_agent":

--- a/backend/services/webrtc_voice.py
+++ b/backend/services/webrtc_voice.py
@@ -28,14 +28,27 @@ from __future__ import annotations
 import asyncio
 import fractions
 import logging
+import os
 import time
-from typing import Awaitable, Callable, Optional
+from typing import Callable, Optional
 
 import av
-from aiortc import MediaStreamTrack, RTCPeerConnection, RTCSessionDescription
+from aiortc import (
+    MediaStreamTrack,
+    RTCConfiguration,
+    RTCIceServer,
+    RTCPeerConnection,
+    RTCSessionDescription,
+)
 from aiortc.mediastreams import MediaStreamError
 
 logger = logging.getLogger(__name__)
+
+# Public STUN so each peer can discover its server-reflexive (NAT) candidate —
+# needed for the browser↔server connection to form over the internet (iPhone on
+# cellular/Wi-Fi behind NAT). If a deployment is behind symmetric NAT on both
+# ends a TURN relay would also be required; configure via JARVIS_WEBRTC_ICE.
+_DEFAULT_STUN = "stun:stun.l.google.com:19302"
 
 STT_RATE = 16000      # feed_audio() input rate (mono s16)
 TTS_RATE = 24000      # RealtimeTTS / Edge PCM rate (mono s16)
@@ -68,6 +81,29 @@ class TtsAudioTrack(MediaStreamTrack):
         """Queue a chunk of 24 kHz mono s16 PCM for playback."""
         if pcm24k:
             self._queue.put_nowait(pcm24k)
+
+    def pending(self) -> bool:
+        """True while there's still TTS audio queued or buffered to play."""
+        return not self._queue.empty() or len(self._buf) >= 2
+
+    async def wait_drained(self) -> None:
+        """Block until every pushed chunk has been emitted as a frame.
+
+        With WebRTC the server paces playback, so this is the authoritative
+        'the user has stopped hearing the bot' edge — the WebRTC analogue of the
+        WS path's client ``playback_done``.
+        """
+        while self.pending():
+            await asyncio.sleep(0.02)
+
+    def flush(self) -> None:
+        """Drop all queued + buffered TTS audio (barge-in — stop playback now)."""
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        self._buf.clear()
 
     def _resample_into_buf(self, pcm24k: bytes) -> None:
         in_frame = av.AudioFrame(format="s16", layout="mono", samples=len(pcm24k) // 2)
@@ -140,10 +176,22 @@ class WebRtcVoiceSession:
     ``feed_audio`` callback (the same one the WS binary path used).
     """
 
-    def __init__(self, feed_audio: FeedAudio, *, on_connection_lost: Optional[Callable[[], None]] = None):
+    def __init__(
+        self,
+        feed_audio: FeedAudio,
+        *,
+        on_connection_lost: Optional[Callable[[], None]] = None,
+        ice_servers: Optional[list[str]] = None,
+    ):
         self._feed_audio = feed_audio
         self._on_connection_lost = on_connection_lost
-        self.pc = RTCPeerConnection()
+        # Default to STUN from env (prod NAT traversal); tests pass [] for a
+        # fast host-only localhost loopback that doesn't hit the network.
+        urls = ice_servers if ice_servers is not None else [
+            u for u in os.environ.get("JARVIS_WEBRTC_ICE", _DEFAULT_STUN).split(",") if u.strip()
+        ]
+        ice = [RTCIceServer(urls=u) for u in urls]
+        self.pc = RTCPeerConnection(configuration=RTCConfiguration(iceServers=ice))
         self.tts_track = TtsAudioTrack()
         self._inbound_task: Optional[asyncio.Task] = None
         self.pc.addTrack(self.tts_track)

--- a/backend/services/webrtc_voice.py
+++ b/backend/services/webrtc_voice.py
@@ -47,8 +47,38 @@ logger = logging.getLogger(__name__)
 # Public STUN so each peer can discover its server-reflexive (NAT) candidate —
 # needed for the browser↔server connection to form over the internet (iPhone on
 # cellular/Wi-Fi behind NAT). If a deployment is behind symmetric NAT on both
-# ends a TURN relay would also be required; configure via JARVIS_WEBRTC_ICE.
+# ends a TURN relay is also required; configure via JARVIS_WEBRTC_ICE as a
+# comma-separated list, e.g.:
+#   JARVIS_WEBRTC_ICE="stun:stun.l.google.com:19302,turn:user:pass@turn.example.com:3478"
 _DEFAULT_STUN = "stun:stun.l.google.com:19302"
+
+
+def parse_ice_servers() -> list[dict]:
+    """Parse JARVIS_WEBRTC_ICE into browser-shaped iceServers dicts.
+
+    Accepts ``stun:host:port`` and ``turn[s]:user:pass@host:port`` entries.
+    Returned shape ({urls, username?, credential?}) is what an RTCConfiguration
+    expects in the browser AND maps cleanly to aiortc's RTCIceServer — so the
+    frontend (via the /ice endpoint) and the server use one source of truth.
+    """
+    raw = os.environ.get("JARVIS_WEBRTC_ICE", _DEFAULT_STUN)
+    servers: list[dict] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "@" in entry:
+            scheme_creds, host = entry.split("@", 1)
+            parts = scheme_creds.split(":")  # e.g. ["turn", "user", "pass"]
+            server: dict = {"urls": f"{parts[0]}:{host}"}
+            if len(parts) > 1:
+                server["username"] = parts[1]
+            if len(parts) > 2:
+                server["credential"] = ":".join(parts[2:])  # pass may contain ':'
+            servers.append(server)
+        else:
+            servers.append({"urls": entry})
+    return servers
 
 STT_RATE = 16000      # feed_audio() input rate (mono s16)
 TTS_RATE = 24000      # RealtimeTTS / Edge PCM rate (mono s16)
@@ -185,12 +215,15 @@ class WebRtcVoiceSession:
     ):
         self._feed_audio = feed_audio
         self._on_connection_lost = on_connection_lost
-        # Default to STUN from env (prod NAT traversal); tests pass [] for a
-        # fast host-only localhost loopback that doesn't hit the network.
-        urls = ice_servers if ice_servers is not None else [
-            u for u in os.environ.get("JARVIS_WEBRTC_ICE", _DEFAULT_STUN).split(",") if u.strip()
-        ]
-        ice = [RTCIceServer(urls=u) for u in urls]
+        # Default to ICE from env (prod NAT traversal, incl. TURN creds); tests
+        # pass ice_servers=[] for a fast host-only localhost loopback.
+        if ice_servers is not None:
+            ice = [RTCIceServer(urls=u) for u in ice_servers]
+        else:
+            ice = [
+                RTCIceServer(urls=s["urls"], username=s.get("username"), credential=s.get("credential"))
+                for s in parse_ice_servers()
+            ]
         self.pc = RTCPeerConnection(configuration=RTCConfiguration(iceServers=ice))
         self.tts_track = TtsAudioTrack()
         self._inbound_task: Optional[asyncio.Task] = None

--- a/backend/services/webrtc_voice.py
+++ b/backend/services/webrtc_voice.py
@@ -1,0 +1,182 @@
+"""WebRTC voice transport — audio over an RTCPeerConnection.
+
+WHY: browser acoustic echo cancellation (AEC) only scrubs the bot's TTS out of
+the mic when playback is a WebRTC media track rendered via ``<audio>``. iOS
+Safari does NOT run AEC for Web Audio API (AudioContext/AudioWorklet) playback,
+so the WS+AudioWorklet path echoes the bot into STT → feedback loop on iPhone.
+Routing the *audio* through WebRTC fixes that on every browser.
+
+SCOPE: only the media (mic in, TTS out) moves to WebRTC. Signaling (SDP/ICE)
+and every control/STT/barge-in event stay on ``/ws/voice`` — this module is a
+self-contained audio bridge the WS handler drives. It exposes:
+
+    * ``TtsAudioTrack``  — outbound: server ``push(pcm_24k)`` → 48 kHz frames.
+    * ``WebRtcVoiceSession`` — wraps RTCPeerConnection, answers an offer, pumps
+      the inbound mic track into a ``feed_audio(pcm_16k)`` callback, and owns the
+      outbound TtsAudioTrack.
+
+Rates: STT wants 16 kHz mono s16 (``feed_audio``); RealtimeTTS/Edge emit 24 kHz
+mono s16; WebRTC/Opus is 48 kHz. av.AudioResampler bridges them.
+
+The audio PLUMBING here is covered by an in-process aiortc loopback test
+(tests/test_services/test_webrtc_voice.py). Audio *fidelity* (pitch/latency) and
+the actual on-device AEC are validated by manual testing — they can't be
+asserted headless.
+"""
+from __future__ import annotations
+
+import asyncio
+import fractions
+import logging
+import time
+from typing import Awaitable, Callable, Optional
+
+import av
+from aiortc import MediaStreamTrack, RTCPeerConnection, RTCSessionDescription
+from aiortc.mediastreams import MediaStreamError
+
+logger = logging.getLogger(__name__)
+
+STT_RATE = 16000      # feed_audio() input rate (mono s16)
+TTS_RATE = 24000      # RealtimeTTS / Edge PCM rate (mono s16)
+WEBRTC_RATE = 48000   # Opus / WebRTC standard
+FRAME_SAMPLES = 960   # 20 ms @ 48 kHz — one outbound frame
+_SILENCE_48K = b"\x00\x00" * FRAME_SAMPLES
+
+FeedAudio = Callable[[bytes], None]
+
+
+class TtsAudioTrack(MediaStreamTrack):
+    """Outbound audio: server pushes 24 kHz TTS PCM; we emit paced 48 kHz frames.
+
+    Emits silence when idle so the track stays live between replies (a dead
+    track would force renegotiation on the next reply). ``recv()`` paces frames
+    to real time using aiortc's documented timestamp/sleep pattern.
+    """
+
+    kind = "audio"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._queue: "asyncio.Queue[bytes]" = asyncio.Queue()
+        self._resampler = av.AudioResampler(format="s16", layout="mono", rate=WEBRTC_RATE)
+        self._buf = bytearray()           # resampled 48 kHz mono s16 awaiting framing
+        self._timestamp: Optional[int] = None
+        self._start = 0.0
+
+    def push(self, pcm24k: bytes) -> None:
+        """Queue a chunk of 24 kHz mono s16 PCM for playback."""
+        if pcm24k:
+            self._queue.put_nowait(pcm24k)
+
+    def _resample_into_buf(self, pcm24k: bytes) -> None:
+        in_frame = av.AudioFrame(format="s16", layout="mono", samples=len(pcm24k) // 2)
+        in_frame.sample_rate = TTS_RATE
+        in_frame.pts = None
+        in_frame.planes[0].update(pcm24k)
+        for out in self._resampler.resample(in_frame):
+            # out.samples*2 bytes of real audio; planes[0] may be padded, so slice.
+            self._buf.extend(bytes(out.planes[0])[: out.samples * 2])
+
+    async def _next_frame_bytes(self) -> bytes:
+        # Top up the buffer until we have a full 20 ms frame, but don't block the
+        # cadence: if no TTS arrives within one frame interval, emit silence.
+        while len(self._buf) < FRAME_SAMPLES * 2:
+            try:
+                pcm24k = await asyncio.wait_for(self._queue.get(), timeout=FRAME_SAMPLES / WEBRTC_RATE)
+            except asyncio.TimeoutError:
+                return _SILENCE_48K
+            self._resample_into_buf(pcm24k)
+        out = bytes(self._buf[: FRAME_SAMPLES * 2])
+        del self._buf[: FRAME_SAMPLES * 2]
+        return out
+
+    async def recv(self) -> av.AudioFrame:
+        if self._timestamp is None:
+            self._start = time.time()
+            self._timestamp = 0
+        else:
+            self._timestamp += FRAME_SAMPLES
+            target = self._start + self._timestamp / WEBRTC_RATE
+            delay = target - time.time()
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+        data = await self._next_frame_bytes()
+        frame = av.AudioFrame(format="s16", layout="mono", samples=FRAME_SAMPLES)
+        frame.sample_rate = WEBRTC_RATE
+        frame.pts = self._timestamp
+        frame.time_base = fractions.Fraction(1, WEBRTC_RATE)
+        frame.planes[0].update(data)
+        return frame
+
+
+async def pump_inbound_track(track: MediaStreamTrack, feed_audio: FeedAudio) -> None:
+    """Read the peer's mic track, resample each frame to 16 kHz mono s16, feed STT.
+
+    Runs until the track ends (peer left / connection closed). Resampling is
+    per-frame; aiortc decodes Opus to PCM frames before we see them.
+    """
+    resampler = av.AudioResampler(format="s16", layout="mono", rate=STT_RATE)
+    try:
+        while True:
+            frame = await track.recv()
+            for out in resampler.resample(frame):
+                pcm = bytes(out.planes[0])[: out.samples * 2]
+                if pcm:
+                    feed_audio(pcm)
+    except MediaStreamError:
+        return  # track ended — normal teardown
+    except Exception:
+        logger.exception("[webrtc] inbound pump crashed")
+
+
+class WebRtcVoiceSession:
+    """One browser ↔ server audio session over WebRTC.
+
+    The WS handler creates this on a ``webrtc_offer`` control frame, calls
+    ``handle_offer`` to get the answer SDP (sent back over the WS), then uses
+    ``send_pcm`` to stream TTS audio. Inbound mic audio is forwarded to the
+    ``feed_audio`` callback (the same one the WS binary path used).
+    """
+
+    def __init__(self, feed_audio: FeedAudio, *, on_connection_lost: Optional[Callable[[], None]] = None):
+        self._feed_audio = feed_audio
+        self._on_connection_lost = on_connection_lost
+        self.pc = RTCPeerConnection()
+        self.tts_track = TtsAudioTrack()
+        self._inbound_task: Optional[asyncio.Task] = None
+        self.pc.addTrack(self.tts_track)
+
+        @self.pc.on("track")
+        def _on_track(track: MediaStreamTrack) -> None:  # noqa: ANN202
+            if track.kind != "audio":
+                return
+            logger.info("[webrtc] inbound %s track", track.kind)
+            self._inbound_task = asyncio.ensure_future(pump_inbound_track(track, self._feed_audio))
+
+        @self.pc.on("connectionstatechange")
+        async def _on_state() -> None:  # noqa: ANN202
+            logger.info("[webrtc] connection state: %s", self.pc.connectionState)
+            if self.pc.connectionState in ("failed", "closed", "disconnected"):
+                if self._on_connection_lost is not None:
+                    self._on_connection_lost()
+
+    async def handle_offer(self, sdp: str, sdp_type: str = "offer") -> dict[str, str]:
+        """Apply the browser's offer, return the answer as ``{sdp, type}``."""
+        await self.pc.setRemoteDescription(RTCSessionDescription(sdp=sdp, type=sdp_type))
+        answer = await self.pc.createAnswer()
+        await self.pc.setLocalDescription(answer)
+        return {"sdp": self.pc.localDescription.sdp, "type": self.pc.localDescription.type}
+
+    def send_pcm(self, pcm24k: bytes) -> None:
+        """Push a chunk of 24 kHz mono s16 TTS PCM to the outbound track."""
+        self.tts_track.push(pcm24k)
+
+    async def close(self) -> None:
+        if self._inbound_task is not None:
+            self._inbound_task.cancel()
+        try:
+            await self.pc.close()
+        except Exception:
+            logger.exception("[webrtc] close failed")

--- a/backend/tests/test_routes/test_ws_voice.py
+++ b/backend/tests/test_routes/test_ws_voice.py
@@ -799,3 +799,36 @@ def test_barge_in_during_playback_tail_flushes_with_no_active_task(ws_client):
         evt = _drain_until(ws, "tts_interruption")
         assert evt["reason"] == "client_barge_in"
         ws.close()
+
+
+def test_webrtc_offer_is_answered_over_ws(ws_client, monkeypatch):
+    """A ``webrtc_offer`` control frame must be answered with a ``webrtc_answer``
+    carrying a valid SDP — proving the WS handler wires the offer into a real
+    WebRtcVoiceSession and routes the answer back. (Media itself is covered by
+    the aiortc loopback in test_services/test_webrtc_voice.py.)
+    """
+    import asyncio as _asyncio
+
+    from aiortc import RTCPeerConnection
+
+    # Host-only ICE on both ends so neither side blocks on a STUN round-trip.
+    monkeypatch.setenv("JARVIS_WEBRTC_ICE", "")
+
+    async def _make_offer_sdp() -> str:
+        pc = RTCPeerConnection()
+        pc.addTransceiver("audio", direction="sendrecv")
+        await pc.setLocalDescription(await pc.createOffer())
+        sdp = pc.localDescription.sdp
+        await pc.close()
+        return sdp
+
+    offer_sdp = _asyncio.run(_make_offer_sdp())
+
+    client, _ = ws_client
+    with client.websocket_connect("/ws/voice") as ws:
+        ws.send_text(json.dumps({"type": "webrtc_offer", "sdp": offer_sdp, "sdp_type": "offer"}))
+        evt = _drain_until(ws, "webrtc_answer")
+        assert evt.get("sdp_type") == "answer"
+        assert "v=0" in (evt.get("sdp") or "")
+        assert "m=audio" in evt["sdp"]
+        ws.close()

--- a/backend/tests/test_routes/test_ws_voice.py
+++ b/backend/tests/test_routes/test_ws_voice.py
@@ -720,3 +720,82 @@ def test_barge_in_keeps_socket_alive_for_further_events(ws_client):
         evt = _drain_until(ws, "partial_transcript")
         assert evt["text"] == "after"
         ws.close()
+
+
+def _collect_until_sentinel(ws, sentinel_text, *, max_msgs: int = 12):
+    """Drain JSON frames until a ``partial_transcript`` carrying ``sentinel_text``.
+
+    Returns the list of event ``type``s seen up to and including the sentinel.
+    Lets a test assert that some event (e.g. ``tts_interruption``) did or did
+    NOT appear before a known marker, without depending on exact ordering.
+    """
+    types: list[str] = []
+    for _ in range(max_msgs):
+        msg = ws.receive()
+        if msg.get("type") == "websocket.disconnect":
+            break
+        if msg.get("text"):
+            evt = json.loads(msg["text"])
+            types.append(evt.get("type"))
+            if evt.get("type") == "partial_transcript" and evt.get("text") == sentinel_text:
+                return types
+    raise AssertionError(f"never saw sentinel {sentinel_text!r}; saw {types}")
+
+
+def test_recording_start_during_bot_speaking_cancels_tts(ws_client):
+    """Onset barge-in (case 2): ``recording_start`` while the user is still
+    hearing the bot must emit ``tts_interruption`` — EVEN in the playback tail
+    where synthesis already finished (tts_end fired) but ``bot_speaking`` is
+    still True because the client hasn't sent ``playback_done`` yet.
+
+    This is the regression that previously slipped through: barge-in only
+    fired on ``final_transcript`` (after the user stopped talking), never on
+    speech onset. The onset trigger had no direct test.
+    """
+    client, fake_stt = ws_client
+    with client.websocket_connect("/ws/voice") as ws:
+        ws.send_text(json.dumps({"type": "speak", "text": "a long reply"}))
+        _drain_until(ws, "tts_end")  # synthesis done; bot_speaking stays True
+        # User starts talking over the still-playing buffered audio.
+        fake_stt.emit("recording_start", {})
+        evt = _drain_until(ws, "tts_interruption")
+        assert evt["reason"] == "user_resumed"
+        ws.close()
+
+
+def test_playback_done_clears_bot_speaking_so_no_barge_in(ws_client):
+    """Once the client reports ``playback_done`` (its buffer drained), the user
+    is no longer hearing the bot, so a subsequent interrupt must be a no-op —
+    no ``tts_interruption``. Locks in the SSoT: bot_speaking tracks real client
+    playback, and ``playback_done`` lowers it.
+
+    Ordering is deterministic: ``playback_done`` and ``barge_in`` are both WS
+    control frames drained by the receive loop in FIFO order, so by the time
+    barge_in runs, playback_done has already cleared bot_speaking.
+    """
+    client, fake_stt = ws_client
+    with client.websocket_connect("/ws/voice") as ws:
+        ws.send_text(json.dumps({"type": "speak", "text": "x"}))
+        _drain_until(ws, "tts_end")
+        ws.send_text(json.dumps({"type": "playback_done"}))  # buffer drained
+        ws.send_text(json.dumps({"type": "barge_in"}))       # nothing to flush
+        fake_stt.emit("partial_transcript", {"text": "__DONE__"})
+        seen = _collect_until_sentinel(ws, "__DONE__")
+        assert "tts_interruption" not in seen, f"unexpected barge-in after playback_done: {seen}"
+        ws.close()
+
+
+def test_barge_in_during_playback_tail_flushes_with_no_active_task(ws_client):
+    """Explicit barge_in during the playback tail (synthesis done, tts_task
+    finished) must still emit ``tts_interruption`` so the client flushes its
+    queued audio. Before the fix this was a silent no-op because there was no
+    task left to cancel.
+    """
+    client, fake_stt = ws_client
+    with client.websocket_connect("/ws/voice") as ws:
+        ws.send_text(json.dumps({"type": "speak", "text": "x"}))
+        _drain_until(ws, "tts_end")            # tts_task now done
+        ws.send_text(json.dumps({"type": "barge_in"}))
+        evt = _drain_until(ws, "tts_interruption")
+        assert evt["reason"] == "client_barge_in"
+        ws.close()

--- a/backend/tests/test_services/test_webrtc_voice.py
+++ b/backend/tests/test_services/test_webrtc_voice.py
@@ -20,7 +20,7 @@ from fractions import Fraction
 import av
 from aiortc import MediaStreamTrack, RTCPeerConnection, RTCSessionDescription
 
-from services.webrtc_voice import WebRtcVoiceSession
+from services.webrtc_voice import WebRtcVoiceSession, parse_ice_servers
 
 
 class _ToneTrack(MediaStreamTrack):
@@ -87,6 +87,33 @@ async def _run_loopback():
     await session.close()
     await browser.close()
     return fed, out_frames
+
+
+def test_parse_ice_servers_stun_and_turn(monkeypatch):
+    """JARVIS_WEBRTC_ICE → browser-shaped iceServers, incl. TURN credentials.
+
+    The /api/voice/ice endpoint + the aiortc session both consume this, so a
+    mis-parse (esp. TURN user:pass) would silently break NAT traversal on prod.
+    """
+    monkeypatch.setenv(
+        "JARVIS_WEBRTC_ICE",
+        "stun:stun.l.google.com:19302, turn:alice:s3cr3t@turn.example.com:3478",
+    )
+    servers = parse_ice_servers()
+    assert servers[0] == {"urls": "stun:stun.l.google.com:19302"}
+    assert servers[1] == {
+        "urls": "turn:turn.example.com:3478",
+        "username": "alice",
+        "credential": "s3cr3t",
+    }
+
+    # Default (env unset) is a public STUN server, never empty.
+    monkeypatch.delenv("JARVIS_WEBRTC_ICE", raising=False)
+    assert parse_ice_servers() == [{"urls": "stun:stun.l.google.com:19302"}]
+
+    # A colon in the TURN password survives.
+    monkeypatch.setenv("JARVIS_WEBRTC_ICE", "turn:u:p:a:ss@h:3478")
+    assert parse_ice_servers()[0]["credential"] == "p:a:ss"
 
 
 def test_webrtc_loopback_bridges_audio_both_directions():

--- a/backend/tests/test_services/test_webrtc_voice.py
+++ b/backend/tests/test_services/test_webrtc_voice.py
@@ -1,0 +1,99 @@
+"""WebRTC voice bridge — in-process aiortc loopback.
+
+Two RTCPeerConnections in one process (a synthetic "browser" + the real
+``WebRtcVoiceSession``) negotiate over localhost and exchange audio, proving the
+plumbing end-to-end WITHOUT a browser:
+
+  * inbound: the browser's mic track → resample 48k→16k → feed_audio callback
+  * outbound: server-pushed 24k TTS PCM → 48k track → frames at the browser
+
+This verifies signalling (offer/answer), track wiring, and both resample paths.
+It does NOT (cannot, headless) verify audio fidelity or on-device AEC — those
+are manual tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from fractions import Fraction
+
+import av
+from aiortc import MediaStreamTrack, RTCPeerConnection, RTCSessionDescription
+
+from services.webrtc_voice import WebRtcVoiceSession
+
+
+class _ToneTrack(MediaStreamTrack):
+    """Synthetic 48 kHz mono mic source — non-silent so resampling yields data."""
+
+    kind = "audio"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._ts: int | None = None
+        self._start = 0.0
+
+    async def recv(self) -> av.AudioFrame:
+        if self._ts is None:
+            self._start = time.time()
+            self._ts = 0
+        else:
+            self._ts += 960
+            delay = self._start + self._ts / 48000 - time.time()
+            if delay > 0:
+                await asyncio.sleep(delay)
+        frame = av.AudioFrame(format="s16", layout="mono", samples=960)
+        frame.sample_rate = 48000
+        frame.pts = self._ts
+        frame.time_base = Fraction(1, 48000)
+        frame.planes[0].update(b"\x20\x00" * 960)
+        return frame
+
+
+async def _run_loopback():
+    fed: list[bytes] = []
+    session = WebRtcVoiceSession(lambda pcm: fed.append(pcm))
+
+    browser = RTCPeerConnection()
+    browser.addTrack(_ToneTrack())
+    out_frames: list[int] = []
+
+    @browser.on("track")
+    def _on_track(track: MediaStreamTrack) -> None:  # noqa: ANN202
+        async def pull() -> None:
+            try:
+                for _ in range(25):
+                    fr = await track.recv()
+                    out_frames.append(fr.samples)
+            except Exception:
+                pass
+        asyncio.ensure_future(pull())
+
+    await browser.setLocalDescription(await browser.createOffer())
+    answer = await session.handle_offer(browser.localDescription.sdp, browser.localDescription.type)
+    await browser.setRemoteDescription(RTCSessionDescription(**answer))
+
+    # Stream some TTS PCM (24 kHz mono s16, 20 ms = 480 samples) out the track.
+    for _ in range(10):
+        session.send_pcm(b"\x15\x00" * 480)
+
+    # Wait for ICE/DTLS + a little media to flow (localhost loopback is fast).
+    for _ in range(50):
+        if fed and out_frames:
+            break
+        await asyncio.sleep(0.1)
+
+    await session.close()
+    await browser.close()
+    return fed, out_frames
+
+
+def test_webrtc_loopback_bridges_audio_both_directions():
+    fed, out_frames = asyncio.run(_run_loopback())
+    # Inbound: the browser's mic reached feed_audio as 16 kHz mono s16 (even byte
+    # count per chunk = valid int16 PCM).
+    assert fed, "inbound mic never reached feed_audio"
+    assert all(len(p) % 2 == 0 for p in fed), "feed_audio got odd-length (non-s16) PCM"
+    # Outbound: the server's TTS track produced frames the browser received.
+    assert out_frames, "outbound TTS track produced no frames at the peer"
+    assert all(n > 0 for n in out_frames)

--- a/backend/tests/test_services/test_webrtc_voice.py
+++ b/backend/tests/test_services/test_webrtc_voice.py
@@ -52,7 +52,8 @@ class _ToneTrack(MediaStreamTrack):
 
 async def _run_loopback():
     fed: list[bytes] = []
-    session = WebRtcVoiceSession(lambda pcm: fed.append(pcm))
+    # No STUN — host-only candidates keep the loopback fast and offline.
+    session = WebRtcVoiceSession(lambda pcm: fed.append(pcm), ice_servers=[])
 
     browser = RTCPeerConnection()
     browser.addTrack(_ToneTrack())

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -98,6 +98,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aioice"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/04/df7286233f468e19e9bedff023b6b246182f0b2ccb04ceeb69b2994021c6/aioice-0.10.2.tar.gz", hash = "sha256:bf236c6829ee33c8e540535d31cd5a066b531cb56de2be94c46be76d68b1a806", size = 44307 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e3/0d23b1f930c17d371ce1ec36ee529f22fd19ebc2a07fe3418e3d1d884ce2/aioice-0.10.2-py3-none-any.whl", hash = "sha256:14911c15ab12d096dd14d372ebb4aecbb7420b52c9b76fdfcf54375dec17fcbf", size = 24875 },
+]
+
+[[package]]
 name = "aiomqtt"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -107,6 +120,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/45/9a/863bc34c64bc4acb9720a9950bfc77d6f324640cdf1f420bb5d9ee624975/aiomqtt-2.4.0.tar.gz", hash = "sha256:ab0f18fc5b7ffaa57451c407417d674db837b00a9c7d953cccd02be64f046c17", size = 82718 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/0c/2720665998d97d3a9521c03b138a22247e035ba54c4738e934da33c68699/aiomqtt-2.4.0-py3-none-any.whl", hash = "sha256:721296e2b79df5f6c7c4dfc91700ae0166953a4127735c92637859619dbd84e4", size = 15908 },
+]
+
+[[package]]
+name = "aiortc"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aioice" },
+    { name = "av" },
+    { name = "cryptography" },
+    { name = "google-crc32c" },
+    { name = "pyee" },
+    { name = "pylibsrtp" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/9c/4e027bfe0195de0442da301e2389329496745d40ae44d2d7c4571c4290ce/aiortc-1.14.0.tar.gz", hash = "sha256:adc8a67ace10a085721e588e06a00358ed8eaf5f6b62f0a95358ff45628dd762", size = 1180864 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ab/31646a49209568cde3b97eeade0d28bb78b400e6645c56422c101df68932/aiortc-1.14.0-py3-none-any.whl", hash = "sha256:4b244d7e482f4e1f67e685b3468269628eca1ec91fa5b329ab517738cfca086e", size = 93183 },
 ]
 
 [[package]]
@@ -248,18 +279,24 @@ wheels = [
 
 [[package]]
 name = "av"
-version = "17.0.1"
+version = "16.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/f0/8c8dca97ae0cf00e8e2a53bb5cb9aca5fd484f585ef3e9b412200aff3ebd/av-17.0.1.tar.gz", hash = "sha256:fbcbd4aa43bca6a8691816283112d1659a27f407bbeb66d1397023691339f5d4", size = 4411938 }
+sdist = { url = "https://files.pythonhosted.org/packages/78/cd/3a83ffbc3cc25b39721d174487fb0d51a76582f4a1703f98e46170ce83d4/av-16.1.0.tar.gz", hash = "sha256:a094b4fd87a3721dacf02794d3d2c82b8d712c85b9534437e82a8a978c175ffd", size = 4285203 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/82/e7007dcef7bd2d2c377e2e85977701384f42d19fc808c2ccb3a99eaf58f2/av-17.0.1-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:987f4f46ceae4da6c614dcbd2b8149be9dbf680c3bb7a6841c58af9cff4d9230", size = 23238802 },
-    { url = "https://files.pythonhosted.org/packages/6b/aa/858b09a08ea6f83f91be44b5a5adad13ae8d9ac8b80fda27e73c24bfb160/av-17.0.1-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:d97f54e55b18a74912f479c1978aadd1341d38d892dee95bb5c2f2dccfa72f32", size = 18709338 },
-    { url = "https://files.pythonhosted.org/packages/a8/8b/8de3fd21c4b0b74d44337421abeab0e71462337fb6a28fff888e0c356cbd/av-17.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e6eee84afa48d0e9321047cd3e4facd44b401493f6bdc753e2e1d1e7c9e6d13e", size = 34007351 },
-    { url = "https://files.pythonhosted.org/packages/02/28/167b291356c2cc315a2d62a95b0ceace72b5b0bf547de30b89313110f032/av-17.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c58c71bffd9383908c85695ac61d3184c668accb04a5bd1b262e0fb8d09f60a5", size = 36345295 },
-    { url = "https://files.pythonhosted.org/packages/04/fa/aae56f2ff2c204c408641e1120f5ca5ce9c3390cf5362245c6f1158704b5/av-17.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:42d6745d30a410ec9b22aef79a52a7ab5a001eb8f5adfd952946606a30983318", size = 35183754 },
-    { url = "https://files.pythonhosted.org/packages/ba/bd/776046f27093aef80155a204ca7d82a887ae4ee72ba4ef8411b46ea7898c/av-17.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3ed6bcd7021fe55832f95b8ef78dd01a4cb21faf3cd71f1e1bf4f20bf100b278", size = 37430809 },
-    { url = "https://files.pythonhosted.org/packages/d9/d5/3261bd2c6b7f6c0aa8379fc970d1ecf496330990b992ad28607785074268/av-17.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:9af524e8632a54032e361d6b88895bd3e7c6212ca560de60f5ccc525323c764c", size = 28889649 },
-    { url = "https://files.pythonhosted.org/packages/98/39/381104e427a0c7231d2ec0d25d538d58fc20fc0458846b95860d3ef8073b/av-17.0.1-cp311-abi3-win_arm64.whl", hash = "sha256:50e58a473d65ea29b645e45c9fd8518a6783737135683ecc40571a91592bdfe4", size = 21918412 },
+    { url = "https://files.pythonhosted.org/packages/75/2a/63797a4dde34283dd8054219fcb29294ba1c25d68ba8c8c8a6ae53c62c45/av-16.1.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:ce2a1b3d8bf619f6c47a9f28cfa7518ff75ddd516c234a4ee351037b05e6a587", size = 26916715 },
+    { url = "https://files.pythonhosted.org/packages/d2/c4/0b49cf730d0ae8cda925402f18ae814aef351f5772d14da72dd87ff66448/av-16.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:408dbe6a2573ca58a855eb8cd854112b33ea598651902c36709f5f84c991ed8e", size = 21452167 },
+    { url = "https://files.pythonhosted.org/packages/51/23/408806503e8d5d840975aad5699b153aaa21eb6de41ade75248a79b7a37f/av-16.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:57f657f86652a160a8a01887aaab82282f9e629abf94c780bbdbb01595d6f0f7", size = 39215659 },
+    { url = "https://files.pythonhosted.org/packages/c4/19/a8528d5bba592b3903f44c28dab9cc653c95fcf7393f382d2751a1d1523e/av-16.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:adbad2b355c2ee4552cac59762809d791bda90586d134a33c6f13727fb86cb3a", size = 40874970 },
+    { url = "https://files.pythonhosted.org/packages/e8/24/2dbcdf0e929ad56b7df078e514e7bd4ca0d45cba798aff3c8caac097d2f7/av-16.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f42e1a68ec2aebd21f7eb6895be69efa6aa27eec1670536876399725bbda4b99", size = 40530345 },
+    { url = "https://files.pythonhosted.org/packages/54/27/ae91b41207f34e99602d1c72ab6ffd9c51d7c67e3fbcd4e3a6c0e54f882c/av-16.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58fe47aeaef0f100c40ec8a5de9abbd37f118d3ca03829a1009cf288e9aef67c", size = 41972163 },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/22158fb923b2a9a00dfab0e96ef2e8a1763a94dd89e666a5858412383d46/av-16.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:565093ebc93b2f4b76782589564869dadfa83af5b852edebedd8fee746457d06", size = 31729230 },
+    { url = "https://files.pythonhosted.org/packages/7f/f1/878f8687d801d6c4565d57ebec08449c46f75126ebca8e0fed6986599627/av-16.1.0-cp313-cp313t-macosx_11_0_x86_64.whl", hash = "sha256:574081a24edb98343fd9f473e21ae155bf61443d4ec9d7708987fa597d6b04b2", size = 27008769 },
+    { url = "https://files.pythonhosted.org/packages/30/f1/bd4ce8c8b5cbf1d43e27048e436cbc9de628d48ede088a1d0a993768eb86/av-16.1.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:9ab00ea29c25ebf2ea1d1e928d7babb3532d562481c5d96c0829212b70756ad0", size = 21590588 },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/c81f6f9209201ff0b5d5bed6da6c6e641eef52d8fbc930d738c3f4f6f75d/av-16.1.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a84a91188c1071f238a9523fd42dbe567fb2e2607b22b779851b2ce0eac1b560", size = 40638029 },
+    { url = "https://files.pythonhosted.org/packages/15/4d/07edff82b78d0459a6e807e01cd280d3180ce832efc1543de80d77676722/av-16.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c2cd0de4dd022a7225ff224fde8e7971496d700be41c50adaaa26c07bb50bf97", size = 41970776 },
+    { url = "https://files.pythonhosted.org/packages/da/9d/1f48b354b82fa135d388477cd1b11b81bdd4384bd6a42a60808e2ec2d66b/av-16.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0816143530624a5a93bc5494f8c6eeaf77549b9366709c2ac8566c1e9bff6df5", size = 41764751 },
+    { url = "https://files.pythonhosted.org/packages/2f/c7/a509801e98db35ec552dd79da7bdbcff7104044bfeb4c7d196c1ce121593/av-16.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e3a28053af29644696d0c007e897d19b1197585834660a54773e12a40b16974c", size = 43034355 },
+    { url = "https://files.pythonhosted.org/packages/36/8b/e5f530d9e8f640da5f5c5f681a424c65f9dd171c871cd255d8a861785a6e/av-16.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e3e67144a202b95ed299d165232533989390a9ea3119d37eccec697dc6dbb0c", size = 31947047 },
 ]
 
 [[package]]
@@ -804,6 +841,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "aiortc" },
     { name = "beautifulsoup4" },
     { name = "croniter" },
     { name = "edge-tts" },
@@ -839,6 +877,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
+    { name = "aiortc", specifier = ">=1.14.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "edge-tts", specifier = ">=7.2.3" },
@@ -1248,6 +1287,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297 },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867 },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344 },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694 },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435 },
+]
+
+[[package]]
 name = "google-genai"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1493,6 +1545,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008 },
+]
+
+[[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314 },
 ]
 
 [[package]]
@@ -3065,6 +3126,28 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pylibsrtp"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a6/6e532bec974aaecbf9fe4e12538489fb1c28456e65088a50f305aeab9f89/pylibsrtp-1.0.0.tar.gz", hash = "sha256:b39dff075b263a8ded5377f2490c60d2af452c9f06c4d061c7a2b640612b34d4", size = 10858 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/af/89e61a62fa3567f1b7883feb4d19e19564066c2fcd41c37e08d317b51881/pylibsrtp-1.0.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:822c30ea9e759b333dc1f56ceac778707c51546e97eb874de98d7d378c000122", size = 1865017 },
+    { url = "https://files.pythonhosted.org/packages/8d/0e/8d215484a9877adcf2459a8b28165fc89668b034565277fd55d666edd247/pylibsrtp-1.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:aaad74e5c8cbc1c32056c3767fea494c1e62b3aea2c908eda2a1051389fdad76", size = 2182739 },
+    { url = "https://files.pythonhosted.org/packages/57/3f/76a841978877ae13eac0d4af412c13bbd5d83b3df2c1f5f2175f2e0f68e5/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9209b86e662ebbd17c8a9e8549ba57eca92a3e87fb5ba8c0e27b8c43cd08a767", size = 2732922 },
+    { url = "https://files.pythonhosted.org/packages/0e/14/cf5d2a98a66fdfe258f6b036cda570f704a644fa861d7883a34bc359501e/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:293c9f2ac21a2bd689c477603a1aa235d85cf252160e6715f0101e42a43cbedc", size = 2434534 },
+    { url = "https://files.pythonhosted.org/packages/bd/08/a3f6e86c04562f7dce6717cd2206a0f84ca85c5e38121d998e0e330194c3/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:81fb8879c2e522021a7cbd3f4bda1b37c192e1af939dfda3ff95b4723b329663", size = 2345818 },
+    { url = "https://files.pythonhosted.org/packages/8e/d5/130c2b5b4b51df5631684069c6f0a6761c59d096a33d21503ac207cf0e47/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ddb562e443cf2e557ea2dfaeef0d7e6b90e96dd38eb079b4ab2c8e34a79f50b", size = 2774490 },
+    { url = "https://files.pythonhosted.org/packages/91/e3/715a453bfee3bea92a243888ad359094a7727cc6d393f21281320fe7798c/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:f02e616c9dfab2b03b32d8cc7b748f9d91814c0211086f987629a60f05f6e2cc", size = 2372603 },
+    { url = "https://files.pythonhosted.org/packages/e3/56/52fa74294254e1f53a4ff170ee2006e57886cf4bb3db46a02b4f09e1d99f/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c134fa09e7b80a5b7fed626230c5bc257fd771bd6978e754343e7a61d96bc7e6", size = 2451269 },
+    { url = "https://files.pythonhosted.org/packages/1e/51/2e9b34f484cbdd3bac999bf1f48b696d7389433e900639089e8fc4e0da0d/pylibsrtp-1.0.0-cp310-abi3-win32.whl", hash = "sha256:bae377c3b402b17b9bbfbfe2534c2edba17aa13bea4c64ce440caacbe0858b55", size = 1247503 },
+    { url = "https://files.pythonhosted.org/packages/c3/70/43db21af194580aba2d9a6d4c7bd8c1a6e887fa52cd810b88f89096ecad2/pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:8d6527c4a78a39a8d397f8862a8b7cdad4701ee866faf9de4ab8c70be61fd34d", size = 1601659 },
+    { url = "https://files.pythonhosted.org/packages/8e/ec/6e02b2561d056ea5b33046e3cad21238e6a9097b97d6ccc0fbe52b50c858/pylibsrtp-1.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:2696bdb2180d53ac55d0eb7b58048a2aa30cd4836dd2ca683669889137a94d2a", size = 1159246 },
 ]
 
 [[package]]

--- a/docs/VOICE_WEBRTC_TESTING.md
+++ b/docs/VOICE_WEBRTC_TESTING.md
@@ -1,0 +1,78 @@
+# Voice WebRTC — manual test guide
+
+The hands-free voice path now runs **audio over WebRTC** (mic + TTS on an
+`RTCPeerConnection`) instead of WebSocket + Web Audio. This is the fix for the
+**iOS Safari echo/feedback loop**: Safari only runs acoustic echo cancellation
+(AEC) for audio played through a WebRTC `<audio>` track, never for Web Audio API
+playback. Control/STT/barge-in events still ride `/ws/voice`.
+
+Automated coverage (all green, headless):
+- backend bridge loopback — `backend/tests/test_services/test_webrtc_voice.py`
+- signalling over the WS handler — `test_ws_voice.py::test_webrtc_offer_is_answered_over_ws`
+- barge-in SSoT — `test_ws_voice.py` (onset / playback-tail / playback_done)
+- frontend negotiation — `frontend/tests/e2e/flows/voice-webrtc.spec.ts`
+
+What automation **cannot** check (needs a real device): audio fidelity and
+whether the browser AEC actually cancels the echo. That's this guide.
+
+---
+
+## 1. Test on **Mac Chrome / localhost first** (no deploy needed)
+
+localhost is a secure context, so WebRTC works fully. This validates ~95% of the
+path before you ever touch prod.
+
+```bash
+./dev.sh            # http://localhost:3000
+```
+
+1. Open `http://localhost:3000` in Chrome, log in.
+2. Open DevTools → Console.
+3. Click the **hands-free mic** in the VoiceBar (top of chat). Allow the mic.
+4. **Confirm WebRTC is in use** — in Console you should see:
+   - `[voice] webrtc connectionState connecting` → `... connected`
+   - no per-chunk audio logs (TTS now plays via the media track).
+   - Network tab: the `/ws/voice` socket carries JSON only (a `webrtc_offer`
+     out, a `webrtc_answer` back), **no binary audio frames**.
+5. Say something → the agent should reply **out loud**.
+6. **Barge-in:** while the bot is talking, start speaking. The TTS must stop
+   **immediately** (not after you finish your sentence).
+
+✅ If all of the above work on Chrome localhost, the plumbing is correct.
+
+**A/B compare with the old path:** in Console run
+`localStorage.voice_transport = 'ws'` then re-toggle the mic to force the legacy
+WS audio path (`delete localStorage.voice_transport` to go back to WebRTC).
+
+## 2. Test on **iPhone Safari** (needs HTTPS → prod)
+
+iPhone can't use the Mac's localhost, and getUserMedia needs HTTPS — so deploy,
+then open the prod URL in Safari on the iPhone.
+
+1. Open the prod site in **Safari**, log in.
+2. Tap the hands-free mic, allow the mic.
+3. Let the bot speak, then **talk while it's speaking**.
+4. **Expected:** the bot does **not** hear itself — no feedback loop, no
+   self-triggered turns. Barge-in stops the bot when *you* speak.
+
+### If it doesn't connect on prod (no audio at all)
+
+WebRTC media is UDP and needs to traverse NAT. We send a public STUN server by
+default. If the connection never reaches `connected`:
+
+- Ensure the server can send/receive **UDP** (host firewall / security group).
+- Behind a strict/symmetric NAT you may need a **TURN** relay (e.g. coturn).
+  Point the backend at it:
+  ```
+  JARVIS_WEBRTC_ICE="stun:your.stun:3478,turn:user:pass@your.turn:3478"
+  ```
+  (comma-separated; the frontend also needs the matching iceServers — tell me
+  and I'll wire it through.)
+- Quick unblock while debugging: `localStorage.voice_transport = 'ws'` falls back
+  to the old WS audio path (works, but no iOS AEC).
+
+## What to report back
+
+For any issue, the fastest fix comes from: the **Console logs** (esp.
+`[voice] webrtc connectionState ...` and any red errors), whether it's Chrome or
+Safari, and whether audio worked at all vs. only the echo/barge-in was wrong.

--- a/frontend/src/composables/playbackDoneTracker.js
+++ b/frontend/src/composables/playbackDoneTracker.js
@@ -1,0 +1,54 @@
+/**
+ * playbackDoneTracker — decides WHEN the client should tell the server it has
+ * finished playing a TTS turn (the ``playback_done`` control frame).
+ *
+ * Why this exists (barge-in SSoT): the server keeps ``bot_speaking`` True from
+ * ``tts_start`` until the client reports ``playback_done``. That window —
+ * "the user is actually hearing the bot" — is what a barge-in checks against.
+ * The naive signal (server synthesis finished) is wrong: the client buffers
+ * several seconds of audio ahead, so synthesis ends long before the user stops
+ * hearing the bot. Reporting playback_done only when BOTH (a) the server sent
+ * ``tts_end`` (no more chunks coming) and (b) the local playback queue has
+ * drained gives the server an accurate "bot is now silent" edge.
+ *
+ * Pure + side-effect-free except the injected ``send`` callback, so the timing
+ * logic is unit-testable without shimming AudioContext / WebSocket. See
+ * playbackDoneTracker.test.js and the wiring in useVoiceSession.js.
+ *
+ * @param {() => void} send  invoked exactly once per turn when playback_done
+ *                           should be sent (the caller does the actual WS send).
+ */
+export function createPlaybackDoneTracker(send) {
+  let productionEnded = false  // server emitted tts_end (no more chunks)
+  let sent = false             // playback_done already sent this turn
+
+  // Fire once, only when production ended AND nothing is left playing.
+  function maybe(queueSize) {
+    if (sent || !productionEnded || queueSize > 0) return
+    sent = true
+    send()
+  }
+
+  return {
+    /** New TTS turn began (tts_start) — re-arm. */
+    ttsStart() {
+      productionEnded = false
+      sent = false
+    },
+    /** Server finished synthesising (tts_end). Fires now if already drained. */
+    ttsEnd(queueSize) {
+      productionEnded = true
+      maybe(queueSize)
+    },
+    /** A buffered chunk finished playing (src.onended). ``queueSize`` is the
+     *  number of chunks STILL scheduled after this one was removed. */
+    chunkEnded(queueSize) {
+      maybe(queueSize)
+    },
+    /** Barge-in flushed the queue — the server already lowered bot_speaking on
+     *  the cancel, so suppress the drain-triggered playback_done. */
+    flush() {
+      sent = true
+    },
+  }
+}

--- a/frontend/src/composables/playbackDoneTracker.test.js
+++ b/frontend/src/composables/playbackDoneTracker.test.js
@@ -1,0 +1,88 @@
+/**
+ * playbackDoneTracker — barge-in SSoT timing logic.
+ *
+ * Verifies the client only reports ``playback_done`` (which lets the server
+ * lower ``bot_speaking``) once the user has TRULY stopped hearing the bot:
+ * after tts_end AND the local playback queue drained. Mis-timing here is the
+ * root cause of both the original bug ("TTS keeps playing while I talk" — fires
+ * too late / never) and a potential regression (firing during the tail would
+ * let a real barge-in be ignored). Pure logic → no AudioContext/WS shims.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createPlaybackDoneTracker } from './playbackDoneTracker.js'
+
+function make() {
+  let sends = 0
+  const t = createPlaybackDoneTracker(() => { sends++ })
+  return { t, sends: () => sends }
+}
+
+test('does NOT fire while chunks are still playing (production not ended)', () => {
+  const { t, sends } = make()
+  t.ttsStart()
+  t.chunkEnded(2)            // a chunk ended but 2 still queued, no tts_end yet
+  t.chunkEnded(0)            // queue empty BUT production hasn't ended
+  assert.equal(sends(), 0)  // more chunks may still arrive — must not fire
+})
+
+test('fires once after tts_end AND queue drains', () => {
+  const { t, sends } = make()
+  t.ttsStart()
+  t.ttsEnd(3)               // server done, but 3 chunks still buffered
+  assert.equal(sends(), 0)
+  t.chunkEnded(2)
+  t.chunkEnded(1)
+  assert.equal(sends(), 0)  // still hearing the bot
+  t.chunkEnded(0)           // last chunk done → user stopped hearing bot
+  assert.equal(sends(), 1)
+})
+
+test('idempotent — never sends twice for one turn', () => {
+  const { t, sends } = make()
+  t.ttsStart()
+  t.ttsEnd(1)
+  t.chunkEnded(0)           // fires
+  t.chunkEnded(0)           // late/duplicate onended — ignored
+  t.ttsEnd(0)               // duplicate tts_end — ignored
+  assert.equal(sends(), 1)
+})
+
+test('short reply: queue already drained before tts_end → fires on tts_end', () => {
+  const { t, sends } = make()
+  t.ttsStart()
+  t.chunkEnded(0)           // the only chunk finished before tts_end landed
+  assert.equal(sends(), 0)  // production not ended yet
+  t.ttsEnd(0)               // now production ends with empty queue → fire
+  assert.equal(sends(), 1)
+})
+
+test('flush (barge-in) suppresses playback_done for the interrupted turn', () => {
+  const { t, sends } = make()
+  t.ttsStart()
+  t.ttsEnd(2)
+  t.flush()                 // user barged in; server already lowered bot_speaking
+  t.chunkEnded(0)           // stop()-triggered onended must NOT send
+  assert.equal(sends(), 0)
+})
+
+test('new turn re-arms after a completed turn', () => {
+  const { t, sends } = make()
+  // Turn 1
+  t.ttsStart(); t.ttsEnd(0)
+  assert.equal(sends(), 1)
+  // Turn 2 — must be able to fire again
+  t.ttsStart(); t.ttsEnd(1)
+  t.chunkEnded(0)
+  assert.equal(sends(), 2)
+})
+
+test('new turn re-arms after a flushed (barged-in) turn', () => {
+  const { t, sends } = make()
+  t.ttsStart(); t.ttsEnd(1); t.flush()
+  assert.equal(sends(), 0)
+  // Next reply must still report playback_done.
+  t.ttsStart(); t.ttsEnd(0)
+  assert.equal(sends(), 1)
+})

--- a/frontend/src/composables/useVoiceSession.js
+++ b/frontend/src/composables/useVoiceSession.js
@@ -107,6 +107,16 @@ function _createVoiceSession() {
   // "TTS doesn't stop when user barges in" bug).
   const playbackSources = new Set()
 
+  // WebRTC audio transport (preferred). Routing mic + TTS over an
+  // RTCPeerConnection lets the browser's AEC scrub the bot's voice out of the
+  // mic — the only reliable fix for the iOS Safari echo/feedback loop (Web Audio
+  // API playback bypasses AEC on Safari; a WebRTC <audio> track does not). When
+  // active, the WS audio paths (worklet mic-send + _enqueueAudio) are bypassed;
+  // we fall back to them only if RTCPeerConnection is unavailable.
+  const pc = shallowRef(null)
+  const remoteAudioEl = shallowRef(null)
+  let webrtcMode = false
+
   function _ensureActiveConversation() {
     if (chatStore.activeConversation) return
     // First voice turn with no chat session active — create a local conv.
@@ -320,6 +330,22 @@ function _createVoiceSession() {
           // turn boundary signal we already handle above.
           break
         case 'wake_word': wakeWordHits.value++; break
+        case 'webrtc_answer':
+          // Server accepted the WebRTC offer — complete the handshake; the
+          // connection forms once ICE finishes and audio starts flowing on the
+          // media track (mic out, TTS in).
+          if (pc.value && msg.sdp) {
+            pc.value
+              .setRemoteDescription({ type: msg.sdp_type || 'answer', sdp: msg.sdp })
+              .catch((e) => console.warn('[voice] setRemoteDescription failed', e))
+          }
+          break
+        case 'webrtc_error':
+          // Server couldn't set up WebRTC. We've already sent {type:start};
+          // surface it — audio won't flow, the user can re-toggle. (Rare; mostly
+          // a server misconfig.)
+          console.warn('[voice] server webrtc_error', msg.detail)
+          break
         case 'tts_start':
           status.value = 'speaking'
           wasInterrupted.value = false
@@ -382,9 +408,10 @@ function _createVoiceSession() {
           status.value = 'error'
           break
       }
-    } else if (ev.data instanceof Blob) {
+    } else if (!webrtcMode && ev.data instanceof Blob) {
+      // WS audio path only — in WebRTC mode TTS arrives on the media track.
       _enqueueAudio(ev.data)
-    } else if (ev.data instanceof ArrayBuffer) {
+    } else if (!webrtcMode && ev.data instanceof ArrayBuffer) {
       _enqueueAudio(new Blob([ev.data]))
     }
   }
@@ -435,6 +462,73 @@ function _createVoiceSession() {
     } catch (e) {
       console.warn('[voice] audio enqueue failed', e)
     }
+  }
+
+  const _webrtcSupported = () =>
+    typeof RTCPeerConnection !== 'undefined' && typeof MediaStream !== 'undefined'
+
+  // Wait for ICE gathering to finish (non-trickle) so the offer SDP carries all
+  // candidates — simplest signalling over our WS. Cap the wait so a browser that
+  // never reports 'complete' still sends the offer with whatever it gathered.
+  function _iceGatheringComplete(peer, timeoutMs = 2500) {
+    if (peer.iceGatheringState === 'complete') return Promise.resolve()
+    return new Promise((resolve) => {
+      const done = () => { peer.removeEventListener('icegatheringstatechange', check); resolve() }
+      const check = () => { if (peer.iceGatheringState === 'complete') done() }
+      peer.addEventListener('icegatheringstatechange', check)
+      setTimeout(done, timeoutMs)
+    })
+  }
+
+  /**
+   * Negotiate WebRTC audio over the already-open WS. Mic goes out as a track;
+   * the bot's TTS comes back as a track we play through a hidden <audio
+   * playsinline> — which is what engages the browser AEC (incl. iOS Safari).
+   * On any failure we leave webrtcMode false so start() uses the WS audio path.
+   */
+  async function _startWebRtc(sock, ms) {
+    const peer = new RTCPeerConnection({
+      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+    })
+    pc.value = peer
+
+    const audioEl = document.createElement('audio')
+    audioEl.autoplay = true
+    audioEl.setAttribute('playsinline', '')   // iOS: play inline, not fullscreen
+    audioEl.style.display = 'none'
+    document.body.appendChild(audioEl)
+    remoteAudioEl.value = audioEl
+    peer.addEventListener('track', (ev) => {
+      audioEl.srcObject = ev.streams[0] || new MediaStream([ev.track])
+      // play() may reject if autoplay is gated; the mic click is a user gesture
+      // so it normally succeeds — swallow the rejection either way.
+      audioEl.play?.().catch(() => {})
+    })
+    peer.addEventListener('connectionstatechange', () => {
+      console.debug('[voice] webrtc connectionState', peer.connectionState)
+    })
+
+    for (const track of ms.getAudioTracks()) peer.addTrack(track, ms)
+
+    await peer.setLocalDescription(await peer.createOffer())
+    await _iceGatheringComplete(peer)
+    sock.send(JSON.stringify({
+      type: 'webrtc_offer',
+      sdp: peer.localDescription.sdp,
+      sdp_type: peer.localDescription.type,
+    }))
+    webrtcMode = true
+  }
+
+  function _teardownWebRtc() {
+    webrtcMode = false
+    try { pc.value?.close() } catch {}
+    pc.value = null
+    const el = remoteAudioEl.value
+    if (el) {
+      try { el.srcObject = null; el.remove() } catch {}
+    }
+    remoteAudioEl.value = null
   }
 
   function _wsUrl() {
@@ -529,24 +623,44 @@ function _createVoiceSession() {
         console.warn('[voice diag] track inspect failed', e)
       }
 
-      const ac = new (window.AudioContext || window.webkitAudioContext)()
-      console.log('[voice diag] AudioContext sampleRate', ac.sampleRate)
-      try {
-        sock.send(JSON.stringify({
-          type: 'diag',
-          stage: 'audio_context',
-          sampleRate: ac.sampleRate,
-        }))
-      } catch (e) { /* noop */ }
-      audioContext.value = ac
-      await ac.audioWorklet.addModule('/voice-worklet.js')
-      const node = new AudioWorkletNode(ac, 'pcm16-resampler', { processorOptions: { targetRate: 16000, frameMs: 100 } })
-      workletNode.value = node
-      const micSource = ac.createMediaStreamSource(ms)
-      micSource.connect(node)
-      // Don't connect to destination — we don't want the user to hear themselves.
-      node.port.onmessage = (e) => {
-        if (sock.readyState === 1) sock.send(e.data)
+      // Escape hatch for debugging / A-B testing: set
+      // localStorage.voice_transport = 'ws' to force the legacy WS audio path.
+      let _forceWs = false
+      try { _forceWs = localStorage.getItem('voice_transport') === 'ws' } catch { /* ignore */ }
+      if (_webrtcSupported() && !_forceWs) {
+        // Preferred: audio over WebRTC so the browser AEC kills the echo (iOS).
+        // Mic + TTS ride the RTCPeerConnection; the WS carries only control.
+        try {
+          await _startWebRtc(sock, ms)
+        } catch (e) {
+          // Negotiation set-up failed before it even started — fall back to the
+          // WS audio path so voice still works (minus the iOS AEC benefit).
+          console.warn('[voice] WebRTC setup failed, falling back to WS audio', e)
+          _teardownWebRtc()
+        }
+      }
+      if (!webrtcMode) {
+        // Legacy WS audio path: capture mic via an AudioWorklet, stream 16 kHz
+        // PCM frames over the WS; TTS arrives as binary frames (_enqueueAudio).
+        const ac = new (window.AudioContext || window.webkitAudioContext)()
+        console.log('[voice diag] AudioContext sampleRate', ac.sampleRate)
+        try {
+          sock.send(JSON.stringify({
+            type: 'diag',
+            stage: 'audio_context',
+            sampleRate: ac.sampleRate,
+          }))
+        } catch (e) { /* noop */ }
+        audioContext.value = ac
+        await ac.audioWorklet.addModule('/voice-worklet.js')
+        const node = new AudioWorkletNode(ac, 'pcm16-resampler', { processorOptions: { targetRate: 16000, frameMs: 100 } })
+        workletNode.value = node
+        const micSource = ac.createMediaStreamSource(ms)
+        micSource.connect(node)
+        // Don't connect to destination — we don't want the user to hear themselves.
+        node.port.onmessage = (e) => {
+          if (sock.readyState === 1) sock.send(e.data)
+        }
       }
       sock.send(JSON.stringify({ type: 'start' }))
       // Tell the server which agent + conversation the dashboard has
@@ -596,6 +710,7 @@ function _createVoiceSession() {
     }
     workletNode.value?.disconnect()
     workletNode.value = null
+    _teardownWebRtc()
     if (stream.value) {
       stream.value.getTracks().forEach(t => t.stop())
       stream.value = null

--- a/frontend/src/composables/useVoiceSession.js
+++ b/frontend/src/composables/useVoiceSession.js
@@ -24,6 +24,7 @@ import { useChatStore } from '../stores/chat.js'
 import { useAudioPlayerStore } from '../stores/audioPlayer.js'
 import { EVENTS, on } from '../auth/bus.js'
 import { expandToolRequest, expandToolDone } from '../utils/toolEvents.js'
+import { createPlaybackDoneTracker } from './playbackDoneTracker.js'
 
 const PCM_PLAYBACK_RATE = 24000  // RealtimeTTS engines emit 24 kHz mono
 
@@ -82,6 +83,16 @@ function _createVoiceSession() {
   // bug). Reset on each successful ``start()``.
   let torn = false
 
+  // Barge-in SSoT: the server keeps ``bot_speaking`` True until WE report that
+  // the buffered TTS audio has finished playing. The tracker decides when —
+  // after tts_end AND the playback queue drains — and we do the actual WS send.
+  // (Timing logic lives in playbackDoneTracker.js so it's unit-testable.)
+  const playbackTracker = createPlaybackDoneTracker(() => {
+    if (ws.value?.readyState === 1) {
+      ws.value.send(JSON.stringify({ type: 'playback_done' }))
+    }
+  })
+
   const ws = shallowRef(null)
   const stream = shallowRef(null)
   const audioContext = shallowRef(null)
@@ -128,6 +139,10 @@ function _createVoiceSession() {
   }
 
   function _flushPlaybackQueue() {
+    // A barge-in already told the server to stop (it lowers bot_speaking on
+    // the cancel), so suppress the drain-triggered playback_done that the
+    // src.stop() ``onended`` callbacks below would otherwise fire.
+    playbackTracker.flush()
     for (const src of playbackSources) {
       try { src.stop() } catch {}
     }
@@ -305,8 +320,16 @@ function _createVoiceSession() {
           // turn boundary signal we already handle above.
           break
         case 'wake_word': wakeWordHits.value++; break
-        case 'tts_start': status.value = 'speaking'; wasInterrupted.value = false; break
+        case 'tts_start':
+          status.value = 'speaking'
+          wasInterrupted.value = false
+          playbackTracker.ttsStart()   // re-arm playback_done for this turn
+          break
         case 'tts_end':
+          // Server finished synthesising. Playback usually continues a few more
+          // seconds; the tracker fires playback_done once the queue drains (or
+          // right now if a very short reply already drained before tts_end).
+          playbackTracker.ttsEnd(playbackSources.size)
           status.value = ws.value?.readyState === 1 ? 'listening' : 'idle'
           break
         case 'barge_in_ack':
@@ -402,7 +425,12 @@ function _createVoiceSession() {
       // Track for barge-in flush; auto-untrack when the chunk finishes
       // playing on its own to keep the set bounded.
       playbackSources.add(src)
-      src.onended = () => playbackSources.delete(src)
+      src.onended = () => {
+        playbackSources.delete(src)
+        // When the LAST buffered chunk finishes (and the server already sent
+        // tts_end), the user has stopped hearing the bot → report playback_done.
+        playbackTracker.chunkEnded(playbackSources.size)
+      }
       playbackTime.value = startAt + audioBuffer.duration
     } catch (e) {
       console.warn('[voice] audio enqueue failed', e)

--- a/frontend/src/composables/useVoiceSession.js
+++ b/frontend/src/composables/useVoiceSession.js
@@ -346,17 +346,27 @@ function _createVoiceSession() {
           console.warn('[voice] server webrtc_error', msg.detail)
           error.value = `Voice transport failed on the server: ${msg.detail || 'unknown error'}`
           status.value = 'error'
+          _teardownWebRtc()   // drop the half-open PC + hidden <audio>
           break
         case 'tts_start':
           status.value = 'speaking'
           wasInterrupted.value = false
-          playbackTracker.ttsStart()   // re-arm playback_done for this turn
+          // WS path only: re-arm playback_done tracking. In WebRTC mode the
+          // server owns the drain edge (see tts_end), so the tracker is unused.
+          if (!webrtcMode) playbackTracker.ttsStart()
           break
         case 'tts_end':
-          // Server finished synthesising. Playback usually continues a few more
-          // seconds; the tracker fires playback_done once the queue drains (or
-          // right now if a very short reply already drained before tts_end).
-          playbackTracker.ttsEnd(playbackSources.size)
+          // WS path: playback continues a few seconds; the tracker fires
+          // playback_done once the queue drains.
+          //
+          // WebRTC path: the client has NO local audio buffer (TTS plays on the
+          // media track), so playbackSources is always empty here — calling the
+          // tracker would fire playback_done *immediately*, clearing the server's
+          // bot_speaking while its real-time track is still playing, which kills
+          // onset barge-in during the tail (the exact bug this work fixes). The
+          // server's wait_drained() is the SSoT for "done playing" in WebRTC
+          // mode, so the client must NOT send playback_done.
+          if (!webrtcMode) playbackTracker.ttsEnd(playbackSources.size)
           status.value = ws.value?.readyState === 1 ? 'listening' : 'idle'
           break
         case 'barge_in_ack':
@@ -474,10 +484,15 @@ function _createVoiceSession() {
   function _iceGatheringComplete(peer, timeoutMs = 2500) {
     if (peer.iceGatheringState === 'complete') return Promise.resolve()
     return new Promise((resolve) => {
-      const done = () => { peer.removeEventListener('icegatheringstatechange', check); resolve() }
+      let timer = null
+      const done = () => {
+        if (timer) { clearTimeout(timer); timer = null }
+        peer.removeEventListener('icegatheringstatechange', check)
+        resolve()
+      }
       const check = () => { if (peer.iceGatheringState === 'complete') done() }
       peer.addEventListener('icegatheringstatechange', check)
-      setTimeout(done, timeoutMs)
+      timer = setTimeout(done, timeoutMs)
     })
   }
 
@@ -487,10 +502,21 @@ function _createVoiceSession() {
    * playsinline> — which is what engages the browser AEC (incl. iOS Safari).
    * On any failure we leave webrtcMode false so start() uses the WS audio path.
    */
+  async function _iceServers() {
+    // Sourced from the backend (JARVIS_WEBRTC_ICE) so adding a TURN server for
+    // prod/iPhone is an env change, not a code change. Fall back to public STUN.
+    try {
+      const res = await fetch('/api/voice/ice', { credentials: 'same-origin' })
+      if (res.ok) {
+        const data = await res.json()
+        if (Array.isArray(data?.iceServers) && data.iceServers.length) return data.iceServers
+      }
+    } catch { /* fall through to default */ }
+    return [{ urls: 'stun:stun.l.google.com:19302' }]
+  }
+
   async function _startWebRtc(sock, ms) {
-    const peer = new RTCPeerConnection({
-      iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
-    })
+    const peer = new RTCPeerConnection({ iceServers: await _iceServers() })
     pc.value = peer
 
     const audioEl = document.createElement('audio')
@@ -514,6 +540,7 @@ function _createVoiceSession() {
       if (st === 'failed') {
         error.value = 'Voice connection failed — WebRTC could not connect (NAT/firewall?).'
         status.value = 'error'
+        _teardownWebRtc()   // drop the dead PC + hidden <audio> now, not next toggle
       }
     })
 

--- a/frontend/src/composables/useVoiceSession.js
+++ b/frontend/src/composables/useVoiceSession.js
@@ -341,10 +341,11 @@ function _createVoiceSession() {
           }
           break
         case 'webrtc_error':
-          // Server couldn't set up WebRTC. We've already sent {type:start};
-          // surface it — audio won't flow, the user can re-toggle. (Rare; mostly
-          // a server misconfig.)
+          // Server couldn't set up WebRTC — fail loud, no fallback. The user
+          // can re-toggle the mic; this is usually a server-side misconfig.
           console.warn('[voice] server webrtc_error', msg.detail)
+          error.value = `Voice transport failed on the server: ${msg.detail || 'unknown error'}`
+          status.value = 'error'
           break
         case 'tts_start':
           status.value = 'speaking'
@@ -505,7 +506,15 @@ function _createVoiceSession() {
       audioEl.play?.().catch(() => {})
     })
     peer.addEventListener('connectionstatechange', () => {
-      console.debug('[voice] webrtc connectionState', peer.connectionState)
+      const st = peer.connectionState
+      console.debug('[voice] webrtc connectionState', st)
+      // Fail loud: if the peer connection can't form (ICE/DTLS failed), surface
+      // it rather than sitting silently with no audio. No fallback — the user
+      // re-toggles, or sets a TURN server (see docs/VOICE_WEBRTC_TESTING.md).
+      if (st === 'failed') {
+        error.value = 'Voice connection failed — WebRTC could not connect (NAT/firewall?).'
+        status.value = 'error'
+      }
     })
 
     for (const track of ms.getAudioTracks()) peer.addTrack(track, ms)
@@ -623,33 +632,21 @@ function _createVoiceSession() {
         console.warn('[voice diag] track inspect failed', e)
       }
 
-      // Escape hatch for debugging / A-B testing: set
-      // localStorage.voice_transport = 'ws' to force the legacy WS audio path.
+      // Audio transport. WebRTC is REQUIRED — it's the only path with browser
+      // AEC (the iOS echo fix). We do NOT silently fall back to the WS audio
+      // path on failure: a broken transport must surface loudly, not degrade to
+      // the echo-prone path behind the user's back. The legacy WS path is only
+      // reachable by an EXPLICIT opt-in (localStorage.voice_transport='ws') for
+      // debugging / A-B testing — a deliberate choice, not a fallback.
       let _forceWs = false
       try { _forceWs = localStorage.getItem('voice_transport') === 'ws' } catch { /* ignore */ }
-      if (_webrtcSupported() && !_forceWs) {
-        // Preferred: audio over WebRTC so the browser AEC kills the echo (iOS).
-        // Mic + TTS ride the RTCPeerConnection; the WS carries only control.
-        try {
-          await _startWebRtc(sock, ms)
-        } catch (e) {
-          // Negotiation set-up failed before it even started — fall back to the
-          // WS audio path so voice still works (minus the iOS AEC benefit).
-          console.warn('[voice] WebRTC setup failed, falling back to WS audio', e)
-          _teardownWebRtc()
-        }
-      }
-      if (!webrtcMode) {
-        // Legacy WS audio path: capture mic via an AudioWorklet, stream 16 kHz
-        // PCM frames over the WS; TTS arrives as binary frames (_enqueueAudio).
+      if (_forceWs) {
+        // Explicit WS audio path: AudioWorklet captures mic → 16 kHz PCM over
+        // the WS; TTS arrives as binary frames (_enqueueAudio).
         const ac = new (window.AudioContext || window.webkitAudioContext)()
         console.log('[voice diag] AudioContext sampleRate', ac.sampleRate)
         try {
-          sock.send(JSON.stringify({
-            type: 'diag',
-            stage: 'audio_context',
-            sampleRate: ac.sampleRate,
-          }))
+          sock.send(JSON.stringify({ type: 'diag', stage: 'audio_context', sampleRate: ac.sampleRate }))
         } catch (e) { /* noop */ }
         audioContext.value = ac
         await ac.audioWorklet.addModule('/voice-worklet.js')
@@ -661,6 +658,13 @@ function _createVoiceSession() {
         node.port.onmessage = (e) => {
           if (sock.readyState === 1) sock.send(e.data)
         }
+      } else {
+        if (!_webrtcSupported()) {
+          // Fail loud rather than degrade — every target browser supports WebRTC.
+          throw new Error('This browser does not support WebRTC, which voice mode requires.')
+        }
+        // Throws on setup failure → caught by start()'s handler → status 'error'.
+        await _startWebRtc(sock, ms)
       }
       sock.send(JSON.stringify({ type: 'start' }))
       // Tell the server which agent + conversation the dashboard has

--- a/frontend/tests/e2e/flows/voice-barge-in.spec.ts
+++ b/frontend/tests/e2e/flows/voice-barge-in.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * E2E flow: hands-free VoiceBar barge-in + playback_done SSoT.
+ *
+ * Guards the production contract behind the "TTS stops the instant I talk"
+ * fix (cross-references backend/tests/test_routes/test_ws_voice.py and the unit
+ * suite src/composables/playbackDoneTracker.test.js):
+ *
+ *   1. Click the VoiceBar mic → useVoiceSession.start() opens /ws/voice and
+ *      sends {type:'start'}. We ack with stt_ready → status 'listening'.
+ *   2. Server speaks: tts_start → PCM chunk(s) → tts_end. Once the client's
+ *      playback queue drains, the client MUST send {type:'playback_done'} so
+ *      the server can lower bot_speaking. This is the SSoT the barge-in checks.
+ *   3. Barge-in: while audio is queued, the server sends tts_interruption. The
+ *      client flushes its playback queue (status → 'listening') and must NOT
+ *      send playback_done for that interrupted turn.
+ *
+ * Why we stub audio HW (not the barge-in logic): the real path needs a mic +
+ * AudioContext we don't have in CI. getUserMedia + AudioContext + AudioWorklet
+ * are stubbed to no-op, and the fake BufferSource fires ``onended`` on the next
+ * macrotask so the REAL drain → playback_done logic runs deterministically.
+ * The barge-in/playback logic itself is production code, unmocked.
+ */
+
+import type { Page, WebSocketRoute } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+/**
+ * Stub mic capture AND TTS playback. Extends the dictation spec's stub with
+ * the playback half (createBuffer/createBufferSource/destination). The fake
+ * BufferSource fires ``onended`` asynchronously on both start() and stop() so
+ * the client's drain detection (and barge-in flush) exercise their real paths.
+ */
+async function stubVoiceAudio(page: Page) {
+  await page.addInitScript(() => {
+    const fakeTrack = { stop() {}, getSettings: () => ({}), getCapabilities: () => ({}) }
+    const fakeStream = { getAudioTracks: () => [fakeTrack], getTracks: () => [fakeTrack] }
+    Object.defineProperty(window.navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: async () => fakeStream },
+    })
+    class FakeAudioWorklet { async addModule() {} }
+    class FakeBufferSource {
+      buffer: unknown = null
+      onended: (() => void) | null = null
+      connect() {}
+      private _fire() { setTimeout(() => { try { this.onended && this.onended() } catch {} }, 0) }
+      start() { this._fire() }   // chunk "finishes playing" → drain check runs
+      stop() { this._fire() }    // barge-in stop() also ends the source
+    }
+    class FakeAudioContext {
+      audioWorklet = new FakeAudioWorklet()
+      currentTime = 0
+      sampleRate = 48000
+      destination = {}
+      createMediaStreamSource() { return { connect() {} } }
+      createBuffer(_ch: number, len: number, rate: number) {
+        return { duration: len / rate, getChannelData: () => new Float32Array(len) }
+      }
+      createBufferSource() { return new FakeBufferSource() }
+      async close() {}
+    }
+    class FakeAudioWorkletNode { port = { onmessage: null }; connect() {} disconnect() {} }
+    // @ts-expect-error — replacing globals for test
+    window.AudioContext = FakeAudioContext
+    // @ts-expect-error
+    window.webkitAudioContext = FakeAudioContext
+    // @ts-expect-error
+    window.AudioWorkletNode = FakeAudioWorkletNode
+  })
+}
+
+/** A minimal binary PCM frame (4 int16 samples of silence). */
+const PCM_CHUNK = Buffer.alloc(8)
+
+async function openVoiceBar(page: Page) {
+  const inbound: string[] = []
+  let routed: WebSocketRoute | null = null
+  await page.routeWebSocket(/\/ws\/voice$/, (ws) => {
+    routed = ws
+    ws.onMessage((data) => {
+      const s = typeof data === 'string' ? data : '<binary>'
+      inbound.push(s)
+      try {
+        if (JSON.parse(s).type === 'start') ws.send(JSON.stringify({ type: 'stt_ready' }))
+      } catch { /* binary mic frame */ }
+    })
+  })
+
+  await page.goto('/chat')
+  const mic = page.locator('.voice-bar .mic-btn')
+  await expect(mic).toBeVisible()
+  await mic.click()
+  // Handshake + ack → listening.
+  await expect.poll(() => inbound.find((m) => m.includes('"type":"start"'))).toBeTruthy()
+  await expect(page.locator('.status-pill.pill-listening')).toBeVisible()
+
+  return { inbound, ws: () => routed! }
+}
+
+test('TTS turn drains → client sends playback_done (SSoT)', async ({ page }) => {
+  await seedApiKey(page)
+  await stubVoiceAudio(page)
+  await mockBackend(page, [NOISE])
+
+  const { inbound, ws } = await openVoiceBar(page)
+
+  await ws().send(JSON.stringify({ type: 'tts_start' }))
+  await expect(page.locator('.status-pill.pill-speaking')).toBeVisible()
+
+  await ws().send(PCM_CHUNK)                         // one audio chunk
+  await ws().send(JSON.stringify({ type: 'tts_end' })) // production ended
+
+  // Once the (fake) chunk's onended fires and the queue is empty, the client
+  // reports playback_done — the moment the user stops hearing the bot.
+  await expect
+    .poll(() => inbound.some((m) => m.includes('"type":"playback_done"')))
+    .toBe(true)
+})
+
+test('barge-in (tts_interruption) flushes audio and sends NO playback_done', async ({ page }) => {
+  await seedApiKey(page)
+  await stubVoiceAudio(page)
+  await mockBackend(page, [NOISE])
+
+  const { inbound, ws } = await openVoiceBar(page)
+
+  await ws().send(JSON.stringify({ type: 'tts_start' }))
+  await ws().send(PCM_CHUNK)
+  await expect(page.locator('.status-pill.pill-speaking')).toBeVisible()
+
+  // User barged in: server cancelled and tells the client to flush.
+  await ws().send(JSON.stringify({ type: 'tts_interruption', reason: 'user_resumed' }))
+
+  // UI returns to listening (audio flushed), and the interrupted turn must NOT
+  // emit playback_done (flush() suppressed it — server already lowered
+  // bot_speaking on the cancel).
+  await expect(page.locator('.status-pill.pill-listening')).toBeVisible()
+  await page.waitForTimeout(200) // give any stray onended a beat to (not) fire
+  expect(inbound.some((m) => m.includes('"type":"playback_done"'))).toBe(false)
+})

--- a/frontend/tests/e2e/flows/voice-barge-in.spec.ts
+++ b/frontend/tests/e2e/flows/voice-barge-in.spec.ts
@@ -38,6 +38,13 @@ const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
  * the client's drain detection (and barge-in flush) exercise their real paths.
  */
 async function stubVoiceAudio(page: Page) {
+  // These specs exercise the WS audio path (playback_done / barge-in flush),
+  // so opt into it explicitly. WebRTC is the default + required transport now
+  // (no silent fallback); the stubbed mic here isn't a real track, so forcing
+  // WS keeps this suite focused on the WS-path SSoT logic.
+  await page.addInitScript(() => {
+    try { localStorage.setItem('voice_transport', 'ws') } catch { /* ignore */ }
+  })
   await page.addInitScript(() => {
     const fakeTrack = { stop() {}, getSettings: () => ({}), getCapabilities: () => ({}) }
     const fakeStream = { getAudioTracks: () => [fakeTrack], getTracks: () => [fakeTrack] }

--- a/frontend/tests/e2e/flows/voice-webrtc.spec.ts
+++ b/frontend/tests/e2e/flows/voice-webrtc.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * E2E: VoiceBar negotiates WebRTC audio.
+ *
+ * Verifies the frontend half of the iOS-AEC fix: when the mic is toggled, the
+ * client creates an RTCPeerConnection and sends a valid ``webrtc_offer`` over
+ * /ws/voice (a real audio SDP), instead of streaming PCM over the WS. This runs
+ * with Chromium's fake media device so getUserMedia yields a REAL
+ * MediaStreamTrack (the stubbed object used by other specs can't be addTrack'd,
+ * so they exercise the WS fallback instead).
+ *
+ * What this does NOT cover (needs a real device): the media actually flowing and
+ * the browser AEC scrubbing the echo — that's the manual test. Here we prove the
+ * negotiation initiates correctly from production code.
+ */
+
+import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+/**
+ * Hand getUserMedia a REAL (silent) MediaStreamTrack via an AudioContext
+ * MediaStreamDestination. Unlike a plain stub object, a real track can be
+ * ``RTCPeerConnection.addTrack``'d — which is what drives the WebRTC offer.
+ * More reliable than --use-fake-device flags (which didn't take headless here).
+ */
+async function stubRealMicStream(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(window.navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: async () => {
+          const AC = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+          const ac = new AC()
+          const dest = ac.createMediaStreamDestination()
+          return dest.stream
+        },
+      },
+    })
+  })
+}
+
+test('mic toggle → client sends a valid webrtc_offer (audio over WebRTC)', async ({ page }) => {
+  await seedApiKey(page)
+  await stubRealMicStream(page)
+  await mockBackend(page, [NOISE])
+
+  const inbound: string[] = []
+  await page.routeWebSocket(/\/ws\/voice$/, (ws) => {
+    ws.onMessage((data) => {
+      const s = typeof data === 'string' ? data : '<binary>'
+      inbound.push(s)
+      try {
+        if (JSON.parse(s).type === 'start') ws.send(JSON.stringify({ type: 'stt_ready' }))
+      } catch { /* binary */ }
+    })
+  })
+
+  await page.goto('/chat')
+  const mic = page.locator('.voice-bar .mic-btn')
+  await expect(mic).toBeVisible()
+  await mic.click()
+
+  // The negotiation must produce a webrtc_offer with a real audio m-line.
+  await expect
+    .poll(() => inbound.find((m) => m.includes('"type":"webrtc_offer"')), { timeout: 8000 })
+    .toBeTruthy()
+  const offer = JSON.parse(inbound.find((m) => m.includes('"type":"webrtc_offer"'))!)
+  expect(offer.sdp_type).toBe('offer')
+  expect(offer.sdp).toContain('m=audio')
+  expect(offer.sdp).toContain('v=0')
+
+  // And it must NOT stream mic PCM over the WS in WebRTC mode (audio rides the
+  // peer connection). Allow control frames; reject binary.
+  expect(inbound.some((m) => m === '<binary>')).toBe(false)
+})

--- a/frontend/tests/e2e/flows/voice-webrtc.spec.ts
+++ b/frontend/tests/e2e/flows/voice-webrtc.spec.ts
@@ -13,7 +13,7 @@
  * negotiation initiates correctly from production code.
  */
 
-import type { Page } from '@playwright/test'
+import type { Page, WebSocketRoute } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -51,7 +51,9 @@ test('mic toggle → client sends a valid webrtc_offer (audio over WebRTC)', asy
   await mockBackend(page, [NOISE])
 
   const inbound: string[] = []
+  let routed: WebSocketRoute | null = null
   await page.routeWebSocket(/\/ws\/voice$/, (ws) => {
+    routed = ws
     ws.onMessage((data) => {
       const s = typeof data === 'string' ? data : '<binary>'
       inbound.push(s)
@@ -78,4 +80,15 @@ test('mic toggle → client sends a valid webrtc_offer (audio over WebRTC)', asy
   // And it must NOT stream mic PCM over the WS in WebRTC mode (audio rides the
   // peer connection). Allow control frames; reject binary.
   expect(inbound.some((m) => m === '<binary>')).toBe(false)
+
+  // Regression guard for the WebRTC bot_speaking SSoT: in WebRTC mode the SERVER
+  // owns the drain edge (its real-time track pacing), so the client must NOT
+  // send playback_done. If it did, the server would clear bot_speaking at
+  // tts_end — while the track is still playing — and kill onset barge-in during
+  // the tail. Drive a full TTS turn and assert no playback_done is ever sent.
+  expect(routed).not.toBeNull()
+  await routed!.send(JSON.stringify({ type: 'tts_start' }))
+  await routed!.send(JSON.stringify({ type: 'tts_end' }))
+  await page.waitForTimeout(300)
+  expect(inbound.some((m) => m.includes('"type":"playback_done"'))).toBe(false)
 })


### PR DESCRIPTION
## What & why

Fixes two voice problems and lays the proper transport for both:

1. **Barge-in latency (desktop):** TTS kept playing when you talked over it, only stopping once your transcript submitted. Root cause: the server flipped `bot_speaking=False` the instant *synthesis* finished, but the client buffers seconds of audio ahead — so a barge-in during the playback tail was a silent no-op.
2. **iPhone Safari echo/feedback loop:** the bot heard its own TTS and transcribed it as a new turn. Root cause: iOS Safari runs acoustic echo cancellation (AEC) only for audio played through a WebRTC `<audio>` track, never for Web Audio API playback — which the old WS+AudioWorklet path used.

## Approach (phased)

- **Phase 0 — barge-in SSoT:** `bot_speaking` now tracks *real client playback* (until `playback_done`), not synthesis. `_cancel_inflight` flushes even with no active task. Client reports `playback_done` via a unit-tested `playbackDoneTracker`. → instant barge-in on AEC-capable browsers (Chrome).
- **Phase 1 — WebRTC audio transport:** audio (mic + TTS) now runs over an `RTCPeerConnection` so the browser AEC scrubs the bot out of the mic (the iOS fix). Control/STT/barge-in stay on `/ws/voice`. Backend uses `aiortc` (`services/webrtc_voice.py`); TTS plays via a hidden `<audio playsinline>`. STUN for NAT (`JARVIS_WEBRTC_ICE` to add TURN).
- **Fail loud, no silent fallback:** WebRTC is required; failures surface an error. The legacy WS audio path is only reachable by an explicit opt-in (`localStorage.voice_transport='ws'`) for A/B debugging.

`feed_audio` (and therefore **Soniox / faster-whisper / gipformer** STT) is unchanged — it still receives 16 kHz mono s16 regardless of transport. The browser↔server hop is the only thing that moved.

## Tests (all green, headless)

- backend: `test_services` + `test_ws_voice` **806** + voice **18** (aiortc loopback both directions; `webrtc_offer→answer` over the real WS handler; onset / playback-tail / `playback_done` barge-in).
- frontend: unit **153** (incl. `playbackDoneTracker` 7); e2e **4** — `voice-webrtc.spec.ts` (real `webrtc_offer` from production code), `voice-barge-in.spec.ts` (WS-path SSoT ×2), dictation regression.

## ⚠️ Needs manual / on-device validation

Audio fidelity and the actual iOS AEC **cannot** be checked headless. See **`docs/VOICE_WEBRTC_TESTING.md`**:
1. **Mac Chrome / localhost first** (no deploy) — validates ~95%: WebRTC connects, `/ws/voice` carries JSON only, barge-in stops TTS instantly.
2. **iPhone Safari (prod / HTTPS)** — confirms no echo loop. If it can't connect over NAT, open UDP or add a TURN server.

## Commits
- barge-in SSoT (BE) · playback_done tracker + e2e (FE) · WebRTC bridge + loopback · wire WebRTC into the session (BE+FE) · fail-loud (no silent fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
