### PR TITLE
fix(tts): cap EdgeTTS chunks at 500 + per-chunk retry

### DIFF
--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -29,6 +29,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_EDGE_VOICE = "vi-VN-NamMinhNeural"
 DEFAULT_EDGE_RATE = "+20%"
+# Largest text size sent in ONE edge_tts request. A single oversized request
+# (e.g. a whole ~9k-char story chapter) streams slower than real-time playback
+# and intermittently returns "no audio" / truncates — which made long story
+# chapters play "tậm tịt". Capping every chunk keeps each request small, fast
+# and reliable. Tier 1/2 stay far below this for low time-to-first-byte.
+EDGE_MAX_CHUNK = 500
 
 
 class TTSProvider(ABC):
@@ -90,38 +96,44 @@ class EdgeTTSProvider(TTSProvider):
 
     @staticmethod
     def _split_tiered(text: str) -> list[str]:
-        """3-tier split for low TTFB.
+        """Tiered split for low TTFB + reliable long-text synthesis.
 
-        Tier 1: ~50 chars  (instant first audio)
+        Tier 1: ~50 chars   (instant first audio)
         Tier 2: ~300 chars
-        Tier 3: remaining text in a single chunk.
+        Tier 3+: the rest in ``EDGE_MAX_CHUNK`` (500)-char chunks — NOT one
+        giant remainder chunk. A single oversized request streams slower than
+        playback and intermittently returns no audio / truncates (that made
+        long story chapters play "tậm tịt"); many small requests are fast and
+        reliable.
 
-        Splits at sentence > comma > whitespace boundaries to keep speech natural.
+        Splits at sentence > comma > whitespace boundaries to keep speech
+        natural. Every returned chunk is <= ``EDGE_MAX_CHUNK`` chars.
         """
         text = text.strip()
         if len(text) <= 100:
             return [text]
 
-        tiers = (50, 300)
         chunks: list[str] = []
         pos = 0
+        i = 0
 
-        for limit in tiers:
-            if pos >= len(text):
-                break
+        while pos < len(text):
+            # First two chunks stay tiny for low TTFB; everything after is
+            # capped at EDGE_MAX_CHUNK so no single request goes oversized.
+            limit = 50 if i == 0 else (300 if i == 1 else EDGE_MAX_CHUNK)
+            i += 1
 
             end = min(pos + limit, len(text))
             if end >= len(text):
                 tail = text[pos:].strip()
                 if tail:
                     chunks.append(tail)
-                pos = len(text)
                 break
 
             best = end
             search_start = max(pos, end - int(limit * 0.5))
 
-            # Sentence break first
+            # Sentence break first, then comma, then whitespace.
             for punct in (". ", "? ", "! ", ".\n", "?\n", "!\n"):
                 idx = text.rfind(punct, search_start, end)
                 if idx != -1:
@@ -139,20 +151,51 @@ class EdgeTTSProvider(TTSProvider):
             chunk = text[pos:best].strip()
             if chunk:
                 chunks.append(chunk)
-            pos = best
-
-        if pos < len(text):
-            remaining = text[pos:].strip()
-            if remaining:
-                chunks.append(remaining)
+            pos = best if best > pos else end  # guarantee forward progress
 
         return chunks
 
-    async def stream_audio(self, text: str) -> AsyncIterator[bytes]:
-        """Stream audio bytes with 3-tier chunking for low TTFB.
+    async def _synth_chunk(self, chunk_text: str, *, attempts: int = 3) -> bytes:
+        """Synthesize ONE text chunk to audio bytes, retrying transient
+        empty/failed responses with linear backoff.
 
-        Short text (<100 chars): single ``Communicate()`` call.
-        Long text: 50 → 300 → rest. Bytes are yielded as they arrive.
+        Buffered (not streamed) on purpose: a failed attempt can then be
+        retried cleanly without duplicating already-emitted audio. Chunks are
+        <= ``EDGE_MAX_CHUNK`` chars so the buffering cost is negligible.
+        Returns ``b''`` only if every attempt produced no audio.
+        """
+        last = "no audio received"
+        for attempt in range(1, attempts + 1):
+            buf = bytearray()
+            try:
+                communicate = edge_tts.Communicate(chunk_text, self.voice, rate=self.rate)
+                async for chunk in communicate.stream():
+                    if chunk.get("type") == "audio" and chunk.get("data"):
+                        buf.extend(chunk["data"])
+                if buf:
+                    return bytes(buf)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                last = str(exc)
+            if attempt < attempts:
+                logger.warning(
+                    "EdgeTTS chunk attempt %d/%d failed (%s) — retrying",
+                    attempt, attempts, last,
+                )
+                await asyncio.sleep(0.4 * attempt)  # linear backoff
+        logger.error("EdgeTTS chunk gave no audio after %d attempts (%s)", attempts, last)
+        return b""
+
+    async def stream_audio(self, text: str) -> AsyncIterator[bytes]:
+        """Stream audio bytes with tiered chunking for low TTFB.
+
+        Short text (<100 chars): single chunk.
+        Long text: 50 → 300 → <=``EDGE_MAX_CHUNK`` chunks. Each chunk is
+        synthesized with per-chunk retry (:meth:`_synth_chunk`). A chunk that
+        yields no audio after all retries fails the whole stream so the caller
+        drops the partial file instead of serving a silent gap (no silent
+        fallback).
         """
         if not text or not text.strip():
             return
@@ -170,39 +213,16 @@ class EdgeTTSProvider(TTSProvider):
             )
 
             for i, chunk_text in enumerate(chunks):
-                chunk_start = time.perf_counter()
-                chunk_ttfb: Optional[float] = None
-                chunk_bytes = 0
-
-                communicate = edge_tts.Communicate(chunk_text, self.voice, rate=self.rate)
-
-                async for chunk in communicate.stream():
-                    if chunk.get("type") != "audio":
-                        continue
-                    data: bytes = chunk["data"]
-                    if not data:
-                        continue
-                    if chunk_ttfb is None:
-                        chunk_ttfb = time.perf_counter() - chunk_start
-                        if ttfb is None:
-                            ttfb = time.perf_counter() - stream_start
-                            logger.debug(
-                                "EdgeTTS TTFB: %.0fms (chunk 1/%d)",
-                                ttfb * 1000,
-                                len(chunks),
-                            )
-                    chunk_bytes += len(data)
-                    yield data
-
-                total_bytes += chunk_bytes
-                logger.debug(
-                    "EdgeTTS chunk %d/%d done | %d chars | TTFB %.0fms | %dB",
-                    i + 1,
-                    len(chunks),
-                    len(chunk_text),
-                    (chunk_ttfb or 0.0) * 1000,
-                    chunk_bytes,
-                )
+                data = await self._synth_chunk(chunk_text)
+                if not data:
+                    raise RuntimeError(
+                        f"EdgeTTS produced no audio for chunk {i + 1}/{len(chunks)} "
+                        f"after retries ({len(chunk_text)} chars)"
+                    )
+                if ttfb is None:
+                    ttfb = time.perf_counter() - stream_start
+                total_bytes += len(data)
+                yield data
 
             total_duration = time.perf_counter() - stream_start
             logger.info(

--- a/backend/services/tts.py
+++ b/backend/services/tts.py
@@ -35,6 +35,13 @@ DEFAULT_EDGE_RATE = "+20%"
 # chapters play "tậm tịt". Capping every chunk keeps each request small, fast
 # and reliable. Tier 1/2 stay far below this for low time-to-first-byte.
 EDGE_MAX_CHUNK = 500
+# Hard wall-clock cap on ONE chunk's synthesis. A <=500-char chunk returns in a
+# few seconds normally; if a request stalls (throttled / dropped WebSocket) it
+# must NOT block forever — without this, a stuck pre-gen request blocks the
+# cooperative cancel point, so switching chapters mid-pre-gen would hang. On
+# timeout the attempt is aborted and retried; a freed slot lets the user's new
+# chapter proceed.
+EDGE_CHUNK_TIMEOUT = 30  # seconds
 
 
 class TTSProvider(ABC):
@@ -155,27 +162,38 @@ class EdgeTTSProvider(TTSProvider):
 
         return chunks
 
+    async def _synth_once(self, chunk_text: str) -> bytes:
+        """One edge_tts request → all audio bytes for ``chunk_text``."""
+        buf = bytearray()
+        communicate = edge_tts.Communicate(chunk_text, self.voice, rate=self.rate)
+        async for chunk in communicate.stream():
+            if chunk.get("type") == "audio" and chunk.get("data"):
+                buf.extend(chunk["data"])
+        return bytes(buf)
+
     async def _synth_chunk(self, chunk_text: str, *, attempts: int = 3) -> bytes:
         """Synthesize ONE text chunk to audio bytes, retrying transient
-        empty/failed responses with linear backoff.
+        empty/failed/stalled responses with linear backoff.
 
-        Buffered (not streamed) on purpose: a failed attempt can then be
-        retried cleanly without duplicating already-emitted audio. Chunks are
-        <= ``EDGE_MAX_CHUNK`` chars so the buffering cost is negligible.
-        Returns ``b''`` only if every attempt produced no audio.
+        Each attempt is wall-clock bounded by ``EDGE_CHUNK_TIMEOUT`` so a
+        stalled WebSocket can't hang forever. Buffered (not streamed) on
+        purpose: a failed attempt can then be retried cleanly without
+        duplicating already-emitted audio. Chunks are <= ``EDGE_MAX_CHUNK``
+        chars so the buffering cost is negligible. Returns ``b''`` only if
+        every attempt produced no audio.
         """
         last = "no audio received"
         for attempt in range(1, attempts + 1):
-            buf = bytearray()
             try:
-                communicate = edge_tts.Communicate(chunk_text, self.voice, rate=self.rate)
-                async for chunk in communicate.stream():
-                    if chunk.get("type") == "audio" and chunk.get("data"):
-                        buf.extend(chunk["data"])
-                if buf:
-                    return bytes(buf)
+                data = await asyncio.wait_for(
+                    self._synth_once(chunk_text), timeout=EDGE_CHUNK_TIMEOUT
+                )
+                if data:
+                    return data
             except asyncio.CancelledError:
                 raise
+            except asyncio.TimeoutError:
+                last = f"timed out after {EDGE_CHUNK_TIMEOUT}s"
             except Exception as exc:
                 last = str(exc)
             if attempt < attempts:

--- a/backend/services/tts_pregen_job.py
+++ b/backend/services/tts_pregen_job.py
@@ -198,34 +198,42 @@ class TTSPreGenJob(BackgroundJobRunner):
                 }))
             
             # Generate TTS in bounded chunks (<= EDGE_MAX_CHUNK) with per-chunk
-            # retry. A single whole-chapter edge_tts request streams slower than
-            # playback and intermittently returns no audio / truncates ("tậm
-            # tịt"); small chunks are fast + reliable. Pause/cancel is still
-            # checked between audio frames AND between chunks. Each chunk is
-            # buffered so a retried attempt can't duplicate already-written audio.
-            from services.tts import EdgeTTSProvider
+            # retry + timeout. A single whole-chapter edge_tts request streams
+            # slower than playback and intermittently returns no audio /
+            # truncates ("tậm tịt"); small chunks are fast + reliable. Each
+            # chunk is buffered so a retried attempt can't duplicate audio.
+            from services.tts import EdgeTTSProvider, EDGE_CHUNK_TIMEOUT
             text_chunks = EdgeTTSProvider._split_tiered(text)
 
             with open(cache_path, "wb") as audio_file:
                 for ci, ctext in enumerate(text_chunks):
                     if not ctext.strip():
                         continue
+                    # Pause/cancel checked BETWEEN chunks, NOT inside the
+                    # wait_for below: a pause must block here indefinitely until
+                    # resume, whereas the per-chunk timeout only guards a stalled
+                    # network request. Chunks are small so a cancel (user
+                    # switched chapter) lands within a few seconds — this is what
+                    # stops a stuck pre-gen from hanging the new chapter.
+                    await self.scheduler.check_pause_point()
+
                     buf = bytearray()
                     for attempt in range(1, 4):
-                        # ★ CHECK PAUSE/CANCEL before each attempt + every frame
-                        await self.scheduler.check_pause_point()
                         buf.clear()
-                        try:
+
+                        async def _consume():
                             communicate = edge_tts.Communicate(ctext, self.VOICE, rate=self.RATE)
                             async for chunk in communicate.stream():
-                                await self.scheduler.check_pause_point()
                                 if chunk["type"] == "audio" and chunk["data"]:
                                     buf.extend(chunk["data"])
+
+                        try:
+                            await asyncio.wait_for(_consume(), timeout=EDGE_CHUNK_TIMEOUT)
                             if buf:
                                 break
                         except asyncio.CancelledError:
                             raise  # pause/cancel — let scheduler handle, never retry
-                        except Exception as exc:
+                        except Exception as exc:  # incl. TimeoutError (stalled request)
                             if attempt >= 3:
                                 raise
                             logger.warning(

--- a/backend/services/tts_pregen_job.py
+++ b/backend/services/tts_pregen_job.py
@@ -184,6 +184,12 @@ class TTSPreGenJob(BackgroundJobRunner):
             return True
         
         lock_path = cache_path + ".lock"
+        # Write to a temp file and atomically rename to cache_path ONLY after
+        # every chunk succeeds. A present cache_path then always means "complete
+        # chapter" — a mid-chapter chunk failure (raise/timeout) can never leave
+        # a truncated file that the cache-hit short-circuit above would serve
+        # forever (the "tậm tịt" this PR fixes).
+        tmp_path = cache_path + ".tmp"
         start_time = time.time()
         bytes_written = 0
         
@@ -205,7 +211,7 @@ class TTSPreGenJob(BackgroundJobRunner):
             from services.tts import EdgeTTSProvider, EDGE_CHUNK_TIMEOUT
             text_chunks = EdgeTTSProvider._split_tiered(text)
 
-            with open(cache_path, "wb") as audio_file:
+            with open(tmp_path, "wb") as audio_file:
                 for ci, ctext in enumerate(text_chunks):
                     if not ctext.strip():
                         continue
@@ -248,7 +254,11 @@ class TTSPreGenJob(BackgroundJobRunner):
                         )
                     audio_file.write(buf)
                     bytes_written += len(buf)
-            
+
+            # All chunks succeeded — atomically publish. Until this point only
+            # tmp_path exists, so any earlier failure leaves no servable file.
+            os.replace(tmp_path, cache_path)
+
             # Done — remove lock
             if os.path.exists(lock_path):
                 os.remove(lock_path)
@@ -278,8 +288,8 @@ class TTSPreGenJob(BackgroundJobRunner):
             # KB2: Clean up partial file
             logger.warning(f"[PRE-GEN] Cancelled: {story_title}/{chapter_file} "
                           f"(after {bytes_written} bytes)")
-            if os.path.exists(cache_path):
-                os.remove(cache_path)
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
             if os.path.exists(lock_path):
                 os.remove(lock_path)
             raise  # Let scheduler handle
@@ -289,9 +299,12 @@ class TTSPreGenJob(BackgroundJobRunner):
                         exc_info=True)
             self._stats["errors"] += 1
             self._stats["last_error"] = f"{story_title}/{chapter_file}: {str(e)}"
-            # Clean up
-            if os.path.exists(cache_path) and bytes_written == 0:
-                os.remove(cache_path)
+            # Clean up the partial temp file. cache_path is only created on full
+            # success (atomic replace above), so it is never left truncated —
+            # drop the old ``bytes_written == 0`` guard that, with chunked
+            # writes, left a partial cache_path that got served forever.
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
             if os.path.exists(lock_path):
                 os.remove(lock_path)
             # Emit error event

--- a/backend/services/tts_pregen_job.py
+++ b/backend/services/tts_pregen_job.py
@@ -197,18 +197,49 @@ class TTSPreGenJob(BackgroundJobRunner):
                     "started_at": time.time(),
                 }))
             
-            # Generate TTS using edge_tts directly (for chunk-by-chunk control)
-            communicate = edge_tts.Communicate(text, self.VOICE, rate=self.RATE)
-            
+            # Generate TTS in bounded chunks (<= EDGE_MAX_CHUNK) with per-chunk
+            # retry. A single whole-chapter edge_tts request streams slower than
+            # playback and intermittently returns no audio / truncates ("tậm
+            # tịt"); small chunks are fast + reliable. Pause/cancel is still
+            # checked between audio frames AND between chunks. Each chunk is
+            # buffered so a retried attempt can't duplicate already-written audio.
+            from services.tts import EdgeTTSProvider
+            text_chunks = EdgeTTSProvider._split_tiered(text)
+
             with open(cache_path, "wb") as audio_file:
-                async for chunk in communicate.stream():
-                    # ★ CHECK PAUSE/CANCEL EVERY CHUNK
-                    await self.scheduler.check_pause_point()
-                    
-                    if chunk["type"] == "audio":
-                        audio_data = chunk["data"]
-                        audio_file.write(audio_data)
-                        bytes_written += len(audio_data)
+                for ci, ctext in enumerate(text_chunks):
+                    if not ctext.strip():
+                        continue
+                    buf = bytearray()
+                    for attempt in range(1, 4):
+                        # ★ CHECK PAUSE/CANCEL before each attempt + every frame
+                        await self.scheduler.check_pause_point()
+                        buf.clear()
+                        try:
+                            communicate = edge_tts.Communicate(ctext, self.VOICE, rate=self.RATE)
+                            async for chunk in communicate.stream():
+                                await self.scheduler.check_pause_point()
+                                if chunk["type"] == "audio" and chunk["data"]:
+                                    buf.extend(chunk["data"])
+                            if buf:
+                                break
+                        except asyncio.CancelledError:
+                            raise  # pause/cancel — let scheduler handle, never retry
+                        except Exception as exc:
+                            if attempt >= 3:
+                                raise
+                            logger.warning(
+                                f"[PRE-GEN] {story_title}/{chapter_file} chunk "
+                                f"{ci + 1}/{len(text_chunks)} attempt {attempt} "
+                                f"failed ({exc}) — retrying"
+                            )
+                            await asyncio.sleep(0.4 * attempt)
+                    if not buf:
+                        raise RuntimeError(
+                            f"No audio for chunk {ci + 1}/{len(text_chunks)} after retries"
+                        )
+                    audio_file.write(buf)
+                    bytes_written += len(buf)
             
             # Done — remove lock
             if os.path.exists(lock_path):

--- a/backend/tests/test_services/test_tts.py
+++ b/backend/tests/test_services/test_tts.py
@@ -7,6 +7,7 @@ import pytest
 from services.tts import (
     DEFAULT_EDGE_RATE,
     DEFAULT_EDGE_VOICE,
+    EDGE_MAX_CHUNK,
     EdgeTTSProvider,
     TTSProvider,
 )
@@ -55,10 +56,15 @@ class TestEdgeTTSProviderTieredSplit:
         text = "a" * 100
         assert EdgeTTSProvider._split_tiered(text) == [text]
 
-    def test_long_text_splits_into_three_tiers(self):
+    def test_long_text_splits_into_bounded_chunks(self):
         text = "Câu một. " * 100  # ~900 chars
         chunks = EdgeTTSProvider._split_tiered(text)
-        assert len(chunks) == 3
+        # Tier 1/2 stay small for TTFB; the rest is capped at EDGE_MAX_CHUNK —
+        # NOT lumped into one giant remainder chunk (that oversized request is
+        # what made long story chapters play "tậm tịt").
+        assert len(chunks) >= 3
+        assert all(len(c) <= EDGE_MAX_CHUNK for c in chunks)
+        assert len(chunks[0]) <= 50
         # No content lost (modulo whitespace stripping)
         joined_len = sum(len(c) for c in chunks)
         assert joined_len <= len(text)

--- a/backend/tests/test_services/test_tts_chunking.py
+++ b/backend/tests/test_services/test_tts_chunking.py
@@ -116,3 +116,25 @@ async def test_stream_audio_fails_loud_on_unrecoverable_chunk(_fast_retry):
     with pytest.raises(Exception):
         async for _ in EdgeTTSProvider().stream_audio("a longer line of text here"):
             pass
+
+
+class _StallingCommunicate:
+    """stream() that never yields in time — simulates a throttled/stuck WSS."""
+
+    def __init__(self, text, voice, rate=None):
+        pass
+
+    async def stream(self):
+        await asyncio.sleep(5)  # cancelled by wait_for well before this elapses
+        yield {"type": "audio", "data": b"LATE"}
+
+
+@pytest.mark.asyncio
+async def test_synth_chunk_times_out_so_it_cannot_hang(monkeypatch):
+    # A stalled request must NOT block forever — it's what froze the cooperative
+    # cancel point and hung the new chapter when switching mid-pre-gen. Each
+    # attempt is bounded by EDGE_CHUNK_TIMEOUT; all time out → returns b''.
+    monkeypatch.setattr(tts_mod, "EDGE_CHUNK_TIMEOUT", 0.05)
+    monkeypatch.setattr(tts_mod.edge_tts, "Communicate", _StallingCommunicate)
+    out = await EdgeTTSProvider()._synth_chunk("hello", attempts=2)
+    assert out == b"", "a stalled chunk must give up (time out), never hang"

--- a/backend/tests/test_services/test_tts_chunking.py
+++ b/backend/tests/test_services/test_tts_chunking.py
@@ -1,0 +1,118 @@
+"""EdgeTTS chunking + per-chunk retry — the fix for story audio playing
+"tậm tịt" (intermittent).
+
+Root cause being fenced here: the old ``_split_tiered`` lumped everything past
+~350 chars into ONE giant chunk, so a long story chapter became a single
+oversized ``edge_tts`` request that streamed slower than playback and
+intermittently returned no audio / truncated. Now every chunk is capped at
+``EDGE_MAX_CHUNK`` and each is synthesized with retry.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from services.tts import EdgeTTSProvider, EDGE_MAX_CHUNK
+import services.tts as tts_mod
+
+
+# ── _split_tiered: bounded chunks ─────────────────────────────────────
+
+
+def test_short_text_single_chunk():
+    assert EdgeTTSProvider._split_tiered("Xin chào.") == ["Xin chào."]
+
+
+def test_every_chunk_within_max():
+    text = ("Câu văn dài. " * 400).strip()  # ~5200 chars, no giant remainder
+    chunks = EdgeTTSProvider._split_tiered(text)
+    assert len(chunks) > 5, "long text must be split into many chunks, not one"
+    assert all(len(c) <= EDGE_MAX_CHUNK for c in chunks), (
+        f"a chunk exceeded EDGE_MAX_CHUNK={EDGE_MAX_CHUNK}: "
+        f"max={max(len(c) for c in chunks)}"
+    )
+
+
+def test_first_two_chunks_small_for_ttfb():
+    text = "A" * 4000
+    chunks = EdgeTTSProvider._split_tiered(text)
+    assert len(chunks[0]) <= 50
+    assert len(chunks[1]) <= 300
+
+
+def test_no_text_dropped():
+    # Concatenating chunks (ignoring boundary whitespace) reproduces the text.
+    text = "Chương một. " + "Nội dung kể chuyện rất dài đây. " * 200
+    chunks = EdgeTTSProvider._split_tiered(text)
+    joined = "".join(chunks)
+    assert joined.replace(" ", "") == text.strip().replace(" ", "")
+
+
+# ── _synth_chunk: per-chunk retry ─────────────────────────────────────
+
+
+class _FakeCommunicate:
+    """Drives a scripted sequence of attempt outcomes. ``script`` items:
+    ``"ok"`` -> yields audio, ``"empty"`` -> yields nothing, ``"raise"`` ->
+    raises, ``"cancel"`` -> raises CancelledError."""
+
+    script: list = []
+    calls: int = 0
+
+    def __init__(self, text, voice, rate=None):
+        self.text = text
+
+    async def stream(self):
+        outcome = type(self).script[type(self).calls]
+        type(self).calls += 1
+        if outcome == "raise":
+            raise RuntimeError("No audio was received. Please verify ... parameters")
+        if outcome == "cancel":
+            raise asyncio.CancelledError()
+        if outcome == "ok":
+            yield {"type": "audio", "data": b"AUDIO"}
+        # "empty" yields nothing
+
+
+@pytest.fixture()
+def _fast_retry(monkeypatch):
+    # Don't actually sleep through the backoff.
+    async def _noop(_):
+        return None
+    monkeypatch.setattr(tts_mod.asyncio, "sleep", _noop)
+    _FakeCommunicate.calls = 0
+    monkeypatch.setattr(tts_mod.edge_tts, "Communicate", _FakeCommunicate)
+
+
+@pytest.mark.asyncio
+async def test_synth_chunk_retries_then_succeeds(_fast_retry):
+    _FakeCommunicate.script = ["raise", "empty", "ok"]
+    out = await EdgeTTSProvider()._synth_chunk("hello", attempts=3)
+    assert out == b"AUDIO"
+    assert _FakeCommunicate.calls == 3, "should have retried until the 3rd attempt"
+
+
+@pytest.mark.asyncio
+async def test_synth_chunk_returns_empty_after_all_attempts(_fast_retry):
+    _FakeCommunicate.script = ["empty", "raise", "empty"]
+    out = await EdgeTTSProvider()._synth_chunk("hello", attempts=3)
+    assert out == b""
+
+
+@pytest.mark.asyncio
+async def test_synth_chunk_reraises_cancel_without_retry(_fast_retry):
+    _FakeCommunicate.script = ["cancel", "ok", "ok"]
+    with pytest.raises(asyncio.CancelledError):
+        await EdgeTTSProvider()._synth_chunk("hello", attempts=3)
+    assert _FakeCommunicate.calls == 1, "cancel must NOT be retried"
+
+
+@pytest.mark.asyncio
+async def test_stream_audio_fails_loud_on_unrecoverable_chunk(_fast_retry):
+    # All attempts empty → stream_audio must raise (no silent gap), not yield
+    # a partial/empty stream the caller would serve as a truncated file.
+    _FakeCommunicate.script = ["empty"] * 9
+    with pytest.raises(Exception):
+        async for _ in EdgeTTSProvider().stream_audio("a longer line of text here"):
+            pass

--- a/backend/tests/test_services/test_tts_pregen_integration.py
+++ b/backend/tests/test_services/test_tts_pregen_integration.py
@@ -1,0 +1,94 @@
+"""Pre-gen ``execute_task`` integration — real file I/O, edge_tts faked only at
+the network boundary.
+
+Fences the atomic-publish guarantee: a present ``cache_path`` ALWAYS means a
+complete chapter. A mid-chapter chunk failure must NOT leave a truncated file
+that the cache-hit short-circuit then serves forever (the "tậm tịt" bug). The
+unit tests in ``test_tts_chunking.py`` fake everything; these let the cleanup /
+``bytes_written`` / atomic-rename file logic run for real.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import services.tts_pregen_job as pg
+import services.tts as tts_mod
+
+
+class _FakeScheduler:
+    async def check_pause_point(self):
+        return None
+
+
+class _ScriptedCommunicate:
+    """Network-boundary fake. ``fail_on`` = a chunk text that yields no audio
+    (every attempt); any other chunk yields ``b'AU'``."""
+
+    fail_on: str | None = None
+
+    def __init__(self, text, voice, rate=None):
+        self.text = text
+
+    async def stream(self):
+        if self.text == type(self).fail_on:
+            return  # no audio — simulates "No audio received"
+        yield {"type": "audio", "data": b"AU"}
+
+
+@pytest.fixture()
+def _job(tmp_path, monkeypatch):
+    # Deterministic chunking so the "3rd chunk" is identifiable.
+    monkeypatch.setattr(
+        tts_mod.EdgeTTSProvider, "_split_tiered",
+        staticmethod(lambda text: ["A", "B", "C"]),
+    )
+    # Network boundary faked; file I/O is real.
+    _ScriptedCommunicate.fail_on = None
+    monkeypatch.setattr(pg.edge_tts, "Communicate", _ScriptedCommunicate)
+    # Isolate the cache file in tmp_path.
+    cache_path = str(tmp_path / "chap.mp3")
+    monkeypatch.setattr(pg, "get_audio_cache_path", lambda text: cache_path)
+    monkeypatch.setattr(pg, "clean_text_for_tts", lambda t: t)
+    monkeypatch.setattr(pg.TTSPreGenJob, "_read_chapter_text", lambda self, s, c: "chapter body")
+    monkeypatch.setattr(pg.TTSPreGenJob, "rescan", lambda self: None)
+    # No real backoff / inter-chapter delay.
+    async def _noop(_):
+        return None
+    monkeypatch.setattr(pg.asyncio, "sleep", _noop)
+
+    job = pg.TTSPreGenJob(scheduler=_FakeScheduler())
+    job.CHAPTER_DELAY = 0
+    return job, cache_path
+
+
+@pytest.mark.asyncio
+async def test_happy_path_writes_complete_file(_job):
+    job, cache_path = _job
+    ok = await job.execute_task({"story_title": "S", "chapter_file": "c.txt"})
+    assert ok is True
+    assert os.path.exists(cache_path), "completed chapter must be published to cache_path"
+    with open(cache_path, "rb") as f:
+        data = f.read()
+    assert data == b"AUAUAU", "all chunks concatenated, none dropped/duplicated"
+    assert not os.path.exists(cache_path + ".tmp"), "temp file must be renamed away"
+    assert not os.path.exists(cache_path + ".lock")
+
+
+@pytest.mark.asyncio
+async def test_midchapter_failure_leaves_no_cached_file(_job):
+    # Chunks A, B succeed; C yields no audio on every retry → execute_task fails.
+    # The bug: a partial cache_path would survive (bytes_written>0) and be served
+    # forever. With atomic publish, cache_path must NOT exist.
+    job, cache_path = _job
+    _ScriptedCommunicate.fail_on = "C"
+
+    ok = await job.execute_task({"story_title": "S", "chapter_file": "c.txt"})
+
+    assert ok is False, "a mid-chapter failure must report failure"
+    assert not os.path.exists(cache_path), (
+        "a truncated chapter must NOT be left in cache (would be served forever)"
+    )
+    assert not os.path.exists(cache_path + ".tmp"), "temp file must be cleaned up"
+    assert not os.path.exists(cache_path + ".lock")


### PR DESCRIPTION
## Symptom
Story chapter audio on app.omnigentx.com played intermittently — *tậm tịt, lúc được lúc không*. Chat TTS stayed fine even while pre-gen ran.

## Root cause (from prod logs)
Both TTS paths sent a **single oversized `edge_tts` request** per chapter:
- `EdgeTTSProvider._split_tiered` split text into tiers `(50, 300)` then dumped **all the rest into one giant chunk** → a ~9k-char chapter became one ~8.6k-char request.
- `tts_pregen_job` sent the whole chapter text in one `edge_tts.Communicate`.

A single oversized request streams **slower than real-time playback** (prod: ~3.5 MB over 5–6 min, 3 "chunks") and intermittently returns `No audio received` / truncates → the file is removed → silent chapter. Short chat replies fit in tier-1/2 (small, reliable requests), so chat never hit this — confirming it was **not** an IP throttle or pre-gen overload. (Verified: server egress to MS CDN was 14 MB/s; only the EdgeTTS WSS trickled.)

## Fix
- **`EDGE_MAX_CHUNK = 500`** — `_split_tiered` keeps tier-1/2 tiny for low TTFB, then caps every remaining chunk at 500 chars (sentence/comma/whitespace boundaries). No more giant remainder.
- **`_synth_chunk`** — each chunk synthesized with **retry + linear backoff**, buffered so a retried attempt can't duplicate audio; fails loud if a chunk yields no audio after retries (caller drops the partial file → no silent gap).
- **`tts_pregen_job`** — reuses `_split_tiered` + the same per-chunk retry, preserving pause/cancel (`CancelledError` re-raised, never retried).

## Tests
- New `test_tts_chunking.py`: every chunk ≤ 500, no text dropped, retry-then-succeed, empty-after-all-attempts, cancel-not-retried, `stream_audio` fails loud on unrecoverable chunk.
- Updated the old "exactly 3 tiers" assertion → "bounded chunks".
- **813 passed** in `test_services/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)