### PR TITLE
feat(voice): Cloudflare TURN credentials for WebRTC NAT traversal

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -72,3 +72,15 @@ CORS_ORIGINS=*
 # Per-user fork URL (e.g. https://github.com/<your-username>/jarvis) is normally
 # stored in the encrypted DB via Settings → Services → jarvis_repo, NOT here.
 # JARVIS_REPO_URL=
+
+# ─── WebRTC TURN (voice from CGNAT/cellular networks) ────────────────────────
+# This deployment has no public UDP inbound (web rides a cloudflared tunnel),
+# so WebRTC voice from outside the LAN/tailnet (e.g. iPhone on 5G) needs a
+# TURN relay. Recommended: Cloudflare Realtime TURN — create a TURN app at
+# dash.cloudflare.com → Realtime → TURN, then set BOTH:
+# JARVIS_CF_TURN_KEY_ID=
+# JARVIS_CF_TURN_API_TOKEN=
+# The backend mints short-lived credentials from these (24h TTL, cached) and
+# serves them to both the browser (/api/voice/ice) and its own RTCPeerConnection.
+# Alternative/fallback — static ICE list (used when the CF vars are unset):
+# JARVIS_WEBRTC_ICE=stun:stun.l.google.com:19302,turn:user:pass@turn.example.com:3478

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -74,13 +74,16 @@ CORS_ORIGINS=*
 # JARVIS_REPO_URL=
 
 # ─── WebRTC TURN (voice from CGNAT/cellular networks) ────────────────────────
-# This deployment has no public UDP inbound (web rides a cloudflared tunnel),
-# so WebRTC voice from outside the LAN/tailnet (e.g. iPhone on 5G) needs a
-# TURN relay. Recommended: Cloudflare Realtime TURN — create a TURN app at
-# dash.cloudflare.com → Realtime → TURN, then set BOTH:
+# Needed only when voice is used from OUTSIDE the host's LAN/VPN (e.g. phone
+# on 5G) and the host has no public UDP inbound. PREFERRED setup path: the
+# Settings → Voice → "Cloudflare TURN (voice relay)" section (or the Setup
+# Wizard services step) — stores the key encrypted in the DB, applies live,
+# no restart. See docs/SELF_HOSTING.md §9 for the walkthrough.
+# The env vars below are a headless/CI bootstrap fallback only; DB-stored
+# values take priority when both exist:
 # JARVIS_CF_TURN_KEY_ID=
 # JARVIS_CF_TURN_API_TOKEN=
 # The backend mints short-lived credentials from these (24h TTL, cached) and
 # serves them to both the browser (/api/voice/ice) and its own RTCPeerConnection.
-# Alternative/fallback — static ICE list (used when the CF vars are unset):
+# Alternative — static ICE list (used when no Cloudflare TURN is configured):
 # JARVIS_WEBRTC_ICE=stun:stun.l.google.com:19302,turn:user:pass@turn.example.com:3478

--- a/backend/routes/setup.py
+++ b/backend/routes/setup.py
@@ -31,6 +31,8 @@ from core.database import (
     get_db_session,
 )
 from middleware.setup_gate import refresh_setup_complete
+from services import voice_config as vc
+from services import voice_engine_registry as registry
 from services.config_service import config_service
 from services.runtime_config import apply_api_key
 
@@ -389,6 +391,20 @@ async def setup_services(payload: ServicesStep, _=Depends(verify_api_key)):
                 detail=f"Invalid service name: {svc_name!r}",
             )
         if not fields:
+            continue
+        # Voice infrastructure services (cloudflare_turn) live in the SAME
+        # encrypted slots Settings → Voice manages (voice.secrets.{name}.{slot})
+        # — NOT under service.{name}. Routing through set_engine_secret keeps
+        # one source of truth and validates slot names against the registry.
+        if registry.get_voice_service(name):
+            for k, v in fields.items():
+                try:
+                    vc.set_engine_secret(
+                        config_service, name, (k or "").strip(), v, updated_by="wizard"
+                    )
+                except ValueError as exc:
+                    raise HTTPException(status_code=400, detail=str(exc))
+            configured.append(name)
             continue
         for k, v in fields.items():
             if not isinstance(k, str) or not k.strip():

--- a/backend/routes/voice.py
+++ b/backend/routes/voice.py
@@ -94,6 +94,9 @@ async def list_engines(_=Depends(verify_api_key)):
     return {
         "tts": registry.list_tts_engines(),
         "stt": registry.list_stt_backends(),
+        # Voice infrastructure (e.g. cloudflare_turn) — same secret-slot shape,
+        # rendered as its own Settings section, never in the engine pickers.
+        "services": registry.list_voice_services(),
     }
 
 
@@ -222,6 +225,7 @@ async def list_secrets_status(_=Depends(verify_api_key)):
     for engine, spec in (
         list(registry.list_tts_engines().items())
         + list(registry.list_stt_backends().items())
+        + list(registry.list_voice_services().items())
     ):
         if engine in seen:
             continue
@@ -251,7 +255,11 @@ async def delete_secret(engine: str, slot: str, _=Depends(verify_api_key)):
     """Clear a previously-set secret — frees the user from manual SQL surgery
     when rotating away from a paid engine.
     """
-    spec = registry.get_tts_engine(engine) or registry.get_stt_backend(engine)
+    spec = (
+        registry.get_tts_engine(engine)
+        or registry.get_stt_backend(engine)
+        or registry.get_voice_service(engine)
+    )
     if not spec or slot not in spec.get("secrets", []):
         raise HTTPException(400, f"Engine {engine!r} has no declared secret {slot!r}")
     cs = _config_service()
@@ -261,7 +269,11 @@ async def delete_secret(engine: str, slot: str, _=Depends(verify_api_key)):
 
 @router.get("/requirements/{engine}")
 async def check_requirements(engine: str, _=Depends(verify_api_key)):
-    spec = registry.get_tts_engine(engine) or registry.get_stt_backend(engine)
+    spec = (
+        registry.get_tts_engine(engine)
+        or registry.get_stt_backend(engine)
+        or registry.get_voice_service(engine)
+    )
     if not spec:
         raise HTTPException(404, f"Unknown engine {engine!r}")
     cs = _config_service()

--- a/backend/routes/ws_voice.py
+++ b/backend/routes/ws_voice.py
@@ -61,7 +61,7 @@ from services.sse_progress import (
     merge_hooks,
     progress_manager,
 )
-from services.webrtc_voice import WebRtcVoiceSession, parse_ice_servers
+from services.webrtc_voice import WebRtcVoiceSession, get_ice_servers
 
 
 def _chunk_rms_peak(pcm_chunk: bytes) -> tuple[int, int]:
@@ -83,12 +83,15 @@ router = APIRouter(tags=["voice-ws"])
 def voice_ice_config() -> dict:
     """ICE servers (STUN/TURN) for the browser's RTCPeerConnection.
 
-    Sourced from ``JARVIS_WEBRTC_ICE`` so a TURN deployment (needed for
-    symmetric-NAT / iPhone-on-cellular) is an env change, not a code change —
-    the frontend fetches this before negotiating. Not secret (TURN creds here
-    are the short-lived/shared kind); behind the same auth as the app.
+    Sourced from ``get_ice_servers`` — Cloudflare-minted TURN creds when
+    ``JARVIS_CF_TURN_KEY_ID``/``JARVIS_CF_TURN_API_TOKEN`` are set (needed for
+    symmetric-NAT / iPhone-on-cellular; this deployment has no public UDP),
+    else ``JARVIS_WEBRTC_ICE``, else public STUN. Not secret (TURN creds here
+    are the short-lived kind); behind the same auth as the app. Sync def on
+    purpose: FastAPI runs it in the threadpool, so a cold-cache CF mint
+    (blocking HTTPS) never stalls the event loop.
     """
-    return {"iceServers": parse_ice_servers()}
+    return {"iceServers": get_ice_servers()}
 
 
 # ─── Auth helpers (cookie / Bearer / query — with CSWSH defence) ────────────
@@ -943,7 +946,11 @@ async def voice_ws(ws: WebSocket) -> None:
                             if stt_service is not None:
                                 stt_service.feed_audio(pcm)
 
-                        webrtc_session = WebRtcVoiceSession(_feed_webrtc)
+                        # Pre-fetch ICE off-loop: a cold Cloudflare TURN mint
+                        # is a blocking HTTPS call (≤10 s) that must not stall
+                        # every other socket frame.
+                        ice_cfg = await asyncio.to_thread(get_ice_servers)
+                        webrtc_session = WebRtcVoiceSession(_feed_webrtc, ice_servers=ice_cfg)
                         answer = await webrtc_session.handle_offer(
                             sdp, payload.get("sdp_type") or "offer"
                         )

--- a/backend/services/runtime_config.py
+++ b/backend/services/runtime_config.py
@@ -280,6 +280,13 @@ def _on_config_change(event) -> None:
                 cfg = _json.loads(new_value) if (action != "delete" and new_value) else None
                 apply_voice_stt_config(cfg)
                 return
+            if key.startswith("secrets.cloudflare_turn."):
+                # TURN key rotation: drop the minted-credential cache so the
+                # next voice session mints with the new key. No TTS/STT
+                # provider involvement — this is WebRTC transport config.
+                from services.webrtc_voice import invalidate_turn_cache
+                invalidate_turn_cache()
+                return
             if key.startswith("secrets."):
                 # Secret rotation: rebuild chat provider so new key is picked up.
                 # (Stories never uses secrets — Edge has none.)

--- a/backend/services/voice_config.py
+++ b/backend/services/voice_config.py
@@ -94,9 +94,14 @@ def _engine_spec(engine: str) -> Optional[dict[str, Any]]:
     engine name and share a single API-key slot (``voice.secrets.<engine>.api_key``).
     Routing every secret call through one lookup keeps that contract honest:
     we never silently fail to recognise a slot because we only checked one
-    half of the registry.
+    half of the registry. Voice infrastructure services (cloudflare_turn)
+    share the same secret-slot plumbing, so they resolve here too.
     """
-    return registry.get_tts_engine(engine) or registry.get_stt_backend(engine)
+    return (
+        registry.get_tts_engine(engine)
+        or registry.get_stt_backend(engine)
+        or registry.get_voice_service(engine)
+    )
 
 
 def get_engine_secrets(config_service, engine: str) -> dict[str, str]:

--- a/backend/services/voice_engine_registry.py
+++ b/backend/services/voice_engine_registry.py
@@ -287,6 +287,33 @@ STT_BACKENDS: dict[str, STTBackendSpec] = {
 }
 
 
+# Voice infrastructure services — NOT TTS/STT engines (they never appear in
+# the engine pickers) but they share the same encrypted secret-slot plumbing
+# (voice.secrets.{name}.{slot}) so the Settings UI / Setup Wizard / API layer
+# handle them with zero new storage code.
+VOICE_SERVICES: dict[str, dict[str, Any]] = {
+    # WebRTC TURN relay — required for voice from networks that can't reach
+    # the host directly (phone on 4G/5G, any network outside your LAN/VPN).
+    # NOT needed for localhost / same-LAN / VPN use. Cloudflare Realtime TURN
+    # has a free 1 TB/month tier; the backend mints short-lived credentials
+    # from the long-term key pair entered here (key itself never reaches the
+    # browser). Env fallback: JARVIS_CF_TURN_KEY_ID / JARVIS_CF_TURN_API_TOKEN.
+    "cloudflare_turn": {
+        "label": "Cloudflare TURN (voice relay)",
+        "description": (
+            "Lets voice work from outside your network (e.g. phone on 4G/5G). "
+            "Not needed on localhost or LAN/VPN. Create a TURN app at "
+            "Cloudflare Dashboard → Realtime → TURN, then paste both values."
+        ),
+        "badges": ["cloud", "free-tier", "optional"],
+        "requires": [],
+        "secrets": ["key_id", "api_token"],
+        "params": [],
+        "docs_url": "https://developers.cloudflare.com/realtime/turn/",
+    },
+}
+
+
 def list_tts_engines() -> dict[str, TTSEngineSpec]:
     return TTS_ENGINES
 
@@ -301,6 +328,14 @@ def get_tts_engine(name: str) -> Optional[TTSEngineSpec]:
 
 def get_stt_backend(name: str) -> Optional[STTBackendSpec]:
     return STT_BACKENDS.get(name)
+
+
+def list_voice_services() -> dict[str, dict[str, Any]]:
+    return VOICE_SERVICES
+
+
+def get_voice_service(name: str) -> Optional[dict[str, Any]]:
+    return VOICE_SERVICES.get(name)
 
 
 def default_tts_chat_config() -> dict[str, Any]:

--- a/backend/services/webrtc_voice.py
+++ b/backend/services/webrtc_voice.py
@@ -90,10 +90,14 @@ def parse_ice_servers() -> list[dict]:
 # credentials minted on demand from a long-term key — the key stays server-side
 # (env), the minted creds are what /api/voice/ice hands to the browser.
 #
-# Configure with:
-#   JARVIS_CF_TURN_KEY_ID    — TURN key id (Cloudflare dashboard → Realtime → TURN)
-#   JARVIS_CF_TURN_API_TOKEN — the key's API token (a secret; never sent to clients)
-# When unset, get_ice_servers() falls back to JARVIS_WEBRTC_ICE / default STUN.
+# Configured via Settings → Voice (or the Setup Wizard) — stored encrypted as
+# voice.secrets.cloudflare_turn.{key_id,api_token} (see voice_engine_registry
+# VOICE_SERVICES). The DB is the authoritative source; the env vars
+# JARVIS_CF_TURN_KEY_ID / JARVIS_CF_TURN_API_TOKEN are a bootstrap/headless
+# fallback only, consulted when the DB slots are empty.
+# When neither is set, get_ice_servers() falls back to JARVIS_WEBRTC_ICE /
+# default STUN (fine for localhost / LAN / VPN — TURN is only needed when
+# clients connect from networks that can't reach this host directly).
 _CF_TURN_MINT_URL = (
     "https://rtc.live.cloudflare.com/v1/turn/keys/{key_id}/credentials/generate-ice-servers"
 )
@@ -109,11 +113,37 @@ _cf_lock = threading.Lock()
 _cf_cache: dict = {"servers": None, "minted_at": 0.0}
 
 
+def _db_turn_secrets() -> dict:
+    """TURN secrets stored via Settings/Wizard (encrypted in the config DB).
+
+    Isolated so tests can stub the DB away; a read failure is logged loudly
+    and degrades to the env fallback rather than killing voice signalling.
+    """
+    try:
+        from services.config_service import config_service as _cs
+        from services import voice_config as _vc
+        return _vc.get_engine_secrets(_cs, "cloudflare_turn")
+    except Exception:
+        logger.exception("[webrtc] reading TURN secrets from config DB failed")
+        return {}
+
+
+def invalidate_turn_cache() -> None:
+    """Drop cached minted credentials — called by the config-change listener
+    when the user saves/clears TURN secrets so the next session re-mints with
+    the new key immediately (no restart, no 12 h cache tail)."""
+    with _cf_lock:
+        _cf_cache["servers"] = None
+        _cf_cache["minted_at"] = 0.0
+    logger.info("[webrtc] TURN credential cache invalidated (config change)")
+
+
 def _cloudflare_ice_servers() -> Optional[list[dict]]:
     """Mint (or serve cached) Cloudflare TURN credentials. None = not configured
     or mint failed with no valid cached batch — caller falls back to env ICE."""
-    key_id = os.environ.get("JARVIS_CF_TURN_KEY_ID", "").strip()
-    token = os.environ.get("JARVIS_CF_TURN_API_TOKEN", "").strip()
+    db = _db_turn_secrets()
+    key_id = (db.get("key_id") or os.environ.get("JARVIS_CF_TURN_KEY_ID", "")).strip()
+    token = (db.get("api_token") or os.environ.get("JARVIS_CF_TURN_API_TOKEN", "")).strip()
     if not key_id or not token:
         return None
 

--- a/backend/services/webrtc_voice.py
+++ b/backend/services/webrtc_voice.py
@@ -29,6 +29,7 @@ import asyncio
 import fractions
 import logging
 import os
+import threading
 import time
 from typing import Callable, Optional
 
@@ -79,6 +80,92 @@ def parse_ice_servers() -> list[dict]:
         else:
             servers.append({"urls": entry})
     return servers
+
+
+# ─── Cloudflare Realtime TURN ────────────────────────────────────────────────
+# The deployment has NO public UDP inbound (web traffic rides a cloudflared
+# tunnel; the host sits behind home NAT + docker bridge NAT), so WebRTC from
+# any network outside the tailnet (e.g. iPhone on 5G CGNAT) has no ICE path
+# unless a TURN relay brokers it. Cloudflare Realtime TURN issues SHORT-LIVED
+# credentials minted on demand from a long-term key — the key stays server-side
+# (env), the minted creds are what /api/voice/ice hands to the browser.
+#
+# Configure with:
+#   JARVIS_CF_TURN_KEY_ID    — TURN key id (Cloudflare dashboard → Realtime → TURN)
+#   JARVIS_CF_TURN_API_TOKEN — the key's API token (a secret; never sent to clients)
+# When unset, get_ice_servers() falls back to JARVIS_WEBRTC_ICE / default STUN.
+_CF_TURN_MINT_URL = (
+    "https://rtc.live.cloudflare.com/v1/turn/keys/{key_id}/credentials/generate-ice-servers"
+)
+_CF_TURN_TTL = 86400  # 24 h — far longer than any voice session
+# Refresh at half-life so creds handed to a NEW session always have ≥12 h of
+# validity left; keep serving a stale-but-valid batch (up to TTL minus a 10-min
+# safety margin) if a refresh attempt fails, so a transient CF API blip doesn't
+# take voice down with it.
+_CF_REFRESH_AFTER = _CF_TURN_TTL / 2
+_CF_HARD_EXPIRY = _CF_TURN_TTL - 600
+
+_cf_lock = threading.Lock()
+_cf_cache: dict = {"servers": None, "minted_at": 0.0}
+
+
+def _cloudflare_ice_servers() -> Optional[list[dict]]:
+    """Mint (or serve cached) Cloudflare TURN credentials. None = not configured
+    or mint failed with no valid cached batch — caller falls back to env ICE."""
+    key_id = os.environ.get("JARVIS_CF_TURN_KEY_ID", "").strip()
+    token = os.environ.get("JARVIS_CF_TURN_API_TOKEN", "").strip()
+    if not key_id or not token:
+        return None
+
+    with _cf_lock:
+        age = time.monotonic() - _cf_cache["minted_at"]
+        if _cf_cache["servers"] is not None and age < _CF_REFRESH_AFTER:
+            return _cf_cache["servers"]
+
+        try:
+            import httpx
+
+            resp = httpx.post(
+                _CF_TURN_MINT_URL.format(key_id=key_id),
+                headers={"Authorization": f"Bearer {token}"},
+                json={"ttl": _CF_TURN_TTL},
+                timeout=10.0,
+            )
+            resp.raise_for_status()
+            servers = resp.json()["iceServers"]
+            if not isinstance(servers, list) or not servers:
+                raise ValueError(f"unexpected iceServers payload: {servers!r}")
+            _cf_cache["servers"] = servers
+            _cf_cache["minted_at"] = time.monotonic()
+            logger.info(
+                "[webrtc] Cloudflare TURN credentials minted (ttl=%ss, %d server entries)",
+                _CF_TURN_TTL, len(servers),
+            )
+            return servers
+        except Exception:
+            logger.exception("[webrtc] Cloudflare TURN credential mint FAILED")
+            if _cf_cache["servers"] is not None and age < _CF_HARD_EXPIRY:
+                logger.warning(
+                    "[webrtc] serving stale-but-valid TURN credentials (age %.0fs)", age
+                )
+                return _cf_cache["servers"]
+            logger.error(
+                "[webrtc] no valid TURN credentials — falling back to %s; "
+                "voice WILL fail from CGNAT/cellular networks until the CF API recovers",
+                os.environ.get("JARVIS_WEBRTC_ICE", _DEFAULT_STUN),
+            )
+            return None
+
+
+def get_ice_servers() -> list[dict]:
+    """Browser-shaped iceServers — the ONE source for both /api/voice/ice and
+    the server's own RTCPeerConnection (aiortc), so the two ends always agree.
+
+    Order of precedence: Cloudflare-minted TURN creds → JARVIS_WEBRTC_ICE →
+    default public STUN. May block on an HTTPS call (≤10 s) when the CF cache
+    is cold — event-loop callers must wrap in ``asyncio.to_thread``.
+    """
+    return _cloudflare_ice_servers() or parse_ice_servers()
 
 STT_RATE = 16000      # feed_audio() input rate (mono s16)
 TTS_RATE = 24000      # RealtimeTTS / Edge PCM rate (mono s16)
@@ -211,19 +298,23 @@ class WebRtcVoiceSession:
         feed_audio: FeedAudio,
         *,
         on_connection_lost: Optional[Callable[[], None]] = None,
-        ice_servers: Optional[list[str]] = None,
+        ice_servers: Optional[list] = None,
     ):
         self._feed_audio = feed_audio
         self._on_connection_lost = on_connection_lost
-        # Default to ICE from env (prod NAT traversal, incl. TURN creds); tests
-        # pass ice_servers=[] for a fast host-only localhost loopback.
-        if ice_servers is not None:
-            ice = [RTCIceServer(urls=u) for u in ice_servers]
-        else:
-            ice = [
-                RTCIceServer(urls=s["urls"], username=s.get("username"), credential=s.get("credential"))
-                for s in parse_ice_servers()
-            ]
+        # ``ice_servers`` entries may be plain url strings OR browser-shaped
+        # dicts ({urls, username?, credential?}) — the ws_voice handler passes
+        # the latter, pre-fetched off-loop via ``asyncio.to_thread(get_ice_servers)``
+        # because the Cloudflare mint can block. Tests pass ice_servers=[] for a
+        # fast host-only localhost loopback. The default (None) self-serves from
+        # get_ice_servers() as a safety net — blocking, so prefer pre-fetching.
+        if ice_servers is None:
+            ice_servers = get_ice_servers()
+        ice = [
+            RTCIceServer(urls=s["urls"], username=s.get("username"), credential=s.get("credential"))
+            if isinstance(s, dict) else RTCIceServer(urls=s)
+            for s in ice_servers
+        ]
         self.pc = RTCPeerConnection(configuration=RTCConfiguration(iceServers=ice))
         self.tts_track = TtsAudioTrack()
         self._inbound_task: Optional[asyncio.Task] = None

--- a/backend/services/webrtc_voice.py
+++ b/backend/services/webrtc_voice.py
@@ -31,6 +31,7 @@ import logging
 import os
 import threading
 import time
+import urllib.parse
 from typing import Callable, Optional
 
 import av
@@ -156,7 +157,9 @@ def _cloudflare_ice_servers() -> Optional[list[dict]]:
             import httpx
 
             resp = httpx.post(
-                _CF_TURN_MINT_URL.format(key_id=key_id),
+                # Percent-encode: a stray "/" in a mistyped key_id must fail as a
+                # clear CF 404, not silently hit a different API path.
+                _CF_TURN_MINT_URL.format(key_id=urllib.parse.quote(key_id, safe="")),
                 headers={"Authorization": f"Bearer {token}"},
                 json={"ttl": _CF_TURN_TTL},
                 timeout=10.0,

--- a/backend/tests/test_routes/test_setup.py
+++ b/backend/tests/test_routes/test_setup.py
@@ -340,6 +340,65 @@ class TestServicesStep:
         )
         assert resp.status_code == 400
 
+    def test_cloudflare_turn_lands_in_voice_secrets(self, client, db_factory):
+        """Wizard TURN entry must share the Settings → Voice storage slots
+        (voice.secrets.cloudflare_turn.*), NOT service.cloudflare_turn —
+        one source of truth for the WebRTC credential reader."""
+        client.post("/api/setup/auth", json={})
+        resp = client.post(
+            "/api/setup/services",
+            json={
+                "services": {
+                    "cloudflare_turn": {
+                        "key_id": "cf-key-id-1",
+                        "api_token": "cf-api-token-1",
+                    }
+                }
+            },
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        svc_step = next(s for s in body["steps"] if s["name"] == "services")
+        assert "cloudflare_turn" in svc_step["data"]["configured"]
+
+        with db_factory() as db:
+            rows = (
+                db.query(SystemConfig)
+                .filter(SystemConfig.category == "voice")
+                .filter(SystemConfig.key.like("secrets.cloudflare_turn.%"))
+                .all()
+            )
+            assert {r.key for r in rows} == {
+                "secrets.cloudflare_turn.key_id",
+                "secrets.cloudflare_turn.api_token",
+            }
+            assert all(r.is_secret for r in rows)
+            # No parallel copy under the generic service.* category.
+            stray = (
+                db.query(SystemConfig)
+                .filter(SystemConfig.category == "service.cloudflare_turn")
+                .count()
+            )
+            assert stray == 0
+
+        # The WebRTC credential reader sees the wizard-written values through
+        # the same decryption path (cross-layer: route → ConfigService → reader).
+        from services.webrtc_voice import _db_turn_secrets
+        assert _db_turn_secrets() == {
+            "key_id": "cf-key-id-1",
+            "api_token": "cf-api-token-1",
+        }
+
+    def test_cloudflare_turn_rejects_unknown_slot(self, client):
+        client.post("/api/setup/auth", json={})
+        resp = client.post(
+            "/api/setup/services",
+            json={"services": {"cloudflare_turn": {"bogus_slot": "x"}}},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 400
+
     def test_jarvis_repo_resolves_immediately_after_wizard(
         self, client, monkeypatch
     ):

--- a/backend/tests/test_services/test_runtime_config_voice.py
+++ b/backend/tests/test_services/test_runtime_config_voice.py
@@ -91,6 +91,28 @@ class TestListenerDispatch:
             runtime_config._on_config_change(evt)
         fn.assert_called_once()
 
+    def test_turn_secret_rotation_invalidates_mint_cache_not_tts(self):
+        # TURN creds are WebRTC transport config — rotating them must drop
+        # the minted-credential cache (so the next session mints with the
+        # new key) and must NOT rebuild the TTS provider.
+        from services import webrtc_voice
+
+        evt = ConfigChangeEvent(
+            category="voice",
+            key="secrets.cloudflare_turn.api_token",
+            old_value=None,
+            new_value="new-token",
+            is_secret=True,
+            action="update",
+        )
+        webrtc_voice._cf_cache["servers"] = [{"urls": "turn:stale"}]
+        webrtc_voice._cf_cache["minted_at"] = 12345.0
+        with patch.object(runtime_config, "apply_voice_chat_config") as fn:
+            runtime_config._on_config_change(evt)
+        fn.assert_not_called()
+        assert webrtc_voice._cf_cache["servers"] is None
+        assert webrtc_voice._cf_cache["minted_at"] == 0.0
+
     def test_secret_rotation_rebuilds_chat_provider(self):
         # Setting a new ElevenLabs API key must propagate to the live provider
         # without restart, so a hot-reload of the chat factory is the dispatch.

--- a/backend/tests/test_services/test_webrtc_voice.py
+++ b/backend/tests/test_services/test_webrtc_voice.py
@@ -20,7 +20,11 @@ from fractions import Fraction
 import av
 from aiortc import MediaStreamTrack, RTCPeerConnection, RTCSessionDescription
 
-from services.webrtc_voice import WebRtcVoiceSession, parse_ice_servers
+import httpx
+import pytest
+
+from services import webrtc_voice
+from services.webrtc_voice import WebRtcVoiceSession, get_ice_servers, parse_ice_servers
 
 
 class _ToneTrack(MediaStreamTrack):
@@ -114,6 +118,125 @@ def test_parse_ice_servers_stun_and_turn(monkeypatch):
     # A colon in the TURN password survives.
     monkeypatch.setenv("JARVIS_WEBRTC_ICE", "turn:u:p:a:ss@h:3478")
     assert parse_ice_servers()[0]["credential"] == "p:a:ss"
+
+
+# ─── Cloudflare TURN minting (get_ice_servers) ──────────────────────────────
+
+_CF_RESPONSE = {
+    "iceServers": [
+        {"urls": ["stun:stun.cloudflare.com:3478"]},
+        {
+            "urls": [
+                "turn:turn.cloudflare.com:3478?transport=udp",
+                "turns:turn.cloudflare.com:5349?transport=tcp",
+            ],
+            "username": "minted-user",
+            "credential": "minted-pass",
+        },
+    ]
+}
+
+
+@pytest.fixture
+def _cf_env(monkeypatch):
+    """CF TURN env set + module cache reset (it's process-global)."""
+    monkeypatch.setenv("JARVIS_CF_TURN_KEY_ID", "key123")
+    monkeypatch.setenv("JARVIS_CF_TURN_API_TOKEN", "tok456")
+    monkeypatch.setitem(webrtc_voice._cf_cache, "servers", None)
+    monkeypatch.setitem(webrtc_voice._cf_cache, "minted_at", 0.0)
+
+
+class _FakeResp:
+    def __init__(self, payload, status=201):
+        self._payload = payload
+        self._status = status
+
+    def raise_for_status(self):
+        if self._status >= 400:
+            raise httpx.HTTPStatusError("boom", request=None, response=None)
+
+    def json(self):
+        return self._payload
+
+
+def test_get_ice_servers_without_cf_env_falls_back_to_parse(monkeypatch):
+    monkeypatch.delenv("JARVIS_CF_TURN_KEY_ID", raising=False)
+    monkeypatch.delenv("JARVIS_CF_TURN_API_TOKEN", raising=False)
+    monkeypatch.delenv("JARVIS_WEBRTC_ICE", raising=False)
+    assert get_ice_servers() == [{"urls": "stun:stun.l.google.com:19302"}]
+
+
+def test_get_ice_servers_mints_from_cloudflare_and_caches(_cf_env, monkeypatch):
+    calls: list[dict] = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls.append({"url": url, "headers": headers, "json": json})
+        return _FakeResp(_CF_RESPONSE)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    servers = get_ice_servers()
+    assert servers == _CF_RESPONSE["iceServers"]
+    assert calls[0]["url"].endswith("/turn/keys/key123/credentials/generate-ice-servers")
+    assert calls[0]["headers"]["Authorization"] == "Bearer tok456"
+    assert calls[0]["json"] == {"ttl": webrtc_voice._CF_TURN_TTL}
+
+    # Second call inside the refresh window: served from cache, no new mint.
+    assert get_ice_servers() == _CF_RESPONSE["iceServers"]
+    assert len(calls) == 1
+
+
+def test_get_ice_servers_refreshes_after_half_life(_cf_env, monkeypatch):
+    calls: list[int] = []
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: (calls.append(1), _FakeResp(_CF_RESPONSE))[1])
+
+    get_ice_servers()
+    # Age the cache past the refresh threshold → next call re-mints.
+    webrtc_voice._cf_cache["minted_at"] = (
+        time.monotonic() - webrtc_voice._CF_REFRESH_AFTER - 1
+    )
+    get_ice_servers()
+    assert len(calls) == 2
+
+
+def test_get_ice_servers_serves_stale_when_mint_fails(_cf_env, monkeypatch):
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _FakeResp(_CF_RESPONSE))
+    assert get_ice_servers() == _CF_RESPONSE["iceServers"]
+
+    # Past refresh threshold but still inside hard expiry; CF API now erroring.
+    webrtc_voice._cf_cache["minted_at"] = (
+        time.monotonic() - webrtc_voice._CF_REFRESH_AFTER - 1
+    )
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: _FakeResp({}, status=500))
+    assert get_ice_servers() == _CF_RESPONSE["iceServers"], "stale-but-valid creds must keep voice alive"
+
+    # Past hard expiry with the API still down → env/STUN fallback, never stale creds.
+    monkeypatch.delenv("JARVIS_WEBRTC_ICE", raising=False)
+    webrtc_voice._cf_cache["minted_at"] = (
+        time.monotonic() - webrtc_voice._CF_HARD_EXPIRY - 1
+    )
+    assert get_ice_servers() == [{"urls": "stun:stun.l.google.com:19302"}]
+
+
+def test_session_accepts_browser_shaped_ice_dicts():
+    """ws_voice passes get_ice_servers() output (dicts with creds + url LISTS)
+    straight into the session — a shape regression here breaks prod silently."""
+    async def build_and_close():
+        session = WebRtcVoiceSession(
+            lambda pcm: None,
+            ice_servers=[
+                {"urls": ["stun:stun.cloudflare.com:3478"]},
+                {
+                    "urls": ["turn:turn.cloudflare.com:3478?transport=udp"],
+                    "username": "u",
+                    "credential": "c",
+                },
+                "stun:stun.l.google.com:19302",  # legacy plain-string entry
+            ],
+        )
+        await session.close()
+
+    asyncio.run(build_and_close())
 
 
 def test_webrtc_loopback_bridges_audio_both_directions():

--- a/backend/tests/test_services/test_webrtc_voice.py
+++ b/backend/tests/test_services/test_webrtc_voice.py
@@ -229,6 +229,20 @@ def test_get_ice_servers_mints_from_cloudflare_and_caches(_cf_env, monkeypatch):
     assert len(calls) == 1
 
 
+def test_mint_url_percent_encodes_key_id(_cf_env, monkeypatch):
+    """A mistyped key_id with a '/' must not silently hit a different API path."""
+    monkeypatch.setenv("JARVIS_CF_TURN_KEY_ID", "bad/key id")
+    calls: list[str] = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        calls.append(url)
+        return _FakeResp(_CF_RESPONSE)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    get_ice_servers()
+    assert calls[0].endswith("/turn/keys/bad%2Fkey%20id/credentials/generate-ice-servers")
+
+
 def test_get_ice_servers_refreshes_after_half_life(_cf_env, monkeypatch):
     calls: list[int] = []
     monkeypatch.setattr(httpx, "post", lambda *a, **k: (calls.append(1), _FakeResp(_CF_RESPONSE))[1])

--- a/backend/tests/test_services/test_webrtc_voice.py
+++ b/backend/tests/test_services/test_webrtc_voice.py
@@ -139,9 +139,13 @@ _CF_RESPONSE = {
 
 @pytest.fixture
 def _cf_env(monkeypatch):
-    """CF TURN env set + module cache reset (it's process-global)."""
+    """CF TURN env set + module cache reset (it's process-global).
+
+    DB secrets are stubbed empty so these tests exercise the env fallback
+    deterministically (no config DB involvement)."""
     monkeypatch.setenv("JARVIS_CF_TURN_KEY_ID", "key123")
     monkeypatch.setenv("JARVIS_CF_TURN_API_TOKEN", "tok456")
+    monkeypatch.setattr(webrtc_voice, "_db_turn_secrets", lambda: {})
     monkeypatch.setitem(webrtc_voice._cf_cache, "servers", None)
     monkeypatch.setitem(webrtc_voice._cf_cache, "minted_at", 0.0)
 
@@ -163,7 +167,46 @@ def test_get_ice_servers_without_cf_env_falls_back_to_parse(monkeypatch):
     monkeypatch.delenv("JARVIS_CF_TURN_KEY_ID", raising=False)
     monkeypatch.delenv("JARVIS_CF_TURN_API_TOKEN", raising=False)
     monkeypatch.delenv("JARVIS_WEBRTC_ICE", raising=False)
+    monkeypatch.setattr(webrtc_voice, "_db_turn_secrets", lambda: {})
     assert get_ice_servers() == [{"urls": "stun:stun.l.google.com:19302"}]
+
+
+def test_db_secrets_take_priority_over_env(monkeypatch):
+    """Settings/Wizard-stored creds (DB) are authoritative; env is bootstrap
+    fallback only. A divergence must resolve to the DB value."""
+    monkeypatch.setenv("JARVIS_CF_TURN_KEY_ID", "env-key")
+    monkeypatch.setenv("JARVIS_CF_TURN_API_TOKEN", "env-tok")
+    monkeypatch.setattr(
+        webrtc_voice, "_db_turn_secrets",
+        lambda: {"key_id": "db-key", "api_token": "db-tok"},
+    )
+    monkeypatch.setitem(webrtc_voice._cf_cache, "servers", None)
+    monkeypatch.setitem(webrtc_voice._cf_cache, "minted_at", 0.0)
+
+    seen: list[tuple[str, str]] = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        seen.append((url, headers["Authorization"]))
+        return _FakeResp(_CF_RESPONSE)
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    get_ice_servers()
+    assert seen[0][0].endswith("/turn/keys/db-key/credentials/generate-ice-servers")
+    assert seen[0][1] == "Bearer db-tok"
+
+
+def test_invalidate_turn_cache_forces_remint(_cf_env, monkeypatch):
+    """Saving new TURN secrets in Settings fires the config listener →
+    invalidate_turn_cache() → next call re-mints instead of serving cache."""
+    calls: list[int] = []
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: (calls.append(1), _FakeResp(_CF_RESPONSE))[1])
+
+    get_ice_servers()
+    get_ice_servers()
+    assert len(calls) == 1  # cache hit
+    webrtc_voice.invalidate_turn_cache()
+    get_ice_servers()
+    assert len(calls) == 2
 
 
 def test_get_ice_servers_mints_from_cloudflare_and_caches(_cf_env, monkeypatch):

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -250,6 +250,25 @@ sudo certbot --nginx -d your-domain.com
 
 ---
 
+## 9. (Tùy chọn) Voice từ ngoài mạng — Cloudflare TURN
+
+**Khi nào cần:** chỉ khi bạn dùng voice chat từ **ngoài** mạng đặt server — ví dụ điện thoại 4G/5G, Wi-Fi công ty. Chạy `localhost`, cùng LAN, hoặc qua VPN (Tailscale…) thì **không cần** mục này.
+
+**Tại sao:** voice dùng WebRTC (UDP) đi thẳng giữa trình duyệt và server, KHÔNG đi qua HTTP/tunnel. Nếu server không có cổng UDP public (sau NAT nhà, sau cloudflared tunnel) và client ở sau CGNAT nhà mạng, hai bên không thể nối trực tiếp — cần một TURN relay làm trung gian. Đây là chuẩn ngành (Meet/Zoom/Discord đều dùng hạ tầng tương tự).
+
+**Cách bật (≈3 phút, miễn phí 1 TB/tháng):**
+
+1. Vào [Cloudflare Dashboard → Realtime → TURN](https://dash.cloudflare.com/?to=/:account/calls) (account Cloudflare free là đủ)
+2. Bấm **Create**, đặt tên tùy ý (ví dụ `jarvis-voice`)
+3. Copy **Turn Token ID** và **API Token**
+4. Dán vào Jarvis tại **Settings → Voice → Cloudflare TURN (voice relay)** — hoặc nhập ngay ở bước Services của Setup Wizard. Áp dụng tức thì, không cần restart.
+
+Key được lưu mã hóa trong DB của server và không bao giờ gửi xuống trình duyệt — trình duyệt chỉ nhận credentials ngắn hạn (24h) được mint từ key đó.
+
+> Fallback cho môi trường headless/CI: đặt env `JARVIS_CF_TURN_KEY_ID` + `JARVIS_CF_TURN_API_TOKEN` (DB luôn được ưu tiên nếu có), hoặc TURN server tự host qua `JARVIS_WEBRTC_ICE` — xem `backend/.env.example`.
+
+---
+
 ## Deploy thủ công (khi cần)
 
 ```bash

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -250,22 +250,22 @@ sudo certbot --nginx -d your-domain.com
 
 ---
 
-## 9. (Tùy chọn) Voice từ ngoài mạng — Cloudflare TURN
+## 9. (Optional) Voice from outside your network — Cloudflare TURN
 
-**Khi nào cần:** chỉ khi bạn dùng voice chat từ **ngoài** mạng đặt server — ví dụ điện thoại 4G/5G, Wi-Fi công ty. Chạy `localhost`, cùng LAN, hoặc qua VPN (Tailscale…) thì **không cần** mục này.
+**When you need this:** only when you use voice chat from **outside** the network the server lives on — e.g. a phone on 4G/5G, office Wi-Fi. On `localhost`, the same LAN, or over a VPN (Tailscale, …) you do **not** need this section.
 
-**Tại sao:** voice dùng WebRTC (UDP) đi thẳng giữa trình duyệt và server, KHÔNG đi qua HTTP/tunnel. Nếu server không có cổng UDP public (sau NAT nhà, sau cloudflared tunnel) và client ở sau CGNAT nhà mạng, hai bên không thể nối trực tiếp — cần một TURN relay làm trung gian. Đây là chuẩn ngành (Meet/Zoom/Discord đều dùng hạ tầng tương tự).
+**Why:** voice uses WebRTC (UDP) flowing directly between the browser and the server — it does NOT ride the HTTP/tunnel path. If the server has no public UDP inbound (behind home NAT, behind a cloudflared tunnel) and the client sits behind carrier CGNAT, the two sides can never connect directly — a TURN relay must broker the traffic. This is the industry-standard fix (Meet/Zoom/Discord all run equivalent infrastructure).
 
-**Cách bật (≈3 phút, miễn phí 1 TB/tháng):**
+**How to enable (≈3 minutes, free 1 TB/month):**
 
-1. Vào [Cloudflare Dashboard → Realtime → TURN](https://dash.cloudflare.com/?to=/:account/calls) (account Cloudflare free là đủ)
-2. Bấm **Create**, đặt tên tùy ý (ví dụ `jarvis-voice`)
-3. Copy **Turn Token ID** và **API Token**
-4. Dán vào Jarvis tại **Settings → Voice → Cloudflare TURN (voice relay)** — hoặc nhập ngay ở bước Services của Setup Wizard. Áp dụng tức thì, không cần restart.
+1. Open the [Cloudflare Dashboard → Realtime → TURN](https://dash.cloudflare.com/?to=/:account/calls) (a free Cloudflare account is enough)
+2. Click **Create** and give the TURN app any name (e.g. `jarvis-voice`)
+3. Copy the **Turn Token ID** and the **API Token**
+4. Paste them into Jarvis under **Settings → Voice → Cloudflare TURN (voice relay)** — or enter them in the Services step of the Setup Wizard. Applies immediately, no restart.
 
-Key được lưu mã hóa trong DB của server và không bao giờ gửi xuống trình duyệt — trình duyệt chỉ nhận credentials ngắn hạn (24h) được mint từ key đó.
+The key is stored encrypted in the server's DB and never reaches the browser — browsers only receive short-lived (24 h) credentials minted from it.
 
-> Fallback cho môi trường headless/CI: đặt env `JARVIS_CF_TURN_KEY_ID` + `JARVIS_CF_TURN_API_TOKEN` (DB luôn được ưu tiên nếu có), hoặc TURN server tự host qua `JARVIS_WEBRTC_ICE` — xem `backend/.env.example`.
+> Headless/CI fallback: set the env vars `JARVIS_CF_TURN_KEY_ID` + `JARVIS_CF_TURN_API_TOKEN` (DB-stored values take priority when both exist), or point `JARVIS_WEBRTC_ICE` at a self-hosted TURN server — see `backend/.env.example`.
 
 ---
 

--- a/frontend/src/views/settings/SettingsVoice.vue
+++ b/frontend/src/views/settings/SettingsVoice.vue
@@ -22,7 +22,7 @@ const loading = ref(true)
 const saving = ref(false)
 const saveSuccess = ref(false)
 const error = ref('')
-const engines = ref({ tts: {}, stt: {} })
+const engines = ref({ tts: {}, stt: {}, services: {} })
 const active = ref({ tts_chat: null, tts_stories: null, stt: null })
 const secretsStatus = ref({})
 const requirements = ref({})
@@ -117,6 +117,11 @@ onMounted(async () => {
       if (spec.requires?.length || spec.secrets?.length) probeIds.add(id)
     }
     for (const [id, spec] of Object.entries(reg.stt || {})) {
+      if (spec.requires?.length || spec.secrets?.length) probeIds.add(id)
+    }
+    // Voice infrastructure services (TURN relay) share the same secret-slot
+    // plumbing — probe them too so their "ready / set key" badge is live.
+    for (const [id, spec] of Object.entries(reg.services || {})) {
       if (spec.requires?.length || spec.secrets?.length) probeIds.add(id)
     }
     const checks = Array.from(probeIds).map(
@@ -238,8 +243,10 @@ const secretReveal = ref({})
 function _hasReqOrSecrets(engine) {
   const tts = engines.value.tts?.[engine]
   const stt = engines.value.stt?.[engine]
+  const svc = engines.value.services?.[engine]
   return !!(tts?.requires?.length || tts?.secrets?.length
-         || stt?.requires?.length || stt?.secrets?.length)
+         || stt?.requires?.length || stt?.secrets?.length
+         || svc?.requires?.length || svc?.secrets?.length)
 }
 async function setSecret(engine, slot) {
   const key = `${engine}.${slot}`
@@ -668,6 +675,92 @@ const chatProviderLabel = computed(() => {
         </div>
       </section>
 
+      <!-- 04 / Voice infrastructure services (TURN relay). Registry-driven
+           like the engine cards — a new entry in VOICE_SERVICES (backend)
+           shows up here with zero frontend changes. Secrets reuse the exact
+           setSecret/clearSecret path of the engine cards. -->
+      <section
+        v-for="(svc, svcId) in (engines.services || {})"
+        :key="svcId"
+        class="panel-card"
+        :data-testid="`voice-service-${svcId}`"
+      >
+        <header>
+          <div class="icon-circle">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="2" y1="12" x2="22" y2="12" />
+              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+            </svg>
+          </div>
+          <div>
+            <h2><span class="mono-num">04 /</span> {{ svc.label }}</h2>
+            <p>{{ svc.description }}</p>
+          </div>
+        </header>
+
+        <div class="provider-hint">
+          <span v-if="reqBadgeFor(svcId)" class="key-status" :class="reqBadgeFor(svcId).tone === 'ok' ? 'stored' : 'missing'">
+            {{ reqBadgeFor(svcId).tone === 'ok' ? 'configured — relay active' : reqBadgeFor(svcId).text }}
+          </span>
+        </div>
+
+        <ol v-if="svcId === 'cloudflare_turn'" class="turn-steps">
+          <li>
+            <strong>When do I need this?</strong> Only when you open Jarvis from
+            outside the network the server lives on — phone on 4G/5G, office Wi-Fi,
+            a friend's house. On <code>localhost</code>, the same LAN, or a VPN
+            (Tailscale etc.) voice already works without it.
+          </li>
+          <li>
+            Open the
+            <a href="https://dash.cloudflare.com/?to=/:account/calls" target="_blank" rel="noopener">
+              Cloudflare Dashboard → Realtime → TURN</a>
+            (free Cloudflare account is enough — the free tier includes 1&nbsp;TB/month of relay traffic).
+          </li>
+          <li>Click <strong>Create</strong>, give the TURN app any name (e.g. <code>jarvis-voice</code>).</li>
+          <li>
+            Copy the <strong>Turn Token ID</strong> into <code>key_id</code> and the
+            <strong>API Token</strong> into <code>api_token</code> below, then save both.
+            Applies immediately — no restart. The key never leaves this server;
+            browsers only ever receive short-lived credentials minted from it.
+          </li>
+        </ol>
+
+        <div v-for="slot in (svc.secrets || [])" :key="slot" class="field">
+          <label :for="`svc-secret-${svcId}-${slot}`">
+            Secret · {{ slot }}
+            <span v-if="(secretsStatus[svcId] || {})[slot]" class="key-status stored">stored · hidden</span>
+            <span v-else class="key-status missing">not set</span>
+          </label>
+          <div class="input-group">
+            <input
+              :id="`svc-secret-${svcId}-${slot}`"
+              class="pwd-input"
+              :type="secretReveal[`${svcId}.${slot}`] ? 'text' : 'password'"
+              autocomplete="off"
+              :placeholder="(secretsStatus[svcId] || {})[slot] ? 'Leave blank to keep current' : 'Paste value'"
+              :value="secretInput[`${svcId}.${slot}`] || ''"
+              @input="secretInput[`${svcId}.${slot}`] = $event.target.value"
+            />
+            <button type="button" class="icon-btn" @click="secretReveal[`${svcId}.${slot}`] = !secretReveal[`${svcId}.${slot}`]">
+              <svg v-if="secretReveal[`${svcId}.${slot}`]" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                <line x1="1" y1="1" x2="23" y2="23" />
+              </svg>
+              <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            </button>
+          </div>
+          <div class="action-row" style="margin-top: 8px;">
+            <button type="button" class="btn ghost" :disabled="!(secretsStatus[svcId] || {})[slot]" @click="clearSecret(svcId, slot)">Clear</button>
+            <button type="button" class="btn primary" :disabled="!secretInput[`${svcId}.${slot}`]" @click="setSecret(svcId, slot)">Save key</button>
+          </div>
+        </div>
+      </section>
+
       <p v-if="previewError" class="error-msg">{{ previewError }}</p>
 
       <div class="footer-row">
@@ -682,6 +775,28 @@ const chatProviderLabel = computed(() => {
 
 <style scoped>
 .voice-sections { display: flex; flex-direction: column; gap: 18px; }
+
+/* TURN setup walkthrough — numbered steps inside the service card. */
+.turn-steps {
+  margin: 0 0 14px;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+.turn-steps strong { color: var(--text); }
+.turn-steps code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.turn-steps a { color: var(--primary); text-decoration: underline; }
 .loading { color: var(--text-muted); font-size: 13px; }
 
 /* ── Provider split (HUD glance card) ─────────────────────────────── */

--- a/frontend/src/views/setup/StepServices.vue
+++ b/frontend/src/views/setup/StepServices.vue
@@ -41,6 +41,20 @@ const SERVICES = [
     ],
   },
   {
+    // Stored in voice.secrets.cloudflare_turn.* (same slots Settings → Voice
+    // manages) — routes/setup.py maps it there so both surfaces share one
+    // source of truth. See VOICE_SERVICES in voice_engine_registry.py.
+    id: 'cloudflare_turn',
+    label: 'Cloudflare TURN (Voice relay)',
+    desc: 'Lets voice chat work when you open Jarvis from OUTSIDE your home network — phone on 4G/5G, office Wi-Fi. Not needed for localhost / LAN / VPN use, and you can add it later in Settings → Voice. Get both values free at dash.cloudflare.com → Realtime → TURN → Create (free tier: 1 TB/month relay traffic).',
+    mode: 'fields',
+    fields: [
+      { key: 'key_id', label: 'Turn Token ID', secret: false },
+      { key: 'api_token', label: 'API Token', secret: true },
+    ],
+    requireAllIfAny: true,
+  },
+  {
     id: 'github',
     label: 'GitHub & Git',
     desc: 'Personal access token so dev agents can git clone/push/pull private repos (and drive the GitHub MCP). Name + email are used as the commit identity. Create a token at https://github.com/settings/tokens with the "repo" scope.',

--- a/frontend/tests/e2e/fixtures/settings_voice_turn.yaml
+++ b/frontend/tests/e2e/fixtures/settings_voice_turn.yaml
@@ -1,0 +1,139 @@
+# Settings → Voice — Cloudflare TURN relay configuration flow.
+#
+# What this fixture stages:
+#   * GET /api/voice/engines returns the registry INCLUDING the new
+#     ``services.cloudflare_turn`` entry (VOICE_SERVICES on the backend).
+#     SettingsVoice.vue renders one panel per service — registry-driven,
+#     so this is exactly what the live backend emits.
+#   * GET /api/voice/secrets reports neither TURN slot on file, then flips
+#     per save: after key_id → {key_id: true}; after api_token → both true.
+#   * GET /api/voice/requirements/cloudflare_turn is probed on mount
+#     (services join the same probe loop as engines with secrets) and
+#     re-probed after each save — badge walks "set key_id · api_token"
+#     → "set api_token" → "configured — relay active".
+#
+# Backend contract this asserts:
+#   * voice_engine_registry.VOICE_SERVICES exposes cloudflare_turn with
+#     secrets [key_id, api_token]
+#   * routes/voice.list_engines includes the "services" key
+#   * routes/voice.list_secrets_status + check_requirements resolve
+#     voice-service names (not just TTS/STT engines)
+#   * routes/voice.set_secret accepts engine=cloudflare_turn
+
+backend_source:
+  - "backend/services/voice_engine_registry.py::VOICE_SERVICES['cloudflare_turn']"
+  - "backend/routes/voice.py::list_engines, list_secrets_status, set_secret, check_requirements"
+  - "dashboard/src/views/settings/SettingsVoice.vue::setSecret (voice-service section)"
+
+responses:
+  "GET /api/settings":
+    status: 200
+    json:
+      categories: {}
+
+  "GET /api/voice/engines":
+    status: 200
+    json:
+      tts:
+        edge:
+          label: "Microsoft Edge TTS"
+          description: "Free, no API key."
+          badges: ["free", "cloud"]
+          requires: []
+          secrets: []
+          realtimetts_engine: "EdgeEngine"
+          output_format: "mp3"
+          params:
+            - key: "voice"
+              type: "select"
+              label: "Voice"
+              default: "vi-VN-NamMinhNeural"
+              options: ["vi-VN-NamMinhNeural"]
+      stt:
+        faster_whisper:
+          label: "faster-whisper (local)"
+          description: "Local inference."
+          badges: ["free", "local"]
+          params:
+            - key: "model"
+              type: "select"
+              label: "Final model"
+              default: "base"
+              options: ["tiny", "base"]
+          wake_word_backends:
+            off:
+              label: "Disabled"
+              params: []
+      services:
+        cloudflare_turn:
+          label: "Cloudflare TURN (voice relay)"
+          description: "Lets voice work from outside your network (e.g. phone on 4G/5G). Not needed on localhost or LAN/VPN."
+          badges: ["cloud", "free-tier", "optional"]
+          requires: []
+          secrets: ["key_id", "api_token"]
+          params: []
+          docs_url: "https://developers.cloudflare.com/realtime/turn/"
+
+  "GET /api/voice/active":
+    status: 200
+    json:
+      tts_chat:
+        engine: "edge"
+        params: { voice: "vi-VN-NamMinhNeural" }
+      tts_stories:
+        voice: "vi-VN-NamMinhNeural"
+        rate: "+20%"
+      stt:
+        backend: "faster_whisper"
+        params: { model: "base" }
+        wake_word: { backend: "off", params: {} }
+
+  "GET /api/voice/backends":
+    status: 200
+    json:
+      tts:
+        enabled: ["edge"]
+        known: ["edge"]
+      stt:
+        enabled: ["faster_whisper"]
+        known: ["faster_whisper"]
+
+  # Sequenced: mount → after key_id save → after api_token save.
+  "GET /api/voice/secrets":
+    - status: 200
+      json:
+        engines:
+          cloudflare_turn: { key_id: false, api_token: false }
+    - status: 200
+      json:
+        engines:
+          cloudflare_turn: { key_id: true, api_token: false }
+    - status: 200
+      json:
+        engines:
+          cloudflare_turn: { key_id: true, api_token: true }
+
+  "GET /api/voice/requirements/cloudflare_turn":
+    - status: 200
+      json:
+        ok: false
+        missing_binaries: []
+        secrets_present: { key_id: false, api_token: false }
+    - status: 200
+      json:
+        ok: false
+        missing_binaries: []
+        secrets_present: { key_id: true, api_token: false }
+    - status: 200
+      json:
+        ok: true
+        missing_binaries: []
+        secrets_present: { key_id: true, api_token: true }
+
+  "POST /api/voice/secrets/cloudflare_turn/key_id":
+    status: 200
+    json: { status: "ok" }
+
+  "POST /api/voice/secrets/cloudflare_turn/api_token":
+    status: 200
+    json: { status: "ok" }

--- a/frontend/tests/e2e/fixtures/wizard_services_turn.yaml
+++ b/frontend/tests/e2e/fixtures/wizard_services_turn.yaml
@@ -1,0 +1,58 @@
+# Wizard Step 3 (Services) — Cloudflare TURN entry.
+#
+# The wizard collects key_id + api_token under the ``cloudflare_turn``
+# service card and submits them in the single POST /api/setup/services
+# payload. The backend maps that service name into the SAME encrypted
+# slots Settings → Voice manages (voice.secrets.cloudflare_turn.*) — see
+# routes/setup.py::setup_services — so the spec only needs to assert the
+# wire payload here; the storage mapping is covered by backend tests
+# (test_setup.py::test_cloudflare_turn_lands_in_voice_secrets).
+
+backend_source:
+  - "backend/routes/setup.py::get_setup_status, setup_services"
+  - "backend/routes/oauth.py::status (GoogleOAuthCard mounts on this page)"
+  - "dashboard/src/views/setup/StepServices.vue::SERVICES['cloudflare_turn']"
+
+responses:
+  "GET /api/setup/auth/probe":
+    status: 200
+    json:
+      configured: true
+
+  "GET /api/setup/status":
+    status: 200
+    json:
+      steps:
+        - { name: "auth",        completed: true,  skipped: false }
+        - { name: "llm",         completed: true,  skipped: false }
+        - { name: "services",    completed: false, skipped: false }
+        - { name: "yaml_config", completed: false, skipped: false }
+        - { name: "verify",      completed: false, skipped: false }
+      overall_complete: false
+      current_step: "services"
+
+  # GoogleOAuthCard mounts on the services page — keep it inert.
+  "GET /api/oauth/google/status":
+    status: 200
+    json:
+      client_configured: false
+      client_type: "none"
+      desktop_redirect_uri: null
+      connected: false
+      scopes: []
+      expires_at: null
+      has_refresh_token: false
+      project_number: null
+      required_apis: []
+
+  "POST /api/setup/services":
+    status: 200
+    json:
+      steps:
+        - { name: "auth",        completed: true,  skipped: false }
+        - { name: "llm",         completed: true,  skipped: false }
+        - { name: "services",    completed: true,  skipped: false, data: { configured: ["cloudflare_turn"] } }
+        - { name: "yaml_config", completed: false, skipped: false }
+        - { name: "verify",      completed: false, skipped: false }
+      overall_complete: false
+      current_step: "yaml_config"

--- a/frontend/tests/e2e/flows/settings-voice-turn.spec.ts
+++ b/frontend/tests/e2e/flows/settings-voice-turn.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * E2E flows: Cloudflare TURN credential entry — Settings → Voice AND the
+ * Setup Wizard services step.
+ *
+ * Why this exists: voice over WebRTC silently has NO path from networks
+ * outside the host's LAN/VPN unless a TURN relay is configured (the
+ * 2026-06-10 "iPhone on 5G — ICE failed" incident). The fix ships as a
+ * registry-driven VOICE_SERVICES entry; these flows guard the two surfaces
+ * a user can configure it from:
+ *
+ *   1. Settings → Voice: the TURN panel renders from GET /api/voice/engines
+ *      ``services`` (a backend regression hiding the key would kill the
+ *      panel), the setup walkthrough is visible, and saving each slot fires
+ *      POST /api/voice/secrets/cloudflare_turn/{slot} with the pasted value.
+ *      Pills must flip on re-fetch ("not set" → "stored · hidden", badge
+ *      "set key_id · api_token" → "configured — relay active").
+ *   2. Setup Wizard step 3: the TURN card renders, partial fill blocks
+ *      submit (requireAllIfAny), and the final POST /api/setup/services
+ *      carries {cloudflare_turn: {key_id, api_token}} — the backend maps it
+ *      into the SAME voice.secrets.* slots (covered by backend tests).
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, NetworkRecorder, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+test('Settings → Voice: TURN panel renders, both slots save, pills flip', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const backend = await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'settings_voice_turn.yaml'),
+  ])
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+
+  await page.goto('/settings')
+  await page.getByRole('button', { name: 'Voice', exact: true }).click()
+
+  // ── (1) Registry-driven panel + walkthrough ────────────────────────────
+  const panel = page.getByTestId('voice-service-cloudflare_turn')
+  await expect(panel).toBeVisible()
+  await expect(
+    panel.getByRole('heading', { name: /Cloudflare TURN \(voice relay\)/i }),
+  ).toBeVisible()
+  // The "when do I need this" guidance is the OSS-user contract — a fresh
+  // self-hoster must be able to tell whether this section applies to them.
+  await expect(panel.getByText('When do I need this?', { exact: false })).toBeVisible()
+  await expect(panel.getByText('localhost', { exact: false }).first()).toBeVisible()
+  // Mount probe: neither slot set → badge lists both (reqBadgeFor joins
+  // missing slots with ", ").
+  await expect(panel.getByText('set key_id, api_token', { exact: false })).toBeVisible()
+
+  // ── (2) Save key_id ────────────────────────────────────────────────────
+  await panel.locator('#svc-secret-cloudflare_turn-key_id').fill('cf-key-id-123')
+  const keyIdRow = panel.locator('.field', {
+    has: page.locator('#svc-secret-cloudflare_turn-key_id'),
+  })
+  const [keyIdResp] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/voice/secrets/cloudflare_turn/key_id',
+    ),
+    keyIdRow.getByRole('button', { name: 'Save key', exact: true }).click(),
+  ])
+  expect(keyIdResp.status()).toBe(200)
+  const keyIdCall = recorder.assertContains(
+    'POST',
+    '/api/voice/secrets/cloudflare_turn/key_id',
+  )
+  expect((keyIdCall.body as { value: string }).value).toBe('cf-key-id-123')
+
+  // ── (3) Save api_token — badge flips to the configured state ──────────
+  await panel.locator('#svc-secret-cloudflare_turn-api_token').fill('cf-api-token-456')
+  const tokenRow = panel.locator('.field', {
+    has: page.locator('#svc-secret-cloudflare_turn-api_token'),
+  })
+  const [tokenResp] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/voice/secrets/cloudflare_turn/api_token',
+    ),
+    tokenRow.getByRole('button', { name: 'Save key', exact: true }).click(),
+  ])
+  expect(tokenResp.status()).toBe(200)
+
+  await expect(panel.getByText('configured — relay active', { exact: true })).toBeVisible()
+  // Both slots now report stored.
+  await expect(panel.getByText('stored · hidden', { exact: true })).toHaveCount(2)
+
+  if (backend.unexpected.length > 0) {
+    console.log('UNEXPECTED:', JSON.stringify(backend.unexpected, null, 2))
+  }
+  expect(backend.unexpected.length).toBe(0)
+})
+
+test('Setup Wizard: TURN card collects both values into POST /api/setup/services', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const backend = await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'wizard_services_turn.yaml'),
+  ])
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+
+  await page.goto('/setup/services')
+
+  const card = page.getByTestId('wizard-service-cloudflare_turn')
+  await expect(card).toBeVisible()
+  // The card copy must tell a fresh user when they need this and that it
+  // is skippable — the OSS onboarding contract.
+  await expect(card.getByText('OUTSIDE your home network', { exact: false })).toBeVisible()
+  await expect(card.getByText('Not needed for localhost', { exact: false })).toBeVisible()
+
+  await card.getByRole('button', { name: 'Configure', exact: true }).click()
+
+  // requireAllIfAny: filling only one field blocks submit with a visible error.
+  await card.locator('#cloudflare_turn-key_id').fill('cf-key-id-123')
+  await expect(
+    page.getByText(/Cloudflare TURN.*please also fill/i),
+  ).toBeVisible()
+
+  await card.locator('#cloudflare_turn-api_token').fill('cf-api-token-456')
+  await expect(page.getByText(/please also fill/i)).toHaveCount(0)
+
+  const [resp] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/setup/services',
+    ),
+    page.getByRole('button', { name: /Save & Continue/i }).click(),
+  ])
+  expect(resp.status()).toBe(200)
+
+  const call = recorder.assertContains('POST', '/api/setup/services')
+  const body = call.body as {
+    services: Record<string, Record<string, string>>
+  }
+  expect(body.services.cloudflare_turn).toEqual({
+    key_id: 'cf-key-id-123',
+    api_token: 'cf-api-token-456',
+  })
+
+  if (backend.unexpected.length > 0) {
+    console.log('UNEXPECTED:', JSON.stringify(backend.unexpected, null, 2))
+  }
+  expect(backend.unexpected.length).toBe(0)
+})


### PR DESCRIPTION
## Why

Voice over WebRTC has **no ICE path from any network outside the tailnet**. The deployment has zero public UDP inbound (web traffic rides a cloudflared tunnel; the host sits behind home NAT + docker bridge NAT). Evidence from prod logs (iPhone Safari on 5G, 2026-06-10):

```
aioice: Check CandidatePair(('172.19.0.3', 54772) -> ('215.67.92.112', 52149)) -> FAILED
aioice: Check CandidatePair(('172.19.0.3', 54772) -> ('171.244.120.115', 7806)) -> FAILED
aioice: ICE failed
```

Desktop Chrome only ever worked because the Mac runs Tailscale, whose interface contributes a candidate the server can route to (`100.114.26.107` — confirmed as the only SUCCEEDED pair in prod logs). Industry-standard fix for this topology: a TURN relay.

## What

- `get_ice_servers()` in `services/webrtc_voice.py` — the **single source of truth** for ICE config, consumed by both `/api/voice/ice` (browser) and the server's own `RTCPeerConnection`:
  1. Cloudflare Realtime TURN creds, minted on demand from `JARVIS_CF_TURN_KEY_ID` + `JARVIS_CF_TURN_API_TOKEN` (`POST /v1/turn/keys/{id}/credentials/generate-ice-servers`, TTL 24 h)
  2. fallback: existing `JARVIS_WEBRTC_ICE` static list
  3. fallback: public STUN (unchanged default)
- Mint cache refreshes at half-life (12 h) so creds handed to a new session always outlive it; a stale-but-valid batch is served if the CF API blips (loud `logger.exception`, no silent fallback). Hard expiry at TTL−10 min.
- `WebRtcVoiceSession(ice_servers=…)` now accepts browser-shaped dicts (urls list + username/credential) as well as plain url strings; the ws handler pre-fetches via `asyncio.to_thread` so a cold mint (blocking HTTPS ≤10 s) never stalls the event loop.
- `backend/.env.example` documents the new vars.

With the CF vars **unset**, behavior is byte-identical to before (STUN-only) — safe to deploy ahead of credential provisioning.

## Click-flow

iPhone Safari (5G/CGNAT) → app.omnigentx.com/chat → mic on → frontend fetches `/api/voice/ice` (now contains `turn.cloudflare.com` + minted creds) → `webrtc_offer` over WS → both peers allocate relay candidates on Cloudflare's edge → ICE succeeds via relay → mic RTP reaches `pump_inbound_track` → Soniox STT → transcripts.

## Tests

- `tests/test_services/test_webrtc_voice.py` — **7 passed**: CF mint happy path (URL/auth-header/TTL asserted), cache hit, half-life re-mint, stale-serve on API failure + hard-expiry fallback, dict/str `ice_servers` shapes, and the existing aiortc loopback e2e (real RTCPeerConnection pair, no mocks of the changed subsystem).
- `tests/test_routes/test_ws_voice.py` — **17 passed** (webrtc_offer signalling path included).
- Real-relay e2e (forced `relay` ICE policy through live Cloudflare TURN) requires the TURN key — will run post-provisioning with the aiortc client harness used during diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)