### PR TITLE
fix(mcp): surface stdio MCP server startup failures in the UI (+ story_server crash fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ backend/data/*.bak.*
 *.aab
 
 # Codex (sensitive credentials)
+.codex/
 backend/.codex/
 backend/meetings/
 

--- a/backend/tools/story_server.py
+++ b/backend/tools/story_server.py
@@ -7,6 +7,16 @@ import unicodedata
 from pathlib import Path
 from bs4 import BeautifulSoup
 
+# Bootstrap sys.path BEFORE importing helpers.*: when this file is launched as a
+# script (python tools/story_server.py) by the MCP runtime, sys.path[0] is the
+# tools/ dir, not backend/, so `helpers` is unresolvable and the server crashes
+# at startup with ModuleNotFoundError (shows up as "story-server Failed" in UI).
+# Inserting backend/ here — above the helpers imports — is the fix.
+import sys
+_backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _backend_dir not in sys.path:
+    sys.path.insert(0, _backend_dir)
+
 from helpers.http_safety import get_capped_text
 from helpers.path_safety import safe_story_path
 from mcp.server.fastmcp import FastMCP
@@ -24,11 +34,7 @@ logger = logging.getLogger("story_server")
 # DATA_DIR: absolute path to backend/data/ — works in MCP subprocess context
 DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
 
-# Load .env from backend directory
-_backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-import sys
-if _backend_dir not in sys.path:
-    sys.path.insert(0, _backend_dir)
+# Load .env from backend directory (_backend_dir set during sys.path bootstrap above)
 load_dotenv(os.path.join(_backend_dir, ".env"))
 
 # NOTE: Crawl execution is decoupled from MCP subprocess.

--- a/frontend/src/views/AgentDetail.vue
+++ b/frontend/src/views/AgentDetail.vue
@@ -1300,17 +1300,24 @@ function historyBadgeLabel(type) {
   opacity: 0.55;
 }
 .server-error-banner {
-  background: rgba(239, 68, 68, 0.08);
-  border: 1px solid rgba(239, 68, 68, 0.25);
-  color: #fca5a5;
+  background: var(--danger-bg);
+  border: 1px solid rgba(239, 68, 68, 0.30);
+  color: var(--danger);
   font-size: 12px;
+  line-height: 1.5;
   padding: 8px 12px;
   border-radius: 6px;
   margin: 8px 0;
 }
+/* Light theme keeps --danger at #EF4444 (red-500), which is too pale on the
+   light danger-bg — drop to red-700 for AA-legible text. */
+:root[data-theme="light"] .server-error-banner {
+  color: #B91C1C;
+  border-color: rgba(185, 28, 28, 0.30);
+}
 .server-error-banner.muted {
   background: rgba(239, 68, 68, 0.04);
-  color: #9ca3af;
+  color: var(--text-muted);
 }
 .runtime-pending-skeleton {
   display: flex;


### PR DESCRIPTION
## Summary

Surfaces MCP stdio-server startup failures end-to-end and fixes the original `story_server` crash that triggered them. Five commits, rebased fresh on `main`.

This branch was split out of the (already-merged) PR #80 branch — its mobile-responsive work shipped in #80; what's left here is unrelated MCP-error-surfacing work, now on its own properly-named branch.

## What's in it

| Commit | Change |
|---|---|
| `fix(crawl)` | `story_server.py` crashed at MCP startup: launched as a script (`python tools/story_server.py`) `sys.path[0]` is `tools/`, so `helpers.*` was unresolvable → `ModuleNotFoundError` → "story-server Failed" in UI. Bootstrap `backend/` onto `sys.path` **before** the `helpers` imports. |
| `chore(submodule)` ×3 → squashed-in-spirit | Bump `fast-agent` to merged `main` (`711bd604`, PR omnigentx/fast-agent#8): surface failed-server attach errors in `collect_server_status`, capture stdio subprocess stderr (was discarded to `/dev/null`), guard the stderr deque + document the teardown backstop. |
| `fix(ui)` | MCP attach-error banner was hardcoded `#fca5a5` (dark-theme tint) → near-invisible on light theme. Switch to `--danger`/`--danger-bg` tokens + red-700 under `[data-theme="light"]` for AA-legible contrast. |
| `chore(gitignore)` | Ignore root `.codex/` (Codex credentials). |

Together: a broken stdio MCP server now shows its **real** cause in the UI (e.g. `ModuleNotFoundError: No module named 'helpers'`) instead of a blank "No error message reported", and the banner is legible in both themes.

## Test plan

- [x] **Regression repro**: launching `story_server.py` as a script with `cwd=tools/` (the exact MCP-runtime invocation) now exits cleanly with **no `ModuleNotFoundError`** — previously crashed at import.
- [x] `pytest tests/test_helpers/test_path_safety.py tests/test_services/test_fastagent_config_defaults.py` — **26 pass**.
- [x] `fast-agent` PR #8 carries its own suite (real-subprocess integration test asserting the child's `ModuleNotFoundError` reaches `collect_server_status().error_message`) — green; reviewed in omnigentx/fast-agent#8.
- [ ] Manual: a deliberately-broken stdio MCP server shows its subprocess stderr in the AgentDetail banner, legible on both light & dark themes.

### Coverage gaps (surfaced, not hidden)
- The `fix(ui)` CSS change has no automated coverage (banner is a pure styling tweak); verified by the manual item above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
