### PR TITLE
fix(auth): reload after modal login so 401-poisoned views recover

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,7 +7,8 @@ import ConfirmModal from './components/ConfirmModal.vue'
 import AuthGate from './components/AuthGate.vue'
 import { useConfirmState } from './composables/useConfirm'
 import { onSetupRequired, onUnauthorized } from './api'
-import { useAuthStore } from './stores/auth'
+import { useAuthStore, STATUS as AUTH_STATUS } from './stores/auth'
+import { on as onAuthEvent, EVENTS as AUTH_EVENTS } from './auth/bus.js'
 
 // Single globally-mounted confirmation dialog driven by useConfirm().  Views
 // call ``await confirm({...})`` instead of ``window.confirm(...)`` so every
@@ -37,6 +38,21 @@ onMounted(async () => {
   // (re-probes once before locking the UI; see stores/auth.js#on401).
   onUnauthorized((reason) => {
     auth.on401(reason)
+  })
+
+  // Recovering from a LOCKOUT (AuthGate modal login — passkey or API key)
+  // reloads the page. Views mount behind the gate overlay (it is not a
+  // route guard), so their onMounted fetches already 401'd; only SSE
+  // composables and ChatView replay on RESTORED, every other view stays
+  // broken until a refresh. Rather than wiring a RESTORED listener into
+  // 20+ views (and every future one), replay everything: at lockout there
+  // is no in-page state worth preserving — it is all 401-poisoned.
+  // Boot probe (from === 'unknown') and challenged-recovery must NOT
+  // reload — those paths have healthy in-page state.
+  onAuthEvent(AUTH_EVENTS.RESTORED, ({ from } = {}) => {
+    if (from === AUTH_STATUS.UNAUTHENTICATED) {
+      window.location.reload()
+    }
   })
 
   // Boot probe: ask the backend whether the existing cookie is still good.

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -14,4 +14,9 @@ app.use(router)
 // resolves makes meta read as {} for one tick — the probe then runs on
 // /setup, flips the auth store to 'unauthenticated' mid-wizard, and the
 // AppLayout chrome (with its SSE streams) flashes over the wizard.
-router.isReady().then(() => app.mount('#app'))
+// isReady() rejects if a navigation guard throws — degrade to mounting
+// anyway (router lands on the resolved-or-error state) instead of a
+// blank page with no surfaced error.
+router.isReady()
+  .catch((err) => console.error('[main] initial route failed:', err))
+  .then(() => app.mount('#app'))

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,4 +8,10 @@ import './assets/tokens.css'
 const app = createApp(App)
 app.use(createPinia())
 app.use(router)
-app.mount('#app')
+// Wait for the initial route: App.vue's onMounted branches on
+// route.meta.layout (bare /setup pages skip the boot auth probe, and the
+// template picks bare vs AppLayout chrome). Mounting before the router
+// resolves makes meta read as {} for one tick — the probe then runs on
+// /setup, flips the auth store to 'unauthenticated' mid-wizard, and the
+// AppLayout chrome (with its SSE streams) flashes over the wizard.
+router.isReady().then(() => app.mount('#app'))

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -303,8 +303,11 @@ export const useAuthStore = defineStore('auth', {
       this.expiresAt = expiresIn ? Math.floor(Date.now() / 1000) + expiresIn : null
       _scheduleRefresh(this, expiresIn)
       if (wasUnauth) {
-        emit(EVENTS.RESTORED, { from: prevStatus })
+        // Broadcast BEFORE the local emit: App.vue's RESTORED listener may
+        // call window.location.reload(), and sibling-tab notification must
+        // not depend on reload() letting the current task finish.
         this._broadcast(expiresIn)
+        emit(EVENTS.RESTORED, { from: prevStatus })
       }
     },
 

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -291,14 +291,19 @@ export const useAuthStore = defineStore('auth', {
      * "authenticated" state and notify subscribers. Idempotent.
      */
     setAuthenticated(csrfToken, expiresIn) {
-      const wasUnauth = this.status !== STATUS.AUTHENTICATED
+      // ``from`` rides on RESTORED so subscribers can distinguish a modal
+      // login (from === 'unauthenticated' — page state is 401-poisoned and
+      // needs a full replay) from the boot probe (from === 'unknown') or a
+      // challenged-recovery, where in-page state is still good.
+      const prevStatus = this.status
+      const wasUnauth = prevStatus !== STATUS.AUTHENTICATED
       this.status = STATUS.AUTHENTICATED
       this.csrfToken = csrfToken || getCsrfToken()
       this.lastReason = ''
       this.expiresAt = expiresIn ? Math.floor(Date.now() / 1000) + expiresIn : null
       _scheduleRefresh(this, expiresIn)
       if (wasUnauth) {
-        emit(EVENTS.RESTORED)
+        emit(EVENTS.RESTORED, { from: prevStatus })
         this._broadcast(expiresIn)
       }
     },
@@ -323,7 +328,8 @@ export const useAuthStore = defineStore('auth', {
      */
     _applyRemoteTransition(status, csrfToken, expiresIn) {
       if (status === STATUS.AUTHENTICATED) {
-        const wasUnauth = this.status !== STATUS.AUTHENTICATED
+        const prevStatus = this.status
+        const wasUnauth = prevStatus !== STATUS.AUTHENTICATED
         this.status = STATUS.AUTHENTICATED
         this.csrfToken = csrfToken || getCsrfToken()
         this.lastReason = ''
@@ -331,7 +337,9 @@ export const useAuthStore = defineStore('auth', {
           this.expiresAt = Math.floor(Date.now() / 1000) + expiresIn
           _scheduleRefresh(this, expiresIn)
         }
-        if (wasUnauth) emit(EVENTS.RESTORED)
+        // ``from`` is THIS tab's previous status — a locked sibling tab
+        // (modal showing) recovers exactly like the tab that logged in.
+        if (wasUnauth) emit(EVENTS.RESTORED, { from: prevStatus })
       } else if (status === STATUS.UNAUTHENTICATED) {
         const wasAuth = this.status === STATUS.AUTHENTICATED
         this.status = STATUS.UNAUTHENTICATED

--- a/frontend/src/stores/auth.test.js
+++ b/frontend/src/stores/auth.test.js
@@ -210,6 +210,56 @@ test('login() success → status=authenticated + RESTORED + broadcast', async ()
   assert.equal(otherTabMsgs[0].status, STATUS.AUTHENTICATED)
 })
 
+// ---- RESTORED payload (drives the App.vue reload-after-lockout) -------------
+// App.vue reloads the page only when RESTORED carries from='unauthenticated'
+// (modal login — in-page state is 401-poisoned). Boot probe must carry
+// from='unknown' so it never triggers a reload loop.
+
+test('RESTORED from boot probe carries from=unknown (no reload path)', async () => {
+  _setFetch(async () => new Response(JSON.stringify({ authenticated: true, expires_in: 3600 }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  }))
+
+  const payloads = []
+  on(EVENTS.RESTORED, (p) => { payloads.push(p) })
+
+  const auth = useAuthStore()
+  await auth.probe()
+
+  assert.equal(payloads.length, 1)
+  assert.equal(payloads[0].from, STATUS.UNKNOWN)
+})
+
+test('RESTORED from modal login after lockout carries from=unauthenticated', async () => {
+  _setFetch(async () => new Response(JSON.stringify({ status: 'ok', csrf_token: 'c', expires_in: 3600 }), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  }))
+
+  const auth = useAuthStore()
+  auth.$patch({ status: STATUS.UNAUTHENTICATED })
+
+  const payloads = []
+  on(EVENTS.RESTORED, (p) => { payloads.push(p) })
+
+  await auth.login('good-key')
+
+  assert.equal(payloads.length, 1)
+  assert.equal(payloads[0].from, STATUS.UNAUTHENTICATED)
+})
+
+test('RESTORED from cross-tab transition carries THIS tab previous status', () => {
+  const auth = useAuthStore()
+  auth.$patch({ status: STATUS.UNAUTHENTICATED })
+
+  const payloads = []
+  on(EVENTS.RESTORED, (p) => { payloads.push(p) })
+
+  auth._applyRemoteTransition(STATUS.AUTHENTICATED, 'csrf-x', 3600)
+
+  assert.equal(payloads.length, 1)
+  assert.equal(payloads[0].from, STATUS.UNAUTHENTICATED)
+})
+
 test('login() 401 returns reason from backend, status stays unchanged', async () => {
   _setFetch(async () => new Response(JSON.stringify({
     detail: { error: 'unauthorized', reason: 'invalid_credentials' },

--- a/frontend/tests/e2e/fixtures/auth_gate_login_success.yaml
+++ b/frontend/tests/e2e/fixtures/auth_gate_login_success.yaml
@@ -1,12 +1,11 @@
 # Login flow: user types key → POST /api/auth/login → returns 200 + csrf
 # in body + sets cookies. Whoami then flips to authenticated:true.
 #
-# Two-phase fixture: the FIRST whoami call returns false (boot probe
-# before login); subsequent calls return true. The mock-backend harness
-# doesn't natively support response-by-call-number, so we keep
-# whoami=true and rely on the dashboard's reaction to the login response
-# directly. The store's _setAuthenticated is fired off the login response
-# body (csrf_token + expires_in), not off whoami, so this works.
+# Two-phase whoami (sequence): the FIRST call returns false (boot probe
+# before login, opens the gate); subsequent calls return true. The second
+# phase matters because a successful modal login RELOADS the page
+# (App.vue's RESTORED listener) — the post-reload boot probe must
+# authenticate or the gate would re-open and the test would deadlock.
 
 backend_source:
   - "backend/routes/auth.py::login"
@@ -16,8 +15,10 @@ backend_source:
 
 responses:
   "GET /api/auth/whoami":
-    status: 200
-    json: { authenticated: false }
+    - status: 200
+      json: { authenticated: false }
+    - status: 200
+      json: { authenticated: true, expires_in: 3600 }
 
   "GET /api/auth/passkey/has-any":
     status: 200

--- a/frontend/tests/e2e/fixtures/auth_gate_reload_recovery.yaml
+++ b/frontend/tests/e2e/fixtures/auth_gate_reload_recovery.yaml
@@ -1,0 +1,83 @@
+# Reload-after-lockout recovery — the bug this guards against:
+#
+#   AuthGate is an OVERLAY, not a route guard. Deep-linking to a view
+#   while logged out mounts it behind the modal; its onMounted fetch
+#   401s and (pre-fix) was never replayed, so the view stayed broken
+#   after passkey/API-key login until a MANUAL page refresh.
+#
+# The fix (App.vue RESTORED listener, from === 'unauthenticated')
+# reloads the page after a modal login, replaying every mount fetch.
+# Sequenced entries model the auth state flipping server-side:
+#   whoami:  false (boot probe, locked)  → true (post-reload probe)
+#   metrics: 401  (mount fetch, locked)  → 200 (post-reload mount fetch)
+
+backend_source:
+  - "backend/routes/auth.py::login, whoami"
+  - "backend/routes/token_usage.py::get_token_metrics"
+  - "dashboard/src/App.vue::RESTORED reload listener"
+  - "dashboard/src/views/TokenUsage.vue::fetchMetrics"
+
+responses:
+  "GET /api/auth/whoami":
+    - status: 200
+      json: { authenticated: false }
+    - status: 200
+      json: { authenticated: true, expires_in: 3600 }
+
+  "GET /api/auth/passkey/has-any":
+    status: 200
+    json: { has_passkey: false }
+
+  "POST /api/auth/login":
+    status: 200
+    headers:
+      set-cookie: "jarvis_csrf=fixture-csrf-reload; Path=/; SameSite=Lax"
+    json:
+      status: "ok"
+      csrf_token: "fixture-csrf-reload"
+      expires_in: 3600
+
+  "GET /api/metrics/tokens":
+    - status: 401
+      json: { detail: { error: "unauthorized", reason: "invalid_or_missing_credentials" } }
+    - status: 200
+      json:
+        period: "24h"
+        totals:
+          input_tokens: 900000
+          output_tokens: 334500
+          total_tokens: 1234500
+          cached_tokens: 100000
+          reasoning_tokens: 0
+          est_cost: 12.34
+          llm_calls: 42
+        agents:
+          - agent_name: "Jarvis"
+            input_tokens: 900000
+            output_tokens: 334500
+            total_tokens: 1234500
+            cached_tokens: 100000
+            reasoning_tokens: 0
+            est_cost: 12.34
+            llm_calls: 42
+        models:
+          - model: "claude-sonnet-4-6"
+            input_tokens: 900000
+            output_tokens: 334500
+            total_tokens: 1234500
+            cached_tokens: 100000
+            reasoning_tokens: 0
+            est_cost: 12.34
+            llm_calls: 42
+
+  "GET /api/setup/status":
+    status: 200
+    json:
+      steps:
+        - { name: "auth",        completed: true,  skipped: false }
+        - { name: "llm",         completed: true,  skipped: false }
+        - { name: "services",    completed: true,  skipped: false }
+        - { name: "yaml_config", completed: true,  skipped: false }
+        - { name: "verify",      completed: true,  skipped: false }
+      overall_complete: true
+      current_step: "verify"

--- a/frontend/tests/e2e/fixtures/auth_gate_reload_recovery.yaml
+++ b/frontend/tests/e2e/fixtures/auth_gate_reload_recovery.yaml
@@ -14,8 +14,8 @@
 backend_source:
   - "backend/routes/auth.py::login, whoami"
   - "backend/routes/token_usage.py::get_token_metrics"
-  - "dashboard/src/App.vue::RESTORED reload listener"
-  - "dashboard/src/views/TokenUsage.vue::fetchMetrics"
+  - "frontend/src/App.vue::RESTORED reload listener"
+  - "frontend/src/views/TokenUsage.vue::fetchMetrics"
 
 responses:
   "GET /api/auth/whoami":

--- a/frontend/tests/e2e/flows/auth-cookie-only.spec.ts
+++ b/frontend/tests/e2e/flows/auth-cookie-only.spec.ts
@@ -18,7 +18,7 @@ import { expect, test } from '@playwright/test'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { clearAllAuth, mockBackend, NetworkRecorder } from '../harness'
+import { clearAllAuth, mockBackend, NetworkRecorder, waitForPostLoginReload } from '../harness'
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
 
@@ -33,7 +33,9 @@ test('after API-key login the key never lands in localStorage', async ({ page })
   await expect(modal).toBeVisible()
 
   await page.locator('#auth-gate-key').fill('test-api-key-e2e')
+  const settled = waitForPostLoginReload(page)
   await page.getByRole('button', { name: /^continue$/i }).click()
+  await settled
   await expect(modal).toBeHidden({ timeout: 3000 })
 
   // The credential MUST NOT have leaked into any localStorage key.
@@ -66,7 +68,9 @@ test('mutations after login carry X-CSRF-Token but NOT Authorization: Bearer',
 
     await page.goto('/')
     await page.locator('#auth-gate-key').fill('test-api-key-e2e')
+    const settled = waitForPostLoginReload(page)
     await page.getByRole('button', { name: /^continue$/i }).click()
+    await settled
     await expect(
       page.getByRole('dialog', { name: /authentication required/i }),
     ).toBeHidden()
@@ -115,7 +119,9 @@ test('SSE URLs do not carry ?api_key=', async ({ page }) => {
   ])
   await page.goto('/')
   await page.locator('#auth-gate-key').fill('test-api-key-e2e')
+  const settled = waitForPostLoginReload(page)
   await page.getByRole('button', { name: /^continue$/i }).click()
+  await settled
   await expect(
     page.getByRole('dialog', { name: /authentication required/i }),
   ).toBeHidden()

--- a/frontend/tests/e2e/flows/auth-gate-login.spec.ts
+++ b/frontend/tests/e2e/flows/auth-gate-login.spec.ts
@@ -15,7 +15,7 @@ import { expect, test } from '@playwright/test'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { clearAllAuth, mockBackend, NetworkRecorder } from '../harness'
+import { clearAllAuth, mockBackend, NetworkRecorder, waitForPostLoginReload } from '../harness'
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
 
@@ -32,9 +32,14 @@ test('typing the right key dismisses the modal', async ({ page }) => {
   await expect(modal).toBeVisible()
 
   await page.locator('#auth-gate-key').fill('test-api-key-e2e')
+  // Successful login reloads the page (App.vue RESTORED listener);
+  // wait for the post-reload boot probe so assertions run on the
+  // settled, authenticated document.
+  const settled = waitForPostLoginReload(page)
   await page.getByRole('button', { name: /continue/i }).click()
+  await settled
 
-  // Modal should disappear once the login response sets store status.
+  // Modal must stay gone on the reloaded, authenticated page.
   await expect(modal).toBeHidden({ timeout: 3000 })
 
   // The login POST must have been observed by the mock backend.
@@ -53,7 +58,9 @@ test('login attaches X-CSRF-Token to subsequent mutations', async ({ page }) => 
 
   await page.goto('/')
   await page.locator('#auth-gate-key').fill('test-api-key-e2e')
+  const settled = waitForPostLoginReload(page)
   await page.getByRole('button', { name: /continue/i }).click()
+  await settled
   await expect(
     page.getByRole('dialog', { name: /authentication required/i }),
   ).toBeHidden()

--- a/frontend/tests/e2e/flows/auth-gate-reload-recovery.spec.ts
+++ b/frontend/tests/e2e/flows/auth-gate-reload-recovery.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * E2E: modal login reloads the page so 401-poisoned views recover.
+ *
+ * Regression under test (the "401 until manual refresh" bug):
+ *   AuthGate is an overlay, NOT a route guard — deep-linking to a view
+ *   while logged out mounts it behind the modal. Its onMounted fetch
+ *   401s, and (pre-fix) nothing ever replayed it: only SSE composables
+ *   and ChatView listened to RESTORED, so every other view stayed
+ *   broken after a passkey/API-key login until the user reloaded by
+ *   hand.
+ *
+ * The fix: App.vue listens to RESTORED and reloads the page when the
+ * login recovered a LOCKOUT (from === 'unauthenticated'). The reload
+ * replays every mount fetch with the fresh session cookie. The boot
+ * probe (from === 'unknown') must NOT reload — covered by the negative
+ * test below (no reload loop).
+ *
+ * Flow: deep-link /token-usage logged out → mount fetch 401s → modal →
+ * type key → page reloads ITSELF → metrics re-fetched with 200 → data
+ * renders. No manual page.reload() anywhere in this spec.
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { clearAllAuth, mockBackend, waitForPostLoginReload } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+test('login after lockout self-reloads and the deep-linked view recovers', async ({
+  page,
+}) => {
+  await clearAllAuth(page)
+  const backend = await mockBackend(page, [
+    NOISE,
+    join(FIXTURES, 'auth_gate_reload_recovery.yaml'),
+  ])
+
+  await page.goto('/token-usage')
+
+  // Locked out: gate is up, and the view's mount fetch already 401'd.
+  const modal = page.getByRole('dialog', { name: /authentication required/i })
+  await expect(modal).toBeVisible()
+  await expect
+    .poll(() =>
+      backend.fulfilled.filter(
+        (c) => c.path.startsWith('/api/metrics/tokens') && c.status === 401,
+      ).length,
+    )
+    .toBeGreaterThanOrEqual(1)
+
+  // Login via the modal. The app must reload ITSELF — the spec never
+  // calls page.reload().
+  await page.locator('#auth-gate-key').fill('test-api-key-e2e')
+  const settled = waitForPostLoginReload(page)
+  await page.getByRole('button', { name: /continue/i }).click()
+  await settled
+
+  // Recovery: modal gone, mount fetch replayed (200 this time), data on
+  // screen — previously this required a manual refresh.
+  await expect(modal).toBeHidden()
+  await expect(page.getByText('1.2M', { exact: true }).first()).toBeVisible()
+  const okMetrics = backend.fulfilled.filter(
+    (c) => c.path.startsWith('/api/metrics/tokens') && c.status === 200,
+  )
+  expect(okMetrics.length).toBeGreaterThanOrEqual(1)
+
+  // Negative guard: the post-reload boot probe authenticates with
+  // from='unknown' and must NOT trigger another reload. A reload loop
+  // would re-run the boot probe over and over — assert the whoami count
+  // has gone quiet instead of pinning an exact total (SSE composables may
+  // legitimately add a probe, see useSSEConnection's pre-onopen 401 path).
+  await page.waitForTimeout(500)
+  const countWhoami = () =>
+    backend.fulfilled.filter((c) => c.path.startsWith('/api/auth/whoami')).length
+  const settledCount = countWhoami()
+  await page.waitForTimeout(1000)
+  expect(countWhoami()).toBe(settledCount)
+  expect(page.url()).toContain('/token-usage')
+})

--- a/frontend/tests/e2e/harness/auth.ts
+++ b/frontend/tests/e2e/harness/auth.ts
@@ -58,6 +58,27 @@ export async function seedCsrfCookie(
 }
 
 /**
+ * A successful modal login (API key or passkey) makes the app reload
+ * itself (App.vue's RESTORED listener, ``from === 'unauthenticated'``) so
+ * every view's mount-time fetch replays with the fresh cookie. The
+ * reload's boot probe re-hits ``/api/auth/whoami`` — waiting for that
+ * response is the deterministic "reload finished" signal.
+ *
+ * Start the wait BEFORE triggering the login click, then await it after:
+ *
+ *     const settled = waitForPostLoginReload(page)
+ *     await page.getByRole('button', { name: /continue/i }).click()
+ *     await settled
+ *
+ * The fixture's whoami entry must be a sequence (``[false, true]``) so
+ * the post-reload probe authenticates instead of re-opening the gate.
+ */
+export async function waitForPostLoginReload(page: Page): Promise<void> {
+  await page.waitForResponse((r) => r.url().includes('/api/auth/whoami'))
+  await page.waitForLoadState()
+}
+
+/**
  * Wipe everything the dashboard stores about auth: localStorage key,
  * session cookie, csrf cookie. Use in beforeEach for tests that simulate
  * a fresh-browser scenario.

--- a/frontend/tests/e2e/harness/index.ts
+++ b/frontend/tests/e2e/harness/index.ts
@@ -6,7 +6,7 @@
 export { mockBackend } from './mock-backend'
 export type { MockBackend, RequestRecord } from './mock-backend'
 
-export { seedApiKey, clearApiKey, seedCsrfCookie, clearAllAuth } from './auth'
+export { seedApiKey, clearApiKey, seedCsrfCookie, clearAllAuth, waitForPostLoginReload } from './auth'
 
 export { installVirtualAuthenticator } from './passkey'
 export type { VirtualAuthenticatorHandle } from './passkey'


### PR DESCRIPTION
## Bug

After a passkey (or API-key) sign-in via the AuthGate modal, some routes kept showing 401-failed/empty state until the user manually reloaded the page. Previously "fixed", but it kept happening.

## Root cause

`AuthGate` is an **overlay, not a route guard** (`App.vue`): deep-linking to a view while logged out mounts it behind the modal, its `onMounted` fetch 401s, and nothing replays it. The previous fix wired `EVENTS.RESTORED` re-fetch into **ChatView only** (plus the SSE composables) — every other view (~20) and `AppLayout`'s boot fetches stayed 401-poisoned after login.

**Scope note (review F-84.5):** this fixes recovery after a **lockout** login (`unauthenticated → authenticated`, AuthGate modal — passkey or API key, local or cross-tab). A transient mid-session 401 that self-heals via `challenged → authenticated` intentionally does NOT reload (in-page state there is still healthy); that path keeps the pre-existing per-listener wiring (SSE + ChatView). `TeamMonitor` was the worst case: it sits in `<keep-alive>`, so even navigating away/back never remounted it.

## Fix (class-level, not per-view)

- `stores/auth.js`: `RESTORED` now carries `{ from: previousStatus }` (both local transitions and cross-tab `_applyRemoteTransition`).
- `App.vue`: on `RESTORED` with `from === 'unauthenticated'` (modal login recovering a lockout) → `window.location.reload()`. Boot probe (`from === 'unknown'`) and challenged-recovery never reload → no reload loop. Locked sibling tabs recover identically via BroadcastChannel.
- At lockout time there is no in-page state worth preserving — it is all 401-poisoned, so a reload is the cleanest full replay and removes the need to wire (and remember to wire) a RESTORED listener into every current and future view.

## Latent race surfaced & fixed

`main.js` mounted the app before `router.isReady()` → `route.meta` read `{}` for one tick, so the boot auth probe ran on bare `/setup` pages (flipping the store to `unauthenticated` mid-wizard — which made the wizard's inline login trigger the new reload and restart the wizard) and the AppLayout chrome flashed over the wizard. Now mounts after `router.isReady()`.

## Click-flow (e2e: `auth-gate-reload-recovery.spec.ts`)

1. Deep-link `/token-usage` logged out → view mounts behind the gate, metrics fetch 401s
2. Type API key in the modal → app **reloads itself** (spec never calls `page.reload()`)
3. Metrics re-fetched (200) → `1.2M` renders → whoami count goes quiet (no reload loop) → still on `/token-usage`

## Tests

- Unit: 3 new (RESTORED payload from boot probe / modal login / cross-tab) — **156 passed**
- E2E: 1 new happy-path spec above; existing login specs updated for the self-reload via shared `waitForPostLoginReload` harness helper; `whoami` fixtures now two-phase `[false, true]` (sequence support already in harness) — **84 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
