### PR TITLE
fix(voice): stop TTS dropping the head of replies + auto-recover WebRTC on mobile

### DIFF
--- a/backend/services/webrtc_voice.py
+++ b/backend/services/webrtc_voice.py
@@ -205,6 +205,12 @@ TTS_RATE = 24000      # RealtimeTTS / Edge PCM rate (mono s16)
 WEBRTC_RATE = 48000   # Opus / WebRTC standard
 FRAME_SAMPLES = 960   # 20 ms @ 48 kHz — one outbound frame
 _SILENCE_48K = b"\x00\x00" * FRAME_SAMPLES
+# recv() must never repay pacing debt by emitting frames faster than real
+# time: the receiver's jitter buffer treats a catch-up burst as late packets
+# and DISCARDS them (the "TTS loses its first seconds on prod" bug). Past this
+# lag we re-anchor the pacing clock to "now" instead of bursting. Two frames
+# (40 ms) of slack still lets normal scheduling jitter self-correct.
+_MAX_PACING_LAG_S = 2 * FRAME_SAMPLES / WEBRTC_RATE
 
 FeedAudio = Callable[[bytes], None]
 
@@ -264,14 +270,27 @@ class TtsAudioTrack(MediaStreamTrack):
             # out.samples*2 bytes of real audio; planes[0] may be padded, so slice.
             self._buf.extend(bytes(out.planes[0])[: out.samples * 2])
 
-    async def _next_frame_bytes(self) -> bytes:
-        # Top up the buffer until we have a full 20 ms frame, but don't block the
-        # cadence: if no TTS arrives within one frame interval, emit silence.
+    def _next_frame_bytes(self) -> bytes:
+        # Non-blocking: top up the buffer only with data that has ALREADY
+        # arrived. All pacing lives in recv()'s sleep — the previous version
+        # awaited the queue with a 20 ms timeout *in series with* the pacing
+        # sleep, so every idle frame silently ran ~1 ms over cadence. That
+        # drift accumulated (~50 ms per idle second) and was then repaid as a
+        # faster-than-real-time burst when the next reply arrived, which the
+        # client's jitter buffer dropped — heard as "the reply's head is gone".
         while len(self._buf) < FRAME_SAMPLES * 2:
             try:
-                pcm24k = await asyncio.wait_for(self._queue.get(), timeout=FRAME_SAMPLES / WEBRTC_RATE)
-            except asyncio.TimeoutError:
-                return _SILENCE_48K
+                pcm24k = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                if self._buf:
+                    # Queue ran dry with a partial frame buffered (reply tail,
+                    # or a mid-reply underrun). Flush it padded with silence —
+                    # leaving it would strand pending()=True forever and hang
+                    # wait_drained() whenever a reply isn't frame-aligned.
+                    out = bytes(self._buf) + _SILENCE_48K[len(self._buf):]
+                    self._buf.clear()
+                    return out
+                return _SILENCE_48K  # idle keepalive between replies
             self._resample_into_buf(pcm24k)
         out = bytes(self._buf[: FRAME_SAMPLES * 2])
         del self._buf[: FRAME_SAMPLES * 2]
@@ -287,8 +306,13 @@ class TtsAudioTrack(MediaStreamTrack):
             delay = target - time.time()
             if delay > 0:
                 await asyncio.sleep(delay)
+            elif -delay > _MAX_PACING_LAG_S:
+                # Fell behind wall clock (event-loop stall, slow consumer).
+                # Re-anchor so queued TTS plays from "now" at real-time pace
+                # rather than bursting the backlog (see _MAX_PACING_LAG_S).
+                self._start = time.time() - self._timestamp / WEBRTC_RATE
 
-        data = await self._next_frame_bytes()
+        data = self._next_frame_bytes()
         frame = av.AudioFrame(format="s16", layout="mono", samples=FRAME_SAMPLES)
         frame.sample_rate = WEBRTC_RATE
         frame.pts = self._timestamp

--- a/backend/tests/test_routes/test_ws_voice.py
+++ b/backend/tests/test_routes/test_ws_voice.py
@@ -832,3 +832,39 @@ def test_webrtc_offer_is_answered_over_ws(ws_client, monkeypatch):
         assert "v=0" in (evt.get("sdp") or "")
         assert "m=audio" in evt["sdp"]
         ws.close()
+
+
+def test_webrtc_reoffer_replaces_session_over_same_ws(ws_client, monkeypatch):
+    """Mid-session ICE recovery: when the client's RTCPeerConnection dies
+    (5G cell handover, NAT rebind), the frontend re-sends ``webrtc_offer`` on
+    the SAME control WS. The handler must replace the dead WebRtcVoiceSession
+    with a fresh one and answer again — this is the server half of the
+    reconnect flow in useVoiceSession.js/_restartWebRtc."""
+    import asyncio as _asyncio
+
+    from aiortc import RTCPeerConnection
+
+    monkeypatch.setenv("JARVIS_WEBRTC_ICE", "")  # host-only ICE, no STUN wait
+
+    async def _make_offer_sdp() -> str:
+        pc = RTCPeerConnection()
+        pc.addTransceiver("audio", direction="sendrecv")
+        await pc.setLocalDescription(await pc.createOffer())
+        sdp = pc.localDescription.sdp
+        await pc.close()
+        return sdp
+
+    first_sdp = _asyncio.run(_make_offer_sdp())
+    second_sdp = _asyncio.run(_make_offer_sdp())  # the post-failure fresh PC
+
+    client, _ = ws_client
+    with client.websocket_connect("/ws/voice") as ws:
+        ws.send_text(json.dumps({"type": "webrtc_offer", "sdp": first_sdp, "sdp_type": "offer"}))
+        first = _drain_until(ws, "webrtc_answer")
+        assert first.get("sdp_type") == "answer"
+
+        ws.send_text(json.dumps({"type": "webrtc_offer", "sdp": second_sdp, "sdp_type": "offer"}))
+        second = _drain_until(ws, "webrtc_answer")
+        assert second.get("sdp_type") == "answer"
+        assert "m=audio" in (second.get("sdp") or "")
+        ws.close()

--- a/backend/tests/test_services/test_webrtc_voice.py
+++ b/backend/tests/test_services/test_webrtc_voice.py
@@ -305,3 +305,50 @@ def test_webrtc_loopback_bridges_audio_both_directions():
     # Outbound: the server's TTS track produced frames the browser received.
     assert out_frames, "outbound TTS track produced no frames at the peer"
     assert all(n > 0 for n in out_frames)
+
+
+def test_tts_track_paces_backlog_instead_of_bursting():
+    """Pacing debt must NEVER be repaid as a faster-than-real-time burst.
+
+    When recv() falls behind wall clock (idle-frame drift or an event-loop
+    stall), the old code emitted the entire backlog instantly once TTS data
+    arrived; the browser's jitter buffer treats those frames as late and
+    discards them — heard on prod (iPhone/5G) as the reply's first seconds
+    missing. The fix re-anchors the pacing clock instead, so the first
+    second of a reply must take ~1 s of wall time to emit.
+    """
+    async def run() -> float:
+        track = webrtc_voice.TtsAudioTrack()
+        for _ in range(5):  # prime the pacing clock
+            await track.recv()
+        await asyncio.sleep(1.0)  # starve recv() → 1 s of pacing debt
+        for _ in range(20):  # a 2 s reply, pushed in 100 ms chunks
+            track.push(b"\x11\x00" * 2400)
+        t0 = time.time()
+        emitted = 0
+        while emitted < webrtc_voice.WEBRTC_RATE:  # pull 1.0 s of media
+            await track.recv()
+            emitted += webrtc_voice.FRAME_SAMPLES
+        return time.time() - t0
+
+    elapsed = asyncio.run(run())
+    assert elapsed >= 0.8, (
+        f"first 1.0s of reply emitted in {elapsed:.3f}s wall — catch-up burst; "
+        "the receiver's jitter buffer will drop the head of the reply"
+    )
+    assert elapsed <= 1.5, f"pacing too slow: {elapsed:.3f}s wall for 1.0s of media"
+
+
+def test_tts_track_flushes_partial_tail_so_wait_drained_completes():
+    """A reply whose PCM isn't 20 ms-frame-aligned must still drain: the
+    partial tail is flushed padded with silence, otherwise pending() stays
+    True forever and speak()'s wait_drained() hangs bot_speaking high."""
+    async def run() -> None:
+        track = webrtc_voice.TtsAudioTrack()
+        track.push(b"\x11\x00" * 720)  # 30 ms @ 24 kHz → 1.5 outbound frames
+        await track.recv()             # full frame
+        await track.recv()             # padded tail flush
+        assert not track.pending(), "partial tail left pending() stuck True"
+        await asyncio.wait_for(track.wait_drained(), timeout=1.0)
+
+    asyncio.run(run())

--- a/docs/VOICE_WEBRTC_TESTING.md
+++ b/docs/VOICE_WEBRTC_TESTING.md
@@ -8,9 +8,15 @@ playback. Control/STT/barge-in events still ride `/ws/voice`.
 
 Automated coverage (all green, headless):
 - backend bridge loopback — `backend/tests/test_services/test_webrtc_voice.py`
+- TTS track pacing (no catch-up burst → no dropped reply head) —
+  `test_webrtc_voice.py::test_tts_track_paces_backlog_instead_of_bursting`
 - signalling over the WS handler — `test_ws_voice.py::test_webrtc_offer_is_answered_over_ws`
+- mid-session re-offer (ICE-death recovery, server half) —
+  `test_ws_voice.py::test_webrtc_reoffer_replaces_session_over_same_ws`
 - barge-in SSoT — `test_ws_voice.py` (onset / playback-tail / playback_done)
-- frontend negotiation — `frontend/tests/e2e/flows/voice-webrtc.spec.ts`
+- frontend negotiation + ICE-failure reconnect policy —
+  `frontend/tests/e2e/flows/voice-webrtc.spec.ts`,
+  `frontend/src/composables/webrtcRecovery.test.js`
 
 What automation **cannot** check (needs a real device): audio fidelity and
 whether the browser AEC actually cancels the echo. That's this guide.

--- a/frontend/src/composables/useVoiceSession.js
+++ b/frontend/src/composables/useVoiceSession.js
@@ -25,6 +25,7 @@ import { useAudioPlayerStore } from '../stores/audioPlayer.js'
 import { EVENTS, on } from '../auth/bus.js'
 import { expandToolRequest, expandToolDone } from '../utils/toolEvents.js'
 import { createPlaybackDoneTracker } from './playbackDoneTracker.js'
+import { createWebRtcRecovery } from './webrtcRecovery.js'
 
 const PCM_PLAYBACK_RATE = 24000  // RealtimeTTS engines emit 24 kHz mono
 
@@ -116,6 +117,11 @@ function _createVoiceSession() {
   const pc = shallowRef(null)
   const remoteAudioEl = shallowRef(null)
   let webrtcMode = false
+  // Recovery policy for mid-session ICE death (5G handover, NAT rebind —
+  // routine on mobile). Lives OUTSIDE the per-PC listeners so the retry
+  // budget survives PC rebuilds; created lazily by _startWebRtc, stopped on
+  // stop()/give-up. Decision logic is unit-tested in webrtcRecovery.test.js.
+  let webrtcRecovery = null
 
   function _ensureActiveConversation() {
     if (chatStore.activeConversation) return
@@ -346,7 +352,10 @@ function _createVoiceSession() {
           console.warn('[voice] server webrtc_error', msg.detail)
           error.value = `Voice transport failed on the server: ${msg.detail || 'unknown error'}`
           status.value = 'error'
-          _teardownWebRtc()   // drop the half-open PC + hidden <audio>
+          webrtcRecovery?.stop()   // server-side misconfig — reconnecting won't help
+          webrtcRecovery = null
+          _teardownWebRtc()   // drop the half-open PC
+          _removeAudioEl()    // …and the hidden <audio> (no reconnect coming)
           break
         case 'tts_start':
           status.value = 'speaking'
@@ -515,16 +524,64 @@ function _createVoiceSession() {
     return [{ urls: 'stun:stun.l.google.com:19302' }]
   }
 
+  async function _restartWebRtc(attempt) {
+    // Mid-session ICE death is routine on mobile networks; the /ws/voice
+    // control socket (HTTPS/cloudflared) usually survives the blip. Recovery
+    // = full re-negotiation with a FRESH RTCPeerConnection over that socket:
+    // the server replaces its session on a repeat ``webrtc_offer`` (the same
+    // ws_voice.py path every session start exercises), so no fragile
+    // ICE-restart semantics are involved. The mic MediaStream is reused.
+    if (torn) return
+    if (ws.value?.readyState !== 1 || !stream.value) {
+      _failWebRtc('control socket closed during webrtc reconnect')
+      return
+    }
+    console.warn('[voice] webrtc reconnect attempt', attempt)
+    _teardownWebRtc()
+    try {
+      await _startWebRtc(ws.value, stream.value)
+    } catch (e) {
+      console.warn('[voice] webrtc reconnect attempt failed', e)
+      webrtcRecovery?.onRestartError()
+    }
+  }
+
+  function _failWebRtc(reason) {
+    // Recovery exhausted (or impossible) — surface the original fail-loud
+    // error. The user re-toggles the mic to start a fresh session.
+    console.warn('[voice] webrtc recovery gave up:', reason)
+    error.value = 'Voice connection failed — WebRTC could not connect (NAT/firewall?).'
+    status.value = 'error'
+    webrtcRecovery?.stop()
+    webrtcRecovery = null
+    _teardownWebRtc()
+    _removeAudioEl()
+  }
+
   async function _startWebRtc(sock, ms) {
+    if (!webrtcRecovery) {
+      webrtcRecovery = createWebRtcRecovery({
+        restart: (attempt) => { _restartWebRtc(attempt) },
+        fail: (reason) => _failWebRtc(reason),
+      })
+    }
     const peer = new RTCPeerConnection({ iceServers: await _iceServers() })
     pc.value = peer
 
-    const audioEl = document.createElement('audio')
-    audioEl.autoplay = true
-    audioEl.setAttribute('playsinline', '')   // iOS: play inline, not fullscreen
-    audioEl.style.display = 'none'
-    document.body.appendChild(audioEl)
-    remoteAudioEl.value = audioEl
+    // Reuse ONE hidden <audio> across reconnects: iOS Safari blesses the
+    // element that first played under the mic-click user gesture; a fresh
+    // element created during an automatic ICE reconnect has no gesture, so
+    // its play() would be autoplay-blocked → "reconnected but silent" on
+    // iPhone. Swapping srcObject on the blessed element keeps audio flowing.
+    let audioEl = remoteAudioEl.value
+    if (!audioEl) {
+      audioEl = document.createElement('audio')
+      audioEl.autoplay = true
+      audioEl.setAttribute('playsinline', '')   // iOS: play inline, not fullscreen
+      audioEl.style.display = 'none'
+      document.body.appendChild(audioEl)
+      remoteAudioEl.value = audioEl
+    }
     peer.addEventListener('track', (ev) => {
       audioEl.srcObject = ev.streams[0] || new MediaStream([ev.track])
       // play() may reject if autoplay is gated; the mic click is a user gesture
@@ -534,14 +591,14 @@ function _createVoiceSession() {
     peer.addEventListener('connectionstatechange', () => {
       const st = peer.connectionState
       console.debug('[voice] webrtc connectionState', st)
-      // Fail loud: if the peer connection can't form (ICE/DTLS failed), surface
-      // it rather than sitting silently with no audio. No fallback — the user
-      // re-toggles, or sets a TURN server (see docs/VOICE_WEBRTC_TESTING.md).
-      if (st === 'failed') {
-        error.value = 'Voice connection failed — WebRTC could not connect (NAT/firewall?).'
-        status.value = 'error'
-        _teardownWebRtc()   // drop the dead PC + hidden <audio> now, not next toggle
-      }
+      // Events from a PC we already replaced during a reconnect are stale.
+      if (peer !== pc.value) return
+      // Recovery policy (webrtcRecovery.js): 'disconnected' gets a grace
+      // window to self-heal, 'failed' re-offers immediately, and repeated
+      // consecutive failures give up via _failWebRtc — which surfaces the
+      // same fail-loud error as before. A first transient ICE blip (routine
+      // on 5G) no longer kills the session.
+      webrtcRecovery?.onState(st)
     })
 
     for (const track of ms.getAudioTracks()) peer.addTrack(track, ms)
@@ -557,9 +614,19 @@ function _createVoiceSession() {
   }
 
   function _teardownWebRtc() {
+    // Drops the PC only. The hidden <audio> deliberately survives — it holds
+    // the iOS autoplay blessing needed by automatic reconnects (see
+    // _startWebRtc); _removeAudioEl() disposes it on final teardown paths.
     webrtcMode = false
     try { pc.value?.close() } catch {}
     pc.value = null
+    const el = remoteAudioEl.value
+    if (el) {
+      try { el.srcObject = null } catch {}
+    }
+  }
+
+  function _removeAudioEl() {
     const el = remoteAudioEl.value
     if (el) {
       try { el.srcObject = null; el.remove() } catch {}
@@ -741,7 +808,10 @@ function _createVoiceSession() {
     }
     workletNode.value?.disconnect()
     workletNode.value = null
+    webrtcRecovery?.stop()   // user-initiated teardown — no reconnects after this
+    webrtcRecovery = null
     _teardownWebRtc()
+    _removeAudioEl()
     if (stream.value) {
       stream.value.getTracks().forEach(t => t.stop())
       stream.value = null

--- a/frontend/src/composables/webrtcRecovery.js
+++ b/frontend/src/composables/webrtcRecovery.js
@@ -1,0 +1,84 @@
+/**
+ * webrtcRecovery — decides WHEN to re-negotiate a dead RTCPeerConnection.
+ *
+ * Why this exists: on mobile networks (5G cell handover, CGNAT rebind, brief
+ * radio loss) the ICE candidate pair dies mid-session as a matter of course.
+ * The original handler treated the first ``failed`` as fatal — error banner,
+ * dead mic — even though the /ws/voice control socket (which rides HTTPS/
+ * cloudflared) usually survives the blip and can carry a fresh ``webrtc_offer``
+ * within a second or two.
+ *
+ * Policy encoded here:
+ *   * ``disconnected`` is usually transient — give the browser ``graceMs`` to
+ *     recover on its own before forcing a re-offer (the timer is cancelled if
+ *     the connection comes back).
+ *   * ``failed`` re-offers immediately.
+ *   * ``connected`` resets the retry budget — only *consecutive* failures
+ *     count toward giving up.
+ *   * After ``maxRetries`` consecutive attempts, give up via ``fail`` (the
+ *     caller surfaces the existing error banner).
+ *
+ * Pure timing/decision logic — the actual teardown + re-offer lives in
+ * useVoiceSession.js (``restart`` callback), so this is unit-testable without
+ * shimming RTCPeerConnection. Mirrors the playbackDoneTracker.js pattern.
+ *
+ * @param {object} opts
+ * @param {(attempt: number) => void} opts.restart  perform one re-negotiation
+ * @param {(reason: string) => void}  opts.fail     give up — surface the error
+ * @param {number} [opts.maxRetries]  consecutive attempts before giving up
+ * @param {number} [opts.graceMs]     how long 'disconnected' may self-heal
+ */
+export function createWebRtcRecovery({ restart, fail, maxRetries = 2, graceMs = 4000 }) {
+  let retries = 0
+  let timer = null
+  let stopped = false
+
+  function clearTimer() {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function attempt() {
+    if (stopped) return
+    if (retries >= maxRetries) {
+      fail(`webrtc reconnect gave up after ${retries} attempts`)
+      return
+    }
+    retries++
+    restart(retries)
+  }
+
+  return {
+    /** Feed every RTCPeerConnection ``connectionstatechange`` here. */
+    onState(state) {
+      if (stopped) return
+      if (state === 'connected') {
+        retries = 0
+        clearTimer()
+      } else if (state === 'disconnected') {
+        if (timer === null) {
+          timer = setTimeout(() => {
+            timer = null
+            attempt()
+          }, graceMs)
+        }
+      } else if (state === 'failed') {
+        clearTimer()
+        attempt()
+      }
+    },
+    /** A restart attempt itself blew up (offer send failed, ICE fetch error). */
+    onRestartError() {
+      if (stopped) return
+      // Count as a failed pair: either retry (budget left) or give up.
+      attempt()
+    },
+    /** Session torn down (user stop / WS closed) — never fire again. */
+    stop() {
+      stopped = true
+      clearTimer()
+    },
+  }
+}

--- a/frontend/src/composables/webrtcRecovery.test.js
+++ b/frontend/src/composables/webrtcRecovery.test.js
@@ -1,0 +1,88 @@
+/**
+ * webrtcRecovery — ICE-failure recovery policy.
+ *
+ * The prod bug (iPhone/5G): a mid-session ICE failure showed the fatal
+ * "WebRTC could not connect" banner on the FIRST blip, even though the WS
+ * control channel was still up and a re-offer would have recovered in ~1 s.
+ * These tests pin the policy: failed → restart, disconnected → grace then
+ * restart (cancelled on self-heal), consecutive-failure budget, reset on
+ * connected, and silence after stop().
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createWebRtcRecovery } from './webrtcRecovery.js'
+
+function make(opts = {}) {
+  const calls = { restarts: [], fails: [] }
+  const r = createWebRtcRecovery({
+    restart: (n) => calls.restarts.push(n),
+    fail: (reason) => calls.fails.push(reason),
+    graceMs: 10, // real timers, kept tiny so tests stay fast
+    ...opts,
+  })
+  return { r, calls }
+}
+
+const tick = (ms) => new Promise((res) => setTimeout(res, ms))
+
+test('failed → restarts immediately', () => {
+  const { r, calls } = make()
+  r.onState('failed')
+  assert.deepEqual(calls.restarts, [1])
+  assert.equal(calls.fails.length, 0)
+})
+
+test('disconnected → waits grace, then restarts if not recovered', async () => {
+  const { r, calls } = make()
+  r.onState('disconnected')
+  assert.equal(calls.restarts.length, 0) // inside grace window — no action yet
+  await tick(30)
+  assert.deepEqual(calls.restarts, [1])
+})
+
+test('disconnected → connected within grace cancels the restart', async () => {
+  const { r, calls } = make()
+  r.onState('disconnected')
+  r.onState('connected')
+  await tick(30)
+  assert.equal(calls.restarts.length, 0)
+})
+
+test('gives up via fail() after maxRetries consecutive failures', () => {
+  const { r, calls } = make()
+  r.onState('failed') // attempt 1
+  r.onState('failed') // attempt 2 (new PC failed too)
+  r.onState('failed') // budget exhausted → fail
+  assert.deepEqual(calls.restarts, [1, 2])
+  assert.equal(calls.fails.length, 1)
+})
+
+test('connected resets the retry budget — only consecutive failures count', () => {
+  const { r, calls } = make()
+  r.onState('failed')    // attempt 1
+  r.onState('connected') // recovered — budget back to full
+  r.onState('failed')    // attempt 1 again, not attempt 2
+  r.onState('failed')    // attempt 2
+  assert.deepEqual(calls.restarts, [1, 1, 2])
+  assert.equal(calls.fails.length, 0)
+})
+
+test('onRestartError consumes budget and eventually fails', () => {
+  const { r, calls } = make()
+  r.onState('failed')   // attempt 1
+  r.onRestartError()    // attempt 1's setup blew up → attempt 2
+  r.onRestartError()    // attempt 2's setup blew up → budget exhausted
+  assert.deepEqual(calls.restarts, [1, 2])
+  assert.equal(calls.fails.length, 1)
+})
+
+test('stop() silences everything, including a pending grace timer', async () => {
+  const { r, calls } = make()
+  r.onState('disconnected')
+  r.stop()
+  await tick(30)
+  r.onState('failed')
+  assert.equal(calls.restarts.length, 0)
+  assert.equal(calls.fails.length, 0)
+})

--- a/frontend/tests/e2e/flows/voice-webrtc.spec.ts
+++ b/frontend/tests/e2e/flows/voice-webrtc.spec.ts
@@ -92,3 +92,75 @@ test('mic toggle → client sends a valid webrtc_offer (audio over WebRTC)', asy
   await page.waitForTimeout(300)
   expect(inbound.some((m) => m.includes('"type":"playback_done"'))).toBe(false)
 })
+
+/**
+ * Track every RTCPeerConnection the app creates and let the test force the
+ * NEWEST one into a connection state — the only way to exercise the ICE-death
+ * recovery path headless (Playwright can't make a real ICE pair die on cue).
+ * The composable's own ``connectionstatechange`` listener receives the event,
+ * so everything downstream (webrtcRecovery policy, re-offer, give-up banner)
+ * is production code.
+ */
+async function trackPeerConnections(page: Page) {
+  await page.addInitScript(() => {
+    const pcs: RTCPeerConnection[] = []
+    const Orig = window.RTCPeerConnection
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).RTCPeerConnection = class extends Orig {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(...args: any[]) {
+        super(...args)
+        pcs.push(this)
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).__pcCount = () => pcs.length
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).__failNewestPc = () => {
+      const pc = pcs[pcs.length - 1]
+      Object.defineProperty(pc, 'connectionState', { configurable: true, get: () => 'failed' })
+      pc.dispatchEvent(new Event('connectionstatechange'))
+    }
+  })
+}
+
+test('ICE failure mid-session → re-offers over the live WS; exhausted retries → error banner', async ({ page }) => {
+  await seedApiKey(page)
+  await stubRealMicStream(page)
+  await trackPeerConnections(page)
+  await mockBackend(page, [NOISE])
+
+  const offers: string[] = []
+  await page.routeWebSocket(/\/ws\/voice$/, (ws) => {
+    ws.onMessage((data) => {
+      const s = typeof data === 'string' ? data : '<binary>'
+      if (s.includes('"type":"webrtc_offer"')) offers.push(s)
+      try {
+        if (JSON.parse(s).type === 'start') ws.send(JSON.stringify({ type: 'stt_ready' }))
+      } catch { /* binary */ }
+    })
+  })
+
+  await page.goto('/chat')
+  const mic = page.locator('.voice-bar .mic-btn')
+  await expect(mic).toBeVisible()
+  await mic.click()
+  await expect.poll(() => offers.length, { timeout: 8000 }).toBe(1)
+
+  // First ICE death (routine on 5G: handover/NAT rebind) → the client must
+  // re-negotiate with a fresh PC over the still-open WS, NOT show the fatal
+  // banner (the prod bug this pins).
+  await page.evaluate(() => (window as unknown as { __failNewestPc: () => void }).__failNewestPc())
+  await expect.poll(() => offers.length, { timeout: 8000 }).toBe(2)
+  await expect(page.locator('.voice-bar .err-msg')).toHaveCount(0)
+
+  // Second consecutive death → second (last-budget) reconnect attempt.
+  await page.evaluate(() => (window as unknown as { __failNewestPc: () => void }).__failNewestPc())
+  await expect.poll(() => offers.length, { timeout: 8000 }).toBe(3)
+
+  // Third consecutive death → budget exhausted → fail loud, no more offers.
+  await page.evaluate(() => (window as unknown as { __failNewestPc: () => void }).__failNewestPc())
+  await expect(page.locator('.voice-bar .err-msg')).toContainText('WebRTC could not connect')
+  await page.waitForTimeout(500)
+  expect(offers.length).toBe(3)
+})


### PR DESCRIPTION
## What

Two independent voice/WebRTC reliability fixes that surfaced during manual testing.

### 1. TTS dropped the first seconds of replies
\`TtsAudioTrack._next_frame_bytes\` awaited the queue with a 20 ms timeout **in series with** \`recv()\`'s pacing sleep, so every idle frame ran ~1 ms over cadence. That drift (~50 ms/idle-second) was repaid as a faster-than-real-time burst when the next reply arrived — and the client's jitter buffer discards a catch-up burst as "late packets". Result: the reply's head was audibly missing on prod.

- \`_next_frame_bytes\` is now **non-blocking**: it drains only already-arrived data and flushes a partial frame padded with silence (so \`pending()\` can't strand \`wait_drained()\`).
- All pacing lives in \`recv()\`, which **re-anchors its clock to "now"** once lag exceeds two frames (40 ms) instead of bursting.

### 2. WebRTC died on mobile networks
Mobile networks routinely kill the ICE candidate pair mid-session (5G handover, CGNAT rebind, brief radio loss). The old handler treated the first \`failed\` as fatal — error banner, dead mic — even though the \`/ws/voice\` control socket usually survives and can carry a fresh offer.

New \`webrtcRecovery.js\` encodes the re-negotiation policy:
- \`disconnected\` → grace window before forcing a re-offer (cancelled if it recovers on its own);
- \`failed\` → re-offer immediately over the live control WS;
- \`connected\` → reset the retry budget (only *consecutive* failures count);
- past \`maxRetries\` → give up via the existing error banner.

## Tests
- Backend: \`test_webrtc_voice.py\`, \`test_ws_voice.py\` green.
- Frontend unit: \`webrtcRecovery.test.js\` green.
- E2E: \`voice-webrtc.spec.ts\` (mic toggle → valid offer; ICE failure mid-session → re-offer; exhausted retries → banner) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)