### PR TITLE
fix(ui): theme-aware delete/code modals + mobile responsive polish

### DIFF
--- a/frontend/src/components/MarkdownRenderer.vue
+++ b/frontend/src/components/MarkdownRenderer.vue
@@ -324,6 +324,11 @@ onMounted(() => {
 
 .md-content pre {
   background: #0A0C12;
+  /* The code window is always dark in BOTH themes, so its text must be a
+     fixed light colour — not var(--text), which is near-black in light
+     theme and rendered untokenised code (lang "text") invisible on the
+     dark window. hljs token colours below already assume a dark bg. */
+  color: #e3e6ef;
   border: 0;
   border-radius: 0;
   padding: 14px 16px;

--- a/frontend/src/components/agent/SkillDeleteModal.vue
+++ b/frontend/src/components/agent/SkillDeleteModal.vue
@@ -69,7 +69,7 @@ function _friendly(err) {
 <template>
   <Teleport to="body">
     <Transition name="sd-modal">
-      <div v-if="visible" class="sd-overlay" @click.self="emit('close')">
+      <div v-if="visible" class="sd-overlay jv" @click.self="emit('close')">
         <div class="sd-card">
           <div class="sd-icon-wrap">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -129,10 +129,15 @@ function _friendly(err) {
   justify-content: center;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  font-family: var(--font-body);
+  color: var(--text);
 }
 .sd-card {
-  background: #0c0e15;
-  border: 1px solid #1a1d2e;
+  /* Theme tokens, not hardcoded dark — this modal rendered black in
+     light theme because every colour below was a literal hex. */
+  background: var(--bg-2);
+  border: 1px solid var(--border-bright);
   border-radius: 16px;
   padding: 28px;
   width: 440px;
@@ -143,7 +148,7 @@ function _friendly(err) {
   max-height: calc(100dvh - 32px);
   overflow-y: auto;
   text-align: center;
-  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);
 }
 .sd-icon-wrap {
   width: 52px; height: 52px;
@@ -157,59 +162,59 @@ function _friendly(err) {
   margin: 0 0 8px;
   font-size: 18px;
   font-weight: 600;
-  color: #f0f2f5;
+  color: var(--text);
 }
 .sd-desc {
   margin: 0 0 12px;
   font-size: 13px;
-  color: #8b8fa3;
+  color: var(--text-dim);
 }
-.sd-desc strong { color: #f0f2f5; font-family: ui-monospace, monospace; }
+.sd-desc strong { color: var(--text); font-family: ui-monospace, monospace; }
 .sd-warn {
   margin: 0 0 16px;
   font-size: 12px;
-  color: #fbbf24;
-  background: rgba(245, 158, 11, 0.08);
+  color: var(--warning);
+  background: var(--warning-bg);
   border: 1px solid rgba(245, 158, 11, 0.2);
   border-radius: 8px;
   padding: 10px 12px;
   text-align: left;
 }
-.sd-warn strong { color: #fbbf24; }
+.sd-warn strong { color: var(--warning); }
 .sd-label {
   display: block;
   margin: 16px 0 6px;
   font-size: 12px;
-  color: #8b8fa3;
+  color: var(--text-muted);
   text-align: left;
 }
 .sd-label code {
-  background: #111318;
-  border: 1px solid #1e2030;
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
   padding: 1px 6px;
   border-radius: 4px;
-  color: #f0f2f5;
+  color: var(--text);
   font-family: ui-monospace, monospace;
 }
 .sd-input {
   width: 100%;
   margin-top: 6px;
-  background: #111318;
-  border: 1px solid #1e2030;
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
   border-radius: 8px;
   padding: 10px 12px;
-  color: #f0f2f5;
+  color: var(--text);
   font-family: ui-monospace, monospace;
   font-size: 13px;
 }
 .sd-input:focus {
   outline: none;
-  border-color: #ef4444;
+  border-color: var(--danger);
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
 }
 .sd-error {
   margin: 12px 0 0;
-  color: #f87171;
+  color: var(--danger);
   font-size: 12px;
   text-align: left;
 }
@@ -229,15 +234,15 @@ function _friendly(err) {
 }
 .sd-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .sd-btn-cancel {
-  background: #111318;
-  border-color: #1a1d2e;
-  color: #c4c8d4;
+  background: transparent;
+  border-color: var(--border-strong);
+  color: var(--text-dim);
 }
-.sd-btn-cancel:hover:not(:disabled) { background: #1e2233; }
+.sd-btn-cancel:hover:not(:disabled) { background: var(--bg-3); color: var(--text); }
 .sd-btn-delete {
-  background: rgba(239, 68, 68, 0.15);
+  background: var(--danger-bg);
   border-color: rgba(239, 68, 68, 0.3);
-  color: #f87171;
+  color: var(--danger);
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/views/ApprovalsView.vue
+++ b/frontend/src/views/ApprovalsView.vue
@@ -1124,5 +1124,10 @@ const knownTypes = [
      the push on mobile so status sits inline with buttons or wraps
      naturally below them. */
   .approvals__resolve-status { margin-left: 0; width: 100%; }
+
+  /* Long button labels ("✓ Approve · agent continues") overflowed the
+     card on narrow phones. Stack full-width so neither button clips. */
+  .approvals__resolve-actions { flex-direction: column; align-items: stretch; }
+  .approvals__resolve-actions .btn { width: 100%; }
 }
 </style>

--- a/frontend/src/views/McpServersView.vue
+++ b/frontend/src/views/McpServersView.vue
@@ -86,16 +86,37 @@ function unattachedAgents(server) {
 }
 
 const attachOpen = ref(false)
-const attachMenuPos = ref({ top: 0, left: 0, width: 240 })
+const attachMenuPos = ref({ top: null, bottom: null, left: 0, width: 240, maxHeight: 320 })
 const attachTriggerRef = ref(null)
 function _measureAttachAnchor() {
   const el = attachTriggerRef.value
   if (!el) return
   const r = el.getBoundingClientRect()
-  attachMenuPos.value = {
-    top: r.bottom + 4,
-    left: r.left,
-    width: Math.max(r.width, 240),
+  const vw = window.innerWidth
+  const vh = window.innerHeight
+  const GAP = 4
+  // Reserve room for the mobile bottom tab bar / mini player so the menu
+  // never opens behind them (the "+ Attach to…" trigger sits low in the
+  // detail pane → downward menu was clipped off-screen).
+  const BOTTOM_RESERVE = 88
+  const DESIRED = 320
+  const width = Math.max(r.width, 240)
+  const left = Math.max(8, Math.min(r.left, vw - width - 8))
+  const spaceBelow = vh - r.bottom - GAP - BOTTOM_RESERVE
+  const spaceAbove = r.top - GAP
+  if (spaceBelow >= 160 || spaceBelow >= spaceAbove) {
+    // Open downward, capped to the space above the reserved bottom area.
+    attachMenuPos.value = {
+      top: r.bottom + GAP, bottom: null, left, width,
+      maxHeight: Math.max(140, Math.min(DESIRED, spaceBelow)),
+    }
+  } else {
+    // Not enough room below — flip up, anchoring the menu's bottom just
+    // above the trigger.
+    attachMenuPos.value = {
+      top: null, bottom: vh - r.top + GAP, left, width,
+      maxHeight: Math.max(140, Math.min(DESIRED, spaceAbove)),
+    }
   }
 }
 function toggleAttachMenu() {
@@ -667,7 +688,13 @@ function fmtTime(ts) {
           <div
             v-if="attachOpen && tab === 'agents'"
             class="mcp-attach-menu jv"
-            :style="{ top: attachMenuPos.top + 'px', left: attachMenuPos.left + 'px', minWidth: attachMenuPos.width + 'px' }"
+            :style="{
+              top: attachMenuPos.top != null ? attachMenuPos.top + 'px' : undefined,
+              bottom: attachMenuPos.bottom != null ? attachMenuPos.bottom + 'px' : undefined,
+              left: attachMenuPos.left + 'px',
+              minWidth: attachMenuPos.width + 'px',
+              maxHeight: attachMenuPos.maxHeight + 'px',
+            }"
             @click.stop
           >
             <div v-if="!unattachedAgents(selected).length" class="mcp-attach-menu__empty">
@@ -1427,6 +1454,12 @@ function fmtTime(ts) {
      wrapping to its own line, so it spilled past the right edge. Give
      it the full row width so its own flex-wrap can actually engage. */
   .mcp-detail__actions { flex-basis: 100%; flex-wrap: wrap; gap: 6px; }
+
+  /* Tool rows: the 200px-min name column + center alignment left the
+     name floating in a tall empty column while the description wrapped
+     into a sliver beside it. Stack name over full-width description. */
+  .mcp-tool { flex-direction: column; align-items: flex-start; gap: 2px; }
+  .mcp-tool__name { min-width: 0; }
 
   /* Env row: 4 columns × 90px is unreadable on a 360px viewport.
      Stack: key/value share row 1 (key 1fr, remove auto), value

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -229,13 +229,14 @@ function labelFor(id) {
   }
   /* Flat strip on mobile: the desktop active state is a rounded lavender
      pill, which collided with the horizontal-scroll clipping and read as
-     "broken". Drop the pill fill — a bottom-border + tinted text is the
-     correct tab-strip affordance here. */
+     "broken". Drop the pill fill — the bottom-border alone marks active.
+     Keep the inherited var(--text) label (not --primary-hover, a light
+     lavender ~2.7:1 on the white light-theme strip, below WCAG AA); the
+     border carries the accent, the text stays high-contrast. */
   .nav-item.active {
     background: transparent;
     border-left-color: transparent;
     border-bottom-color: var(--primary);
-    color: var(--primary-hover);
   }
   .page-header { padding: 20px 18px 14px; }
   .panel { padding: 18px; }

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -224,11 +224,18 @@ function labelFor(id) {
   .nav-item {
     border-left: none;
     border-bottom: 2px solid transparent;
+    border-radius: 0;
     padding: 8px 12px;
   }
+  /* Flat strip on mobile: the desktop active state is a rounded lavender
+     pill, which collided with the horizontal-scroll clipping and read as
+     "broken". Drop the pill fill — a bottom-border + tinted text is the
+     correct tab-strip affordance here. */
   .nav-item.active {
+    background: transparent;
     border-left-color: transparent;
     border-bottom-color: var(--primary);
+    color: var(--primary-hover);
   }
   .page-header { padding: 20px 18px 14px; }
   .panel { padding: 18px; }

--- a/frontend/src/views/settings/SettingsRunningTemplates.vue
+++ b/frontend/src/views/settings/SettingsRunningTemplates.vue
@@ -1291,5 +1291,12 @@ onMounted(() => loadSessions())
 }
 @media (max-width: 720px) {
   .diff-grid { grid-template-columns: 1fr; }
+
+  /* The 3-column ROLES | editor | HISTORY layout (200px + 1fr + 320px)
+     overflowed the viewport on phones — HISTORY was clipped off the
+     right edge and the middle editor squeezed to a sliver. Stack into a
+     single column so each pane gets full width. */
+  .layout { grid-template-columns: 1fr; }
+  .role-list, .history-rail { max-height: 240px; }
 }
 </style>


### PR DESCRIPTION
Sửa 6 bug UI theo ảnh báo cáo (light theme + responsive mobile). Toàn bộ là CSS/positioning, không đổi hành vi.

## Bugs & fix

| Bug (ảnh) | Nguyên nhân | Fix |
|---|---|---|
| **Popup Delete đen ở light theme** | `SkillDeleteModal.vue` hardcode toàn bộ màu dark hex, không dùng token | Chuyển sang theme tokens (`--bg-2`, `--text`, `--border-*`, `--danger`…) như `ConfirmModal` |
| **Text payload approval trùng nền (dark-on-dark)** | Code window nền cố định `#0A0C12`, nhưng code lang `text` (không tokenize) kế thừa `var(--text)` → đen trên đen ở light theme | Set màu chữ sáng cố định cho `.md-content pre` |
| **Dropdown "Attach to…" bị cắt khi sát đáy** | Menu `position:fixed` luôn mở xuống `top: r.bottom`, sát đáy → tràn / bị tabbar che | Lật lên khi thiếu chỗ + cap `max-height` chừa tabbar + clamp ngang |
| **Tools list vỡ (cột tên rỗng, desc dồn cột hẹp)** | `.mcp-tool` flex row, `name { min-width:200px }` + `align-items:center` | Mobile: stack dọc (tên trên, desc full-width) |
| **Settings tab strip nhìn vỡ** | Tab active mobile vẫn giữ pill bo tròn desktop + scroll clip | Mobile: strip phẳng (chỉ border-bottom indicator) |
| **Running Templates 3 cột tràn (HISTORY bị cắt)** | Grid `200px 1fr 320px` không reflow | Stack 1 cột < 720px |
| **(phụ) Nút Approve/Reject dài dễ cắt mobile** | flex-wrap không đủ | Stack full-width < 768px |

## Files
- `components/agent/SkillDeleteModal.vue`
- `components/MarkdownRenderer.vue`
- `views/McpServersView.vue`
- `views/SettingsView.vue` · `views/settings/SettingsRunningTemplates.vue`
- `views/ApprovalsView.vue`

## Verify
- `vite build` ✓ (không lỗi cú pháp/template).
- **Gap:** chưa chụp visual e2e ở light theme + mobile width (các màn sau AuthGate, cần full stack + auth + data). Thay đổi thuần CSS/positioning, rủi ro thấp. Khuyến nghị anh xem nhanh: light theme → mở Delete skill, mở approval có payload; mobile → MCP server tools + Attach dropdown sát đáy, Settings → Running Templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)