### PR TITLE
feat(scheduler): creation-time approval gate for agent-created cron jobs

### DIFF
--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -425,6 +425,17 @@ class CronJobModel(Base):
     updated_at = Column(Float, nullable=False, default=lambda: datetime.now().timestamp())
     created_by = Column(String(20), default="user")  # user | agent
 
+    # Approval — SINGLE SOURCE OF TRUTH for "may this job fire?".
+    # Decided ONCE at creation time (not at fire time) so an agent-created
+    # job can't run unsupervised before a human has vetted its payload —
+    # the prompt-injection defence. Dashboard-created jobs are 'approved'
+    # immediately (the user is present and in control). Agent-created
+    # agent_turn jobs start 'pending' until the user resolves the matching
+    # ApprovalRequest card. At fire time the scheduler only READS this flag;
+    # it never blocks waiting for a human (see cron_scheduler._execute_agent_turn).
+    # Default 'approved' so jobs created before this column existed keep running.
+    approval_status = Column(String(20), default="approved")  # approved | pending | rejected
+
 
 class CronRunModel(Base):
     """Cron job execution history."""
@@ -745,6 +756,10 @@ def init_db():
             "ALTER TABLE spawn_records ADD COLUMN runtime_config_json TEXT",
             "ALTER TABLE agent_activities ADD COLUMN session_id VARCHAR(100)",
             "ALTER TABLE mcp_servers ADD COLUMN cwd TEXT",
+            # Pre-existing cron jobs predate creation-time approval — default
+            # them to 'approved' so the new gate doesn't silently freeze jobs
+            # that were already running.
+            "ALTER TABLE cron_jobs ADD COLUMN approval_status VARCHAR(20) DEFAULT 'approved'",
         ]
         for sql in migrations:
             try:

--- a/backend/routes/scheduler.py
+++ b/backend/routes/scheduler.py
@@ -63,6 +63,7 @@ def _format_job_api(job: CronJobModel) -> dict:
         "created_at": job.created_at,
         "updated_at": job.updated_at,
         "created_by": job.created_by,
+        "approval_status": job.approval_status,
     }
 
 
@@ -195,6 +196,17 @@ async def update_job(job_id: str, request: Request, _auth: bool = Depends(verify
             if field in body and body[field] is not None:
                 setattr(job, field, body[field])
 
+        # Dashboard edits are user-driven and trusted (the user is present and
+        # in control). If this job was awaiting agent-approval (or was
+        # rejected), the user editing it HERE is the vetting step → mark it
+        # approved so it can run. We also resolve any stale pending approval
+        # card below (after commit) so a later click on it can't approve a
+        # payload the user never saw — the SSoT (job.approval_status) and the
+        # inbox card stay consistent.
+        was_unapproved = job.approval_status != "approved"
+        if was_unapproved:
+            job.approval_status = "approved"
+
         if "one_shot" in body:
             job.one_shot = bool(body["one_shot"])
 
@@ -219,14 +231,53 @@ async def update_job(job_id: str, request: Request, _auth: bool = Depends(verify
 
         job.updated_at = time.time()
         db.commit()
-
-        cron_scheduler.wake()
-        return {"job": _format_job_api(job)}
+        job_api = _format_job_api(job)
     except Exception as e:
         db.rollback()
         return {"error": str(e)}
     finally:
         db.close()
+
+    # After commit + close so the resolve's own sessions don't nest in ours.
+    if was_unapproved:
+        _approve_pending_cron_cards(job_id)
+
+    cron_scheduler.wake()
+    return {"job": job_api}
+
+
+def _approve_pending_cron_cards(job_id: str) -> None:
+    """Resolve (as approved) any pending cron_approval card pointing at this
+    job. Used when the user edits the job on the dashboard — a trusted action
+    that supersedes the agent-created approval request. Best-effort: a missing
+    card just means there's nothing to clear (the job flag is already the SSoT)."""
+    from services.approval_service import approval_service
+    from core.database import ApprovalRequestModel
+
+    db = get_db_session()
+    try:
+        cards = (
+            db.query(ApprovalRequestModel)
+            .filter(
+                ApprovalRequestModel.approval_type == "cron_approval",
+                ApprovalRequestModel.status == "pending",
+            )
+            .all()
+        )
+        ids = [
+            c.id for c in cards
+            if json.loads(c.metadata_json or "{}").get("job_id") == job_id
+        ]
+    finally:
+        db.close()
+
+    for cid in ids:
+        try:
+            approval_service.resolve_approval(
+                cid, decision="approve", comment="approved via dashboard edit",
+            )
+        except Exception as exc:
+            logger.warning("[scheduler] could not resolve cron card %s: %s", cid, exc)
 
 
 @router.delete("/jobs/{job_id}")

--- a/backend/routes/scheduler.py
+++ b/backend/routes/scheduler.py
@@ -197,14 +197,18 @@ async def update_job(job_id: str, request: Request, _auth: bool = Depends(verify
                 setattr(job, field, body[field])
 
         # Dashboard edits are user-driven and trusted (the user is present and
-        # in control). If this job was awaiting agent-approval (or was
-        # rejected), the user editing it HERE is the vetting step → mark it
-        # approved so it can run. We also resolve any stale pending approval
-        # card below (after commit) so a later click on it can't approve a
-        # payload the user never saw — the SSoT (job.approval_status) and the
-        # inbox card stay consistent.
-        was_unapproved = job.approval_status != "approved"
-        if was_unapproved:
+        # in control). If this job is awaiting agent-approval, the user editing
+        # it HERE is the vetting step → mark it approved so it can run. We also
+        # resolve any stale pending approval card below (after commit) so a
+        # later click on it can't approve a payload the user never saw — the
+        # SSoT (job.approval_status) and the inbox card stay consistent.
+        #
+        # A `rejected` job is deliberately NOT auto-approved here: rejection is
+        # an explicit "no", and a trivial dashboard edit (e.g. a rename) must
+        # not silently revive it. Reviving a rejected job takes an explicit
+        # approve action, not an incidental field change.
+        was_pending = job.approval_status == "pending"
+        if was_pending:
             job.approval_status = "approved"
 
         if "one_shot" in body:
@@ -239,7 +243,7 @@ async def update_job(job_id: str, request: Request, _auth: bool = Depends(verify
         db.close()
 
     # After commit + close so the resolve's own sessions don't nest in ours.
-    if was_unapproved:
+    if was_pending:
         _approve_pending_cron_cards(job_id)
 
     cron_scheduler.wake()

--- a/backend/services/approval_service.py
+++ b/backend/services/approval_service.py
@@ -84,6 +84,17 @@ class ApprovalService:
         approval_id = str(uuid.uuid4())
         now = time.time()
 
+        # Enforce ONE pending cron_approval card per job. If the agent re-gates
+        # a job (edited payload / agent / schedule) while an OLDER card is still
+        # pending, two cards would point at the same job — and approving the
+        # STALE one would vet old bytes while the job runs the NEW ones
+        # (vet-v1-run-v2). Supersede the stale card(s) so only this fresh one,
+        # which shows the current payload, is actionable.
+        if data.get("approval_type") == "cron_approval":
+            _job_id = (data.get("metadata") or {}).get("job_id")
+            if _job_id:
+                self._supersede_pending_cron_cards(_job_id)
+
         # Resolve team membership AUTHORITATIVELY from ``spawn_records``.
         # ``team_name`` arrives from the MCP tool as a free-text LLM
         # parameter — the LLM frequently picks the workspace basename
@@ -247,6 +258,53 @@ class ApprovalService:
         self._broadcast_stats()
 
         return result
+
+    def _supersede_pending_cron_cards(self, job_id: str) -> None:
+        """Mark any still-pending cron_approval card(s) for ``job_id`` as
+        ``cancelled`` so a fresh card (vetting the current payload) is the only
+        actionable one. Cleanup ONLY — deliberately does NOT write through to
+        ``CronJobModel.approval_status``: superseding a stale card is not a user
+        decision, and the re-gate that triggered this already set the job back
+        to ``pending``. Broadcasts ``approval_resolved`` so the inbox clears the
+        stale card live."""
+        db = SessionLocal()
+        superseded: list[tuple] = []
+        try:
+            cards = db.query(ApprovalRequestModel).filter(
+                ApprovalRequestModel.approval_type == "cron_approval",
+                ApprovalRequestModel.status == "pending",
+            ).all()
+            now = time.time()
+            for c in cards:
+                try:
+                    meta = json.loads(c.metadata_json or "{}")
+                except (TypeError, ValueError):
+                    meta = {}
+                if meta.get("job_id") == job_id:
+                    c.status = "cancelled"
+                    c.resolved_at = now
+                    superseded.append((c.id, c.agent_name, c.title))
+            if superseded:
+                db.commit()
+        finally:
+            db.close()
+
+        for cid, agent_name, title in superseded:
+            activity_stream_manager.broadcast({
+                "agent_name": agent_name,
+                "event_type": "approval_resolved",
+                "message": f"Approval superseded: {title}",
+                "timestamp": time.time(),
+                "data": {
+                    "approval_id": cid,
+                    "decision": "cancelled",
+                    "agent_name": agent_name,
+                },
+            })
+        if superseded:
+            self._broadcast_stats()
+            logger.info("[APPROVAL] Superseded %d stale cron card(s) for job %s",
+                        len(superseded), job_id)
 
     def _apply_cron_decision(self, job_id: Optional[str], decision: str) -> None:
         """Mirror an approval decision onto the cron job's approval_status

--- a/backend/services/approval_service.py
+++ b/backend/services/approval_service.py
@@ -101,6 +101,18 @@ class ApprovalService:
         team_name: str | None = None
         pause_agents: list[str]
 
+        # ``pause=False`` opts out of the team-pause machinery entirely.
+        # Used by deferred gates (e.g. cron creation-time approval) where the
+        # approval is NOT blocking a live agent turn — the requesting agent
+        # may be Jarvis mid-conversation with the user, and pausing it would
+        # freeze that chat. These approvals just sit in the inbox until
+        # resolved; nothing is held.
+        if not data.get("pause", True):
+            pause_agents = []
+            return self._persist_and_broadcast(
+                approval_id, now, data, team_name=None, pause_agents=pause_agents,
+            )
+
         # Single session for both lookups (team_name + team members).
         # Was two consecutive SessionLocal() blocks; merged because they
         # don't need transactional isolation between them and the second
@@ -146,6 +158,18 @@ class ApprovalService:
         finally:
             _db.close()
 
+        return self._persist_and_broadcast(
+            approval_id, now, data, team_name=team_name, pause_agents=pause_agents,
+        )
+
+    def _persist_and_broadcast(
+        self, approval_id: str, now: float, data: dict, *,
+        team_name: Optional[str], pause_agents: list,
+    ) -> dict:
+        """Insert the approval row, pause ``pause_agents`` (may be empty),
+        and broadcast SSE. Shared by the normal team-pause path and the
+        ``pause=False`` deferred-gate path so both produce identical rows
+        and events."""
         db = SessionLocal()
         try:
             record = ApprovalRequestModel(
@@ -224,6 +248,43 @@ class ApprovalService:
 
         return result
 
+    def _apply_cron_decision(self, job_id: Optional[str], decision: str) -> None:
+        """Mirror an approval decision onto the cron job's approval_status
+        (the scheduler's source of truth) and wake the scheduler so an
+        approved job is re-evaluated immediately rather than on the next tick.
+        Best-effort: a missing job_id/job is logged, not raised — the
+        approval itself is already resolved."""
+        if not job_id:
+            logger.warning("[APPROVAL] cron_approval resolved with no job_id in metadata")
+            return
+        from core.database import CronJobModel
+        db = SessionLocal()
+        try:
+            job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+            if not job:
+                logger.warning("[APPROVAL] cron_approval job %s not found", job_id)
+                return
+            job.approval_status = "approved" if decision == "approve" else "rejected"
+            job.updated_at = time.time()
+            db.commit()
+            new_status = job.approval_status
+            job_name = job.name
+            logger.info("[APPROVAL] cron job %s approval_status → %s", job_id, new_status)
+        finally:
+            db.close()
+        try:
+            from services.cron_scheduler import cron_scheduler
+            # Push to the Scheduler dashboard so the pending badge flips live.
+            cron_scheduler._broadcast_event("job_approval_changed", {
+                "job_id": job_id,
+                "job_name": job_name,
+                "approval_status": new_status,
+            })
+            if decision == "approve":
+                cron_scheduler.wake()  # re-evaluate now instead of next tick
+        except Exception as exc:  # scheduler may be down in tests
+            logger.debug("[APPROVAL] could not notify scheduler: %s", exc)
+
     def resolve_approval(self, approval_id: str, decision: str, comment: Optional[str] = None) -> dict:
         """Resolve an approval request (approve/reject).
 
@@ -251,8 +312,21 @@ class ApprovalService:
 
             result = self._record_to_dict(record)
             paused_agents = json.loads(record.paused_agents or "[]")
+            # Captured here (while the row is loaded) for the cron write-through
+            # below — _record_to_dict intentionally omits metadata_json.
+            resolved_type = record.approval_type
+            resolved_meta = json.loads(record.metadata_json or "{}")
         finally:
             db.close()
+
+        # Write-through for deferred cron gates: the ApprovalRequest card is
+        # just the user's inbox surface — CronJobModel.approval_status is the
+        # SINGLE SOURCE OF TRUTH the scheduler reads at fire time. Mirror the
+        # decision onto the job so it can (or can't) fire. Done here so BOTH
+        # resolution surfaces (Approvals page, RPC) stay consistent through
+        # one write path.
+        if resolved_type == "cron_approval":
+            self._apply_cron_decision(resolved_meta.get("job_id"), decision)
 
         # Resume via PauseController — iterate the authoritative
         # ``paused_agents`` list stored on the approval row. This

--- a/backend/services/config_service.py
+++ b/backend/services/config_service.py
@@ -30,7 +30,7 @@ from typing import Callable, Iterable, Optional
 from sqlalchemy.orm import Session
 
 from core import secrets_crypto
-from core.database import ConfigHistory, SessionLocal, SystemConfig
+from core.database import ConfigHistory, SessionLocal, SystemConfig  # noqa: F401  (SessionLocal re-exported so tests/fixtures can monkeypatch config_service.SessionLocal)
 
 logger = logging.getLogger(__name__)
 
@@ -82,11 +82,26 @@ class ConfigService:
 
     def __init__(
         self,
-        db_factory: Callable[[], Session] = SessionLocal,
+        db_factory: Optional[Callable[[], Session]] = None,
     ) -> None:
-        self._db_factory = db_factory
+        # Store an EXPLICIT factory (tests inject one) but otherwise resolve
+        # ``core.database.SessionLocal`` lazily per-call via the ``_db_factory``
+        # property — never snapshot it here. The module-level singleton can be
+        # first instantiated DURING a test that has monkeypatched SessionLocal
+        # onto a temporary SAVEPOINT connection; capturing that snapshot would
+        # leave the singleton permanently bound to a connection closed at the
+        # test's teardown ("This Connection is closed"). Late-binding keeps ONE
+        # source of truth for the session factory. (SSoT — see CLAUDE.md #9.)
+        self._db_factory_override = db_factory
         self._listeners: list[ChangeListener] = []
         self._lock = threading.RLock()
+
+    @property
+    def _db_factory(self) -> Callable[[], Session]:
+        if self._db_factory_override is not None:
+            return self._db_factory_override
+        from core.database import SessionLocal
+        return SessionLocal
 
     # ---- Listener API -------------------------------------------------------
 

--- a/backend/services/cron_scheduler.py
+++ b/backend/services/cron_scheduler.py
@@ -36,9 +36,14 @@ class ApprovalBlocked(Exception):
     no auto-disable) and "code crashed" (counts toward 5-strike disable).
     """
 
-    def __init__(self, reason: str):
+    def __init__(self, reason: str, notify: bool = True):
         super().__init__(reason)
         self.reason = reason
+        # When False, _execute_job records the blocked run but does NOT push a
+        # notification. Used for "awaiting approval" skips: the approval card
+        # already notified the user once at creation; re-notifying on every
+        # tick while they haven't approved yet is just inbox spam.
+        self.notify = notify
 
 
 class CronScheduler:
@@ -380,36 +385,40 @@ class CronScheduler:
                 "reason": block_reason,
             })
 
-            # Blocked notification — distinct from `error` so the dashboard
-            # can colour-code it (amber) vs failed (red).
-            notif = NotificationModel(
-                run_id=run_id,
-                job_id=job.id,
-                type="blocked",
-                title=job.name,
-                preview=f"Blocked: {block_reason[:180]}",
-                content=f"## Job blocked: {job.name}\n\n```\n{block_reason}\n```",
-                content_type="markdown",
-                is_read=0,
-                created_at=completed_at,
-                metadata_json=json.dumps({
-                    "agent": job.exec_agent or "system",
-                    "exec_mode": job.exec_mode,
-                    "duration_ms": duration_ms,
-                    "status": "blocked",
-                }),
-            )
-            db.add(notif)
-            db.commit()
-            db.refresh(notif)
+            # Suppress the inbox notification for "awaiting approval" skips
+            # (exc.notify=False) — those repeat every tick and the approval
+            # card already notified the user. Other blocks still notify.
+            if getattr(exc, "notify", True):
+                # Blocked notification — distinct from `error` so the dashboard
+                # can colour-code it (amber) vs failed (red).
+                notif = NotificationModel(
+                    run_id=run_id,
+                    job_id=job.id,
+                    type="blocked",
+                    title=job.name,
+                    preview=f"Blocked: {block_reason[:180]}",
+                    content=f"## Job blocked: {job.name}\n\n```\n{block_reason}\n```",
+                    content_type="markdown",
+                    is_read=0,
+                    created_at=completed_at,
+                    metadata_json=json.dumps({
+                        "agent": job.exec_agent or "system",
+                        "exec_mode": job.exec_mode,
+                        "duration_ms": duration_ms,
+                        "status": "blocked",
+                    }),
+                )
+                db.add(notif)
+                db.commit()
+                db.refresh(notif)
 
-            self._broadcast_event("new_notification", {
-                "id": notif.id,
-                "notif_type": "blocked",
-                "title": job.name,
-                "preview": f"Blocked: {block_reason[:150]}",
-                "created_at": completed_at,
-            })
+                self._broadcast_event("new_notification", {
+                    "id": notif.id,
+                    "notif_type": "blocked",
+                    "title": job.name,
+                    "preview": f"Blocked: {block_reason[:150]}",
+                    "created_at": completed_at,
+                })
 
             logger.warning("[CRON] Job '%s' blocked: %s", job.name, block_reason)
             return
@@ -511,12 +520,15 @@ class CronScheduler:
     async def _execute_agent_turn(self, job: CronJobModel) -> str:
         """Execute agent turn — send message to specified agent via session.
 
-        Human-approval gate: cron payloads are LLM-supplied (the agent calls
-        ``cron_create(exec_payload=...)``) and run unsupervised at fire time
-        with the configured agent's full tool set — including terminal exec.
-        Block the first fire of every (job_id, hash(payload)) pair so the
-        operator sees the prompt before it goes live. Same hash on repeat
-        fires auto-proceeds.
+        Human-approval gate (READ-ONLY here): cron payloads are LLM-supplied
+        (the agent calls ``cron_create(exec_payload=...)``) and run unsupervised
+        with the configured agent's full tool set — including terminal exec. The
+        decision to allow this is made ONCE at CREATION time and stored on
+        ``job.approval_status`` (the single source of truth). At fire time we
+        only READ that flag — we never block waiting for a human, so an absent
+        user can't leave the scheduler hung. A not-yet-approved job simply skips
+        this fire and retries on the next tick; the Approvals resolve hook flips
+        the flag the moment the user decides.
         """
         if not self._agent_app or not self._session_service:
             raise RuntimeError("Agent references not set — cannot execute agent_turn")
@@ -526,41 +538,26 @@ class CronScheduler:
 
         logger.info("[CRON] Agent turn: '%s' → agent=%s payload='%s'", job.name, agent_name, payload[:80])
 
-        # Approval gate. Coalesces on (job_id, payload_hash) so re-runs of
-        # an already-approved cron skip the prompt.
-        from services.approval_gate import gate as _gate
-        content_md = (
-            f"## Cron job: `{job.name}`\n\n"
-            f"**Schedule:** `{job.schedule_cron}` ({job.calendar_type})\n"
-            f"**Target agent:** `{agent_name}`\n\n"
-            f"**Payload to run:**\n\n```text\n{(payload or '').rstrip()}\n```\n\n"
-            f"---\n\n"
-            f"⚠️ **Use at your own risk.** Approving lets this exact payload "
-            f"run on the schedule above, unsupervised. The target agent has "
-            f"its full tool set available — including any that touch the "
-            f"filesystem, shell, network, or external accounts.\n\n"
-            f"Approve only if you recognise the payload and trust the source "
-            f"that created this job."
-        )
-        approved, reason = await _gate(
-            approval_type="cron_first_fire",
-            scope_key=f"cron:{job.id}",
-            content_md=content_md,
-            title=f"Cron first run: {job.name}",
-            agent_name=agent_name,
-        )
-        if not approved:
-            logger.warning("[CRON] Job %s blocked by approval gate: %s", job.id, reason)
-            self._broadcast_event("agent_turn_blocked", {
-                "job_id": job.id,
-                "job_name": job.name,
-                "reason": reason,
-            })
-            # Raise so _execute_job records this as `blocked` rather than
-            # success. Different from failure: no fail_count bump, no
-            # auto-disable — the user simply hasn't approved this payload
-            # yet (or rejected it).
-            raise ApprovalBlocked(reason)
+        # Read the approval requirement fresh so the Settings toggle
+        # (scheduler.REQUIRE_APPROVAL) hot-reloads without a restart. Fail
+        # SAFE: if the config can't be read, require approval.
+        try:
+            from services.config_service import config_service
+            require_approval = str(
+                config_service.get("scheduler", "REQUIRE_APPROVAL", default="true")
+            ).strip().lower() in ("1", "true", "yes", "on")
+        except Exception:
+            require_approval = True
+        if require_approval and job.approval_status != "approved":
+            reason = (
+                "awaiting your approval — not yet approved"
+                if job.approval_status == "pending"
+                else f"approval was {job.approval_status}"
+            )
+            logger.info("[CRON] Job %s skipped: %s", job.id, reason)
+            # notify=False: don't spam the inbox every tick. The approval card
+            # created at job-creation time is the user's actionable surface.
+            raise ApprovalBlocked(reason, notify=False)
 
         # Tag every LLM call this turn makes with a deterministic run_id
         # so the dashboard can correlate ``token_usage`` rows back to the

--- a/backend/services/cron_scheduler.py
+++ b/backend/services/cron_scheduler.py
@@ -345,14 +345,44 @@ class CronScheduler:
             )
 
         except ApprovalBlocked as exc:
-            # Gate refused / timed out. NOT a failure — the user simply
-            # hasn't approved this payload yet (or rejected it). Record
-            # the run as `blocked`, do NOT bump fail_count, and let the
-            # job stay `active` for its next scheduled fire.
+            # Gate refused. NOT a failure — the user simply hasn't approved
+            # this payload yet (or rejected it). Never bumps fail_count; the
+            # job stays `active` for its next scheduled fire.
             completed_at = time.time()
             duration_ms = int((completed_at - started_at) * 1000)
             block_reason = exc.reason[:500]
+            silent = not getattr(exc, "notify", True)
 
+            job.last_run_at = completed_at
+            job.last_result = "blocked"
+            job.last_error = block_reason
+            job.status = "active"  # Restore from 'running'
+            if not job.one_shot:
+                job.next_run_at = self.compute_next_run(
+                    job.schedule_cron, job.calendar_type, job.schedule_timezone, job.lunar_leap
+                )
+
+            if silent:
+                # "Awaiting approval" skip (notify=False): a RECURRING no-op,
+                # not an event. Drop the run row we optimistically opened and
+                # skip the run_count bump — otherwise a never-approved `*/5`
+                # job accrues ~288 blocked rows/day, unbounded, until it's
+                # approved/rejected/deleted. The pending badge
+                # (job.approval_status) + the creation-time approval card are
+                # the user's signal; nothing per-tick is worth persisting or
+                # broadcasting.
+                if run_id:
+                    stale = db.query(CronRunModel).filter(CronRunModel.id == run_id).first()
+                    if stale:
+                        db.delete(stale)
+                job.updated_at = time.time()
+                db.commit()
+                logger.info("[CRON] Job '%s' awaiting approval — skipped (no run recorded)", job.name)
+                return
+
+            # Genuine one-off block (notify=True): persist the blocked run and
+            # notify so the dashboard shows why the job didn't run. run_count
+            # counts this attempt so the dashboard reflects that it ticked.
             if run_id:
                 run = db.query(CronRunModel).filter(CronRunModel.id == run_id).first()
                 if run:
@@ -360,21 +390,7 @@ class CronScheduler:
                     run.completed_at = completed_at
                     run.duration_ms = duration_ms
                     run.error = f"approval gate: {block_reason}"
-
-            job.last_run_at = completed_at
-            job.last_result = "blocked"
-            job.last_error = block_reason
-            # run_count counts attempts including blocked ones so the dashboard
-            # shows the job *did* tick. fail_count stays put — no auto-disable
-            # for blocked runs.
             job.run_count = (job.run_count or 0) + 1
-
-            job.status = "active"  # Restore from 'running'
-            if not job.one_shot:
-                job.next_run_at = self.compute_next_run(
-                    job.schedule_cron, job.calendar_type, job.schedule_timezone, job.lunar_leap
-                )
-
             job.updated_at = time.time()
             db.commit()
 
@@ -385,40 +401,36 @@ class CronScheduler:
                 "reason": block_reason,
             })
 
-            # Suppress the inbox notification for "awaiting approval" skips
-            # (exc.notify=False) — those repeat every tick and the approval
-            # card already notified the user. Other blocks still notify.
-            if getattr(exc, "notify", True):
-                # Blocked notification — distinct from `error` so the dashboard
-                # can colour-code it (amber) vs failed (red).
-                notif = NotificationModel(
-                    run_id=run_id,
-                    job_id=job.id,
-                    type="blocked",
-                    title=job.name,
-                    preview=f"Blocked: {block_reason[:180]}",
-                    content=f"## Job blocked: {job.name}\n\n```\n{block_reason}\n```",
-                    content_type="markdown",
-                    is_read=0,
-                    created_at=completed_at,
-                    metadata_json=json.dumps({
-                        "agent": job.exec_agent or "system",
-                        "exec_mode": job.exec_mode,
-                        "duration_ms": duration_ms,
-                        "status": "blocked",
-                    }),
-                )
-                db.add(notif)
-                db.commit()
-                db.refresh(notif)
+            # Blocked notification — distinct from `error` so the dashboard
+            # can colour-code it (amber) vs failed (red).
+            notif = NotificationModel(
+                run_id=run_id,
+                job_id=job.id,
+                type="blocked",
+                title=job.name,
+                preview=f"Blocked: {block_reason[:180]}",
+                content=f"## Job blocked: {job.name}\n\n```\n{block_reason}\n```",
+                content_type="markdown",
+                is_read=0,
+                created_at=completed_at,
+                metadata_json=json.dumps({
+                    "agent": job.exec_agent or "system",
+                    "exec_mode": job.exec_mode,
+                    "duration_ms": duration_ms,
+                    "status": "blocked",
+                }),
+            )
+            db.add(notif)
+            db.commit()
+            db.refresh(notif)
 
-                self._broadcast_event("new_notification", {
-                    "id": notif.id,
-                    "notif_type": "blocked",
-                    "title": job.name,
-                    "preview": f"Blocked: {block_reason[:150]}",
-                    "created_at": completed_at,
-                })
+            self._broadcast_event("new_notification", {
+                "id": notif.id,
+                "notif_type": "blocked",
+                "title": job.name,
+                "preview": f"Blocked: {block_reason[:150]}",
+                "created_at": completed_at,
+            })
 
             logger.warning("[CRON] Job '%s' blocked: %s", job.name, block_reason)
             return

--- a/backend/tests/e2e/test_cron_approval_route_e2e.py
+++ b/backend/tests/e2e/test_cron_approval_route_e2e.py
@@ -1,0 +1,122 @@
+"""E2E: the REAL Approvals HTTP route makes an agent-created cron job runnable.
+
+This drives the exact endpoint the frontend's "Approve" button calls —
+``PUT /api/approvals/{id}/resolve`` — through production FastAPI routing,
+auth, the ``approval_service.resolve_approval`` resolve hook, and back onto
+``CronJobModel.approval_status``. Real SQLite; nothing in the path is mocked.
+
+It closes the gap left by the service-level integration tests, which call
+``resolve_approval`` directly and never exercise the HTTP layer the user
+actually hits.
+
+The MCP subprocess → UDS RPC → ``approval.create`` transport is proven
+separately in ``test_services/test_approval_rpc.py``; here we seed the same
+row that path produces and focus on the resolve-via-HTTP click-flow.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.database import (
+    get_db_session, CronJobModel, ApprovalRequestModel, CronRunModel,
+)
+from services.approval_service import approval_service
+
+JOB_ID = "e2eaprjob"
+
+
+def _cleanup():
+    db = get_db_session()
+    try:
+        db.query(CronRunModel).filter(CronRunModel.job_id == JOB_ID).delete()
+        db.query(CronJobModel).filter(CronJobModel.id == JOB_ID).delete()
+        db.query(ApprovalRequestModel).filter(
+            ApprovalRequestModel.approval_type == "cron_approval"
+        ).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture(autouse=True)
+def _open_setup_gate(monkeypatch):
+    """The setup-gate middleware returns 503 on a fresh DB until the wizard is
+    complete. Force it open so we exercise the approvals route, not the gate."""
+    from middleware import setup_gate
+    monkeypatch.setattr(setup_gate, "is_setup_complete", lambda: True)
+
+
+@pytest.fixture()
+def _seeded_pending_job():
+    """An agent-created agent_turn job in 'pending' + its approval card —
+    the exact state cron_create produces in production."""
+    # Service tests that ran earlier use a SAVEPOINT fixture that closes its
+    # engine connection at teardown, which can leave a stale connection in the
+    # shared SQLite pool. Dispose it so this engine-backed e2e starts clean
+    # regardless of test order.
+    from core.database import engine
+    engine.dispose()
+    _cleanup()
+    db = get_db_session()
+    try:
+        db.add(CronJobModel(
+            id=JOB_ID, user_id="default", name="E2E approve me",
+            schedule_cron="*/5 * * * *", calendar_type="solar",
+            exec_mode="agent_turn", exec_payload="run report", exec_agent="Jarvis",
+            status="active", created_by="agent", approval_status="pending",
+        ))
+        db.commit()
+    finally:
+        db.close()
+    card = approval_service.create_approval({
+        "agent_name": "Jarvis",
+        "approval_type": "cron_approval",
+        "title": "Schedule approval: E2E approve me",
+        "content": "## payload\n\nrun report",
+        "content_format": "markdown",
+        "pause": False,
+        "metadata": {"job_id": JOB_ID},
+    })
+    yield card
+    _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_resolve_route_approve_makes_job_runnable(app_client, _seeded_pending_job):
+    card_id = _seeded_pending_job["id"]
+
+    resp = await app_client.put(
+        f"/api/approvals/{card_id}/resolve", json={"decision": "approve"}
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The job the scheduler reads at fire time is now approved.
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == JOB_ID).first()
+        assert job.approval_status == "approved"
+    finally:
+        db.close()
+
+    # And the dashboard API surfaces it (the badge source).
+    jobs = (await app_client.get("/api/scheduler/jobs")).json()["jobs"]
+    mine = next(j for j in jobs if j["id"] == JOB_ID)
+    assert mine["approval_status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_resolve_route_reject_blocks_job(app_client, _seeded_pending_job):
+    card_id = _seeded_pending_job["id"]
+
+    resp = await app_client.put(
+        f"/api/approvals/{card_id}/resolve",
+        json={"decision": "reject", "comment": "did not ask for this"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == JOB_ID).first()
+        assert job.approval_status == "rejected"
+    finally:
+        db.close()

--- a/backend/tests/e2e/test_cron_approval_route_e2e.py
+++ b/backend/tests/e2e/test_cron_approval_route_e2e.py
@@ -120,3 +120,54 @@ async def test_resolve_route_reject_blocks_job(app_client, _seeded_pending_job):
         assert job.approval_status == "rejected"
     finally:
         db.close()
+
+
+def _seed_job(approval_status: str):
+    """Seed an agent-created agent_turn job at a given approval_status.
+    Disposes the shared engine first (see _seeded_pending_job for why)."""
+    from core.database import engine
+    engine.dispose()
+    _cleanup()
+    db = get_db_session()
+    try:
+        db.add(CronJobModel(
+            id=JOB_ID, user_id="default", name="Edit me",
+            schedule_cron="*/5 * * * *", calendar_type="solar",
+            exec_mode="agent_turn", exec_payload="run report", exec_agent="Jarvis",
+            status="active", created_by="agent", approval_status=approval_status,
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_edit_of_pending_job_approves_via_route(app_client):
+    """The REAL PUT /api/scheduler/jobs/{id} — a trusted dashboard edit of a
+    PENDING job is the vetting step → it becomes approved."""
+    _seed_job("pending")
+    try:
+        resp = await app_client.put(
+            f"/api/scheduler/jobs/{JOB_ID}", json={"name": "Renamed by user"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["job"]["approval_status"] == "approved"
+    finally:
+        _cleanup()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_edit_of_rejected_job_stays_rejected_via_route(app_client):
+    """A REJECTED job is a deliberate 'no'. An incidental dashboard edit (a
+    rename) must NOT silently revive it — approval_status stays rejected."""
+    _seed_job("rejected")
+    try:
+        resp = await app_client.put(
+            f"/api/scheduler/jobs/{JOB_ID}", json={"name": "Sneaky rename"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["job"]["approval_status"] == "rejected", (
+            "a trivial edit must not auto-approve a job the user explicitly rejected"
+        )
+    finally:
+        _cleanup()

--- a/backend/tests/test_services/test_cron_creation_approval.py
+++ b/backend/tests/test_services/test_cron_creation_approval.py
@@ -1,0 +1,388 @@
+"""Creation-time approval for cron jobs — integration + e2e.
+
+Design under test (replaces the old fire-time blocking gate):
+
+* Approval is decided ONCE, at job CREATION, and stored on
+  ``CronJobModel.approval_status`` — the single source of truth the scheduler
+  reads at fire time. The scheduler NEVER blocks waiting for a human.
+* Jobs an AGENT creates (``cron_create``) that run an agent turn start
+  ``pending`` and get an ApprovalRequest card. Reminders / dashboard jobs are
+  ``approved`` immediately.
+* Resolving the card writes through to ``approval_status`` (approve → runs,
+  reject → never runs).
+* An agent editing the payload of an approved job resets it to ``pending``.
+* Settings toggle ``scheduler.REQUIRE_APPROVAL=false`` bypasses the gate.
+
+These run against the REAL DB (rolled back per-test via ``mcp_db_isolation``)
+and the REAL ``create_approval`` / ``resolve_approval`` / ``_execute_agent_turn``
+code. The only thing faked is the UDS RPC transport the MCP subprocess would
+use to reach the backend — we route ``approval.create`` straight to
+``approval_service.create_approval``, which is exactly what the production RPC
+handler ``_approval_create`` does.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.database import (
+    get_db_session, CronJobModel, ApprovalRequestModel, CronRunModel, NotificationModel,
+)
+from services.approval_service import approval_service
+from services.cron_scheduler import ApprovalBlocked, CronScheduler
+
+
+@pytest.fixture(autouse=True)
+def _isolate_db(mcp_db_isolation):
+    """All DB writes land in a SAVEPOINT rolled back on teardown."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _fake_rpc(monkeypatch):
+    """Route the subprocess RPC ``approval.create`` to the in-process service,
+    mirroring the real ``approval_rpc_handlers._approval_create`` forward. This
+    lets ``cron_create`` build + ship its real approval-card params without a
+    live Unix socket."""
+    def _dispatch(method, params=None, **_kw):
+        if method == "approval.create":
+            return approval_service.create_approval(params or {})
+        raise AssertionError(f"unexpected RPC method in test: {method}")
+
+    monkeypatch.setattr("tools.runtime_rpc_client.call", _dispatch, raising=True)
+
+
+def _only_job() -> CronJobModel:
+    db = get_db_session()
+    try:
+        jobs = db.query(CronJobModel).all()
+        assert len(jobs) == 1, f"expected exactly one job, got {len(jobs)}"
+        return jobs[0]
+    finally:
+        db.close()
+
+
+def _cron_approvals() -> list[ApprovalRequestModel]:
+    db = get_db_session()
+    try:
+        return (
+            db.query(ApprovalRequestModel)
+            .filter(ApprovalRequestModel.approval_type == "cron_approval")
+            .all()
+        )
+    finally:
+        db.close()
+
+
+# ── Creation-time gating ──────────────────────────────────────────────
+
+
+def test_agent_agent_turn_job_starts_pending_with_card():
+    from tools import cron_server
+
+    out = cron_server.cron_create(
+        name="Daily digest",
+        cron_expr="*/5 * * * *",
+        exec_mode="agent_turn",
+        exec_payload="Summarize today's AI news",
+        exec_agent="ResearchAgent",
+    )
+    assert "AWAITING YOUR APPROVAL" in out
+
+    job = _only_job()
+    assert job.created_by == "agent"
+    assert job.approval_status == "pending", "agent-created agent_turn must start pending"
+
+    cards = _cron_approvals()
+    assert len(cards) == 1
+    card = cards[0]
+    assert card.status == "pending"
+    assert json.loads(card.metadata_json)["job_id"] == job.id
+    # pause=False: a deferred gate must NOT freeze the (possibly chatting) agent.
+    assert json.loads(card.paused_agents or "[]") == []
+
+
+def test_agent_reminder_job_is_approved_no_card():
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Take meds",
+        cron_expr="0 8 * * *",
+        exec_mode="reminder",
+        exec_payload="Take your medicine",
+    )
+    job = _only_job()
+    assert job.approval_status == "approved", "reminders carry no exec risk → no gate"
+    assert _cron_approvals() == []
+
+
+def test_toggle_off_bypasses_creation_gate(monkeypatch):
+    """scheduler.REQUIRE_APPROVAL=false → agent_turn job is created already
+    approved with no card (use at your own risk)."""
+    from tools import cron_server
+
+    monkeypatch.setattr(
+        "services.config_service.config_service.get",
+        lambda category, key, default=None: "false"
+        if (category, key) == ("scheduler", "REQUIRE_APPROVAL") else default,
+    )
+    cron_server.cron_create(
+        name="No-gate job",
+        cron_expr="*/5 * * * *",
+        exec_mode="agent_turn",
+        exec_payload="do thing",
+        exec_agent="Jarvis",
+    )
+    job = _only_job()
+    assert job.approval_status == "approved"
+    assert _cron_approvals() == []
+
+
+# ── Resolve write-through ──────────────────────────────────────────────
+
+
+def test_approve_flips_job_to_approved():
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Approve me", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="run report", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+    card = _cron_approvals()[0]
+
+    approval_service.resolve_approval(card.id, decision="approve")
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "approved"
+    finally:
+        db.close()
+
+
+def test_reject_marks_job_rejected():
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Reject me", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="rm -rf /", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+    card = _cron_approvals()[0]
+
+    approval_service.resolve_approval(card.id, decision="reject", comment="nope")
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "rejected"
+    finally:
+        db.close()
+
+
+# ── Edit re-gates ──────────────────────────────────────────────────────
+
+
+def test_agent_payload_edit_resets_to_pending():
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Editable", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="original", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+    approval_service.resolve_approval(_cron_approvals()[0].id, decision="approve")
+
+    # Agent swaps the payload after approval — must re-gate.
+    cron_server.cron_update(job_id=job_id, exec_payload="MALICIOUS new payload")
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "pending", "edited payload must reset approval"
+    finally:
+        db.close()
+    # A fresh card for the new payload exists (pending).
+    pending = [c for c in _cron_approvals() if c.status == "pending"]
+    assert len(pending) == 1
+
+
+def test_agent_no_op_edit_keeps_approval():
+    """Re-sending the SAME payload is not a change → no reset."""
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Same", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="same payload", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+    approval_service.resolve_approval(_cron_approvals()[0].id, decision="approve")
+
+    cron_server.cron_update(job_id=job_id, exec_payload="same payload")
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "approved"
+    finally:
+        db.close()
+
+
+# ── Dashboard edit supersedes a pending agent approval ────────────────
+
+
+def test_dashboard_edit_approves_pending_and_clears_card():
+    """A trusted dashboard edit of an agent-created pending job marks it
+    approved and resolves the stale card — so a later click on the old card
+    can't approve a payload the user never saw."""
+    from tools import cron_server
+    from routes.scheduler import _approve_pending_cron_cards
+    from core.database import ApprovalRequestModel
+
+    cron_server.cron_create(
+        name="Dash edit", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="agent payload", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+    assert _only_job().approval_status == "pending"
+
+    # Simulate the dashboard PUT having flipped the flag, then clearing cards.
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        job.approval_status = "approved"
+        db.commit()
+    finally:
+        db.close()
+    _approve_pending_cron_cards(job_id)
+
+    assert _only_job().approval_status == "approved"
+    # No pending cron card remains.
+    db = get_db_session()
+    try:
+        pending = (
+            db.query(ApprovalRequestModel)
+            .filter(
+                ApprovalRequestModel.approval_type == "cron_approval",
+                ApprovalRequestModel.status == "pending",
+            )
+            .all()
+        )
+        assert pending == []
+    finally:
+        db.close()
+
+
+# ── End-to-end: creation → approval → fire ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_e2e_pending_job_skipped_then_runs_after_approval():
+    """Full flow: agent creates job → fire is SKIPPED while pending → user
+    approves → next fire RUNS the real resume_and_send."""
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="E2E", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="do the thing", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+
+    sched = CronScheduler()
+    sched._agent_app = MagicMock()
+    sched._session_service = MagicMock()
+    sched._session_service.resume_and_send = AsyncMock(return_value=("done", "sid"))
+
+    def _fresh_job():
+        db = get_db_session()
+        try:
+            return db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        finally:
+            db.close()
+
+    # 1) Pending → fire is skipped (ApprovalBlocked, no inbox spam, no run).
+    with pytest.raises(ApprovalBlocked) as ex:
+        await sched._execute_agent_turn(_fresh_job())
+    assert ex.value.notify is False
+    sched._session_service.resume_and_send.assert_not_called()
+
+    # 2) User approves.
+    approval_service.resolve_approval(_cron_approvals()[0].id, decision="approve")
+
+    # 3) Next fire runs for real.
+    result = await sched._execute_agent_turn(_fresh_job())
+    assert result == "done"
+    sched._session_service.resume_and_send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_job_records_blocked_run_without_notification_then_runs():
+    """Through the REAL scheduler entry point ``_execute_job`` (what the loop
+    calls), not just ``_execute_agent_turn``:
+
+    * a pending job → run row recorded ``blocked``, NO inbox notification
+      (the approval card already notified), no fail-count bump, job stays
+      ``active`` for the next tick.
+    * after approval → the same path RUNS, records ``success`` + one
+      ``agent_result`` notification.
+
+    Only the LLM seam (``resume_and_send``) is mocked.
+    """
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Sched path", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="do it", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+
+    sched = CronScheduler()
+    sched._agent_app = MagicMock()
+    sched._session_service = MagicMock()
+    sched._session_service.resume_and_send = AsyncMock(return_value=("done", "sid"))
+
+    # 1) Pending → _execute_job catches ApprovalBlocked and records 'blocked'.
+    db = get_db_session()
+    try:
+        await sched._execute_job(
+            db.query(CronJobModel).filter(CronJobModel.id == job_id).first(), db
+        )
+    finally:
+        db.close()
+
+    db = get_db_session()
+    try:
+        runs = db.query(CronRunModel).filter(CronRunModel.job_id == job_id).all()
+        assert len(runs) == 1 and runs[0].status == "blocked"
+        notifs = db.query(NotificationModel).filter(NotificationModel.job_id == job_id).all()
+        assert notifs == [], "pending-approval skip must NOT create an inbox notification"
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "pending"
+        assert job.status == "active"
+        assert (job.fail_count or 0) == 0
+    finally:
+        db.close()
+    sched._session_service.resume_and_send.assert_not_called()
+
+    # 2) Approve → next _execute_job runs for real.
+    approval_service.resolve_approval(_cron_approvals()[0].id, decision="approve")
+    db = get_db_session()
+    try:
+        await sched._execute_job(
+            db.query(CronJobModel).filter(CronJobModel.id == job_id).first(), db
+        )
+    finally:
+        db.close()
+
+    sched._session_service.resume_and_send.assert_called_once()
+    db = get_db_session()
+    try:
+        runs = db.query(CronRunModel).filter(CronRunModel.job_id == job_id).order_by(CronRunModel.id).all()
+        assert runs[-1].status == "success"
+        notifs = db.query(NotificationModel).filter(NotificationModel.job_id == job_id).all()
+        assert len(notifs) == 1, "successful agent run records one agent_result notification"
+    finally:
+        db.close()

--- a/backend/tests/test_services/test_cron_creation_approval.py
+++ b/backend/tests/test_services/test_cron_creation_approval.py
@@ -278,6 +278,40 @@ def test_agent_changing_schedule_resets_to_pending():
     assert len([c for c in _cron_approvals() if c.status == "pending"]) == 1
 
 
+def test_agent_editing_prompt_before_approval_supersedes_stale_card():
+    """The agent updates the prompt (payload) while the FIRST card is still
+    pending. There must be exactly ONE actionable card — vetting the NEW
+    payload — so the user can't approve the stale card (v1) and have the job
+    silently run the new payload (v2). The stale card is cancelled."""
+    from tools import cron_server
+    from core.database import ApprovalRequestModel
+
+    cron_server.cron_create(
+        name="Pre-approval edit", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="v1 original", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+
+    # Agent edits the payload BEFORE the user has approved the first card.
+    cron_server.cron_update(job_id=job_id, exec_payload="v2 replacement")
+
+    db = get_db_session()
+    try:
+        cards = (
+            db.query(ApprovalRequestModel)
+            .filter(ApprovalRequestModel.approval_type == "cron_approval")
+            .all()
+        )
+        pending = [c for c in cards if c.status == "pending"]
+        cancelled = [c for c in cards if c.status == "cancelled"]
+        assert len(pending) == 1, f"exactly one actionable card expected, got {len(pending)}"
+        assert "v2 replacement" in pending[0].content, "surviving card must vet the NEW payload"
+        assert "v1 original" not in pending[0].content
+        assert len(cancelled) == 1, "the stale v1 card must be cancelled, not left pending"
+    finally:
+        db.close()
+
+
 # ── Dashboard edit supersedes a pending agent approval ────────────────
 
 

--- a/backend/tests/test_services/test_cron_creation_approval.py
+++ b/backend/tests/test_services/test_cron_creation_approval.py
@@ -278,6 +278,29 @@ def test_agent_changing_schedule_resets_to_pending():
     assert len([c for c in _cron_approvals() if c.status == "pending"]) == 1
 
 
+def test_agent_changing_calendar_type_resets_to_pending():
+    """calendar_type is a vetted artifact (the card shows it beside the
+    schedule). solar↔lunar shifts WHEN the approved payload fires → re-gate."""
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Calendar swap", cron_expr="0 7 1 * *", exec_mode="agent_turn",
+        exec_payload="do it", exec_agent="Jarvis", calendar_type="solar",
+    )
+    job_id = _only_job().id
+    approval_service.resolve_approval(_cron_approvals()[0].id, decision="approve")
+
+    cron_server.cron_update(job_id=job_id, calendar_type="lunar")
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "pending", "changing calendar_type must re-gate"
+    finally:
+        db.close()
+    assert len([c for c in _cron_approvals() if c.status == "pending"]) == 1
+
+
 def test_agent_editing_prompt_before_approval_supersedes_stale_card():
     """The agent updates the prompt (payload) while the FIRST card is still
     pending. There must be exactly ONE actionable card — vetting the NEW

--- a/backend/tests/test_services/test_cron_creation_approval.py
+++ b/backend/tests/test_services/test_cron_creation_approval.py
@@ -231,6 +231,53 @@ def test_agent_no_op_edit_keeps_approval():
         db.close()
 
 
+def test_agent_swapping_exec_agent_resets_to_pending():
+    """exec_agent is a vetted artifact (the card shows the target agent). An
+    agent that swaps a WEAK approved agent for a POWERFUL one — same payload —
+    must re-gate; otherwise the vetted toolset is bypassed."""
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Agent swap", cron_expr="*/5 * * * *", exec_mode="agent_turn",
+        exec_payload="do it", exec_agent="WeakAgent",
+    )
+    job_id = _only_job().id
+    approval_service.resolve_approval(_cron_approvals()[0].id, decision="approve")
+
+    cron_server.cron_update(job_id=job_id, exec_agent="PowerfulAgent")
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "pending", "swapping exec_agent must re-gate"
+    finally:
+        db.close()
+    assert len([c for c in _cron_approvals() if c.status == "pending"]) == 1
+
+
+def test_agent_changing_schedule_resets_to_pending():
+    """schedule_cron is a vetted artifact (the card shows the schedule). An
+    agent that changes WHEN / how often an approved payload fires must re-gate."""
+    from tools import cron_server
+
+    cron_server.cron_create(
+        name="Reschedule", cron_expr="0 9 * * *", exec_mode="agent_turn",
+        exec_payload="do it", exec_agent="Jarvis",
+    )
+    job_id = _only_job().id
+    approval_service.resolve_approval(_cron_approvals()[0].id, decision="approve")
+
+    cron_server.cron_update(job_id=job_id, cron_expr="*/1 * * * *")
+
+    db = get_db_session()
+    try:
+        job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
+        assert job.approval_status == "pending", "changing the schedule must re-gate"
+    finally:
+        db.close()
+    assert len([c for c in _cron_approvals() if c.status == "pending"]) == 1
+
+
 # ── Dashboard edit supersedes a pending agent approval ────────────────
 
 
@@ -319,13 +366,14 @@ async def test_e2e_pending_job_skipped_then_runs_after_approval():
 
 
 @pytest.mark.asyncio
-async def test_execute_job_records_blocked_run_without_notification_then_runs():
+async def test_pending_job_skips_silently_then_runs_after_approval():
     """Through the REAL scheduler entry point ``_execute_job`` (what the loop
     calls), not just ``_execute_agent_turn``:
 
-    * a pending job → run row recorded ``blocked``, NO inbox notification
-      (the approval card already notified), no fail-count bump, job stays
-      ``active`` for the next tick.
+    * a pending job → skipped SILENTLY: no run row, no inbox notification
+      (the approval card already notified), no fail-count / run-count bump,
+      job stays ``active`` for the next tick. Ticking repeatedly must not
+      accrue rows (unbounded-growth guard).
     * after approval → the same path RUNS, records ``success`` + one
       ``agent_result`` notification.
 
@@ -344,25 +392,33 @@ async def test_execute_job_records_blocked_run_without_notification_then_runs():
     sched._session_service = MagicMock()
     sched._session_service.resume_and_send = AsyncMock(return_value=("done", "sid"))
 
-    # 1) Pending → _execute_job catches ApprovalBlocked and records 'blocked'.
-    db = get_db_session()
-    try:
-        await sched._execute_job(
-            db.query(CronJobModel).filter(CronJobModel.id == job_id).first(), db
-        )
-    finally:
-        db.close()
+    # 1) Pending → _execute_job catches ApprovalBlocked and records NOTHING:
+    #    no run row, no notification. Tick it THREE times to prove an
+    #    unapproved recurring job does not accrue blocked rows per tick (the
+    #    ~288-rows/day unbounded-growth regression).
+    for _ in range(3):
+        db = get_db_session()
+        try:
+            await sched._execute_job(
+                db.query(CronJobModel).filter(CronJobModel.id == job_id).first(), db
+            )
+        finally:
+            db.close()
 
     db = get_db_session()
     try:
         runs = db.query(CronRunModel).filter(CronRunModel.job_id == job_id).all()
-        assert len(runs) == 1 and runs[0].status == "blocked"
+        assert runs == [], (
+            "awaiting-approval skip must NOT persist a run row — a never-approved "
+            f"recurring job would grow unbounded; saw {len(runs)} rows after 3 ticks"
+        )
         notifs = db.query(NotificationModel).filter(NotificationModel.job_id == job_id).all()
         assert notifs == [], "pending-approval skip must NOT create an inbox notification"
         job = db.query(CronJobModel).filter(CronJobModel.id == job_id).first()
         assert job.approval_status == "pending"
         assert job.status == "active"
         assert (job.fail_count or 0) == 0
+        assert (job.run_count or 0) == 0, "silent skip must not inflate run_count"
     finally:
         db.close()
     sched._session_service.resume_and_send.assert_not_called()

--- a/backend/tests/test_services/test_cron_scheduler_agent_turn.py
+++ b/backend/tests/test_services/test_cron_scheduler_agent_turn.py
@@ -16,28 +16,20 @@ this test.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from services.cron_scheduler import ApprovalBlocked, CronScheduler
 
 
-# All tests in this module exercise the *post-gate* behaviour of
-# ``_execute_agent_turn``. The approval gate itself has its own
-# coverage in test_approval_gate.py — here we patch it to auto-
-# approve so each test can focus on the resume_and_send contract
-# (originally added for the 2026-05-05 "no agent_name" regression).
-# ``_execute_agent_turn`` imports the gate locally as
-# ``from services.approval_gate import gate as _gate`` — patching
-# at the source module ``services.approval_gate.gate`` is the only
-# anchor that intercepts that local re-bind.
-@pytest.fixture(autouse=True)
-def _auto_approve_gate():
-    async def _allow(**_kw):
-        return True, "test auto-approve"
-    with patch("services.approval_gate.gate", side_effect=_allow):
-        yield
+# All tests in this module exercise the *post-approval* behaviour of
+# ``_execute_agent_turn``. Approval is now decided at CREATION time and
+# stored on ``job.approval_status`` (single source of truth) — the run path
+# only READS it (no blocking gate any more). So "auto-approve" here simply
+# means setting ``job.approval_status = "approved"`` on the stub job. The
+# creation-time gating + resolve flow has its own coverage in
+# test_cron_creation_approval.py.
 
 
 @pytest.mark.asyncio
@@ -58,6 +50,7 @@ async def test_execute_agent_turn_passes_configured_agent_name():
     job.name = "Daily AI digest"
     job.exec_agent = "ResearchAgent"
     job.exec_payload = "Tổng hợp tin tức AI"
+    job.approval_status = "approved"  # vetted at creation time
 
     result = await sched._execute_agent_turn(job)
 
@@ -90,6 +83,7 @@ async def test_execute_agent_turn_logs_warning_on_empty_response(caplog):
     job.name = "Empty response job"
     job.exec_agent = "ResearchAgent"
     job.exec_payload = "do something"
+    job.approval_status = "approved"
 
     with caplog.at_level(logging.WARNING, logger="services.cron_scheduler"):
         result = await sched._execute_agent_turn(job)
@@ -221,17 +215,13 @@ async def test_run_job_isolated_uses_fresh_db_session(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_execute_agent_turn_raises_approval_blocked_when_gate_refuses(_auto_approve_gate):
-    """When the approval gate returns ``approved=False`` the agent turn
-    MUST raise :class:`ApprovalBlocked`. This is the contract _execute_job
-    catches separately so a gate-blocked run is recorded as ``blocked``
-    rather than ``success`` (PR #57 reviewer finding, comment on
-    cron_scheduler.py:405).
+async def test_execute_agent_turn_raises_approval_blocked_when_not_approved():
+    """A not-yet-approved job (``approval_status='pending'``) MUST raise
+    :class:`ApprovalBlocked` at fire time — NEVER block waiting for a human,
+    and NEVER run the payload. _execute_job catches this and records the run
+    as ``blocked`` (not ``success``). This is the creation-time-approval
+    replacement for the old fire-time blocking gate.
     """
-    # Replace the auto-approve fixture's gate with one that refuses.
-    async def _refuse(**_kw):
-        return False, "user rejected: not happy with payload"
-
     sched = CronScheduler()
     sched._agent_app = MagicMock()
     sched._session_service = MagicMock()
@@ -244,11 +234,41 @@ async def test_execute_agent_turn_raises_approval_blocked_when_gate_refuses(_aut
     job.exec_payload = "do thing"
     job.schedule_cron = "* * * * *"
     job.calendar_type = "solar"
+    job.approval_status = "pending"  # agent-created, not yet vetted
 
-    with patch("services.approval_gate.gate", side_effect=_refuse):
-        with pytest.raises(ApprovalBlocked) as excinfo:
-            await sched._execute_agent_turn(job)
+    # Default config (no scheduler.REQUIRE_APPROVAL row) → approval required.
+    with pytest.raises(ApprovalBlocked) as excinfo:
+        await sched._execute_agent_turn(job)
 
-    assert "user rejected" in str(excinfo.value)
-    # The actual resume_and_send must NEVER be called when the gate refused.
+    assert excinfo.value.notify is False, "pending-approval skips must not spam the inbox"
+    assert "approval" in str(excinfo.value).lower()
+    # The actual resume_and_send must NEVER be called for an unapproved job.
     sched._session_service.resume_and_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_agent_turn_runs_when_approval_disabled(monkeypatch):
+    """With the Settings toggle scheduler.REQUIRE_APPROVAL=false, an
+    otherwise-pending job runs immediately — the documented "use at your own
+    risk" bypass."""
+    sched = CronScheduler()
+    sched._agent_app = MagicMock()
+    sched._session_service = MagicMock()
+    sched._session_service.resume_and_send = AsyncMock(return_value=("ran", "sid"))
+
+    job = MagicMock()
+    job.id = "bypass1"
+    job.name = "Bypass job"
+    job.exec_agent = "Jarvis"
+    job.exec_payload = "do thing"
+    job.approval_status = "pending"
+
+    monkeypatch.setattr(
+        "services.config_service.config_service.get",
+        lambda category, key, default=None: "false"
+        if (category, key) == ("scheduler", "REQUIRE_APPROVAL") else default,
+    )
+
+    result = await sched._execute_agent_turn(job)
+    assert result == "ran"
+    sched._session_service.resume_and_send.assert_called_once()

--- a/backend/tests/test_services/test_token_persistence_central.py
+++ b/backend/tests/test_services/test_token_persistence_central.py
@@ -188,6 +188,10 @@ async def test_cron_scheduler_sets_context_var_during_agent_turn():
     job.name = "test"
     job.exec_agent = "Jarvis"
     job.exec_payload = "hello"
+    # Approved at creation time — this test exercises the token-context
+    # contract downstream of the creation-time approval gate, not the gate
+    # itself (a bare MagicMock's approval_status would block the turn).
+    job.approval_status = "approved"
 
     # Pre-condition: outside the call, ContextVar is its default empty.
     assert current_run_id.get() == ""
@@ -229,6 +233,9 @@ async def test_cron_scheduler_resets_context_var_on_exception():
     job.name = "boom job"
     job.exec_agent = "Jarvis"
     job.exec_payload = "x"
+    # Approved so the turn proceeds to the agent send (where the boom is
+    # raised) rather than being short-circuited by the approval gate.
+    job.approval_status = "approved"
 
     with pytest.raises(RuntimeError, match="Agent turn failed"):
         await sched._execute_agent_turn(job)

--- a/backend/tools/cron_server.py
+++ b/backend/tools/cron_server.py
@@ -370,6 +370,8 @@ def cron_update(
 
         changes = []
         payload_changed = False
+        agent_changed = False
+        schedule_changed = False
 
         if name is not None:
             job.name = name
@@ -380,8 +382,9 @@ def cron_update(
             payload_changed = True
             changes.append(f"payload updated")
 
-        if exec_agent is not None:
+        if exec_agent is not None and exec_agent != job.exec_agent:
             job.exec_agent = exec_agent
+            agent_changed = True
             changes.append(f"exec_agent → {exec_agent}")
 
         if calendar_type is not None:
@@ -407,6 +410,8 @@ def cron_update(
             error = _validate_cron_expr(cron_expr)
             if error:
                 return f"❌ {error}"
+            if cron_expr != job.schedule_cron:
+                schedule_changed = True
             job.schedule_cron = cron_expr
             changes.append(f"cron → {cron_expr}")
 
@@ -422,19 +427,25 @@ def cron_update(
             except Exception as e:
                 return f"❌ next_run computation failed: {e}"
 
-        # An agent editing the payload of an agent_turn job invalidates any
-        # prior approval — the bytes that were vetted no longer match what
-        # will run. Re-gate it. This closes the "create benign job → get it
-        # approved → quietly swap in a malicious payload" path without needing
-        # to hash anything: the approval flag is the state, reset it on edit.
+        # An agent editing any VETTED field of an agent_turn job invalidates
+        # the prior approval — what was vetted no longer matches what will run.
+        # The approval card (``_approval_content``) shows the payload, the
+        # target agent AND the schedule, so all three are vetted artifacts:
+        #   - payload  → the bytes that execute
+        #   - exec_agent → which tool set runs them (WeakAgent vs PowerfulAgent)
+        #   - schedule_cron → when / how often they fire
+        # Re-gate on any of them. This closes the "create benign job → get it
+        # approved → quietly swap in a stronger agent / different schedule"
+        # path without hashing: the approval flag IS the state, reset on edit.
+        sensitive_changed = payload_changed or agent_changed or schedule_changed
         reapproval_needed = (
-            payload_changed
+            sensitive_changed
             and job.exec_mode == "agent_turn"
             and _require_approval()
         )
         if reapproval_needed:
             job.approval_status = "pending"
-            changes.append("approval reset → pending (payload changed)")
+            changes.append("approval reset → pending (vetted field changed)")
 
         job.updated_at = time.time()
         # Snapshot fields for the post-commit approval card.

--- a/backend/tools/cron_server.py
+++ b/backend/tools/cron_server.py
@@ -390,6 +390,10 @@ def cron_update(
         if calendar_type is not None:
             if calendar_type not in ("solar", "lunar"):
                 return "❌ calendar_type must be 'solar' or 'lunar'"
+            # calendar_type is a vetted artifact too — the card shows it next to
+            # the schedule, and solar↔lunar shifts WHEN the vetted payload fires.
+            if calendar_type != job.calendar_type:
+                schedule_changed = True
             job.calendar_type = calendar_type
             changes.append(f"calendar → {calendar_type}")
 

--- a/backend/tools/cron_server.py
+++ b/backend/tools/cron_server.py
@@ -86,6 +86,62 @@ def _compute_next_run(cron_expr: str, calendar_type: str, tz_name: str, lunar_le
         raise ValueError(f"Unknown calendar_type: {calendar_type}")
 
 
+def _require_approval() -> bool:
+    """Whether agent-created agent_turn jobs need human approval before they
+    may fire. Default ON. The Settings toggle ``scheduler.REQUIRE_APPROVAL``
+    can disable it (use at your own risk). Fail safe: if the toggle can't be
+    read, require approval.
+    """
+    try:
+        from services.config_service import config_service
+        v = config_service.get("scheduler", "REQUIRE_APPROVAL", default="true")
+        return str(v).strip().lower() in ("1", "true", "yes", "on")
+    except Exception:
+        return True
+
+
+def _approval_content(job: CronJobModel) -> str:
+    """Markdown shown in the approval card for an agent-created job."""
+    return (
+        f"## Agent-created schedule: `{job.name}`\n\n"
+        f"**Schedule:** `{job.schedule_cron}` ({job.calendar_type})\n"
+        f"**Target agent:** `{job.exec_agent}`\n\n"
+        f"**Payload that will run:**\n\n```text\n{(job.exec_payload or '').rstrip()}\n```\n\n"
+        f"---\n\n"
+        f"⚠️ **Use at your own risk.** Approving lets this exact payload run on "
+        f"the schedule above, unsupervised, with the target agent's full tool "
+        f"set — including anything that touches the filesystem, shell, network, "
+        f"or external accounts.\n\n"
+        f"Approve only if you recognise the payload and trust the source that "
+        f"created this job. (This job was created by an agent, not from the "
+        f"dashboard — if you didn't ask for it, reject it.)"
+    )
+
+
+def _create_cron_approval_card(*, job_id: str, name: str, exec_agent: str, content_md: str) -> None:
+    """Create the user-facing approval card for an agent-created job, via the
+    backend RPC socket. Best-effort: the job row is already ``pending`` so it
+    can't fire even if the card fails to materialise (fail-safe). ``pause`` is
+    False — this is a deferred gate, not a hold on a live agent turn, so the
+    agent the user may be chatting with must NOT be frozen.
+    """
+    from tools.runtime_rpc_client import RuntimeRpcError, call as rpc_call
+    try:
+        rpc_call("approval.create", {
+            "agent_name": exec_agent or "Jarvis",
+            "approval_type": "cron_approval",
+            "title": f"Schedule approval: {name}",
+            "content": content_md,
+            "content_format": "markdown",
+            "urgency": "normal",
+            "pause": False,
+            "metadata": {"job_id": job_id},
+        })
+    except RuntimeRpcError as exc:
+        print(f"[cron_create] approval card RPC failed (job stays pending): {exc}",
+              file=sys.stderr)
+
+
 def _format_job(job: CronJobModel) -> dict:
     """Format a job for display."""
     tz = ZoneInfo(job.schedule_timezone or "Asia/Ho_Chi_Minh")
@@ -99,6 +155,7 @@ def _format_job(job: CronJobModel) -> dict:
         "exec_payload": job.exec_payload[:100] if job.exec_payload else "",
         "exec_agent": job.exec_agent,
         "status": job.status,
+        "approval_status": job.approval_status,
         "last_result": job.last_result,
         "run_count": job.run_count or 0,
         "fail_count": job.fail_count or 0,
@@ -161,6 +218,15 @@ def cron_create(
     except Exception as e:
         return f"❌ next_run computation failed: {e}"
 
+    # Approval gate — decided HERE at creation time, not at fire time.
+    # An agent created this job (created_by='agent'); only agent_turn jobs
+    # carry execution risk (reminders just broadcast text). When approval is
+    # required, the job starts 'pending' and cannot fire until the user
+    # resolves the approval card below. This is the prompt-injection defence:
+    # a poisoned cron can't run unsupervised before a human vets its payload.
+    needs_approval = exec_mode == "agent_turn" and _require_approval()
+    approval_status = "pending" if needs_approval else "approved"
+
     # Create job
     job_id = str(uuid.uuid4())[:8]
     now = time.time()
@@ -183,28 +249,49 @@ def cron_create(
             created_at=now,
             updated_at=now,
             created_by="agent",
+            approval_status=approval_status,
         )
         db.add(job)
         db.commit()
+        # Build the approval-card markdown while the row is live, so we don't
+        # touch the ORM object after the session closes.
+        card_content = _approval_content(job) if needs_approval else None
 
-        formatted = _format_job(job)
         tz = ZoneInfo(tz_name)
         next_str = datetime.fromtimestamp(next_run, tz=tz).strftime("%Y-%m-%d %H:%M %Z")
-
-        return (
-            f"✅ Job created\n"
-            f"• ID: {job_id}\n"
-            f"• Name: {name}\n"
-            f"• Cron: {cron_expr} ({calendar_type})\n"
-            f"• Mode: {exec_mode}\n"
-            f"• One-shot: {'yes' if one_shot else 'no'}\n"
-            f"• Next run: {next_str}"
-        )
     except Exception as e:
         db.rollback()
         return f"❌ Failed to create job: {e}"
     finally:
         db.close()
+
+    if needs_approval:
+        # After commit (job durably 'pending') so the card always points at a
+        # real row, and outside the DB session so an RPC stall can't hold it.
+        _create_cron_approval_card(
+            job_id=job_id, name=name, exec_agent=exec_agent, content_md=card_content,
+        )
+        return (
+            f"✅ Job created — ⏳ AWAITING YOUR APPROVAL before it can run\n"
+            f"• ID: {job_id}\n"
+            f"• Name: {name}\n"
+            f"• Cron: {cron_expr} ({calendar_type})\n"
+            f"• Mode: {exec_mode}\n"
+            f"• One-shot: {'yes' if one_shot else 'no'}\n"
+            f"• Next run: {next_str} (will be SKIPPED until approved)\n"
+            f"\n⚠️ This job will NOT run until you approve it in the Approvals "
+            f"page. Tell the user to review and approve it."
+        )
+
+    return (
+        f"✅ Job created\n"
+        f"• ID: {job_id}\n"
+        f"• Name: {name}\n"
+        f"• Cron: {cron_expr} ({calendar_type})\n"
+        f"• Mode: {exec_mode}\n"
+        f"• One-shot: {'yes' if one_shot else 'no'}\n"
+        f"• Next run: {next_str}"
+    )
 
 
 @mcp.tool()
@@ -282,13 +369,15 @@ def cron_update(
             return f"❌ Job not found: {job_id}"
 
         changes = []
+        payload_changed = False
 
         if name is not None:
             job.name = name
             changes.append(f"name → {name}")
 
-        if exec_payload is not None:
+        if exec_payload is not None and exec_payload != job.exec_payload:
             job.exec_payload = exec_payload
+            payload_changed = True
             changes.append(f"payload updated")
 
         if exec_agent is not None:
@@ -333,11 +422,34 @@ def cron_update(
             except Exception as e:
                 return f"❌ next_run computation failed: {e}"
 
+        # An agent editing the payload of an agent_turn job invalidates any
+        # prior approval — the bytes that were vetted no longer match what
+        # will run. Re-gate it. This closes the "create benign job → get it
+        # approved → quietly swap in a malicious payload" path without needing
+        # to hash anything: the approval flag is the state, reset it on edit.
+        reapproval_needed = (
+            payload_changed
+            and job.exec_mode == "agent_turn"
+            and _require_approval()
+        )
+        if reapproval_needed:
+            job.approval_status = "pending"
+            changes.append("approval reset → pending (payload changed)")
+
         job.updated_at = time.time()
+        # Snapshot fields for the post-commit approval card.
+        card_content = _approval_content(job) if reapproval_needed else None
+        card_name, card_agent = job.name, job.exec_agent
         db.commit()
 
         if not changes:
             return f"ℹ️ No changes for job [{job_id}]"
+
+        if reapproval_needed:
+            _create_cron_approval_card(
+                job_id=job_id, name=card_name, exec_agent=card_agent, content_md=card_content,
+            )
+            changes.append("⏳ job will NOT run until you re-approve it")
 
         return f"✅ Updated job [{job_id}] {job.name}:\n• " + "\n• ".join(changes)
     except Exception as e:

--- a/frontend/src/stores/approvals.js
+++ b/frontend/src/stores/approvals.js
@@ -189,9 +189,14 @@ export const useApprovalsStore = defineStore('approvals', () => {
         const id = data?.approval_id
         if (id && approvals.value.has(id)) {
           const existing = approvals.value.get(id)
+          // 'cancelled' = a stale cron card superseded by a newer one (the
+          // agent re-edited the job); keep it distinct from a user 'reject'.
+          const resolvedStatus = data.decision === 'approve'
+            ? 'approved'
+            : data.decision === 'cancelled' ? 'cancelled' : 'rejected'
           approvals.value.set(id, {
             ...existing,
-            status: data.decision === 'approve' ? 'approved' : 'rejected',
+            status: resolvedStatus,
             user_decision: data.decision,
             user_comment: data.comment,
             resolved_at: event.timestamp,

--- a/frontend/src/views/ApprovalsView.vue
+++ b/frontend/src/views/ApprovalsView.vue
@@ -371,8 +371,9 @@ const knownTypes = [
                 :class="{
                   'chip-success': item.status === 'approved',
                   'chip-danger': item.status === 'rejected',
+                  'chip-muted': item.status === 'cancelled',
                 }"
-              ><span class="chip-dot"></span> {{ item.status }}</span>
+              ><span class="chip-dot"></span> {{ item.status === 'cancelled' ? 'superseded' : item.status }}</span>
             </div>
             <div class="approvals-row__title">{{ item.title }}</div>
             <div class="approvals-row__meta">
@@ -558,10 +559,12 @@ const knownTypes = [
             :class="{
               'chip-success': detail.status === 'approved',
               'chip-danger': detail.status === 'rejected',
+              'chip-muted': detail.status === 'cancelled',
             }"
           >
             <span class="chip-dot"></span>
-            {{ detail.status === 'approved' ? 'Approved' : 'Rejected' }}
+            {{ detail.status === 'approved' ? 'Approved'
+               : detail.status === 'cancelled' ? 'Superseded' : 'Rejected' }}
           </span>
         </div>
       </section>

--- a/frontend/src/views/SchedulerDashboard.vue
+++ b/frontend/src/views/SchedulerDashboard.vue
@@ -75,6 +75,15 @@ function handleSSEEvent(event) {
     stats.value = event.stats
     return
   }
+  if (event.type === 'job_approval_changed') {
+    // Approval was resolved on the Approvals page — refresh so the pending
+    // badge flips and next-run reflects the now-runnable (or rejected) job.
+    const name = event.job_name || 'Job'
+    if (event.approval_status === 'approved') toast.success(`✅ Approved: ${name} can now run`)
+    else if (event.approval_status === 'rejected') toast.info(`🚫 Rejected: ${name} will not run`)
+    fetchAll()
+    return
+  }
   if (['job_started', 'job_completed', 'job_failed', 'reminder'].includes(event.type)) {
     const name = event.job_name || 'Job'
     if (event.type === 'reminder') {
@@ -440,6 +449,8 @@ onMounted(() => {
           <span class="scheduler__col-name">
             <span class="scheduler__job-name">{{ job.name }}</span>
             <span v-if="job.calendar_type === 'lunar'" class="scheduler__job-tag">🌙</span>
+            <span v-if="job.approval_status === 'pending'" class="scheduler__approval-badge" title="Created by an agent — awaiting your approval before it can run">⏳ Awaiting approval</span>
+            <span v-else-if="job.approval_status === 'rejected'" class="scheduler__approval-badge scheduler__approval-badge--rejected" title="Approval rejected — this job will not run">🚫 Rejected</span>
           </span>
           <span class="scheduler__col-cron">
             <code class="scheduler__cron">{{ job.schedule_cron }}</code>
@@ -471,6 +482,8 @@ onMounted(() => {
             <span class="scheduler__job-card-name">
               {{ job.name }}
               <span v-if="job.calendar_type === 'lunar'" style="margin-left: 4px;">🌙</span>
+              <span v-if="job.approval_status === 'pending'" class="scheduler__approval-badge">⏳ Awaiting approval</span>
+              <span v-else-if="job.approval_status === 'rejected'" class="scheduler__approval-badge scheduler__approval-badge--rejected">🚫 Rejected</span>
             </span>
             <span
               class="scheduler__badge"
@@ -886,6 +899,22 @@ onMounted(() => {
 }
 .scheduler__job-name { color: var(--text); font-weight: 500; }
 .scheduler__job-tag { margin-left: 4px; font-size: 10px; color: var(--text-muted); }
+.scheduler__approval-badge {
+  margin-left: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 7px;
+  border-radius: 10px;
+  white-space: nowrap;
+  background: var(--warning-bg);
+  color: var(--warning);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+}
+.scheduler__approval-badge--rejected {
+  background: var(--danger-bg);
+  color: var(--danger);
+  border-color: rgba(239, 68, 68, 0.3);
+}
 .scheduler__cron {
   font-family: var(--font-mono);
   font-size: 11px;

--- a/frontend/src/views/settings/SettingsExperimental.vue
+++ b/frontend/src/views/settings/SettingsExperimental.vue
@@ -17,6 +17,8 @@ import { apiFetch, ApiError } from '../../api'
 
 const CATEGORY = 'experimental'
 
+// `category` defaults to CATEGORY; `default` is the value used when no DB row
+// exists yet (most flags default off — security flags default ON).
 const features = ref([
   {
     key: 'SELF_IMPROVING_ENABLED',
@@ -27,6 +29,27 @@ const features = ref([
       'Every state change writes a notification so you can review what the agent did.',
     requiresRestart: false,
     value: false,
+    saving: false,
+    error: '',
+  },
+  {
+    // Security flag — lives under the `scheduler` config category (the backend
+    // reads scheduler.REQUIRE_APPROVAL). Surfaced here for now; will move to a
+    // dedicated Security section when that is planned.
+    key: 'REQUIRE_APPROVAL',
+    category: 'scheduler',
+    default: true,
+    danger: true,
+    label: 'Require approval for agent-created schedules',
+    description:
+      'When ON (recommended), any schedule an AGENT creates that runs an agent turn ' +
+      'is held for your approval before it can fire — your defence against a ' +
+      'prompt-injected cron running unsupervised. Schedules YOU create on the ' +
+      'dashboard are never gated. ' +
+      'Turn this OFF to let agent-created schedules run immediately without approval — ' +
+      '⚠ use at your own risk.',
+    requiresRestart: false,
+    value: true,
     saving: false,
     error: '',
   },
@@ -42,12 +65,12 @@ async function loadAll() {
     for (const f of features.value) {
       try {
         const res = await apiFetch(
-          `/api/settings/${CATEGORY}/${f.key}`,
+          `/api/settings/${f.category || CATEGORY}/${f.key}`,
         )
         f.value = _coerceBool(res?.value)
       } catch (err) {
         if (err instanceof ApiError && err.status === 404) {
-          f.value = false // no row yet → default off
+          f.value = f.default ?? false // no row yet → per-feature default
         } else {
           throw err
         }
@@ -65,7 +88,7 @@ async function toggle(feature) {
   feature.error = ''
   const next = !feature.value
   try {
-    await apiFetch(`/api/settings/${CATEGORY}/${feature.key}`, {
+    await apiFetch(`/api/settings/${feature.category || CATEGORY}/${feature.key}`, {
       method: 'PUT',
       body: JSON.stringify({ value: next ? 'true' : 'false', is_secret: false }),
     })
@@ -112,6 +135,7 @@ onMounted(loadAll)
           <div class="feature-title-row">
             <h3>{{ f.label }}</h3>
             <span v-if="f.requiresRestart" class="pill">Requires Restart</span>
+            <span v-if="f.danger && !f.value" class="pill pill-danger">⚠ Approval off — at your own risk</span>
           </div>
           <p class="feature-desc">{{ f.description }}</p>
           <p v-if="f.error" class="error">{{ f.error }}</p>
@@ -185,6 +209,11 @@ onMounted(loadAll)
   background: var(--warning-bg);
   color: var(--warning);
   border: 1px solid rgba(245, 158, 11, 0.25);
+}
+.pill-danger {
+  background: var(--danger-bg, rgba(239, 68, 68, 0.12));
+  color: var(--danger);
+  border-color: rgba(239, 68, 68, 0.3);
 }
 .feature-desc {
   margin: 0;


### PR DESCRIPTION
## What & why

Agent-created cron jobs that run an **agent turn** execute unsupervised at fire time with the target agent's full tool set (shell, network, filesystem). The old design blocked at *fire time*, which could hang the scheduler waiting on an absent human. This PR moves the decision to **creation time**, stored on `CronJobModel.approval_status` — the single source of truth the scheduler only **reads** at fire time. Prompt-injection defence without ever hanging the scheduler.

- **Agent-created agent_turn job** → starts `pending` + an ApprovalRequest card in the inbox. Skips firing (no inbox spam) until resolved; retries each tick.
- **Reminders / dashboard-created jobs** → `approved` immediately (the user is present and in control).
- **Dashboard edit** of an unapproved job *is* the vetting step → marks it approved and clears the stale card.
- **Settings toggle** `scheduler.REQUIRE_APPROVAL` (default ON) hot-reloads; OFF = run at your own risk.

## Click-flow

1. Agent calls `cron_create(exec_mode="agent_turn", …)` → job saved `pending`, approval card appears, dashboard shows **⏳ Awaiting approval** badge.
2. At fire time the scheduler reads `approval_status`; `pending` → skips (records a non-failing blocked run, no notification), no `fail_count` bump.
3. User clicks **Approve** on the Approvals page → `PUT /api/approvals/{id}/resolve` writes through to `approval_status=approved`, broadcasts `job_approval_changed`, scheduler wakes → job runs next tick. Reject → job never runs.

## Notable fix (root-cause)

`config_service` snapshotted `SessionLocal` via a default arg at singleton construction. When the singleton was first imported *during* an isolated test, it captured the test's SAVEPOINT connection — which closed at teardown, making every later config read raise `ResourceClosedError: This Connection is closed`. Now resolves `SessionLocal` lazily per-call (SSoT). This was what blocked the new e2e suite.

## Tests

- `test_cron_creation_approval.py` — integration over real `create_approval`/`resolve_approval`/`_execute_agent_turn` (only the UDS RPC transport faked).
- `test_cron_approval_route_e2e.py` — real `PUT /api/approvals/{id}/resolve` through production FastAPI routing → `approval_status`, nothing mocked.
- Green: **801 passed** in `test_services/`; **18 passed** across the 3 cron suites.

### Known unrelated issue
`test_ws_voice` has a pre-existing order-dependent hang in a full `test_routes/` run (`test_cancelled_turn_does_not_emit_empty_assistant_message`) — reproduced on baseline without this branch's changes, so out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)