### PR TITLE
feat(context): LLM-only compaction, overflow recovery, serving-model window

### DIFF
--- a/backend/routes/context_compaction.py
+++ b/backend/routes/context_compaction.py
@@ -39,6 +39,8 @@ class CompactionSettingsPatch(BaseModel):
     min_savings_ratio: float | None = None
     snapshot_versions_visible: int | None = None
     emit_live_status: bool | None = None
+    compactor_model: str | None = None
+    compactor_input_ratio: float | None = None
 
 
 @router.get("/settings", dependencies=[Depends(verify_api_key)])

--- a/backend/services/context_compaction.py
+++ b/backend/services/context_compaction.py
@@ -7,8 +7,7 @@ Flow (all inside ``before_llm_call``, never touching the pending delta):
 
     threshold check (real provider tokens when available)
     -> save raw snapshot (append-only audit, trigger="pre_compaction")
-    -> rule-based compactor produces a plan (same contract a future
-       LLM compactor must honour)
+    -> LLM compactor (dedicated compactor agent) produces a plan
     -> backend-side validation (independent of the compactor)
     -> working context built from deep copies
     -> agent.load_message_history(working)   # the ONLY live mutation
@@ -40,15 +39,18 @@ fabricate savings).
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import re
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Bump when the rule-based planner's behaviour changes in a way that
-# alters what a stored plan means (used to interpret old event rows).
+# Bump when the compactor's plan semantics change in a way that alters
+# what a stored plan means (used to interpret old event rows).
 POLICY_VERSION = 1
 
 CONFIG_CATEGORY = "context_compaction"
@@ -65,6 +67,7 @@ SUMMARY_SECTIONS = (
     "Important decisions:",
     "Tool findings:",
     "Errors / unresolved issues:",
+    "File references:",
     "Recent state:",
     "Next actions:",
     "Raw references:",
@@ -84,10 +87,22 @@ DEFAULTS: dict[str, Any] = {
     "min_savings_ratio": 0.05,
     "snapshot_versions_visible": 3,
     "emit_live_status": True,
+    # Model for the DEDICATED compactor agent (spec §1–2: compaction is
+    # performed by a separate compactor component/agent). A model with a
+    # larger context window than the origin agent's lets one compactor
+    # call feed more history at once. Empty = use the origin agent's own
+    # LLM (no separate agent configured yet).
+    "compactor_model": "",
+    # Fraction of the COMPACTOR's context window a single compaction call
+    # may consume as input — the rest is headroom for the instruction
+    # scaffold, the JSON output, and provider overhead. Larger = fewer
+    # chunks (faster, cheaper) but riskier of overflowing the compactor.
+    "compactor_input_ratio": 0.7,
 }
 
-# Fallback context window when neither config nor the model database
-# knows the limit. Matches the spec's suggested default.
+# Conservative window used ONLY to size LLM-compactor chunks when the
+# real window is unknown (overflow recovery must still work). Never used
+# as a compaction threshold — an unknown window fails loud instead.
 _FALLBACK_CONTEXT_TOKENS = 120000
 
 # Compaction is pointless (and the validator would reject it) when the
@@ -105,6 +120,8 @@ class CompactionConfig:
     min_savings_ratio: float
     snapshot_versions_visible: int
     emit_live_status: bool
+    compactor_model: str
+    compactor_input_ratio: float
 
 
 # Single source for the valid numeric ranges — used by the typed PATCH
@@ -117,6 +134,7 @@ _RANGES: dict[str, tuple[float, float]] = {
     "max_tool_result_tokens_in_context": (100, 100000),
     "min_savings_ratio": (0.0, 0.9),
     "snapshot_versions_visible": (1, 50),
+    "compactor_input_ratio": (0.1, 0.9),
 }
 # max_context_tokens is special-cased: 0 (= auto) or within this range.
 _MAX_CONTEXT_TOKENS_RANGE = (10000, 2000000)
@@ -232,6 +250,10 @@ def validate_config_updates(updates: dict[str, Any]) -> list[str]:
         lo, hi = _MAX_CONTEXT_TOKENS_RANGE
         if v is not None and v != 0 and not (lo <= v <= hi):
             errors.append(f"max_context_tokens must be 0 (auto) or between {lo} and {hi}")
+    if "compactor_model" in updates:
+        v = updates["compactor_model"]
+        if not isinstance(v, str) or len(v) > 200:
+            errors.append("compactor_model must be a string of at most 200 characters")
     return errors
 
 
@@ -271,18 +293,35 @@ def _current_context_tokens(agent: Any, history: list) -> tuple[int, str]:
     return estimate_tokens(history), "estimate"
 
 
-def _context_token_limit(agent: Any, cfg: CompactionConfig) -> int:
+def _context_token_limit(agent: Any, cfg: CompactionConfig, agent_name: str = "") -> int | None:
+    """Authoritative context limit, or None when it is genuinely unknown.
+
+    NO invented fallback here: thresholding against a made-up number
+    either compacts prematurely (small guess) or never (big guess). The
+    caller fails loud on None so the operator can fix the config.
+    """
     if cfg.max_context_tokens > 0:
         return cfg.max_context_tokens
+    window = None
     try:
         acc = getattr(agent, "usage_accumulator", None)
         if acc is not None:
             window = getattr(acc, "context_window_size", None)
-            if window:
-                return int(window)
     except Exception:
-        pass
-    return _FALLBACK_CONTEXT_TOKENS
+        window = None
+    if window:
+        # Gateway combos rotate between real models with different
+        # windows; threshold against the smallest window seen this
+        # session so a mid-conversation switch to a smaller model
+        # cannot overflow before the next check.
+        window = int(window)
+        seen = _min_window_seen.get(agent_name)
+        if seen is not None:
+            window = min(seen, window)
+        if agent_name:
+            _min_window_seen[agent_name] = window
+        return window
+    return _min_window_seen.get(agent_name)
 
 
 # ---------------------------------------------------------------------------
@@ -310,14 +349,6 @@ def _tool_result_texts(msg: Any) -> list[tuple[str, str, bool]]:
                 parts.append(text)
         out.append((call_id, "\n".join(parts), bool(getattr(result, "isError", False))))
     return out
-
-
-def _tool_call_names(msg: Any) -> list[str]:
-    names = []
-    for _id, call in (getattr(msg, "tool_calls", None) or {}).items():
-        params = getattr(call, "params", None)
-        names.append(getattr(params, "name", "unknown") if params else "unknown")
-    return names
 
 
 def _clip(text: str, limit: int) -> str:
@@ -380,14 +411,12 @@ def _pair_safe_tail_start(messages: list, head_end: int, keep_recent: int) -> in
 # ---------------------------------------------------------------------------
 
 
-def plan_compaction(messages: list, cfg: CompactionConfig, raw_snapshot_id: int | None) -> dict | None:
-    """Produce a compaction plan, or None when there is nothing worth
-    compacting (middle zone too small).
-
-    Contract (spec §8): summary_message, keep_verbatim, summarize,
-    delete_from_working_context, promote_to_memory, raw_references,
-    risks, confidence. Indices refer to positions in the CURRENT
-    message_history (== the raw snapshot saved just before planning).
+def _plan_zones(messages: list, cfg: CompactionConfig) -> tuple[int, int, list[int], list[int]] | None:
+    """(head_end, tail_start, keep, middle) — the structural safety zones
+    the LLM compactor builds on (templates kept, pair-safe tail, latest
+    user verbatim). None when the middle zone is too small to be worth
+    compacting (also the feasibility pre-check, kept LLM-free so an
+    infeasible history is a cheap silent no-op).
     """
     head_end = _template_prefix_len(messages)
     tail_start = _pair_safe_tail_start(messages, head_end, cfg.keep_recent_messages)
@@ -404,15 +433,17 @@ def plan_compaction(messages: list, cfg: CompactionConfig, raw_snapshot_id: int 
         middle.remove(forced_user_idx)
         keep.append(forced_user_idx)
         keep.sort()
+    return head_end, tail_start, keep, middle
 
-    summary = _build_summary(messages, middle, raw_snapshot_id)
 
-    # Oversized tool results inside the kept tail get truncated (full
-    # text stays in the raw snapshot) — except the final message, whose
-    # tool result may be the one the next LLM call reasons over.
-    # Per-BLOCK check, matching exactly what _truncate_tool_result will
-    # cut — a joined-text check would flag messages nothing gets removed
-    # from (PR #85 review F7).
+def _tail_truncations(messages: list, tail_start: int, cfg: CompactionConfig) -> list[dict]:
+    """Oversized tool results inside the kept tail get truncated (full
+    text stays in the raw snapshot) — except the final message, whose
+    tool result may be the one the next LLM call reasons over.
+    Per-BLOCK check, matching exactly what _truncate_tool_result will
+    cut — a joined-text check would flag messages nothing gets removed
+    from (PR #85 review F7).
+    """
     max_chars = cfg.max_tool_result_tokens_in_context * 4
     summarize: list[dict] = []
     for idx in range(tail_start, len(messages) - 1):
@@ -427,9 +458,16 @@ def plan_compaction(messages: list, cfg: CompactionConfig, raw_snapshot_id: int 
                         "max_chars": max_chars,
                     }
                 )
+    return summarize
 
+
+def _plan_skeleton(
+    keep: list[int],
+    middle: list[int],
+    summarize: list[dict],
+    raw_snapshot_id: int | None,
+) -> dict:
     return {
-        "summary_message": summary,
         "keep_verbatim": keep,
         "summarize": summarize,
         "delete_from_working_context": middle,
@@ -440,75 +478,322 @@ def plan_compaction(messages: list, cfg: CompactionConfig, raw_snapshot_id: int 
                 "message_indexes": [middle[0], middle[-1]] if middle else [],
             }
         ],
-        "risks": [
-            "rule-based summary may miss implicit decisions buried in dropped turns",
-        ],
-        # Fixed mid confidence: the rule-based planner is structurally
-        # safe but semantically blind; an LLM compactor should set this
-        # from its own judgement.
-        "confidence": 0.6,
     }
 
 
-def _build_summary(messages: list, middle: list[int], raw_snapshot_id: int | None) -> str:
-    first_user = next(
-        (
-            _msg_text(messages[i])
-            for i in range(len(messages))
-            if str(getattr(messages[i], "role", "")) == "user" and _msg_text(messages[i]).strip()
-        ),
-        "",
+# ---------------------------------------------------------------------------
+# LLM compactor — THE only compactor. A dedicated compactor agent
+# (``compactor_model``, falling back to the origin agent's LLM) reads the
+# dropped turns and writes the summary, so semantics survive. There is no
+# rule-based fallback: a compaction that cannot run fails loud.
+# ---------------------------------------------------------------------------
+
+# Floor so a tiny/unknown window still yields workable chunks.
+_COMPACTOR_MIN_CHUNK_TOKENS = 8000
+_COMPACTOR_CALL_TIMEOUT_S = 180
+
+_CHUNK_PROMPT = """You are a faithful compression layer for an AI agent's conversation history. Your ONLY job is to preserve, without loss of meaning, the information a continuation would need. You do NOT interpret, conclude, or steer.
+
+Below is part {part} of {total} of the history. Extract what it actually contains.
+
+Rules:
+- Record only what the excerpt explicitly establishes. Never infer, embellish, or invent.
+- Do NOT judge whether the task is complete or unfinished, and do NOT decide what should happen next. Whether to continue, stop, or ask the user is the agent's own decision — it makes that decision from your summary plus the verbatim recent messages it still holds, so prejudging it corrupts the outcome.
+- "state" = the factual situation exactly as the excerpt last leaves it (what was done, what is underway), stated neutrally — not a verdict on progress.
+- "next_actions" = only steps the user or the agent EXPLICITLY stated as pending in this excerpt; if none are stated, return an empty list rather than guessing one.
+- Preserve user instructions and intent verbatim in meaning; never paraphrase them into a conclusion.
+
+Return STRICT JSON (no markdown fences, no commentary) with exactly these keys, each a list of short strings (empty list when nothing applies):
+{{"goal": [], "constraints": [], "architecture_facts": [], "decisions": [], "tool_findings": [], "errors": [], "file_references": [], "state": [], "next_actions": []}}
+
+"file_references" must list every file path the agent read, edited, or discussed — these let the agent re-open its working set.
+
+Conversation excerpt:
+{body}"""
+
+# Dedicated compactor LLM instances, one per configured model name.
+_compactor_llm_cache: dict[str, Any] = {}
+
+
+def _get_compactor_llm(agent: Any, cfg: CompactionConfig) -> tuple[Any, int | None, str]:
+    """(llm, context_window, label) for the compactor.
+
+    Spec §1–2: compaction is performed by a SEPARATE compactor
+    component/agent — when ``compactor_model`` is configured we build a
+    dedicated LLM (reusing the origin agent's context for provider
+    config/keys), so a larger-window model can feed more history per
+    call. Unset → the origin agent's own LLM as a degraded default.
+    """
+    model = (cfg.compactor_model or "").strip()
+    if model:
+        llm = _compactor_llm_cache.get(model)
+        if llm is None:
+            from fast_agent.agents.agent_types import AgentConfig
+            from fast_agent.agents.llm_agent import LlmAgent
+            from fast_agent.llm.model_factory import ModelFactory
+
+            ctx = getattr(agent, "_context", None) or getattr(agent, "context", None)
+            shell = LlmAgent(AgentConfig(name="context-compactor"), context=ctx)
+            llm = ModelFactory.create_factory(model)(shell)
+            _compactor_llm_cache[model] = llm
+        from fast_agent.llm.model_database import ModelDatabase
+
+        return llm, ModelDatabase.get_context_window(model), model
+    llm = getattr(agent, "_llm", None)
+    if llm is None:
+        raise RuntimeError("agent has no attached LLM and no compactor_model configured")
+    return llm, None, "origin-agent-model"
+
+
+# Path-shaped tokens inside tool-call arguments (file_path, paths in
+# queries, …). Arguments are the reliable source — result texts are huge
+# and full of incidental paths.
+_PATH_RE = re.compile(r"(?:[\w.~-]+)?(?:/[\w.-]+){2,}")
+
+
+def _file_references(messages: list, idxs: list[int], cap: int = 15) -> list[str]:
+    out: list[str] = []
+    for i in idxs:
+        for _call_id, call in (getattr(messages[i], "tool_calls", None) or {}).items():
+            args = getattr(getattr(call, "params", None), "arguments", None) or {}
+            for value in args.values():
+                if not isinstance(value, str):
+                    continue
+                for match in _PATH_RE.findall(value)[:3]:
+                    if match not in out:
+                        out.append(match)
+    return out[:cap]
+
+
+def _pair_safe_chunks(messages: list, middle: list[int], chunk_tokens: int) -> list[list[int]]:
+    """Split the middle zone into contiguous chunks of ~chunk_tokens each,
+    cutting only where every tool call so far has its result — a chunk
+    must be independently summarizable without dangling pairs.
+    """
+    chunks: list[list[int]] = []
+    cur: list[int] = []
+    cur_tokens = 0
+    open_calls: set[str] = set()
+    for idx in middle:
+        msg = messages[idx]
+        cur.append(idx)
+        cur_tokens += estimate_tokens([msg])
+        for call_id in getattr(msg, "tool_calls", None) or {}:
+            open_calls.add(call_id)
+        for call_id in getattr(msg, "tool_results", None) or {}:
+            open_calls.discard(call_id)
+        if cur_tokens >= chunk_tokens and not open_calls:
+            chunks.append(cur)
+            cur, cur_tokens = [], 0
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+def _render_for_summary(messages: list, idxs: list[int]) -> str:
+    lines: list[str] = []
+    for i in idxs:
+        msg = messages[i]
+        role = str(getattr(msg, "role", ""))
+        text = _clip(_msg_text(msg), 2000)
+        if text:
+            lines.append(f"[{i}] {role}: {text}")
+        for _call_id, call in (getattr(msg, "tool_calls", None) or {}).items():
+            params = getattr(call, "params", None)
+            name = getattr(params, "name", "unknown") if params else "unknown"
+            args = getattr(params, "arguments", None) or {}
+            lines.append(f"[{i}] {role} called {name}({_clip(json.dumps(args, default=str), 300)})")
+        for _call_id, rtext, is_err in _tool_result_texts(msg):
+            if rtext.strip():
+                tag = "tool_error" if is_err else "tool_result"
+                lines.append(f"[{i}] {tag}: {_clip(rtext, 1200)}")
+    return "\n".join(lines)
+
+
+def _parse_chunk_json(text: str) -> dict:
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = re.sub(r"^```[a-zA-Z]*\n?", "", t)
+        t = re.sub(r"\n?```$", "", t.strip())
+    start, end = t.find("{"), t.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError("compactor output contains no JSON object")
+    data = json.loads(t[start : end + 1])
+    if not isinstance(data, dict):
+        raise ValueError("compactor output is not a JSON object")
+    return data
+
+
+@contextmanager
+def _detached_stream_listeners(llm: Any):
+    """Swap the LLM's stream-listener sets for empty ones so compactor
+    tokens never leak into the live chat stream. MUST wrap the whole
+    batch of concurrent compactor calls (a per-call save/restore would
+    race: the last call to finish could restore another call's empty
+    set and silently kill the chat stream).
+    """
+    saved_stream = getattr(llm, "_stream_listeners", None)
+    saved_tool_stream = getattr(llm, "_tool_stream_listeners", None)
+    if saved_stream is not None:
+        llm._stream_listeners = set()
+    if saved_tool_stream is not None:
+        llm._tool_stream_listeners = set()
+    try:
+        yield
+    finally:
+        if saved_stream is not None:
+            llm._stream_listeners = saved_stream
+        if saved_tool_stream is not None:
+            llm._tool_stream_listeners = saved_tool_stream
+
+
+async def _llm_one_shot(llm: Any, prompt_text: str) -> str:
+    """One isolated LLM call on the agent's own model.
+
+    Uses ``llm.generate`` directly (history is caller-managed there, so
+    the agent's message_history is untouched). The caller detaches
+    stream listeners around the whole batch via
+    ``_detached_stream_listeners``. Usage IS recorded on the agent's
+    accumulator — the cost is real.
+    """
+    from fast_agent.core.prompt import Prompt
+
+    response = await asyncio.wait_for(
+        llm.generate([Prompt.user(prompt_text)], request_params=None, tools=None),
+        timeout=_COMPACTOR_CALL_TIMEOUT_S,
     )
+    return _msg_text(response)
+
+
+def _merge_chunk_sections(
+    parts: list[dict],
+    messages: list,
+    middle: list[int],
+    raw_snapshot_id: int | None,
+) -> str:
+    """Deterministic merge of per-chunk JSON into ONE summary message with
+    the exact SUMMARY_SECTIONS structure (a second LLM merge pass would
+    add cost and a new failure mode for no structural gain). File
+    references union the LLM-extracted paths with the deterministic
+    tool-argument scan, so a path the model overlooked still survives.
+    """
+
+    def gather(key: str, cap: int) -> list[str]:
+        out: list[str] = []
+        for p in parts:
+            for item in p.get(key) or []:
+                s = str(item).strip()
+                if s and s not in out:
+                    out.append(s)
+        return out[-cap:]
+
+    def block(items: list[str], fallback: str = "(none)") -> str:
+        return "\n".join(f"- {x}" for x in items) or fallback
+
     latest_idx = _latest_user_text_index(messages)
     latest_user = _msg_text(messages[latest_idx]) if latest_idx is not None else ""
-
-    tool_counts: dict[str, int] = {}
-    findings: list[str] = []
-    errors: list[str] = []
-    carried: list[str] = []
-    decisions: list[str] = []
-
-    for i in middle:
-        msg = messages[i]
-        text = _msg_text(msg)
-        if text.startswith(SUMMARY_MARKER):
-            carried.append(_clip(text, 1500))
-            continue
-        if str(getattr(msg, "role", "")) == "assistant" and text.strip():
-            decisions.append(_clip(text, 400))
-        for name in _tool_call_names(msg):
-            tool_counts[name] = tool_counts.get(name, 0) + 1
-        for _call_id, rtext, is_err in _tool_result_texts(msg):
-            if not rtext.strip():
-                continue
-            if is_err:
-                errors.append(_clip(rtext, 300))
-            else:
-                findings.append(_clip(rtext, 200))
-
-    tools_line = (
-        ", ".join(f"{n}×{c}" for n, c in sorted(tool_counts.items())) or "(none)"
+    goal = _clip(latest_user, 600) or "; ".join(gather("goal", 3)) or "(none captured)"
+    state_items = gather("state", 4)
+    recent_state = state_items[-1] if state_items else "(see recent messages below)"
+    next_actions = block(
+        gather("next_actions", 6),
+        "Continue the current task with the recent messages below.",
     )
-    findings_block = "\n".join(f"- {f}" for f in findings[-5:]) or "(none captured)"
-    errors_block = "\n".join(f"- {e}" for e in errors[-5:]) or "(none)"
-    decisions_block = "\n".join(f"- {d}" for d in decisions[-3:]) or "(none captured)"
-    recent_state = decisions[-1] if decisions else "(see recent messages below)"
-    carried_block = ("\n\nCarried from previous compaction:\n" + "\n---\n".join(carried)) if carried else ""
     ref_range = f"messages {middle[0]}–{middle[-1]}" if middle else "(none)"
+    file_refs = gather("file_references", 20)
+    for path in _file_references(messages, middle):
+        if path not in file_refs:
+            file_refs.append(path)
+    file_refs = file_refs[:20]
 
+    # Neutral, non-steering header: states only WHAT this block is, so the
+    # agent reads the sections as compressed history (not a new instruction)
+    # and still decides for itself whether to continue, stop, or ask —
+    # exactly as it would have with the full history.
     return (
         f"{SUMMARY_MARKER}\n\n"
-        f"Current goal:\n{_clip(latest_user or first_user, 600) or '(none captured)'}\n\n"
-        f"User constraints:\n(not captured by rule-based compactor)\n\n"
-        f"Architecture facts:\n(not captured by rule-based compactor)\n\n"
-        f"Important decisions:\n{decisions_block}\n\n"
-        f"Tool findings:\nTools used: {tools_line}\n{findings_block}\n\n"
-        f"Errors / unresolved issues:\n{errors_block}\n\n"
+        f"The following is a faithful, compressed summary of earlier turns in this "
+        f"same conversation; the most recent messages remain verbatim below it.\n\n"
+        f"Current goal:\n{goal}\n\n"
+        f"User constraints:\n{block(gather('constraints', 8), '(none captured)')}\n\n"
+        f"Architecture facts:\n{block(gather('architecture_facts', 10), '(none captured)')}\n\n"
+        f"Important decisions:\n{block(gather('decisions', 10), '(none captured)')}\n\n"
+        f"Tool findings:\n{block(gather('tool_findings', 12), '(none captured)')}\n\n"
+        f"Errors / unresolved issues:\n{block(gather('errors', 8))}\n\n"
+        f"File references:\n{block(file_refs, '(none captured)')}\n\n"
         f"Recent state:\n{_clip(recent_state, 400)}\n\n"
-        f"Next actions:\nContinue the current task with the recent messages below.\n\n"
+        f"Next actions:\n{next_actions}\n\n"
         f"Raw references:\nraw snapshot #{raw_snapshot_id}, {ref_range}"
-        f"{carried_block}"
     )
+
+
+async def plan_compaction_llm(
+    agent: Any,
+    messages: list,
+    cfg: CompactionConfig,
+    raw_snapshot_id: int | None,
+    *,
+    agent_name: str = "",
+) -> dict | None:
+    """The compaction plan, summary written by the DEDICATED compactor
+    agent (``compactor_model`` setting; falls back to the origin agent's
+    own LLM when unset). Builds on the structural zones in ``_plan_zones``.
+
+    The middle zone is summarized by ONE call when it fits the configured
+    fraction (``compactor_input_ratio``) of the COMPACTOR's window,
+    otherwise split into pair-safe chunks summarized CONCURRENTLY and
+    merged deterministically (the map-reduce path for contexts larger
+    than any single compactor call). Raises on any LLM/parsing failure —
+    the caller fails loud (no rule-based fallback).
+    """
+    zones = _plan_zones(messages, cfg)
+    if zones is None:
+        return None
+    _head_end, tail_start, keep, middle = zones
+    if not middle:
+        return None
+
+    llm, compactor_window, compactor_label = _get_compactor_llm(agent, cfg)
+
+    # Chunk sizing uses the COMPACTOR's window (a bigger compactor model
+    # feeds more history per call). Unknown window only degrades sizing,
+    # never blocks recovery — use the conservative constant.
+    window = (
+        compactor_window
+        or _context_token_limit(agent, cfg, agent_name)
+        or _FALLBACK_CONTEXT_TOKENS
+    )
+    chunk_tokens = max(_COMPACTOR_MIN_CHUNK_TOKENS, int(window * cfg.compactor_input_ratio))
+    chunks = _pair_safe_chunks(messages, middle, chunk_tokens)
+
+    async def summarize(part_no: int, idxs: list[int]) -> dict:
+        prompt = _CHUNK_PROMPT.format(
+            part=part_no, total=len(chunks), body=_render_for_summary(messages, idxs)
+        )
+        raw = await _llm_one_shot(llm, prompt)
+        return _parse_chunk_json(raw)
+
+    # Concurrent calls on one LLM instance are safe here: each generate()
+    # is an independent HTTP request; shared instance state is limited to
+    # the usage accumulator (append-only) and stream listeners (detached
+    # once around the whole batch).
+    with _detached_stream_listeners(llm):
+        parts = await asyncio.gather(*(summarize(n + 1, c) for n, c in enumerate(chunks)))
+
+    plan = _plan_skeleton(keep, middle, _tail_truncations(messages, tail_start, cfg), raw_snapshot_id)
+    plan.update(
+        {
+            "summary_message": _merge_chunk_sections(list(parts), messages, middle, raw_snapshot_id),
+            "compactor": "llm",
+            "compactor_model": compactor_label,
+            "compactor_chunks": len(chunks),
+            "risks": [
+                "LLM summary may omit details — the raw snapshot preserves everything",
+            ],
+            "confidence": 0.8,
+        }
+    )
+    return plan
 
 
 def build_working_context(messages: list, plan: dict) -> list:
@@ -672,6 +957,11 @@ def validate_working_context(
 # subsequent LLM call (it retries only after the history grows).
 _locks: dict[str, asyncio.Lock] = {}
 _last_attempt_len: dict[str, int] = {}
+# Smallest context window observed per agent this session (gateway combos
+# rotate real models) and agents already loudly alerted about an unknown
+# window (alert once per session, not once per LLM call).
+_min_window_seen: dict[str, int] = {}
+_window_unknown_alerted: set[str] = set()
 
 
 def _lock_for(agent_name: str) -> asyncio.Lock:
@@ -686,6 +976,9 @@ def reset_compaction_guards() -> None:
     """Test hook: clear per-agent memo/locks."""
     _locks.clear()
     _last_attempt_len.clear()
+    _min_window_seen.clear()
+    _window_unknown_alerted.clear()
+    _compactor_llm_cache.clear()
 
 
 def _emit_status(cfg: CompactionConfig, event_type: str, agent_name: str, run_id: str, data: dict) -> None:
@@ -716,6 +1009,51 @@ def _emit_status(cfg: CompactionConfig, event_type: str, agent_name: str, run_id
         logger.debug("[COMPACT] progress push failed: %s", exc)
 
 
+def _alert_window_unknown(
+    agent: Any,
+    history: list,
+    cfg: CompactionConfig,
+    *,
+    agent_name: str,
+    run_id: str,
+    session_id: str | None,
+    team_name: str | None,
+) -> None:
+    """Surface "auto-compaction cannot run: window unknown" everywhere the
+    operator looks: ERROR log, a failed event row (shows inline on the
+    agent's Context Versions tab), and the SSE failure toast.
+    """
+    if agent_name in _window_unknown_alerted:
+        return
+    _window_unknown_alerted.add(agent_name)
+    model = None
+    try:
+        model = getattr(getattr(agent, "usage_accumulator", None), "model", None)
+    except Exception:
+        pass
+    error = (
+        f"context window unknown for model '{model or 'unknown'}' — auto-compaction is OFF "
+        "for this agent. Fix: set max_context_tokens in Settings → Context Compaction, "
+        "or use a model known to ModelDatabase. (The window is auto-detected from the "
+        "first provider response when the gateway reports a known serving model.)"
+    )
+    logger.error("[COMPACT] %s (%s)", error, agent_name)
+    try:
+        from services.context_persistence import save_compaction_event
+
+        save_compaction_event(
+            agent_name=agent_name, run_id=run_id, session_id=session_id,
+            team_name=team_name, status="failed", error_message=error,
+            trigger="auto_threshold",
+            message_count_before=len(history),
+            estimated_tokens_before=estimate_tokens(history),
+            policy_version=POLICY_VERSION,
+        )
+    except Exception as exc:
+        logger.debug("[COMPACT] window-unknown event not recorded: %s", exc)
+    _emit_status(cfg, "context_compaction_failed", agent_name, run_id, {"error": error})
+
+
 async def maybe_compact_agent(
     agent: Any,
     *,
@@ -740,9 +1078,27 @@ async def maybe_compact_agent(
         if len(history) < cfg.keep_recent_messages + _MIN_MIDDLE_MESSAGES:
             return None
 
-        if reason != "manual":
-            limit = _context_token_limit(agent, cfg)
+        if reason not in ("manual", "context_overflow"):
+            limit = _context_token_limit(agent, cfg, agent_name)
             current, source = _current_context_tokens(agent, history)
+            if limit is None:
+                # Window not configured and not yet detected. Before the
+                # FIRST provider response the serving-model window is
+                # simply unknown *yet* (it is read from response.model
+                # after a call) — not a misconfiguration, so stay silent
+                # and recheck next call. Only once a response has arrived
+                # (source == "provider") and the window is STILL unknown
+                # do we fail LOUD — a guessed limit either compacts
+                # prematurely or never, so we surface the misconfig
+                # (log + failed event + SSE toast) once per agent/session
+                # rather than silently guessing.
+                if source == "provider":
+                    _alert_window_unknown(
+                        agent, history, cfg,
+                        agent_name=agent_name, run_id=run_id,
+                        session_id=session_id, team_name=team_name,
+                    )
+                return None
             if current < limit * cfg.compact_at_ratio:
                 return None
             if _last_attempt_len.get(agent_name) == len(history):
@@ -788,9 +1144,10 @@ async def _run_compaction(
     #    too-small middle zone must be a silent no-op — emitting
     #    ``started`` here with no terminal event would leave the UI
     #    banner stuck, and snapshotting would write an orphan raw row
-    #    on every LLM call. The planner is deterministic, so a
-    #    feasibility pass with a placeholder snapshot id is exact.
-    if plan_compaction(history, cfg, raw_snapshot_id=None) is None:
+    #    on every LLM call. ``_plan_zones`` is deterministic and
+    #    LLM-free, so this stays a cheap pre-check (no compactor call
+    #    is spent on a history that has nothing to compact).
+    if _plan_zones(history, cfg) is None:
         logger.info("[COMPACT] Nothing to compact for %s (middle zone too small)", agent_name)
         return None
 
@@ -832,14 +1189,25 @@ async def _run_compaction(
         if raw_snapshot_id is None:
             return _fail("raw snapshot could not be saved — compaction aborted")
 
-        # 2. Plan (rule-based compactor) — same inputs as the
-        #    feasibility pass, now with the real snapshot id for the
-        #    summary's raw references. Deterministic, so it cannot be
-        #    None here; guard anyway so a planner regression still
-        #    produces a terminal event.
-        plan = plan_compaction(history, cfg, raw_snapshot_id)
+        # 2. Plan — the LLM compactor (dedicated compactor agent, or the
+        #    origin agent's own LLM when ``compactor_model`` is unset) is
+        #    THE only compactor: it reads the dropped turns, so the
+        #    summary actually carries the task state. There is NO
+        #    rule-based fallback — a compaction that cannot run fails LOUD
+        #    (failed event + SSE toast); the agent continues on the raw
+        #    context (and, for overflow, the original error then
+        #    propagates). Silently substituting a semantically-blind
+        #    summary would hide the outage and is exactly what the
+        #    product decision rejects.
+        try:
+            plan = await plan_compaction_llm(
+                agent, history, cfg, raw_snapshot_id, agent_name=agent_name
+            )
+        except Exception as exc:
+            logger.warning("[COMPACT] LLM compactor failed for %s: %s", agent_name, exc)
+            return _fail(f"LLM compactor failed: {exc}")
         if plan is None:
-            return _fail("planner returned no plan after a feasible pre-check")
+            return _fail("LLM compactor produced no plan after a feasible pre-check")
 
         # 3. Build working context from copies.
         working = build_working_context(history, plan)
@@ -905,6 +1273,10 @@ def create_context_compaction_hooks():
     message_history. The pending delta is never touched; the imminent
     LLM call picks the compacted history up automatically because the
     provider payload is rebuilt from message_history on every call.
+
+    ``on_context_overflow`` hook: emergency compaction + single retry
+    when a call overflowed the serving model's window anyway (gateway
+    combos can route to a smaller model mid-conversation).
     """
     from fast_agent.agents.tool_runner import ToolRunnerHooks
 
@@ -923,7 +1295,36 @@ def create_context_compaction_hooks():
             # Never let compaction break the LLM call.
             logger.error("[COMPACT] before_llm_call hook error: %s", exc, exc_info=True)
 
-    return ToolRunnerHooks(before_llm_call=on_before_llm_call)
+    async def on_context_overflow(runner, error) -> bool:
+        """The LLM call overflowed the serving model's window (e.g. the
+        gateway routed to a smaller model mid-conversation). Compact NOW
+        — threshold and grow-memo bypassed — and let the runner reissue
+        the call on the rebuilt payload. False propagates the error.
+        """
+        try:
+            from services.sse_progress import current_run_id, normalize_agent_name
+
+            agent = runner._agent
+            raw_name = getattr(agent, "name", "Agent")
+            logger.warning(
+                "[COMPACT] Context overflow for %s (%s) — attempting emergency compaction",
+                raw_name, error,
+            )
+            stats = await maybe_compact_agent(
+                agent,
+                agent_name=normalize_agent_name(raw_name),
+                run_id=current_run_id.get() or "",
+                reason="context_overflow",
+            )
+            return stats is not None
+        except Exception as exc:
+            logger.error("[COMPACT] on_context_overflow hook error: %s", exc, exc_info=True)
+            return False
+
+    return ToolRunnerHooks(
+        before_llm_call=on_before_llm_call,
+        on_context_overflow=on_context_overflow,
+    )
 
 
 def attach_compaction_hooks_to_all(agent_app) -> int:

--- a/backend/services/sse_progress.py
+++ b/backend/services/sse_progress.py
@@ -578,4 +578,8 @@ def merge_hooks(a: ToolRunnerHooks, b: ToolRunnerHooks) -> ToolRunnerHooks:
             if a.after_turn_complete or b.after_turn_complete else None,
         on_pause_cancel=(lambda r: _any_true(a.on_pause_cancel, b.on_pause_cancel, r))
             if a.on_pause_cancel or b.on_pause_cancel else None,
+        # OR'd like on_pause_cancel: the first hook that handled the
+        # overflow (returned True) wins and the LLM call is reissued.
+        on_context_overflow=(lambda r, e: _any_true(a.on_context_overflow, b.on_context_overflow, r, e))
+            if a.on_context_overflow or b.on_context_overflow else None,
     )

--- a/backend/tests/test_services/test_context_compaction.py
+++ b/backend/tests/test_services/test_context_compaction.py
@@ -24,7 +24,6 @@ from services.context_compaction import (
     build_working_context,
     estimate_tokens,
     maybe_compact_agent,
-    plan_compaction,
     reset_compaction_guards,
     validate_config_updates,
     validate_working_context,
@@ -47,11 +46,11 @@ def text_msg(role: str, text: str, *, is_template: bool = False) -> PromptMessag
     )
 
 
-def tool_pair(call_id: str, name: str, result_text: str, *, is_error: bool = False):
+def tool_pair(call_id: str, name: str, result_text: str, *, is_error: bool = False, arguments=None):
     """(assistant tool_calls msg, user tool_results msg) with matching id."""
     call = CallToolRequest(
         method="tools/call",
-        params=CallToolRequestParams(name=name, arguments={"q": "x"}),
+        params=CallToolRequestParams(name=name, arguments=arguments or {"q": "x"}),
     )
     assistant = PromptMessageExtended(role="assistant", tool_calls={call_id: call})
     result = CallToolResult(
@@ -103,7 +102,10 @@ class FakeAgent:
         self.name = name
         self._history = list(messages)
         self.usage_accumulator = usage
-        self.llm = None
+        # Compaction is LLM-first for every reason — give every fake
+        # agent a working compactor LLM; tests for the no-LLM paths set
+        # ``agent._llm = None`` explicitly.
+        self._llm = FakeCompactorLLM()
 
     @property
     def message_history(self):
@@ -114,12 +116,24 @@ class FakeAgent:
 
 
 # ── Planner ──
+#
+# Compaction is LLM-only. ``make_plan`` drives the real ``plan_compaction_llm``
+# with a FakeCompactorLLM (a valid all-sections summary), so the structural
+# machinery (zones, build, validate, truncation) is exercised exactly as in
+# production. Pure-structure assertions hit ``_plan_zones`` directly.
+
+
+def make_plan(msgs, cfg, raw_snapshot_id=1):
+    agent = FakeAgent(msgs, usage=FakeUsage())
+    return asyncio.run(
+        cc.plan_compaction_llm(agent, msgs, cfg, raw_snapshot_id, agent_name="planner")
+    )
 
 
 def test_plan_keeps_templates_and_recent_tail():
     msgs = build_history()
     cfg = cfg_with(keep_recent_messages=4)
-    plan = plan_compaction(msgs, cfg, raw_snapshot_id=1)
+    plan = make_plan(msgs, cfg)
     assert plan is not None
     keep = set(plan["keep_verbatim"])
     # Templates (0,1) kept; last 4 (pair-safe) kept; middle dropped.
@@ -128,18 +142,20 @@ def test_plan_keeps_templates_and_recent_tail():
     assert plan["delete_from_working_context"]
     assert set(plan["delete_from_working_context"]).isdisjoint(keep)
     assert plan["summary_message"].startswith(SUMMARY_MARKER)
+    assert plan["compactor"] == "llm"
 
 
 def test_pair_safe_cut_never_splits_tool_pair():
     msgs = build_history()
     # keep_recent=3 would cut between assistant(tool_calls) and its
-    # user(tool_results) for some histories — the planner must extend
+    # user(tool_results) for some histories — the zone planner must extend
     # the tail until every tool_result's owner is inside it.
     for keep_recent in range(2, 9):
-        plan = plan_compaction(msgs, cfg_with(keep_recent_messages=keep_recent), 1)
-        if plan is None:
+        zones = cc._plan_zones(msgs, cfg_with(keep_recent_messages=keep_recent))
+        if zones is None:
             continue
-        keep = set(plan["keep_verbatim"])
+        _h, _t, keep_list, _middle = zones
+        keep = set(keep_list)
         owned = set()
         for idx in sorted(keep):
             for cid in (msgs[idx].tool_calls or {}):
@@ -155,27 +171,49 @@ def test_latest_user_request_forced_into_keep():
     for i in range(10, 16):
         a, u = tool_pair(f"call_{i}", "tool_x", "r" * 200)
         msgs.extend([a, u])
-    plan = plan_compaction(msgs, cfg_with(keep_recent_messages=4), 1)
-    assert plan is not None
+    zones = cc._plan_zones(msgs, cfg_with(keep_recent_messages=4))
+    assert zones is not None
+    keep = zones[2]
     latest_user_idx = max(
         i for i, m in enumerate(msgs)
         if str(m.role) == "user" and not m.tool_results
     )
-    assert latest_user_idx in plan["keep_verbatim"]
+    assert latest_user_idx in keep
 
 
 def test_no_plan_when_middle_too_small():
     msgs = build_history(n_pairs=1)
-    assert plan_compaction(msgs, cfg_with(keep_recent_messages=10), 1) is None
+    assert cc._plan_zones(msgs, cfg_with(keep_recent_messages=10)) is None
 
 
 # ── Build + validate ──
 
 
+def test_summary_is_faithful_and_non_steering():
+    # The summary must compress, not steer: it carries the actual goal and
+    # is labelled as compressed history, with NO injected directive telling
+    # the agent to continue/stop/wait. The agent decides for itself from
+    # the goal + verbatim recent messages — so the compactor works for any
+    # task state (in-progress, done, or blocked) without overfitting.
+    msgs = build_history()
+    plan = make_plan(msgs, cfg_with(keep_recent_messages=4))
+    summary = plan["summary_message"]
+    assert summary.startswith(SUMMARY_MARKER)
+    # Faithful: the real latest user instruction is the goal.
+    assert "Now summarize what you found" in summary
+    # Labelled as compressed history (descriptive), not an instruction.
+    assert "compressed summary of earlier turns" in summary
+    # No hardcoded steering verdict in either direction.
+    low = summary.lower()
+    for steer in ("do not stop", "keep going", "task is complete", "task is finished",
+                  "you are mid-task", "await the user", "task complete"):
+        assert steer not in low, f"summary should not steer: {steer!r}"
+
+
 def test_working_context_roundtrips_and_validates():
     msgs = build_history()
     cfg = cfg_with(keep_recent_messages=4)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     working = build_working_context(msgs, plan)
     assert validate_working_context(msgs, working, cfg) == []
     # Round-trip through the canonical serializer.
@@ -192,7 +230,7 @@ def test_working_context_roundtrips_and_validates():
 def test_validation_rejects_dropped_latest_user():
     msgs = build_history()
     cfg = cfg_with(keep_recent_messages=4)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     working = build_working_context(msgs, plan)
     bad = [m for m in working if "Now summarize what you found" not in (
         m.content[0].text if m.content else "")]
@@ -203,7 +241,7 @@ def test_validation_rejects_dropped_latest_user():
 def test_validation_rejects_broken_tool_pairing():
     msgs = build_history()
     cfg = cfg_with(keep_recent_messages=4)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     working = build_working_context(msgs, plan)
     # Drop one tool_results message that pairs an earlier tool_calls.
     victim = next(
@@ -217,7 +255,7 @@ def test_validation_rejects_broken_tool_pairing():
 def test_validation_rejects_missing_summary_sections():
     msgs = build_history()
     cfg = cfg_with(keep_recent_messages=4)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     plan["summary_message"] = SUMMARY_MARKER + "\n\nCurrent goal:\nonly this"
     working = build_working_context(msgs, plan)
     errors = validate_working_context(msgs, working, cfg)
@@ -227,7 +265,7 @@ def test_validation_rejects_missing_summary_sections():
 def test_validation_rejects_template_removal():
     msgs = build_history()
     cfg = cfg_with(keep_recent_messages=4)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     working = build_working_context(msgs, plan)
     bad = [m for m in working if not m.is_template]
     errors = validate_working_context(msgs, bad, cfg)
@@ -237,7 +275,7 @@ def test_validation_rejects_template_removal():
 def test_validation_rejects_insufficient_savings():
     msgs = build_history()
     cfg = cfg_with(keep_recent_messages=4, min_savings_ratio=0.99)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     working = build_working_context(msgs, plan)
     errors = validate_working_context(msgs, working, cfg)
     assert any("savings below minimum" in e for e in errors)
@@ -255,7 +293,7 @@ def test_oversized_tail_tool_result_truncated_except_final():
     final = text_msg("assistant", "done with big tool")
     msgs.extend([a, u, final])
     cfg = cfg_with(keep_recent_messages=4, max_tool_result_tokens_in_context=500)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     assert any(e["action"] == "truncate_tool_result" for e in plan["summarize"])
     working = build_working_context(msgs, plan)
     truncated = next(m for m in working if m.tool_results and "call_huge" in m.tool_results)
@@ -445,7 +483,7 @@ def test_truncation_flag_is_per_block_not_joined(reg_db):
     msgs.append(PromptMessageExtended(role="user", tool_results={"call_multi": result}))
     msgs.append(text_msg("assistant", "done"))
     cfg = cfg_with(keep_recent_messages=4, max_tool_result_tokens_in_context=500)
-    plan = plan_compaction(msgs, cfg, 1)
+    plan = make_plan(msgs, cfg)
     flagged = [e for e in plan["summarize"] if e["call_id"] == "call_multi"]
     assert flagged == []  # joined 7500 chars > 2000, but each block is 1500 < 2000
 
@@ -552,3 +590,368 @@ def test_estimate_tokens_monotonic():
     big = [text_msg("user", "hi" * 1000)]
     assert estimate_tokens(big) > estimate_tokens(small) > 0
     assert estimate_tokens([]) == 0
+
+
+# ── Serving-model window detection + min-window tracking (Tier 1) ──
+
+
+def test_resolve_serving_model_window_handles_gateway_dot_names():
+    from fast_agent.llm.provider.openai.llm_openai import _resolve_serving_model_window
+
+    # 9router reports dotted versions; database keys use dashes.
+    assert _resolve_serving_model_window("claude-sonnet-4.5") == 200000
+    assert _resolve_serving_model_window("gpt-5.5") == 272000
+    # Unknown alias (the requested combo name) stays unresolved.
+    assert _resolve_serving_model_window("coding-agent") is None
+    assert _resolve_serving_model_window(None) is None
+
+
+def test_context_token_limit_tracks_min_window_across_rotation():
+    reset_compaction_guards()
+    cfg = cfg_with()
+    agent = FakeAgent(build_history(), usage=FakeUsage(current=0, window=272000))
+    assert cc._context_token_limit(agent, cfg, "RotA") == 272000
+    # Gateway routes to a smaller model → threshold follows immediately.
+    agent.usage_accumulator.context_window_size = 200000
+    assert cc._context_token_limit(agent, cfg, "RotA") == 200000
+    # Rotation back to the big model must NOT raise the threshold again —
+    # the next call could still land on the small model.
+    agent.usage_accumulator.context_window_size = 272000
+    assert cc._context_token_limit(agent, cfg, "RotA") == 200000
+    # Window temporarily unknown → last known minimum, not the fallback.
+    agent.usage_accumulator.context_window_size = None
+    assert cc._context_token_limit(agent, cfg, "RotA") == 200000
+    reset_compaction_guards()
+
+
+def test_context_token_limit_unknown_is_none_and_explicit_override():
+    reset_compaction_guards()
+    agent = FakeAgent(build_history(), usage=FakeUsage(current=0, window=None))
+    # No invented fallback: unknown window must be None (caller fails loud).
+    assert cc._context_token_limit(agent, cfg_with(), "FreshAgent") is None
+    # Explicit config beats detection entirely.
+    assert (
+        cc._context_token_limit(agent, cfg_with(max_context_tokens=50000), "FreshAgent")
+        == 50000
+    )
+    reset_compaction_guards()
+
+
+def test_window_unknown_before_first_response_is_silent(reg_db, monkeypatch, sse_spy):
+    # current=0 → no provider response yet → the serving-model window is
+    # simply not detected *yet*, not a misconfig. Must be a silent no-op:
+    # no failed event, no scary toast on the user's first message.
+    msgs = build_history()
+    agent = FakeAgent(msgs, usage=FakeUsage(current=0, window=None))
+    assert run_compact(agent, monkeypatch) is None
+    assert get_compaction_events_meta(agent.name, limit=10) == []
+    assert not any(e["event_type"] == "context_compaction_failed" for e in sse_spy)
+
+
+def test_window_unknown_fails_loud_once_and_skips_compaction(reg_db, monkeypatch, sse_spy):
+    # current>0 → a provider response HAS arrived but the window is still
+    # unknown → genuine misconfig → fail loud.
+    msgs = build_history()
+    agent = FakeAgent(msgs, usage=FakeUsage(current=110000, window=None))
+    before_json = to_json(agent.message_history)
+
+    assert run_compact(agent, monkeypatch) is None
+    # History untouched — no compaction against a guessed limit.
+    assert to_json(agent.message_history) == before_json
+    # LOUD: one failed event row visible on the dashboard…
+    events = get_compaction_events_meta(agent.name, limit=10)
+    assert len(events) == 1
+    assert events[0]["status"] == "failed"
+    assert "context window unknown" in events[0]["error_message"]
+    # …and the SSE failure toast fired.
+    assert any(e["event_type"] == "context_compaction_failed" for e in sse_spy)
+
+    # Alerted once per session, not once per LLM call.
+    assert run_compact(agent, monkeypatch) is None
+    assert len(get_compaction_events_meta(agent.name, limit=10)) == 1
+
+
+# ── context_overflow reason: bypass + LLM compactor + fallback ──
+
+
+class FakeCompactorLLM:
+    """Stands in for agent._llm: returns per-call JSON chunk summaries."""
+
+    def __init__(self, garbage=False):
+        self._stream_listeners = {"chat-ui-listener"}
+        self._tool_stream_listeners = {"tool-listener"}
+        self.garbage = garbage
+        self.prompts: list[str] = []
+        self.listeners_during_call: list[set] = []
+
+    async def generate(self, messages, request_params=None, tools=None):
+        self.listeners_during_call.append(set(self._stream_listeners))
+        self.prompts.append(messages[0].content[0].text)
+        n = len(self.prompts)
+        if self.garbage:
+            text = "I am not JSON at all, sorry."
+        else:
+            text = json.dumps(
+                {
+                    "goal": [f"research topic X (part {n})"],
+                    "constraints": [],
+                    "architecture_facts": [],
+                    "decisions": [f"decision-from-part-{n}"],
+                    "tool_findings": [f"finding-from-part-{n}"],
+                    "errors": [],
+                    "file_references": [f"/llm/seen/part-{n}.py"],
+                    "state": [f"state-{n}"],
+                    "next_actions": ["continue"],
+                }
+            )
+        return text_msg("assistant", text)
+
+
+def test_overflow_reason_bypasses_threshold_and_memo(reg_db, monkeypatch):
+    msgs = build_history()
+    # current=1000 is far below any threshold — auto would be a no-op.
+    agent = FakeAgent(msgs, usage=FakeUsage(current=1000, window=120000))
+    assert run_compact(agent, monkeypatch) is None  # proves below threshold
+
+    stats = run_compact(agent, monkeypatch, reason="context_overflow")
+    assert stats is not None
+    conn = sqlite3.connect(reg_db)
+    trigger = conn.execute(
+        "SELECT trigger FROM context_compaction_events WHERE id = ?",
+        (stats["event_id"],),
+    ).fetchone()[0]
+    conn.close()
+    assert trigger == "context_overflow"
+
+
+def test_overflow_respects_disabled_setting(reg_db, monkeypatch):
+    agent = FakeAgent(build_history(), usage=FakeUsage(current=1000))
+    cfg = _trigger_cfg(enabled=False)
+    assert run_compact(agent, monkeypatch, cfg=cfg, reason="context_overflow") is None
+
+
+def test_overflow_uses_llm_compactor_and_restores_listeners(reg_db, monkeypatch):
+    msgs = build_history()
+    agent = FakeAgent(msgs, usage=FakeUsage(current=1000, window=120000))
+    llm = FakeCompactorLLM()
+    agent._llm = llm
+
+    stats = run_compact(agent, monkeypatch, reason="context_overflow")
+    assert stats is not None
+    assert len(llm.prompts) >= 1
+
+    # Stream listeners were detached during the side-channel call and
+    # restored afterwards (compactor tokens must not leak into chat).
+    assert all(seen == set() for seen in llm.listeners_during_call)
+    assert llm._stream_listeners == {"chat-ui-listener"}
+    assert llm._tool_stream_listeners == {"tool-listener"}
+
+    conn = sqlite3.connect(reg_db)
+    plan_json, summary = conn.execute(
+        "SELECT plan_json, summary_message FROM context_compaction_events WHERE id = ?",
+        (stats["event_id"],),
+    ).fetchone()
+    conn.close()
+    plan = json.loads(plan_json)
+    assert plan["compactor"] == "llm"
+    assert "decision-from-part-1" in summary
+    # The applied working context carries the LLM summary.
+    texts = [(m.content[0].text if m.content else "") for m in agent.message_history]
+    assert any(t.startswith(SUMMARY_MARKER) and "decision-from-part-1" in t for t in texts)
+
+
+def test_overflow_llm_garbage_fails_loud_no_rule_fallback(reg_db, monkeypatch):
+    # Compaction is LLM-only: unparseable compactor output is a visible
+    # failed event, NOT a silent downgrade to a rule-based summary. The
+    # overflowing call then fails (the hook returns False → error
+    # propagates), which is the honest outcome.
+    msgs = build_history()
+    agent = FakeAgent(msgs, usage=FakeUsage(current=1000, window=120000))
+    agent._llm = FakeCompactorLLM(garbage=True)
+    before_json = to_json(agent.message_history)
+
+    stats = run_compact(agent, monkeypatch, reason="context_overflow")
+    assert stats is None
+    assert to_json(agent.message_history) == before_json  # untouched
+    events = get_compaction_events_meta(agent.name, limit=10)
+    assert len(events) == 1
+    assert events[0]["status"] == "failed"
+    assert "LLM compactor failed" in events[0]["error_message"]
+
+
+def test_overflow_without_llm_fails_loud(reg_db, monkeypatch):
+    # No LLM and no compactor_model → no compactor → fail loud (no
+    # rule-based rescue exists anymore).
+    agent = FakeAgent(build_history(), usage=FakeUsage(current=1000, window=120000))
+    agent._llm = None
+    stats = run_compact(agent, monkeypatch, reason="context_overflow")
+    assert stats is None
+    events = get_compaction_events_meta(agent.name, limit=10)
+    assert events and events[0]["status"] == "failed"
+
+
+def test_threshold_llm_failure_fails_loud_no_rule_fallback(reg_db, monkeypatch):
+    """Auto-threshold compaction is LLM-only: a compactor failure must be
+    a visible failed event, NOT a silent quality downgrade to rule-based."""
+    msgs = build_history()
+    agent = FakeAgent(msgs, usage=FakeUsage(current=110000, window=120000))
+    agent._llm = FakeCompactorLLM(garbage=True)
+    before_json = to_json(agent.message_history)
+
+    assert run_compact(agent, monkeypatch) is None
+    assert to_json(agent.message_history) == before_json  # untouched
+    events = get_compaction_events_meta(agent.name, limit=10)
+    assert len(events) == 1
+    assert events[0]["status"] == "failed"
+    assert "LLM compactor failed" in events[0]["error_message"]
+
+
+def test_compactor_model_uses_dedicated_llm_not_origin(reg_db, monkeypatch):
+    """compactor_model set → the dedicated compactor agent does the work;
+    the origin agent's own LLM is never called (spec: separate compactor
+    component/agent)."""
+    msgs = build_history()
+    agent = FakeAgent(msgs, usage=FakeUsage(current=110000, window=120000))
+    origin_llm = FakeCompactorLLM(garbage=True)  # would fail if used
+    agent._llm = origin_llm
+    dedicated = FakeCompactorLLM()
+    monkeypatch.setitem(cc._compactor_llm_cache, "big-window-model", dedicated)
+
+    cfg = _trigger_cfg(compactor_model="big-window-model")
+    stats = run_compact(agent, monkeypatch, cfg=cfg)
+    assert stats is not None
+    assert len(dedicated.prompts) >= 1
+    assert origin_llm.prompts == []
+
+    conn = sqlite3.connect(reg_db)
+    plan_json = conn.execute(
+        "SELECT plan_json FROM context_compaction_events WHERE id = ?",
+        (stats["event_id"],),
+    ).fetchone()[0]
+    conn.close()
+    plan = json.loads(plan_json)
+    assert plan["compactor"] == "llm"
+    assert plan["compactor_model"] == "big-window-model"
+
+
+def test_summary_keeps_file_references_from_both_sources(reg_db, monkeypatch):
+    """File references survive compaction: paths the LLM lists AND paths
+    deterministically scanned from tool-call arguments."""
+    msgs = [
+        text_msg("user", "SYSTEM TEMPLATE", is_template=True),
+        text_msg("user", "Refactor the voice module"),
+    ]
+    a, u = tool_pair(
+        "call_read", "Read", "file contents here " + "x" * 400,
+        arguments={"file_path": "/repo/backend/services/webrtc_voice.py"},
+    )
+    msgs.extend([a, u])
+    for i in range(6):
+        a, u = tool_pair(f"call_{i}", "Bash", f"result {i}: " + "x" * 400)
+        msgs.extend([a, u])
+    msgs.append(text_msg("user", "Now summarize"))
+    msgs.append(text_msg("assistant", "Working on it"))
+
+    agent = FakeAgent(msgs, usage=FakeUsage(current=110000, window=120000))
+    stats = run_compact(agent, monkeypatch)
+    assert stats is not None
+    summary = next(
+        m.content[0].text for m in agent.message_history
+        if m.content and m.content[0].text.startswith(SUMMARY_MARKER)
+    )
+    files_section = summary.split("File references:")[1].split("Recent state:")[0]
+    assert "/repo/backend/services/webrtc_voice.py" in files_section  # deterministic scan
+    assert "/llm/seen/part-1.py" in files_section  # LLM-extracted
+
+
+# ── Pair-safe chunking + map-reduce merge ──
+
+
+def _chunk_pairing_ok(messages, chunk):
+    calls, results = set(), set()
+    for i in chunk:
+        calls |= set(getattr(messages[i], "tool_calls", None) or {})
+        results |= set(getattr(messages[i], "tool_results", None) or {})
+    return calls == results
+
+
+def test_pair_safe_chunks_never_split_tool_pairs():
+    msgs = build_history(n_pairs=12, filler_chars=400)
+    cfg = cfg_with(keep_recent_messages=4)
+    zones = cc._plan_zones(msgs, cfg)
+    assert zones is not None
+    _h, _t, _keep, middle = zones
+
+    chunks = cc._pair_safe_chunks(msgs, middle, chunk_tokens=120)
+    assert len(chunks) >= 2
+    assert [i for c in chunks for i in c] == middle  # order + completeness
+    for chunk in chunks:
+        assert _chunk_pairing_ok(msgs, chunk)
+
+
+def test_chunked_map_reduce_merges_all_parts(reg_db, monkeypatch):
+    msgs = build_history(n_pairs=12, filler_chars=400)
+    # Small window so the configured input ratio yields tiny chunks and
+    # forces the map-reduce path.
+    agent = FakeAgent(msgs, usage=FakeUsage(current=1000, window=1500))
+    llm = FakeCompactorLLM()
+    agent._llm = llm
+    monkeypatch.setattr(cc, "_COMPACTOR_MIN_CHUNK_TOKENS", 120)
+
+    cfg = _trigger_cfg(compactor_input_ratio=0.1)
+    plan = asyncio.run(
+        cc.plan_compaction_llm(agent, msgs, cfg, raw_snapshot_id=7, agent_name=agent.name)
+    )
+    assert plan is not None
+    assert plan["compactor"] == "llm"
+    assert plan["compactor_chunks"] == len(llm.prompts) >= 2
+
+    # Items from the FIRST and LAST chunks both survive the merge.
+    summary = plan["summary_message"]
+    assert "decision-from-part-1" in summary
+    assert f"decision-from-part-{len(llm.prompts)}" in summary
+
+    # The merged plan passes the same backend validation.
+    working = build_working_context(msgs, plan)
+    assert validate_working_context(msgs, working, cfg) == []
+
+
+# ── on_context_overflow hook wiring ──
+
+
+def test_on_context_overflow_hook_compacts_and_reports_true(reg_db, monkeypatch):
+    from types import SimpleNamespace
+
+    msgs = build_history()
+    agent = FakeAgent(msgs, usage=FakeUsage(current=1000, window=120000))
+    monkeypatch.setattr(cc, "get_compaction_config", lambda: _trigger_cfg())
+    hooks = cc.create_context_compaction_hooks()
+    assert hooks.on_context_overflow is not None
+
+    handled = asyncio.run(
+        hooks.on_context_overflow(
+            SimpleNamespace(_agent=agent),
+            Exception("This model's maximum context length is 200000 tokens"),
+        )
+    )
+    assert handled is True
+    texts = [(m.content[0].text if m.content else "") for m in agent.message_history]
+    assert any(t.startswith(SUMMARY_MARKER) for t in texts)
+
+
+def test_on_context_overflow_hook_returns_false_when_nothing_to_compact(reg_db, monkeypatch):
+    from types import SimpleNamespace
+
+    # History too small to compact → hook must say False so the error
+    # propagates instead of a futile retry.
+    msgs = build_history(n_pairs=0)
+    agent = FakeAgent(msgs, usage=FakeUsage(current=1000, window=120000))
+    monkeypatch.setattr(cc, "get_compaction_config", lambda: _trigger_cfg())
+    hooks = cc.create_context_compaction_hooks()
+
+    handled = asyncio.run(
+        hooks.on_context_overflow(
+            SimpleNamespace(_agent=agent), Exception("prompt is too long")
+        )
+    )
+    assert handled is False

--- a/docs/context-compaction-versioned-visibility-spec.md
+++ b/docs/context-compaction-versioned-visibility-spec.md
@@ -368,3 +368,110 @@ Shipped in `backend/services/context_compaction.py` + `backend/routes/context_co
 9. **Scope**: the `before_llm_call` hook is attached to **in-process agents** (chat path), mirroring the always-on token-persistence hook. Subprocess team agents are not hooked in v1 — they still benefit via the resume path (newest raw/working). `promote_to_memory` stays in the plan contract but is always empty, and §8's "remove pinned messages" validation rule is dropped — no memory or pinning subsystem exists anywhere in the repo to source either from. `tool_result_artifacts` (spec §5 "optional later") is deferred — `raw_references` point at (raw_snapshot_id, message index range).
 
 10. **Failed compactions are recorded, never disruptive**: any planner/validator/apply error writes a `status='failed'` event row, emits `context_compaction_failed`, and leaves the live history untouched (the working context is built from deep copies and applied in one `load_message_history()` call only after validation passes).
+
+## 17. Overflow recovery + serving-model window detection (2026-06-11)
+
+Motivated by a field incident: the default model is a 9router **combo alias**
+(`openai.coding-agent`) unknown to ModelDatabase, so the auto window detection
+silently fell back to 120000 → threshold 84000 → repeated premature
+compactions at a real context of ~85–88K while the dashboard showed only the
+~24K history estimate. Combos also **rotate** between real models with
+different windows (observed: `claude-sonnet-4.5` 200K vs `gpt-5.5` 272K),
+which the static window assumption cannot survive.
+
+1. **Serving-model window detection (Tier 1).** OpenAI-compatible responses
+   carry the real serving model in `response.model` even when the request
+   used an alias. After every call the OpenAI provider resolves that name
+   through ModelDatabase (normalizing gateway dot-versions,
+   `claude-sonnet-4.5` → `claude-sonnet-4-5`) and updates
+   `usage_accumulator.set_context_window_size()` — unless an explicit
+   `context=1m`-style override is active. The threshold side
+   (`_context_token_limit`) tracks the **minimum window seen per agent per
+   session**: after a rotation to a smaller model the threshold never climbs
+   back, because the next call may land on the small model again. An UNKNOWN
+   window **fails loud instead of falling back**: auto-compaction is skipped
+   and the misconfiguration is surfaced once per agent per session (ERROR
+   log + a `status='failed'` event row on the Context Versions tab + the
+   SSE failure toast) — thresholding against an invented 120000 either
+   compacts prematurely or never, and the operator needs to know either
+   way. The 120000 constant survives only as a chunk-sizing default inside
+   the LLM compactor, where it affects efficiency, not policy.
+
+2. **Context-overflow recovery (reactive backstop).** Rotation can still
+   overflow mid-conversation (context built at 272K, next call lands on a
+   200K model). Overflow errors are classified **fatal** in the provider
+   retry loop (`is_context_overflow_error` — retrying an identical payload is
+   futile) and propagate to the tool runner, where a new
+   `ToolRunnerHooks.on_context_overflow` hook runs
+   `maybe_compact_agent(reason="context_overflow")` — threshold and
+   grow-memo bypassed, `enabled=false` respected — and the LLM call is
+   reissued **once** on the rebuilt payload. A second consecutive overflow
+   propagates (compaction could not shrink below the window).
+
+3. **LLM compaction ONLY — the rule-based planner was removed entirely
+   (2026-06-11 final revision).** Earlier addenda kept a rule-based
+   compactor as the MVP/fallback (spec §3 "rule-based first"). The
+   product decision is that semantic preservation matters more than
+   speed/cost: a blind cut-and-paste summary silently loses the decisions
+   a resumed agent needs. So `plan_compaction`/`_build_summary` are gone;
+   `plan_compaction_llm` is the only planner. The structural helpers
+   (`_plan_zones`, `_tail_truncations`, `_plan_skeleton`,
+   `build_working_context`, `validate_working_context`) remain — they are
+   compactor-agnostic plumbing, not "rule-based compaction".
+
+   The compactor is a **dedicated LLM agent** built from the
+   `compactor_model` setting (Settings → Context Compaction; reuses the
+   origin agent's provider config/keys) — choose a larger-window model so
+   one call can feed more history at once. Empty setting = degraded
+   default: the origin agent's own LLM via an isolated side-channel call.
+
+   When the middle zone exceeds the compactor input budget
+   (`compactor_input_ratio ×` the COMPACTOR's window — UI-configurable,
+   default 0.7), it is split into **pair-safe chunks** (a cut never
+   separates a tool call from its result) summarized concurrently by
+   independent calls, then merged deterministically into the single
+   required summary message — no second LLM merge pass (extra cost, new
+   failure mode, no structural gain). Stream listeners are detached around
+   the whole batch so compactor tokens never leak into the live chat
+   stream.
+
+   **No fallback — fail loud everywhere** (addendum item 1's philosophy,
+   now applied without exception): if the compactor fails (no LLM, timeout,
+   unparseable JSON) the compaction is a `status='failed'` event + SSE
+   toast, and the agent continues on raw context. For overflow recovery
+   the `on_context_overflow` hook then returns False so the original
+   overflow error propagates — an honest failure beats a silently
+   degraded summary. Events record `compactor: "llm"` and
+   `compactor_model` in `plan_json`.
+
+4. **`File references:` summary section (new required section).** Paths the
+   agent read/edited must survive compaction so the resumed agent can
+   re-open its working set. Populated from BOTH sources, unioned: the
+   compactor LLM's `file_references` extraction AND a deterministic scan
+   of tool-call arguments (`_file_references`) — a path the model
+   overlooks still survives.
+
+5. **`compactor_input_ratio` config (UI-editable, range 0.1–0.9, default
+   0.7).** Fraction of the compactor's window one summary call may read.
+   Larger = fewer chunks (faster, cheaper) but riskier of overflowing the
+   compactor. Lives in the config DB like every other compaction setting.
+
+6. **Compactor is a FAITHFUL compressor, never a decision-maker
+   (2026-06-11).** Field incident: during a long "read many files" turn
+   the LLM compactor wrote `Recent state: read phase complete, awaiting
+   user's questions` / `Next actions: answer the user` — a verdict the
+   conversation did not support (the user had said "keep going"). The
+   resumed agent, trusting the summary, ended its turn with empty output.
+   Root cause: the prompt invited the model to JUDGE task state and
+   prescribe next steps. First fix attempt hardcoded a "you are mid-task,
+   do not stop" header — rejected as scenario-overfitting (it would force
+   the agent to fabricate work when a task is genuinely done). General
+   fix: the compactor prompt now forbids interpretation — record only what
+   the excerpt explicitly establishes, never decide whether the task is
+   complete or what to do next; "next_actions" stays empty unless the
+   conversation explicitly states pending steps. The summary header is
+   purely descriptive ("a faithful, compressed summary of earlier turns"),
+   with NO steering in either direction. Whether to continue, stop, or ask
+   the user remains the agent's decision, driven by the preserved goal +
+   verbatim recent messages exactly as with full history — so it adapts to
+   any task state instead of being hardcoded to one outcome.

--- a/frontend/src/views/settings/SettingsCompaction.vue
+++ b/frontend/src/views/settings/SettingsCompaction.vue
@@ -54,6 +54,12 @@ const NUMBER_FIELDS = [
     min: 0, max: 0.9, step: 0.01,
   },
   {
+    key: 'compactor_input_ratio',
+    label: 'Compactor input budget (ratio of compactor window)',
+    hint: 'Fraction of the compactor model’s window one summary call may read. Larger = fewer calls (faster) but riskier. 0.1–0.9.',
+    min: 0.1, max: 0.9, step: 0.05,
+  },
+  {
     key: 'snapshot_versions_visible',
     label: 'Versions shown in the dashboard',
     hint: 'Default number of compaction versions listed on the agent’s Context Versions tab.',
@@ -91,7 +97,9 @@ async function save() {
     for (const k of dirtyKeys.value) {
       patch[k] = typeof config.value[k] === 'boolean'
         ? Boolean(draft.value[k])
-        : Number(draft.value[k])
+        : typeof config.value[k] === 'number'
+          ? Number(draft.value[k])
+          : String(draft.value[k] ?? '').trim()
     }
     config.value = await apiFetch('/api/context-compaction/settings', {
       method: 'PATCH',
@@ -183,6 +191,22 @@ onMounted(load)
         />
       </div>
 
+      <div class="row">
+        <div class="row-info">
+          <h3>Compactor model</h3>
+          <p class="desc">
+            Dedicated compactor agent's model (e.g. a large-window model so one
+            call can summarize more history). Empty = use each agent's own model.
+          </p>
+        </div>
+        <input
+          v-model="draft.compactor_model"
+          class="text-input"
+          type="text"
+          placeholder="e.g. kr/gemini-2.5-pro"
+        />
+      </div>
+
       <div class="actions">
         <button class="save-btn" :disabled="!dirtyKeys.length || saving" @click="save">
           {{ saving ? 'Saving…' : 'Save Changes' }}
@@ -245,6 +269,21 @@ onMounted(load)
   font-size: 13px;
   font-family: var(--font-mono);
 }
+.text-input {
+  flex-shrink: 0;
+  width: 220px;
+  padding: 8px 10px;
+  background: var(--bg-4);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--font-mono);
+}
+.text-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
 .num-input:focus {
   outline: none;
   border-color: var(--primary);
@@ -301,6 +340,7 @@ onMounted(load)
 @media (max-width: 768px) {
   .row { flex-direction: column; gap: 10px; }
   .num-input { width: 100%; }
+  .text-input { width: 100%; }
   .toggle::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## What

Follow-up to #85 (backend-managed context compaction). Fixes the two issues found in manual testing and replaces the rule-based compactor with an LLM compactor.

> **Depends on omnigentx/fast-agent#9** — this PR bumps the `backend/fast-agent` submodule to that branch (overflow hook + serving-model window detection). Merge the fast-agent PR first, then re-point the submodule to its merged commit.

## Why (two field bugs)

**"Compacts at ~24K tokens"** — the model is a 9router combo alias (`coding-agent`) unknown to ModelDatabase, so window auto-detect silently fell back to 120K → threshold 84K → premature compaction. The dashboard showed the ~24K history estimate while the trigger used the real ~85K provider tokens.

**"Agent stops mid-task without finishing"** — after a mid-tool-loop compaction the LLM compactor wrote `Recent state: read phase complete, awaiting user's questions`, a verdict the conversation didn't support (user had said "keep going"). The resumed agent trusted it and ended its turn with empty output.

## Changes

**Window detection** — threshold reads the real window from the serving model the gateway reports (`response.model`, via fast-agent), tracking the **minimum window seen** per agent/session so a rotation to a smaller model can't overflow first. Unknown window **fails loud** (failed event + toast, once per agent) — but only *after* a provider response has arrived, so message 1 (window not detected yet) stays a silent no-op.

**Overflow recovery** — `on_context_overflow` hook runs an emergency compaction and reissues the call, so a gateway routing to a smaller-window model mid-task self-heals instead of erroring.

**LLM-only compaction** — a dedicated compactor agent (`compactor_model` setting, else the origin agent's own LLM) reads the dropped turns and writes the summary. The rule-based planner is **removed entirely**; a compactor failure fails loud, never silently downgrades. Large middle zones are split into **pair-safe chunks** (`compactor_input_ratio` × the compactor window), summarized concurrently and merged deterministically. New **`File references:`** summary section (LLM extraction ∪ deterministic tool-arg scan).

**Faithful compactor** — the prompt forbids interpretation: record only what the conversation establishes, never decide whether the task is complete or what to do next. The summary header is purely descriptive. Continue/stop/ask stays the **agent's** decision (driven by the preserved goal + verbatim recent messages) — so it adapts to any task state instead of being hardcoded.

**New UI settings**: `compactor_model`, `compactor_input_ratio`.

## Tests
- Backend: `test_context_compaction.py`, `test_context_compaction_routes.py` green (window-unknown-before-first-response silent; fail-loud-after-response; LLM-only fail-loud; dedicated compactor used; faithful/non-steering summary; map-reduce chunking; file references).
- E2E: `settings-compaction.spec.ts` green (new field, PATCH-only-changed, 422 inline).

## Verification gap (honest)
The faithful-compactor fix is prompt-level: unit tests prove the summary is faithful/non-steering structurally, but the *semantic* effect (agent continues vs stops correctly) needs a live re-test filling context to trigger compaction. Not exercisable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)