### PR TITLE
fix(ui/mobile) + feat(conversations): mobile UI fixes & sidebar management

### DIFF
--- a/backend/routes/sessions.py
+++ b/backend/routes/sessions.py
@@ -2,11 +2,18 @@
 from typing import Optional
 
 from fastapi import APIRouter, Request, Depends
+from pydantic import BaseModel, Field
 
 from core.auth import verify_api_key
 from services.shared_state import session_service
 
 router = APIRouter(prefix="/api", tags=["sessions"])
+
+
+class BulkDeleteConversations(BaseModel):
+    # Cap mirrors settings.py's bulk endpoint — a generous batch bound that
+    # still rejects a runaway payload. Deleting >200 in one go can re-fire.
+    ids: list[str] = Field(min_length=1, max_length=200)
 
 
 @router.get("/history")
@@ -25,8 +32,22 @@ async def get_history(
 
 
 @router.get("/conversations")
-async def list_conversations(_=Depends(verify_api_key)):
-    return session_service.list_sessions()
+async def list_conversations(
+    agent_name: Optional[str] = None,
+    limit: int = 20,
+    offset: int = 0,
+    _=Depends(verify_api_key),
+):
+    """Paginated conversation list, optionally scoped to one agent.
+
+    Returns ``{"items": [...], "total": N}``. ``agent_name`` filters to a
+    single agent's conversations (the sidebar shows only the active agent's);
+    ``limit``/``offset`` page the result so a user with hundreds of sessions
+    doesn't load them all at once.
+    """
+    return session_service.list_sessions(
+        agent_name=agent_name, limit=limit, offset=offset
+    )
 
 
 @router.post("/conversations")
@@ -40,6 +61,29 @@ async def create_conversation(request: Request, _=Depends(verify_api_key)):
 
     result = session_service.create_session(title=title)
     return result
+
+
+@router.post("/conversations/bulk-delete")
+async def bulk_delete_conversations(
+    payload: BulkDeleteConversations, _=Depends(verify_api_key)
+):
+    """Delete many conversations in one request.
+
+    Per-id failures don't abort the batch — unknown/already-deleted ids land
+    in ``failed`` (delete_session returns False for them) while the rest are
+    removed, so a partially-stale client selection still makes progress.
+    """
+    deleted: list[str] = []
+    failed: list[str] = []
+    for conversation_id in payload.ids:
+        try:
+            if session_service.delete_session(conversation_id):
+                deleted.append(conversation_id)
+            else:
+                failed.append(conversation_id)
+        except Exception:
+            failed.append(conversation_id)
+    return {"deleted": deleted, "failed": failed}
 
 
 @router.delete("/conversations/{conversation_id}")

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -288,7 +288,12 @@ class SessionService:
         session = self._manager.create_session(metadata={"title": "New Chat"})
         return session.info.name
 
-    def list_sessions(self) -> List[Dict]:
+    def list_sessions(
+        self,
+        agent_name: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> Dict:
         """List chat sessions, one row per user-facing conversation.
 
         A session is listed when any agent has saved history to it — we used
@@ -299,37 +304,62 @@ class SessionService:
 
         Sessions with no saved history yet (just-created, never sent) are
         skipped — they have no content to display and no agent to attribute.
-        """
-        all_sessions = self._manager.list_sessions()
-        results = []
 
-        for s in all_sessions:
+        Args:
+            agent_name: when given, only sessions whose primary agent matches
+                are returned (the sidebar is scoped to the active agent).
+            limit/offset: page window over the filtered+sorted set. ``limit``
+                of ``None`` returns everything (kept for internal callers).
+
+        Returns a paginated envelope ``{"items": [...], "total": N}`` where
+        ``total`` is the count AFTER agent filtering but BEFORE the page slice,
+        so the UI knows whether more pages exist.
+
+        Scales with session count: cheap metadata (id/title/agent/timestamps)
+        is collected for every session, but the expensive per-session history
+        read for ``message_count`` is done ONLY for the rows on the requested
+        page — not the whole corpus.
+        """
+        rows = []
+        for s in self._manager.list_sessions():
             session = self._manager.get_session(s.name)
             if not session:
                 continue
 
-            agent_name = _resolve_primary_agent(session)
-            if not agent_name:
+            primary = _resolve_primary_agent(session)
+            if not primary:
                 # No agent has written history yet → nothing to show.
                 continue
+            if agent_name and primary != agent_name:
+                continue
 
-            message_count = 0
-            history_path = session.latest_history_path(agent_name)
-            if history_path and history_path.exists():
-                message_count = len(_extract_display_messages(history_path))
-
-            title = s.metadata.get("title") or s.metadata.get("first_user_preview") or "New Chat"
-
-            results.append({
+            rows.append({
                 "id": s.name,
-                "title": title,
-                "agent_name": agent_name,
+                "title": s.metadata.get("title") or s.metadata.get("first_user_preview") or "New Chat",
+                "agent_name": primary,
                 "created_at": s.created_at.timestamp(),
                 "updated_at": s.last_activity.timestamp(),
-                "message_count": message_count,
+                "_session": session,  # carried for the deferred message_count
             })
 
-        return results
+        # Newest first — matches the frontend's updatedAt-desc ordering so page
+        # boundaries are stable as the user scrolls.
+        rows.sort(key=lambda r: r["updated_at"], reverse=True)
+        total = len(rows)
+
+        page = rows[offset:] if limit is None else rows[offset:offset + limit]
+
+        items = []
+        for r in page:
+            session = r.pop("_session")
+            message_count = 0
+            history_path = session.latest_history_path(r["agent_name"])
+            if history_path and history_path.exists():
+                message_count = len(_extract_display_messages(history_path))
+            r["message_count"] = message_count
+            items.append(r)
+
+        return {"items": items, "total": total}
 
     def delete_session(self, session_id: str) -> bool:
         """Delete a session."""

--- a/backend/tests/test_routes/test_sessions.py
+++ b/backend/tests/test_routes/test_sessions.py
@@ -80,3 +80,70 @@ class TestCreateAndDelete:
         r = client.post("/api/conversations", headers=AUTH)
         assert r.status_code == 200
         assert r.json()["title"] == "New Chat"
+
+
+def _seed(svc, title, agent):
+    """Create a *listable* session (one with a stamped primary agent)."""
+    from services.session_service import PRIMARY_AGENT_META_KEY
+    s = svc._manager.create_session(
+        metadata={"title": title, PRIMARY_AGENT_META_KEY: agent}
+    )
+    return s.info.name
+
+
+class TestListConversations:
+    def test_returns_envelope(self, client):
+        r = client.get("/api/conversations", headers=AUTH)
+        assert r.status_code == 200
+        body = r.json()
+        assert set(body.keys()) == {"items", "total"}
+
+    def test_filters_by_agent(self, client, isolated_session_service):
+        _seed(isolated_session_service, "J1", "Jarvis")
+        _seed(isolated_session_service, "I1", "IoT")
+
+        r = client.get("/api/conversations", params={"agent_name": "Jarvis"}, headers=AUTH)
+        body = r.json()
+        assert body["total"] == 1
+        assert body["items"][0]["agent_name"] == "Jarvis"
+
+    def test_pagination(self, client, isolated_session_service):
+        for i in range(3):
+            _seed(isolated_session_service, f"C{i}", "Jarvis")
+        r = client.get(
+            "/api/conversations",
+            params={"agent_name": "Jarvis", "limit": 2, "offset": 0},
+            headers=AUTH,
+        )
+        body = r.json()
+        assert body["total"] == 3
+        assert len(body["items"]) == 2
+
+    def test_requires_auth(self, client):
+        assert client.get("/api/conversations").status_code == 401
+
+
+class TestBulkDelete:
+    def test_deletes_many_and_reports_partial_failures(self, client, isolated_session_service):
+        a = _seed(isolated_session_service, "A", "Jarvis")
+        b = _seed(isolated_session_service, "B", "Jarvis")
+        r = client.post(
+            "/api/conversations/bulk-delete",
+            headers=AUTH,
+            json={"ids": [a, b, "ghost-id"]},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert set(body["deleted"]) == {a, b}
+        assert body["failed"] == ["ghost-id"]
+        # The two real sessions are gone from the manager.
+        remaining = {info.name for info in isolated_session_service._manager.list_sessions()}
+        assert a not in remaining and b not in remaining
+
+    def test_empty_ids_rejected(self, client):
+        r = client.post("/api/conversations/bulk-delete", headers=AUTH, json={"ids": []})
+        assert r.status_code == 422
+
+    def test_requires_auth(self, client):
+        r = client.post("/api/conversations/bulk-delete", json={"ids": ["x"]})
+        assert r.status_code == 401

--- a/backend/tests/test_services/test_session_multi_agent.py
+++ b/backend/tests/test_services/test_session_multi_agent.py
@@ -177,7 +177,7 @@ class TestListSessions:
         svc._manager.list_sessions.return_value = [empty_info]
         svc._manager.get_session.return_value = empty_session
 
-        assert svc.list_sessions() == []
+        assert svc.list_sessions() == {"items": [], "total": 0}
 
     def test_includes_jarvis_session(self, tmp_path):
         """Classic Jarvis session renders with agent_name=Jarvis."""
@@ -202,10 +202,11 @@ class TestListSessions:
         svc._manager.get_session.return_value = session
 
         result = svc.list_sessions()
-        assert len(result) == 1
-        assert result[0]["id"] == "s-jarvis"
-        assert result[0]["agent_name"] == "Jarvis"
-        assert result[0]["title"] == "Hello"
+        assert result["total"] == 1
+        assert len(result["items"]) == 1
+        assert result["items"][0]["id"] == "s-jarvis"
+        assert result["items"][0]["agent_name"] == "Jarvis"
+        assert result["items"][0]["title"] == "Hello"
 
     def test_hides_legacy_session_with_no_primary_agent(self, tmp_path, caplog):
         """Legacy session (no primary_agent key) is hidden from the list.
@@ -236,7 +237,7 @@ class TestListSessions:
 
         with caplog.at_level("WARNING"):
             result = svc.list_sessions()
-        assert result == []
+        assert result["items"] == []
         assert any("Primary agent missing" in r.message for r in caplog.records)
 
 

--- a/backend/tests/test_services/test_session_service.py
+++ b/backend/tests/test_services/test_session_service.py
@@ -42,15 +42,82 @@ class TestSessionService:
         result = isolated_svc.create_session()
         assert result["title"] == "New Chat"
 
-    def test_list_sessions_returns_list(self, isolated_svc):
-        """list_sessions should return a list."""
-        assert isinstance(isolated_svc.list_sessions(), list)
+    def test_list_sessions_returns_envelope(self, isolated_svc):
+        """list_sessions returns the paginated {items, total} envelope."""
+        result = isolated_svc.list_sessions()
+        assert isinstance(result, dict)
+        assert isinstance(result["items"], list)
+        assert isinstance(result["total"], int)
 
     def test_multiple_sessions_unique_ids(self, isolated_svc):
         """Each created session should have a unique ID."""
         s1 = isolated_svc.create_session("Chat 1")
         s2 = isolated_svc.create_session("Chat 2")
         assert s1["id"] != s2["id"]
+
+
+class TestListSessionsFilterPagination:
+    """Agent-scoping + paging for the conversation sidebar.
+
+    Sessions only become listable once a primary agent is stamped (a bare
+    create has no agent and is hidden), so we seed metadata directly — the
+    same key ``resume_and_send`` writes on the first turn.
+    """
+
+    @staticmethod
+    def _seed(svc, title, agent):
+        from services.session_service import PRIMARY_AGENT_META_KEY
+        s = svc._manager.create_session(
+            metadata={"title": title, PRIMARY_AGENT_META_KEY: agent}
+        )
+        return s.info.name
+
+    def test_filters_by_agent(self, isolated_svc):
+        self._seed(isolated_svc, "J1", "Jarvis")
+        self._seed(isolated_svc, "J2", "Jarvis")
+        self._seed(isolated_svc, "I1", "IoT")
+
+        all_rows = isolated_svc.list_sessions()
+        assert all_rows["total"] == 3
+
+        jarvis = isolated_svc.list_sessions(agent_name="Jarvis")
+        assert jarvis["total"] == 2
+        assert {r["agent_name"] for r in jarvis["items"]} == {"Jarvis"}
+
+        iot = isolated_svc.list_sessions(agent_name="IoT")
+        assert iot["total"] == 1
+        assert iot["items"][0]["agent_name"] == "IoT"
+
+    def test_pagination_window_with_stable_total(self, isolated_svc):
+        for i in range(5):
+            self._seed(isolated_svc, f"C{i}", "Jarvis")
+
+        first = isolated_svc.list_sessions(agent_name="Jarvis", limit=2, offset=0)
+        assert first["total"] == 5
+        assert len(first["items"]) == 2
+
+        last = isolated_svc.list_sessions(agent_name="Jarvis", limit=2, offset=4)
+        assert last["total"] == 5
+        assert len(last["items"]) == 1
+
+        # total stays the filtered count even when the offset is past the end.
+        beyond = isolated_svc.list_sessions(agent_name="Jarvis", limit=2, offset=10)
+        assert beyond["total"] == 5
+        assert beyond["items"] == []
+
+    def test_pages_do_not_overlap(self, isolated_svc):
+        for i in range(5):
+            self._seed(isolated_svc, f"C{i}", "Jarvis")
+        p1 = isolated_svc.list_sessions(agent_name="Jarvis", limit=2, offset=0)
+        p2 = isolated_svc.list_sessions(agent_name="Jarvis", limit=2, offset=2)
+        ids = [r["id"] for r in p1["items"]] + [r["id"] for r in p2["items"]]
+        assert len(ids) == len(set(ids))  # no id appears on two pages
+
+    @pytest.fixture()
+    def isolated_svc(self, tmp_path):
+        svc = SessionService()
+        svc._manager = SessionManager(cwd=tmp_path)
+        return svc
 
 
 class TestDeleteSession:

--- a/frontend/src/assets/tokens.css
+++ b/frontend/src/assets/tokens.css
@@ -118,6 +118,12 @@
   --mobile-tabbar-h: 56px;
   --mobile-header-h: 52px;
   --mini-player-h: 0px;   /* updated to 64px when MiniAudioPlayer is visible */
+  /* Clearance band for the floating chat/voice FABs that hover just above
+     the tab bar (≈52px button + 12px offset). Page content reserves this so
+     the last item never hides under a FAB. Single source of truth — consumed
+     by AppLayout's content padding AND any view that bleeds past it (ChatView).
+     Keep in sync: change here, not inline. */
+  --mobile-fab-band: 64px;
 }
 
 /* Light theme */

--- a/frontend/src/components/AppLayout.vue
+++ b/frontend/src/components/AppLayout.vue
@@ -944,6 +944,6 @@ const searchPlaceholder = computed(() =>
      tab bar. Without the +64 the last content (e.g. a short page's actions)
      stayed underneath the chat/voice FABs with no way to reach it. */
   padding: 16px;
-  padding-bottom: calc(var(--mobile-tabbar-h) + var(--mini-player-h, 0px) + max(16px, var(--safe-bottom)) + 64px);
+  padding-bottom: calc(var(--mobile-tabbar-h) + var(--mini-player-h, 0px) + max(16px, var(--safe-bottom)) + var(--mobile-fab-band));
 }
 </style>

--- a/frontend/src/components/chat/ConversationsPanel.vue
+++ b/frontend/src/components/chat/ConversationsPanel.vue
@@ -1,14 +1,17 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useChatStore } from '../../stores/chat'
 import ConfirmModal from '../ConfirmModal.vue'
 import { useToast } from '../../composables/useToast'
 import { parseYoutubeTags } from '../../utils/youtubeTags'
 
 /**
- * ConversationsPanel — left rail with search, new-chat, and conversation list.
- * Restyled to the new design tokens (var(--bg-1) sidebar, primary border for
- * active item, mono labels). Logic unchanged.
+ * ConversationsPanel — left rail with search, new-chat, the conversation list,
+ * a multi-select bulk-delete mode, and infinite scroll.
+ *
+ * The list is server-scoped to chatStore.activeAgentName (switching agents
+ * reloads it), so this component renders chatStore.sortedConversations as-is.
+ * Infinite scroll pages the rest in via an IntersectionObserver on a sentinel.
  */
 const toast = useToast()
 const chatStore = useChatStore()
@@ -19,10 +22,19 @@ const props = defineProps({
 })
 const emit = defineEmits(['close', 'select'])
 
+// --- Single-delete (per-row trash, non-select mode) ---
 const showDeleteModal = ref(false)
 const deleteTarget = ref(null)
 const isDeleting = ref(false)
 const deleteError = ref('')
+
+// --- Multi-select bulk delete ---
+const selectMode = ref(false)
+const selectedIds = ref(new Set())
+const showBulkDeleteModal = ref(false)
+const isBulkDeleting = ref(false)
+const bulkDeleteError = ref('')
+const selectedCount = computed(() => selectedIds.value.size)
 
 const filtered = computed(() => {
   const q = searchQuery.value.toLowerCase()
@@ -54,6 +66,28 @@ function getLastMessage(conv) {
   return prefix + (text.length > 60 ? text.slice(0, 60) + '...' : text)
 }
 
+// --- Select mode ---
+function toggleSelectMode() {
+  selectMode.value = !selectMode.value
+  if (!selectMode.value) selectedIds.value = new Set()
+}
+
+function toggleSelected(id) {
+  const next = new Set(selectedIds.value)
+  next.has(id) ? next.delete(id) : next.add(id)
+  selectedIds.value = next
+}
+
+function onRowClick(conv) {
+  if (selectMode.value) {
+    toggleSelected(conv.id)
+    return
+  }
+  chatStore.selectConversation(conv.id)
+  emit('select')
+}
+
+// --- Single delete ---
 function confirmDelete(id, title) {
   deleteTarget.value = { id, title }
   deleteError.value = ''
@@ -83,6 +117,64 @@ function handleDeleteCancel() {
   deleteTarget.value = null
   deleteError.value = ''
 }
+
+// --- Bulk delete ---
+function requestBulkDelete() {
+  if (!selectedCount.value) return
+  bulkDeleteError.value = ''
+  showBulkDeleteModal.value = true
+}
+
+async function handleBulkDeleteConfirm() {
+  const ids = [...selectedIds.value]
+  if (!ids.length) return
+  isBulkDeleting.value = true
+  bulkDeleteError.value = ''
+  try {
+    await chatStore.deleteConversations(ids)
+    showBulkDeleteModal.value = false
+    selectMode.value = false
+    selectedIds.value = new Set()
+    toast.success(`Deleted ${ids.length} conversation${ids.length !== 1 ? 's' : ''}`)
+  } catch (e) {
+    bulkDeleteError.value = e.message || 'Failed to delete'
+    toast.error('Bulk delete failed', { description: e.message })
+  } finally {
+    isBulkDeleting.value = false
+  }
+}
+
+function handleBulkDeleteCancel() {
+  showBulkDeleteModal.value = false
+  bulkDeleteError.value = ''
+}
+
+// --- Infinite scroll ---
+// Observe a sentinel at the list bottom; when it enters view, ask the store
+// for the next page. The store self-guards (no-op when already loading or no
+// more pages), so a chatty observer is harmless.
+const listEl = ref(null)
+const sentinel = ref(null)
+let observer = null
+
+onMounted(() => {
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries.some(e => e.isIntersecting)) chatStore.loadMoreConversations()
+    },
+    { root: listEl.value, rootMargin: '160px' },
+  )
+  if (sentinel.value) observer.observe(sentinel.value)
+})
+
+// The sentinel is v-if'd on convHasMore, so (re)observe whenever it mounts.
+watch(sentinel, (el, prev) => {
+  if (!observer) return
+  if (prev) observer.unobserve(prev)
+  if (el) observer.observe(el)
+})
+
+onBeforeUnmount(() => observer?.disconnect())
 </script>
 
 <template>
@@ -95,7 +187,20 @@ function handleDeleteCancel() {
       <div class="conv-head-row">
         <span class="conv-eyebrow">CONVERSATIONS</span>
         <button
-          class="conv-new-btn"
+          class="conv-icon-btn"
+          :class="{ active: selectMode }"
+          data-testid="conv-select-toggle"
+          @click="toggleSelectMode"
+          :title="selectMode ? 'Exit select mode' : 'Select conversations'"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+            <rect x="2" y="2" width="12" height="12" rx="2.5" stroke="currentColor" stroke-width="1.4"/>
+            <path v-if="selectMode" d="M5 8.2l2 2 4-4.4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <button
+          v-if="!selectMode"
+          class="conv-icon-btn"
           @click="chatStore.createConversation(chatStore.activeAgentName)"
           title="New conversation"
         >
@@ -104,7 +209,7 @@ function handleDeleteCancel() {
             <line x1="2" y1="7" x2="12" y2="7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
           </svg>
         </button>
-        <button v-if="showClose" class="conv-close-btn" @click="emit('close')">
+        <button v-if="showClose" class="conv-icon-btn" @click="emit('close')" title="Close">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
             <line x1="3" y1="3" x2="11" y2="11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
             <line x1="11" y1="3" x2="3" y2="11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -124,34 +229,78 @@ function handleDeleteCancel() {
           class="conv-search-input"
         />
       </div>
+
+      <!-- Bulk action bar (select mode) -->
+      <div v-if="selectMode" class="conv-bulk-bar">
+        <span class="conv-bulk-count">{{ selectedCount }} selected</span>
+        <button
+          class="conv-bulk-delete"
+          data-testid="conv-bulk-delete"
+          :disabled="!selectedCount"
+          @click="requestBulkDelete"
+        >
+          Delete
+        </button>
+        <button class="conv-bulk-cancel" @click="toggleSelectMode">Cancel</button>
+      </div>
     </div>
 
-    <div class="conv-list">
+    <div ref="listEl" class="conv-list">
       <div
         v-for="conv in filtered"
         :key="conv.id"
         class="conv-item"
-        :class="{ active: conv.id === chatStore.activeConversationId }"
-        @click="chatStore.selectConversation(conv.id); emit('select')"
+        :class="{
+          active: !selectMode && conv.id === chatStore.activeConversationId,
+          selected: selectMode && selectedIds.has(conv.id),
+        }"
+        @click="onRowClick(conv)"
       >
-        <div class="conv-item-top">
-          <span class="conv-item-title">{{ conv.title }}</span>
-          <div class="conv-item-meta">
-            <span class="conv-item-time">{{ formatTime(conv.updatedAt) }}</span>
-            <button class="conv-item-delete" @click.stop="confirmDelete(conv.id, conv.title)" title="Delete">
-              <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                <path d="M3 4h8M5.5 4V3a1 1 0 011-1h1a1 1 0 011 1v1M4.5 4v7a1 1 0 001 1h3a1 1 0 001-1V4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </button>
+        <span
+          v-if="selectMode"
+          class="conv-check"
+          :class="{ on: selectedIds.has(conv.id) }"
+          aria-hidden="true"
+        >
+          <svg v-if="selectedIds.has(conv.id)" width="11" height="11" viewBox="0 0 16 16" fill="none">
+            <path d="M3.5 8.2l2.7 2.7L12.5 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </span>
+        <div class="conv-item-body">
+          <div class="conv-item-top">
+            <span class="conv-item-title">{{ conv.title }}</span>
+            <div class="conv-item-meta">
+              <span class="conv-item-time">{{ formatTime(conv.updatedAt) }}</span>
+              <button
+                v-if="!selectMode"
+                class="conv-item-delete"
+                @click.stop="confirmDelete(conv.id, conv.title)"
+                title="Delete"
+              >
+                <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                  <path d="M3 4h8M5.5 4V3a1 1 0 011-1h1a1 1 0 011 1v1M4.5 4v7a1 1 0 001 1h3a1 1 0 001-1V4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+            </div>
           </div>
-        </div>
-        <div class="conv-item-preview">
-          {{ getLastMessage(conv) || 'No messages yet' }}
+          <div class="conv-item-preview">
+            {{ getLastMessage(conv) || 'No messages yet' }}
+          </div>
         </div>
       </div>
 
       <div v-if="!filtered.length" class="conv-empty">
         {{ searchQuery ? 'No matching conversations' : 'Start a new conversation' }}
+      </div>
+
+      <!-- Infinite-scroll sentinel + loading footer -->
+      <div
+        v-if="chatStore.convHasMore && !searchQuery"
+        ref="sentinel"
+        data-testid="conv-sentinel"
+        class="conv-sentinel"
+      >
+        <span v-if="chatStore.isLoadingMoreConversations" class="conv-loading">Loading…</span>
       </div>
     </div>
 
@@ -165,6 +314,18 @@ function handleDeleteCancel() {
       :error="deleteError"
       @confirm="handleDeleteConfirm"
       @cancel="handleDeleteCancel"
+    />
+
+    <ConfirmModal
+      :visible="showBulkDeleteModal"
+      title="Delete Conversations"
+      :message="`Delete ${selectedCount} conversation${selectedCount !== 1 ? 's' : ''}? This action cannot be undone.`"
+      confirm-text="Delete"
+      variant="danger"
+      :loading="isBulkDeleting"
+      :error="bulkDeleteError"
+      @confirm="handleBulkDeleteConfirm"
+      @cancel="handleBulkDeleteCancel"
     />
   </aside>
 </template>
@@ -200,7 +361,7 @@ function handleDeleteCancel() {
   letter-spacing: 0.16em;
   color: var(--text-muted);
 }
-.conv-new-btn, .conv-close-btn {
+.conv-icon-btn {
   width: 26px; height: 26px;
   display: flex; align-items: center; justify-content: center;
   background: transparent;
@@ -209,7 +370,8 @@ function handleDeleteCancel() {
   color: var(--text-dim);
   cursor: pointer;
 }
-.conv-new-btn:hover, .conv-close-btn:hover { background: var(--bg-3); color: var(--text); }
+.conv-icon-btn:hover { background: var(--bg-3); color: var(--text); }
+.conv-icon-btn.active { background: var(--primary-bg); color: var(--primary); }
 
 .conv-search {
   display: flex;
@@ -233,6 +395,37 @@ function handleDeleteCancel() {
 }
 .conv-search-input::placeholder { color: var(--text-muted); }
 
+/* Bulk action bar */
+.conv-bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+.conv-bulk-count {
+  flex: 1;
+  font-size: 11.5px;
+  color: var(--text-dim);
+}
+.conv-bulk-delete, .conv-bulk-cancel {
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 4px 12px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-2);
+  color: var(--text);
+}
+.conv-bulk-delete {
+  border-color: transparent;
+  background: var(--danger);
+  color: #fff;
+}
+.conv-bulk-delete:disabled { opacity: 0.45; cursor: not-allowed; }
+.conv-bulk-cancel:hover { background: var(--bg-3); }
+
 .conv-list {
   flex: 1;
   overflow-y: auto;
@@ -240,6 +433,9 @@ function handleDeleteCancel() {
 }
 .conv-item {
   position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
   padding: 10px 12px;
   border-radius: var(--r-md);
   border-left: 2px solid transparent;
@@ -252,6 +448,26 @@ function handleDeleteCancel() {
   background: var(--primary-bg);
   border-left-color: var(--primary);
 }
+.conv-item.selected { background: var(--primary-bg); }
+
+.conv-check {
+  flex-shrink: 0;
+  width: 16px; height: 16px;
+  margin-top: 1px;
+  border: 1.4px solid var(--border-strong);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  transition: background 0.12s var(--ease-out), border-color 0.12s var(--ease-out);
+}
+.conv-check.on {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.conv-item-body { flex: 1; min-width: 0; }
 .conv-item-top {
   display: flex;
   align-items: center;
@@ -306,5 +522,16 @@ function handleDeleteCancel() {
   font-size: 12px;
   color: var(--text-muted);
   text-align: center;
+}
+.conv-sentinel {
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.conv-loading {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
 }
 </style>

--- a/frontend/src/components/global/FloatingChatDock.vue
+++ b/frontend/src/components/global/FloatingChatDock.vue
@@ -269,7 +269,7 @@ function handleKeydown(e) {
 
     <!-- Collapsed FAB -->
     <transition name="dock-fab">
-      <button
+      <!-- <button
         v-if="!expanded"
         class="dock-fab"
         :class="{ streaming: showStreamingBadge, 'dock-fab--hidden': isMobile && !fabShown }"
@@ -277,6 +277,19 @@ function handleKeydown(e) {
         title="Open chat dock"
         @click="toggle"
         aria-label="Open chat dock"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+          <path d="M21 12a8 8 0 0 1-11.6 7.2L4 21l1.8-5.4A8 8 0 1 1 21 12z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span v-if="showStreamingBadge" class="fab-badge" title="Agent is replying" />
+      </button> -->
+
+      <button
+        v-if="visible"
+        class="dock-fab"
+        :class="{ streaming: showStreamingBadge, 'dock-fab--hidden': isMobile && !fabShown }"
+        aria-label="Open chat dock"
+        @click="toggle"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
           <path d="M21 12a8 8 0 0 1-11.6 7.2L4 21l1.8-5.4A8 8 0 1 1 21 12z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
@@ -303,26 +316,30 @@ function handleKeydown(e) {
 
 /* ── Collapsed FAB ── */
 .dock-fab {
-  width: 48px;
-  height: 48px;
+  position: fixed;
+  left: 16px;
+  /* Stack above the tab bar (56px content + safe-area) AND the mini
+     audio player when it's visible. --mini-player-h is 0 by default,
+     64 while playing. */
+  bottom: calc(var(--mobile-tabbar-h) + var(--safe-bottom) + var(--mini-player-h, 0px) + 12px);
+  z-index: 195;
+  width: 52px;
+  height: 52px;
   border-radius: 50%;
-  /* Match the brand: indigo→primary gradient that the main app uses
-     for "talk to Jarvis" actions. Previous navy was off-brand and
-     identical to no other surface in the app. */
-  background: linear-gradient(180deg, var(--primary-hover), var(--primary));
-  border: 0;
-  color: #fff;
-  cursor: pointer;
-  box-shadow: 0 8px 24px var(--primary-glow);
-  position: relative;
-  /* match VoiceFAB: flex + clip the frosted bg / backdrop-filter to the circle.
-     Without overflow:hidden the backdrop-filter rendered as a square behind the
-     icon (it didn't follow border-radius on this relative, nested element). */
   overflow: hidden;
+  border: 0;
+  /* Solid brand gradient — crisp, no translucency/blur (the frosted version
+     looked washed-out and dimmed the icon). Content clearance is handled by a
+     bottom safe-zone + auto-hide-on-scroll + the grip, not by see-through. */
+  background: linear-gradient(180deg, var(--primary-hover), var(--primary));
+  color: white;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.2s var(--ease-out), opacity 0.2s var(--ease-out), box-shadow 0.22s var(--ease-out);
+  cursor: pointer;
+  box-shadow: 0 8px 24px var(--primary-glow);
+  transition: transform 0.2s var(--ease-out), opacity 0.2s var(--ease-out),
+              background 0.22s var(--ease-out), box-shadow 0.22s var(--ease-out);
 }
 .dock-fab:hover { transform: scale(1.06); }
 .dock-fab:active { transform: scale(0.96); }

--- a/frontend/src/stores/chat.js
+++ b/frontend/src/stores/chat.js
@@ -5,6 +5,9 @@ import { useAudioPlayerStore } from './audioPlayer'
 
 const META_STORAGE_KEY = 'jarvis_chat_meta'
 const TTS_STORAGE_KEY = 'jarvis_tts_enabled'
+// Page size for the conversation sidebar's infinite scroll. The sidebar is
+// scoped to one agent at a time, so 20 is plenty per fetch.
+const CONV_PAGE_SIZE = 20
 
 export const useChatStore = defineStore('chat', () => {
   // --- State ---
@@ -13,6 +16,15 @@ export const useChatStore = defineStore('chat', () => {
   const activeAgentName = ref(null)
   const isStreaming = ref(false)
   const isLoadingHistory = ref(false)
+  // Conversation-list pagination (server-side, scoped to activeAgentName).
+  // convOffset == number of backend rows already loaded for the current agent;
+  // convTotal == total backend rows for that agent. hasMore drives infinite
+  // scroll. Both reset whenever the agent changes.
+  const convOffset = ref(0)
+  const convTotal = ref(0)
+  const isLoadingConversations = ref(false)
+  const isLoadingMoreConversations = ref(false)
+  const convHasMore = computed(() => convOffset.value < convTotal.value)
   const ttsEnabled = ref(localStorage.getItem(TTS_STORAGE_KEY) === 'true')
   // Chat TTS plays through the singleton audio player (single source of
   // truth) — ttsPlaying just mirrors it so chat UI reacts without owning
@@ -63,39 +75,89 @@ export const useChatStore = defineStore('chat', () => {
 
   // --- Backend API ---
 
+  function _mapConv(c) {
+    return {
+      id: c.id,
+      title: c.title,
+      // Backend stamps the primary agent per session (see PRIMARY_AGENT_META_KEY
+      // in services/session_service.py). Fall back to Jarvis for any legacy
+      // session where the backend couldn't resolve one.
+      agentName: c.agent_name || 'Jarvis',
+      backendConversationId: c.id,
+      messages: [], // Loaded on-demand via fetchHistory
+      createdAt: c.created_at * 1000,
+      updatedAt: c.updated_at * 1000,
+      messageCount: c.message_count,
+    }
+  }
+
   /**
-   * Fetch conversation list from backend.
-   * Called on page load to populate sidebar.
+   * Fetch the conversation list from backend, scoped to the active agent and
+   * paginated. ``reset`` replaces the list (initial load / agent switch);
+   * otherwise it appends the next page (infinite scroll).
+   *
+   * Server-side filtering means the loaded list already contains ONLY the
+   * active agent's conversations — the sidebar renders it directly, no
+   * client-side agent filter needed. Returns early until an agent is known
+   * so we never flash a cross-agent list on first mount.
    */
-  async function fetchConversations() {
+  async function fetchConversations({ reset = true } = {}) {
+    if (!activeAgentName.value) return
+    if (reset) {
+      if (isLoadingConversations.value) return
+      isLoadingConversations.value = true
+      convOffset.value = 0
+    } else {
+      if (isLoadingMoreConversations.value || !convHasMore.value) return
+      isLoadingMoreConversations.value = true
+    }
+
+    const agentAtRequest = activeAgentName.value
     try {
-      const data = await apiFetch('/api/conversations')
-      if (!Array.isArray(data)) return
+      const params = new URLSearchParams({
+        agent_name: agentAtRequest,
+        limit: String(CONV_PAGE_SIZE),
+        offset: String(convOffset.value),
+      })
+      const data = await apiFetch(`/api/conversations?${params.toString()}`)
+      const items = Array.isArray(data?.items) ? data.items.map(_mapConv) : []
 
-      conversations.value = data.map(c => ({
-        id: c.id,
-        title: c.title,
-        // Backend stamps the primary agent per session (see PRIMARY_AGENT_META_KEY
-        // in services/session_service.py). Fall back to Jarvis for any legacy
-        // session where the backend couldn't resolve one.
-        agentName: c.agent_name || 'Jarvis',
-        backendConversationId: c.id,
-        messages: [], // Loaded on-demand via fetchHistory
-        createdAt: c.created_at * 1000,
-        updatedAt: c.updated_at * 1000,
-        messageCount: c.message_count,
-      }))
+      // Guard against a stale response landing after the user switched agents.
+      if (activeAgentName.value !== agentAtRequest) return
 
-      // Auto-select previously active conversation
-      if (activeConversationId.value) {
+      convTotal.value = Number.isFinite(data?.total) ? data.total : items.length
+
+      if (reset) {
+        // Keep any in-memory, never-sent conversation for THIS agent pinned on
+        // top (created via "+" but not yet persisted, so absent from backend).
+        const unsent = conversations.value.filter(
+          c => !c.backendConversationId && c.agentName === agentAtRequest,
+        )
+        conversations.value = [...unsent, ...items]
+      } else {
+        const seen = new Set(conversations.value.map(c => c.id))
+        conversations.value.push(...items.filter(c => !seen.has(c.id)))
+      }
+      convOffset.value += items.length
+
+      // Auto-load history for the restored active conversation (initial load).
+      if (reset && activeConversationId.value) {
         const exists = conversations.value.find(c => c.id === activeConversationId.value)
-        if (exists && exists.messages.length === 0) {
+        if (exists && exists.backendConversationId && exists.messages.length === 0) {
           await fetchHistory(activeConversationId.value, exists.agentName)
         }
       }
     } catch (e) {
       console.warn('[ChatStore] Failed to fetch conversations:', e)
+    } finally {
+      if (reset) isLoadingConversations.value = false
+      else isLoadingMoreConversations.value = false
     }
+  }
+
+  /** Load the next page of conversations (infinite scroll). */
+  async function loadMoreConversations() {
+    await fetchConversations({ reset: false })
   }
 
   /**
@@ -217,13 +279,56 @@ export const useChatStore = defineStore('chat', () => {
     _saveMeta()
   }
 
-  function setActiveAgent(name) {
+  /**
+   * Bulk-delete conversations (the sidebar's multi-select). Sends one
+   * request for all backend-persisted ids; purely in-memory (never-sent)
+   * conversations are just dropped locally. Re-points the active selection
+   * if it was among the deleted.
+   */
+  async function deleteConversations(ids) {
+    const idSet = new Set(ids)
+    const backendIds = conversations.value
+      .filter(c => idSet.has(c.id) && c.backendConversationId)
+      .map(c => c.backendConversationId)
+
+    if (backendIds.length) {
+      await apiFetch('/api/conversations/bulk-delete', {
+        method: 'POST',
+        body: JSON.stringify({ ids: backendIds }),
+      })
+    }
+
+    conversations.value = conversations.value.filter(c => !idSet.has(c.id))
+    // Keep the paging counters honest so convHasMore stays correct.
+    convTotal.value = Math.max(0, convTotal.value - backendIds.length)
+    convOffset.value = Math.max(0, convOffset.value - backendIds.length)
+
+    if (idSet.has(activeConversationId.value)) {
+      const next = conversations.value[0] || null
+      activeConversationId.value = next?.id || null
+      if (next) activeAgentName.value = next.agentName
+      _saveMeta()
+    }
+  }
+
+  async function setActiveAgent(name) {
+    if (activeAgentName.value === name) return
     activeAgentName.value = name
+    // The active conversation belonged to the previous agent — drop it.
     const conv = activeConversation.value
     if (conv && conv.agentName !== name) {
       activeConversationId.value = null
     }
+    // The list is server-scoped per agent: clear the old agent's rows for
+    // instant feedback (keep this agent's unsent draft if any), reset paging,
+    // then reload the new agent's first page.
+    conversations.value = conversations.value.filter(
+      c => c.agentName === name && !c.backendConversationId,
+    )
+    convOffset.value = 0
+    convTotal.value = 0
     _saveMeta()
+    await fetchConversations({ reset: true })
   }
 
   function toggleTts() {
@@ -391,16 +496,21 @@ export const useChatStore = defineStore('chat', () => {
     activeAgentName,
     isStreaming,
     isLoadingHistory,
+    isLoadingConversations,
+    isLoadingMoreConversations,
+    convHasMore,
     ttsEnabled,
     ttsPlaying,
     activeConversation,
     activeMessages,
     sortedConversations,
     fetchConversations,
+    loadMoreConversations,
     fetchHistory,
     createConversation,
     selectConversation,
     deleteConversation,
+    deleteConversations,
     setActiveAgent,
     toggleTts,
     stopTts,

--- a/frontend/src/views/ApprovalsView.vue
+++ b/frontend/src/views/ApprovalsView.vue
@@ -764,6 +764,7 @@ const knownTypes = [
   border-radius: var(--r-lg);
   overflow: hidden;
   min-height: 0;
+  min-width: 0;  /* grid item: shrink below content min-content (see __detail) */
 }
 .approvals__queue-head {
   padding: 12px 14px;
@@ -869,6 +870,12 @@ const knownTypes = [
   padding: 16px;
   overflow-y: auto;
   min-height: 0;
+  /* Grid items default to min-width:auto (= content min-content). A wide code
+     block in the preview (long unbreakable line) then forces this 1fr track
+     wider than the viewport → whole page scrolls horizontally. iOS Safari is
+     stricter than Blink here. min-width:0 lets the item shrink so the code
+     block's own overflow-x:auto scrolls internally instead of pushing the page. */
+  min-width: 0;
 }
 .approvals__detail--empty {
   display: flex;

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -325,8 +325,13 @@ function handleSwitchAgent(name) {
 .chat-root--mobile {
   --chat-bottom-pad: calc(var(--mobile-tabbar-h) + var(--mini-player-h, 0px) + max(16px, var(--safe-bottom)));
   margin: -16px -12px;
-  margin-bottom: calc(-1 * var(--chat-bottom-pad));
-  height: calc(100% + 16px + var(--chat-bottom-pad));
+  /* AppLayout's content padding-bottom = --chat-bottom-pad + --mobile-fab-band
+     (the band keeps normal pages' content above the floating FABs). The chat
+     composer doesn't need that band — the FABs self-hide on /chat — so bleed
+     the FULL padding (band included), otherwise the band shows as dead space
+     below the composer. Composer still clears the tab bar via padding-bottom. */
+  margin-bottom: calc(-1 * (var(--chat-bottom-pad) + var(--mobile-fab-band)));
+  height: calc(100% + 16px + var(--chat-bottom-pad) + var(--mobile-fab-band));
   padding-bottom: var(--chat-bottom-pad);
 }
 

--- a/frontend/src/views/TeamMonitor.vue
+++ b/frontend/src/views/TeamMonitor.vue
@@ -1287,6 +1287,17 @@ onMounted(() => {
     width: 100%;
     justify-content: center;
   }
+
+  /* Inject bar: inline at the end of the stream, NOT sticky. Sticky honoured
+     app-main's content padding-bottom (tab bar + safe-area + FAB band), so it
+     pinned ~136px above the viewport bottom — i.e. floating mid-screen over the
+     agent stream, worst of all when the FABs are hidden (the reserved FAB band
+     becomes dead space below it). Inline flow puts it after the last agent
+     card; the content padding still clears the tab bar + FABs underneath it. */
+  .bulk-inject-host {
+    position: static;
+    backdrop-filter: none;
+  }
 }
 
 </style>

--- a/frontend/tests/e2e/fixtures/chat_crawl_banner_lang.yaml
+++ b/frontend/tests/e2e/fixtures/chat_crawl_banner_lang.yaml
@@ -13,7 +13,9 @@ backend_source:
 responses:
   "GET /api/conversations":
     status: 200
-    json: []
+    json:
+      items: []
+      total: 0
 
   "GET /api/agents":
     status: 200

--- a/frontend/tests/e2e/fixtures/chat_interrupt.yaml
+++ b/frontend/tests/e2e/fixtures/chat_interrupt.yaml
@@ -22,7 +22,9 @@ backend_source:
 responses:
   "GET /api/conversations":
     status: 200
-    json: []
+    json:
+      items: []
+      total: 0
 
   "GET /api/agents":
     status: 200

--- a/frontend/tests/e2e/fixtures/chat_streaming_error.yaml
+++ b/frontend/tests/e2e/fixtures/chat_streaming_error.yaml
@@ -18,7 +18,9 @@ backend_source:
 responses:
   "GET /api/conversations":
     status: 200
-    json: []
+    json:
+      items: []
+      total: 0
 
   "GET /api/agents":
     status: 200

--- a/frontend/tests/e2e/fixtures/chat_streaming_happy.yaml
+++ b/frontend/tests/e2e/fixtures/chat_streaming_happy.yaml
@@ -29,7 +29,9 @@ responses:
   # ChatView.onMounted → chatStore.fetchConversations
   "GET /api/conversations":
     status: 200
-    json: []
+    json:
+      items: []
+      total: 0
 
   # ChatView → agentsStore.fetchAgents (guarded by `if (!agentsList.length)`)
   "GET /api/agents":

--- a/frontend/tests/e2e/fixtures/chat_streaming_markdown.yaml
+++ b/frontend/tests/e2e/fixtures/chat_streaming_markdown.yaml
@@ -18,7 +18,9 @@ backend_source:
 responses:
   "GET /api/conversations":
     status: 200
-    json: []
+    json:
+      items: []
+      total: 0
 
   "GET /api/agents":
     status: 200

--- a/frontend/tests/e2e/fixtures/chat_streaming_xss.yaml
+++ b/frontend/tests/e2e/fixtures/chat_streaming_xss.yaml
@@ -20,7 +20,9 @@ backend_source:
 responses:
   "GET /api/conversations":
     status: 200
-    json: []
+    json:
+      items: []
+      total: 0
 
   "GET /api/agents":
     status: 200

--- a/frontend/tests/e2e/fixtures/chat_streaming_youtube.yaml
+++ b/frontend/tests/e2e/fixtures/chat_streaming_youtube.yaml
@@ -24,7 +24,9 @@ backend_source:
 responses:
   "GET /api/conversations":
     status: 200
-    json: []
+    json:
+      items: []
+      total: 0
 
   "GET /api/agents":
     status: 200

--- a/frontend/tests/e2e/fixtures/conversations_bulk.yaml
+++ b/frontend/tests/e2e/fixtures/conversations_bulk.yaml
@@ -1,0 +1,66 @@
+# Conversation sidebar — multi-select bulk delete + per-agent scoping.
+#
+# Backend list endpoint is now paginated + agent-scoped:
+#   GET /api/conversations?agent_name=&limit=&offset=  →  { items, total }
+# and supports batch removal:
+#   POST /api/conversations/bulk-delete { ids: [...] }  →  { deleted, failed }
+#
+# The mock matches on method+path only (query ignored), so every list request
+# returns this same page regardless of agent_name/offset — the test asserts the
+# REQUEST wiring (agent_name in query, ids in the bulk body), not server-side
+# filtering, which is covered by backend unit tests.
+
+backend_source:
+  - "backend/routes/sessions.py::list_conversations"
+  - "backend/routes/sessions.py::bulk_delete_conversations"
+  - "backend/routes/agents.py::list_agents"
+
+responses:
+  # total == items → no infinite-scroll sentinel, so request counts stay clean.
+  "GET /api/conversations":
+    status: 200
+    json:
+      total: 3
+      items:
+        - id: "conv-a"
+          title: "Alpha conversation"
+          agent_name: "Jarvis"
+          created_at: 1749600000
+          updated_at: 1749600300
+          message_count: 4
+        - id: "conv-b"
+          title: "Beta conversation"
+          agent_name: "Jarvis"
+          created_at: 1749600100
+          updated_at: 1749600200
+          message_count: 2
+        - id: "conv-c"
+          title: "Gamma conversation"
+          agent_name: "Jarvis"
+          created_at: 1749600200
+          updated_at: 1749600100
+          message_count: 6
+
+  "POST /api/conversations/bulk-delete":
+    status: 200
+    json:
+      deleted: ["conv-a", "conv-b"]
+      failed: []
+
+  "GET /api/agents":
+    status: 200
+    json:
+      - name: "Jarvis"
+        description: "Main orchestrator"
+        status: "idle"
+        is_default: true
+        team_name: null
+      - name: "IoT"
+        description: "Home automation"
+        status: "idle"
+        is_default: false
+        team_name: null
+
+  "GET /api/agents/activities/recent":
+    status: 200
+    json: {}

--- a/frontend/tests/e2e/fixtures/conversations_paged.yaml
+++ b/frontend/tests/e2e/fixtures/conversations_paged.yaml
@@ -1,0 +1,50 @@
+# Conversation sidebar — infinite scroll paging.
+#
+# total (8) > the page we return (3), so chatStore.convHasMore stays true and
+# the IntersectionObserver sentinel renders. When it enters view the store
+# fetches the next page → a SECOND GET /api/conversations fires. The mock
+# returns the same 3 rows (query ignored); the store dedupes by id, so no
+# duplicates render, and offset advances past total to end the loop. The test
+# asserts the second request fired (paging wiring), not paged content.
+
+backend_source:
+  - "backend/routes/sessions.py::list_conversations"
+  - "backend/routes/agents.py::list_agents"
+
+responses:
+  "GET /api/conversations":
+    status: 200
+    json:
+      total: 8
+      items:
+        - id: "conv-1"
+          title: "First conversation"
+          agent_name: "Jarvis"
+          created_at: 1749600000
+          updated_at: 1749600300
+          message_count: 1
+        - id: "conv-2"
+          title: "Second conversation"
+          agent_name: "Jarvis"
+          created_at: 1749600100
+          updated_at: 1749600200
+          message_count: 1
+        - id: "conv-3"
+          title: "Third conversation"
+          agent_name: "Jarvis"
+          created_at: 1749600200
+          updated_at: 1749600100
+          message_count: 1
+
+  "GET /api/agents":
+    status: 200
+    json:
+      - name: "Jarvis"
+        description: "Main orchestrator"
+        status: "idle"
+        is_default: true
+        team_name: null
+
+  "GET /api/agents/activities/recent":
+    status: 200
+    json: {}

--- a/frontend/tests/e2e/flows/conversations-management.spec.ts
+++ b/frontend/tests/e2e/flows/conversations-management.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E: conversation sidebar management — bulk delete, per-agent scoping,
+ * infinite-scroll paging.
+ *
+ * Backend changes under test:
+ *   GET  /api/conversations?agent_name=&limit=&offset=  → { items, total }
+ *   POST /api/conversations/bulk-delete { ids }          → { deleted, failed }
+ *
+ * The mock matches method+path only (query ignored), so these assert the
+ * client wiring — agent_name in the query, ids in the bulk body, a second
+ * page request on scroll — while server-side filtering/paging is covered by
+ * backend unit tests (tests/test_routes/test_sessions.py).
+ */
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, NetworkRecorder, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+test('bulk delete: select two conversations and remove them in one request', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'conversations_bulk.yaml')])
+
+  await page.goto('/chat')
+  await expect(page.locator('.conv-item')).toHaveCount(3)
+
+  // Enter select mode, tick Alpha + Beta.
+  await page.locator('[data-testid="conv-select-toggle"]').click()
+  await page.locator('.conv-item', { hasText: 'Alpha conversation' }).click()
+  await page.locator('.conv-item', { hasText: 'Beta conversation' }).click()
+
+  const bulkBtn = page.locator('[data-testid="conv-bulk-delete"]')
+  await expect(bulkBtn).toBeEnabled()
+  await expect(page.locator('.conv-bulk-count')).toHaveText('2 selected')
+
+  // Confirm the modal.
+  await bulkBtn.click()
+  await page.locator('.cm-btn-variant').click()
+
+  // Only Gamma survives, and exactly one batch request carried both ids.
+  await expect(page.locator('.conv-item')).toHaveCount(1)
+  await expect(page.locator('.conv-item')).toContainText('Gamma conversation')
+
+  const bulk = recorder.calls.filter(
+    (c) => c.method === 'POST' && c.path === '/api/conversations/bulk-delete',
+  )
+  expect(bulk).toHaveLength(1)
+  const ids = (bulk[0].body as { ids: string[] }).ids
+  expect(new Set(ids)).toEqual(new Set(['conv-a', 'conv-b']))
+})
+
+test('per-agent scoping: switching agent refetches that agent’s conversations', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'conversations_bulk.yaml')])
+
+  await page.goto('/chat')
+  await expect(page.locator('.conv-item')).toHaveCount(3)
+  // Initial load scopes to the default agent.
+  await expect
+    .poll(() =>
+      recorder.calls.some(
+        (c) => c.path === '/api/conversations' && c.query.agent_name === 'Jarvis',
+      ),
+    )
+    .toBe(true)
+
+  // Switch to IoT via the header dropdown.
+  await page.locator('.hd-switch-btn').click()
+  await page.locator('.hd-dropdown-item', { hasText: 'IoT' }).click()
+
+  // A fresh list request fires, scoped to the new agent.
+  await expect
+    .poll(() =>
+      recorder.calls.some(
+        (c) => c.path === '/api/conversations' && c.query.agent_name === 'IoT',
+      ),
+    )
+    .toBe(true)
+})
+
+test('infinite scroll: a second page is requested when more remain', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'conversations_paged.yaml')])
+
+  await page.goto('/chat')
+  await expect(page.locator('.conv-item')).toHaveCount(3)
+
+  // total (8) > loaded (3) → the sentinel triggers a follow-up page fetch.
+  await expect
+    .poll(
+      () =>
+        recorder.calls.filter((c) => c.path === '/api/conversations').length,
+      { timeout: 5000 },
+    )
+    .toBeGreaterThanOrEqual(2)
+
+  // Deduped by id — no duplicate rows despite the mock returning the same page.
+  await expect(page.locator('.conv-item')).toHaveCount(3)
+})

--- a/frontend/tests/e2e/flows/mobile-ui-layout.spec.ts
+++ b/frontend/tests/e2e/flows/mobile-ui-layout.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * E2E: mobile layout regressions (375px phone viewport).
+ *
+ * Three bugs reported from on-device QA, each guarded here:
+ *
+ *  1. CHAT — the composer floated ~80px above the bottom tab bar (a band of
+ *     dead space). Cause: ChatView bled only part of AppLayout's content
+ *     padding-bottom, leaving the --mobile-fab-band (64px) as a visible gap.
+ *     Guard: composer sits within ~32px of the tab bar.
+ *
+ *  2. MONITOR — the "INJECT TO N agents" bar was position:sticky and honoured
+ *     the content padding-bottom, so it pinned mid-screen, floating over the
+ *     agent stream. Fix: inline (static) on mobile. Guard: not sticky.
+ *
+ *  3. APPROVALS — a wide code block in the preview pushed the whole page into
+ *     horizontal scroll on iOS Safari (grid item didn't shrink below its
+ *     content min-content). Fix: min-width:0 on the grid items. Guard: the
+ *     document never exceeds the viewport width.
+ */
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+test.use({ viewport: { width: 375, height: 659 } })
+
+test('mobile chat: composer sits just above the tab bar (no dead-space gap)', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'chat_streaming_happy.yaml')])
+  await page.goto('/chat')
+
+  const gap = await page.evaluate(() => {
+    const compose = document.querySelector('.compose-host')!.getBoundingClientRect()
+    const tabbar = document.querySelector('.mobile-tabbar')!.getBoundingClientRect()
+    return tabbar.top - compose.bottom
+  })
+  // The intended breathing room is ~16px (max(16px, safe-area)). The bug left
+  // ~80px. Anything under 32px proves the FAB band is no longer dead space.
+  expect(gap).toBeGreaterThanOrEqual(0)
+  expect(gap).toBeLessThan(32)
+})
+
+test('mobile monitor: inject bar is inline, not a mid-screen sticky float', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'team_monitor_v2_terminal.yaml')])
+  await page.goto('/monitor')
+
+  const bar = page.locator('.bulk-inject-host')
+  await expect(bar).toBeVisible()
+  const position = await bar.evaluate((el) => getComputedStyle(el).position)
+  // Sticky was what pinned it mid-screen above the agent stream.
+  expect(position).toBe('static')
+})
+
+test('mobile approvals: opening a wide code preview does not scroll the page sideways', async ({
+  page,
+}) => {
+  await seedApiKey(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'approvals_cron_pending.yaml')])
+  await page.goto('/approvals')
+  await page.locator('.approvals-row').first().click()
+  await expect(page.locator('.approvals__detail-title')).toBeVisible()
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  )
+  expect(overflow).toBeLessThanOrEqual(0)
+})


### PR DESCRIPTION
Two batches of work on this branch.

## 1 — Mobile UI fixes (commit `ca71221`)

On-device QA surfaced four mobile bugs; each fixed at root cause.

| # | View | Symptom | Fix |
|---|------|---------|-----|
| 1 | Chat | ~80px dead space below composer | `ChatView` bleeds the full content padding incl. `--mobile-fab-band` |
| 2 | Team Monitor | inject bar floats mid-screen | `position: static` on mobile (inline at stream end) |
| 3 | Approvals | page scrolls sideways (iOS) | `min-width: 0` on the grid items |
| 4 | Floating chat FAB | square halo behind round icon (iOS) | `.dock-fab` → `position: fixed` (own layer) |

Verified at 375px in Playwright (bugs 1–2); bugs 3–4 are iOS-Safari-specific, fixed by standard remedies + on-device confirmation. Guard: `tests/e2e/flows/mobile-ui-layout.spec.ts`.

## 2 — Conversation sidebar management (commit `79524f5`)

Per-agent scoping, bulk delete, and pagination for the CONVERSATIONS rail.

**Backend** (`routes/sessions.py`, `services/session_service.py`)
- `GET /api/conversations?agent_name=&limit=&offset=` → `{ items, total }`. Filters by primary agent, sorts newest-first; the per-session `message_count` history read is deferred to the requested page only (scales with session count).
- `POST /api/conversations/bulk-delete { ids }` → `{ deleted, failed }`; per-id failures don't abort the batch.

**Frontend** (`stores/chat.js`, `components/chat/ConversationsPanel.vue`)
- List is server-scoped to the active agent — switching agents in the header resets paging and reloads that agent's conversations.
- Infinite scroll (IntersectionObserver sentinel) pages the rest in; rows deduped by id.
- A "Select" toggle turns rows into checkboxes with a bulk Delete bar + confirm modal; per-row trash kept for single deletes.

**Tests**
- Backend: agent filter, pagination window, bulk-delete partial-failure + validation. Envelope shape updated in existing `list_sessions` assertions.
- Frontend e2e: `conversations-management.spec.ts` (bulk delete, agent-switch refetch, second-page-on-scroll). 7 chat fixtures migrated to the `{items,total}` envelope.

## Verification
- Backend: **51** session tests green.
- Frontend: full flow suite **97** green (incl. 3 mobile-UI + 3 conversation specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)