### PR TITLE
fix(memory): recall correctness — dense-after-forget-all, realtime chip, query-anchored GraphRAG

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -55,7 +55,9 @@ dependencies = [
 # SQLite FTS5 keyword search. The vector + graph store is LadybugDB (an embedded
 # dependency, not a separate container).
 memory = [
-  "FlagEmbedding>=1.4.0",   # BAAI/bge-m3 multilingual embeddings + reranker
+  "FlagEmbedding>=1.4.0",        # BAAI/bge-m3 (optional, still selectable)
+  "sentence-transformers>=3.0",  # Qwen3-Embedding (default) + bge-reranker-v2-m3 cross-encoder
+  "einops",                      # required by some sentence-transformers models
 ]
 
 [tool.uv]

--- a/backend/routes/memory_settings.py
+++ b/backend/routes/memory_settings.py
@@ -27,6 +27,7 @@ class MemorySettingsPatch(BaseModel):
     enabled: bool | None = None
     mode: str | None = None
     auto_capture_preferences: bool | None = None
+    extract_every_n: int | None = None
     approval_policy: str | None = None
     pinned_token_budget: int | None = None
     evidence_token_budget: int | None = None
@@ -37,10 +38,14 @@ class MemorySettingsPatch(BaseModel):
     embedding_model: str | None = None
     embedding_revision: str | None = None
     reranker_enabled: bool | None = None
+    rerank_model: str | None = None
+    rerank_top_k: int | None = None
+    rerank_min_score: float | None = None
     retention_episodic_days: int | None = None
     retention_retrieval_runs_days: int | None = None
     recall_min_similarity: float | None = None
     graph_max_hops: int | None = None
+    hub_max_df: float | None = None
     trigger_lexicon_overrides: dict | None = None
     quality_gate_thresholds: dict | None = None
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -513,37 +513,21 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("[MEMORY] ladybug migration check failed")
 
-    # Embedding-model migration: if the configured embedding model/revision differs
-    # from what the graph was last projected with, the stored vectors live in a
-    # DIFFERENT vector space (e.g. bge-m3 → Qwen3-Embedding) — query vectors (new
-    # model) vs stored vectors (old) compare as garbage and recall silently dies.
-    # We WIPE the graph (not re-embed in place): the HNSW index is built at
-    # CREATE_VECTOR_INDEX time and is effectively static (Kùzu/LadybugDB lineage),
-    # so re-embedding nodes in place does NOT reliably re-index them. The wipe makes
-    # count() < SQLite, so the rebuild we enqueue re-projects everything into a
-    # FRESH graph + index with the new model's vectors.
+    # Embedding-model migration: on a model/revision change, WIPE the graph + re-embed
+    # (the HNSW index is static — re-embedding in place leaves stale vectors). The
+    # helper guards on the new model's deps being installed BEFORE wiping (never
+    # self-inflict a dead graph). See consistency_service.migrate_on_embedding_change.
     try:
         if _mem_cfg and _mem_cfg.enabled:
-            from services.config_service import config_service
-            cur_rev = (_mem_cfg.embedding_revision or _mem_cfg.embedding_model or "")
-            prev_rev = config_service.get("memory", "indexed_embedding_revision")
-            if cur_rev and prev_rev != cur_rev:
-                import time as _t
+            import time as _t
 
-                from core.database import get_db_session
-                from services.indexing import consistency_service as cs
-                from services.indexing.ladybug_store import reset_ladybug_store
-                reset_ladybug_store(getattr(_mem_cfg, "ladybug_path", "data/memory_graph"))
-                _db = get_db_session()
-                try:
-                    enq = cs.rebuild(_db, now=_t.time())
-                finally:
-                    _db.close()
-                # Mark AFTER enqueue (the outbox intents persist across restarts, so
-                # a crash mid-drain just re-drains; the marker won't wrongly skip).
-                config_service.set("memory", "indexed_embedding_revision", cur_rev)
-                logger.info("[MEMORY] embedding model changed (%r → %r) → wiped graph + "
-                            "re-embedding %d records with the new model", prev_rev, cur_rev, enq)
+            from core.database import get_db_session
+            from services.indexing import consistency_service as cs
+            _db = get_db_session()
+            try:
+                cs.migrate_on_embedding_change(_db, _mem_cfg, now=_t.time())
+            finally:
+                _db.close()
     except Exception:
         logger.exception("[MEMORY] embedding-revision migration check failed")
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -513,6 +513,36 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("[MEMORY] ladybug migration check failed")
 
+    # Embedding-model migration: if the configured embedding model/revision differs
+    # from what the graph was last projected with, the stored vectors live in a
+    # DIFFERENT vector space (e.g. bge-m3 → Qwen3-Embedding) — query vectors (new
+    # model) vs stored vectors (old) compare as garbage and recall silently dies.
+    # Both are dim 1024, so we re-embed IN PLACE (rebuild → worker re-upserts each
+    # node with the new model's vector); no wipe/schema change. The under-populated
+    # check above misses this (count is unchanged), so it needs its own trigger.
+    try:
+        if _mem_cfg and _mem_cfg.enabled:
+            from services.config_service import config_service
+            cur_rev = (_mem_cfg.embedding_revision or _mem_cfg.embedding_model or "")
+            prev_rev = config_service.get("memory", "indexed_embedding_revision")
+            if cur_rev and prev_rev != cur_rev:
+                import time as _t
+
+                from core.database import get_db_session
+                from services.indexing import consistency_service as cs
+                _db = get_db_session()
+                try:
+                    enq = cs.rebuild(_db, now=_t.time())
+                finally:
+                    _db.close()
+                # Mark AFTER enqueue (the outbox intents persist across restarts, so
+                # a crash mid-drain just re-drains; the marker won't wrongly skip).
+                config_service.set("memory", "indexed_embedding_revision", cur_rev)
+                logger.info("[MEMORY] embedding model changed (%r → %r) → re-embedding "
+                            "%d records", prev_rev, cur_rev, enq)
+    except Exception:
+        logger.exception("[MEMORY] embedding-revision migration check failed")
+
     # Enable shell execution runtime (equivalent to --shell CLI flag)
     await fast.app.initialize()
     setattr(fast.app.context, "shell_runtime", True)

--- a/backend/server.py
+++ b/backend/server.py
@@ -517,9 +517,11 @@ async def lifespan(app: FastAPI):
     # from what the graph was last projected with, the stored vectors live in a
     # DIFFERENT vector space (e.g. bge-m3 → Qwen3-Embedding) — query vectors (new
     # model) vs stored vectors (old) compare as garbage and recall silently dies.
-    # Both are dim 1024, so we re-embed IN PLACE (rebuild → worker re-upserts each
-    # node with the new model's vector); no wipe/schema change. The under-populated
-    # check above misses this (count is unchanged), so it needs its own trigger.
+    # We WIPE the graph (not re-embed in place): the HNSW index is built at
+    # CREATE_VECTOR_INDEX time and is effectively static (Kùzu/LadybugDB lineage),
+    # so re-embedding nodes in place does NOT reliably re-index them. The wipe makes
+    # count() < SQLite, so the rebuild we enqueue re-projects everything into a
+    # FRESH graph + index with the new model's vectors.
     try:
         if _mem_cfg and _mem_cfg.enabled:
             from services.config_service import config_service
@@ -530,6 +532,8 @@ async def lifespan(app: FastAPI):
 
                 from core.database import get_db_session
                 from services.indexing import consistency_service as cs
+                from services.indexing.ladybug_store import reset_ladybug_store
+                reset_ladybug_store(getattr(_mem_cfg, "ladybug_path", "data/memory_graph"))
                 _db = get_db_session()
                 try:
                     enq = cs.rebuild(_db, now=_t.time())
@@ -538,8 +542,8 @@ async def lifespan(app: FastAPI):
                 # Mark AFTER enqueue (the outbox intents persist across restarts, so
                 # a crash mid-drain just re-drains; the marker won't wrongly skip).
                 config_service.set("memory", "indexed_embedding_revision", cur_rev)
-                logger.info("[MEMORY] embedding model changed (%r → %r) → re-embedding "
-                            "%d records", prev_rev, cur_rev, enq)
+                logger.info("[MEMORY] embedding model changed (%r → %r) → wiped graph + "
+                            "re-embedding %d records with the new model", prev_rev, cur_rev, enq)
     except Exception:
         logger.exception("[MEMORY] embedding-revision migration check failed")
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -479,6 +479,12 @@ async def lifespan(app: FastAPI):
                     "dense recall + knowledge graph are OFF, index writes will "
                     "defer, the graph will stay empty. Install the 'memory' extra "
                     "(FlagEmbedding) or disable memory to silence this.")
+            # Advisory: the recall gate is on the embedding's score scale (review #5).
+            from services.memory.settings import gate_mistuned_warning
+            _gw = gate_mistuned_warning(_mem_cfg.embedding_model, _mem_cfg.recall_min_similarity)
+            if _gw:
+                logger.warning("[MEMORY] recall gate may be mistuned for the embedding "
+                               "model: %s", _gw)
     except Exception:
         logger.exception("Failed to start memory index worker")
 

--- a/backend/services/indexing/consistency_service.py
+++ b/backend/services/indexing/consistency_service.py
@@ -47,6 +47,50 @@ def rebuild(db: Session, *, now: float) -> int:
     return count
 
 
+_MEMORY_CATEGORY = "memory"
+_EMBED_REV_KEY = "indexed_embedding_revision"
+
+
+def migrate_on_embedding_change(db: Session, cfg, *, now: float) -> dict:
+    """If the configured embedding model/revision differs from what the graph was
+    last projected with, WIPE the graph + re-project from SQLite so the HNSW index
+    is rebuilt over the NEW vectors (the index is static — in-place re-embed leaves
+    stale vectors). Returns what happened (for logging/tests).
+
+    GUARD (review #1): probe that the NEW model's backend is importable BEFORE
+    wiping. Otherwise a deploy that ships this code but hasn't installed the new
+    dep would wipe a HEALTHY graph and then fail to re-embed (Null provider) →
+    dense recall dead with no rollback. If the dep is missing we skip the wipe and
+    log loud — degrade in place, never self-inflict the very total-recall failure
+    this subsystem guards against."""
+    from services.config_service import config_service
+    cur_rev = (getattr(cfg, "embedding_revision", "") or getattr(cfg, "embedding_model", "") or "")
+    if not cur_rev:
+        return {"migrated": False, "reason": "no_model"}
+    prev_rev = config_service.get(_MEMORY_CATEGORY, _EMBED_REV_KEY)
+    if prev_rev == cur_rev:
+        return {"migrated": False, "reason": "unchanged"}
+
+    from services.indexing.embedding_provider import get_embedding_provider
+    if not get_embedding_provider(getattr(cfg, "embedding_model", ""),
+                                  getattr(cfg, "embedding_revision", "")).is_available():
+        logger.error("[MEMORY] embedding model changed (%r → %r) but its backend is "
+                     "NOT installed — SKIPPING the graph wipe (run the 'memory' extra "
+                     "/ uv sync). Keeping the existing graph rather than wiping it into "
+                     "a dead state.", prev_rev, cur_rev)
+        return {"migrated": False, "reason": "deps_missing"}
+
+    from services.indexing.ladybug_store import reset_ladybug_store
+    reset_ladybug_store(getattr(cfg, "ladybug_path", "data/memory_graph"))
+    enq = rebuild(db, now=now)
+    # Mark AFTER enqueue: outbox intents persist across restarts, so a crash
+    # mid-drain just re-drains; the marker won't wrongly skip a half-done migration.
+    config_service.set(_MEMORY_CATEGORY, _EMBED_REV_KEY, cur_rev)
+    logger.info("[MEMORY] embedding model changed (%r → %r) → wiped graph + "
+                "re-embedding %d records with the new model", prev_rev, cur_rev, enq)
+    return {"migrated": True, "enqueued": enq}
+
+
 def status(db: Session) -> dict:
     """Counts for the index-status route: SQLite truth vs outbox backlog."""
     mem_by_status = dict(

--- a/backend/services/indexing/embedding_provider.py
+++ b/backend/services/indexing/embedding_provider.py
@@ -112,9 +112,82 @@ class BGEEmbeddingProvider(EmbeddingProvider):
         return self.embed_documents([text])[0]
 
 
-def _deps_available() -> bool:
+# Query-side instruction for instruction-aware encoders (Qwen3-Embedding et al.).
+# Documents are embedded plain; only the query gets this prefix — the asymmetric
+# question→fact framing the model was trained on. Calibrated on real recall data
+# 2026-06-22 (Qwen3-Embedding-0.6B: on-topic ≥0.34, off-topic ≤0.33).
+ST_QUERY_INSTRUCTION = ("Given a user's question, retrieve the user's personal "
+                        "memory facts relevant to answering it")
+
+
+class SentenceTransformerEmbeddingProvider(EmbeddingProvider):
+    """Dense embeddings via ``sentence-transformers`` (Qwen3-Embedding, etc.).
+    Lazy + main-process-only, like the BGE provider. Instruction-aware: the
+    QUERY gets the task-instruction prefix (the model's convention); documents
+    are embedded plain. Output is L2-normalized so the LadybugDB cosine metric
+    and the ``recall_min_similarity`` gate behave as configured."""
+
+    def __init__(self, model_name: str, revision: str = "",
+                 query_instruction: str = ST_QUERY_INSTRUCTION, dim: int = BGE_M3_DIM):
+        self._model_name = model_name
+        self._revision = revision
+        self._instruct = query_instruction
+        self._dim = dim
+        self._model = None
+
+    def is_available(self) -> bool:
+        return True
+
+    def revision(self) -> str:
+        return self._revision or self._model_name
+
+    def dim(self) -> int:
+        return self._dim
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return
+        if not os.environ.get(MAIN_PROCESS_ENV):
+            raise RuntimeError(
+                "embedding model load attempted outside the main backend process; "
+                "agents must use the memory API, not load embedding models.")
+        from sentence_transformers import SentenceTransformer  # heavy, lazy
+        kwargs = {"revision": self._revision} if self._revision else {}
+        self._model = SentenceTransformer(self._model_name, **kwargs)
+        # get_embedding_dimension is the current name; fall back for older ST.
+        _dim_fn = (getattr(self._model, "get_embedding_dimension", None)
+                   or self._model.get_sentence_embedding_dimension)
+        d = _dim_fn()
+        if d:
+            self._dim = int(d)
+        logger.info("[MEMORY] Loaded embedding model %s (sentence-transformers, dim=%d)",
+                    self.revision(), self._dim)
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        self._ensure_model()
+        vecs = self._model.encode(list(texts), normalize_embeddings=True)
+        return [list(map(float, v)) for v in vecs]
+
+    def embed_query(self, text: str) -> list[float]:
+        self._ensure_model()
+        q = f"Instruct: {self._instruct}\nQuery:{text}" if self._instruct else text
+        v = self._model.encode([q], normalize_embeddings=True)[0]
+        return list(map(float, v))
+
+
+def _is_bge_m3(model_name: str) -> bool:
+    return "bge-m3" in (model_name or "").lower()
+
+
+def _dep_for(model_name: str) -> str:
+    """Which optional package a model needs: bge-m3 → FlagEmbedding; everything
+    else (Qwen3-Embedding, …) → sentence-transformers."""
+    return "FlagEmbedding" if _is_bge_m3(model_name) else "sentence_transformers"
+
+
+def _have(pkg: str) -> bool:
     import importlib.util
-    return importlib.util.find_spec("FlagEmbedding") is not None
+    return importlib.util.find_spec(pkg) is not None
 
 
 _WARNED_MISSING_DEPS = False
@@ -122,26 +195,27 @@ _WARNED_MISSING_DEPS = False
 
 def get_embedding_provider(model_name: str = DEFAULT_MODEL,
                            revision: str = "") -> EmbeddingProvider:
-    """Return a usable provider, or a Null provider (degraded) if the embedding
-    deps are not installed.
+    """Return a usable provider, or a Null provider (degraded) if the model's
+    backend package is not installed. Dispatches by model name: ``bge-m3`` →
+    FlagEmbedding; anything else → sentence-transformers (Qwen3-Embedding, …).
 
-    FTS-only is a SUPPORTED mode (the ``memory`` extra is optional), so a missing
-    dep does not crash — but it must NOT be silent: a memory-enabled deployment
-    expecting dense recall + the knowledge graph would otherwise degrade with no
-    signal (the prod incident where the graph stayed empty for an hour). Log it
-    LOUD, once."""
-    if not _deps_available():
+    FTS-only is a SUPPORTED mode, so a missing dep does not crash — but it must
+    NOT be silent (the prod incident where the graph stayed empty for an hour):
+    log it LOUD, once."""
+    dep = _dep_for(model_name)
+    if not _have(dep):
         global _WARNED_MISSING_DEPS
         if not _WARNED_MISSING_DEPS:
             _WARNED_MISSING_DEPS = True
             logger.error(
-                "[MEMORY] FlagEmbedding is NOT installed — dense vector recall AND "
-                "the knowledge graph are DISABLED; memory degraded to FTS-only "
-                "keyword search. Index writes will DEFER (graph stays empty). Fix: "
-                "install the 'memory' extra (uv sync --extra memory / "
-                "pip install 'FlagEmbedding>=1.4.0').")
-        return NullEmbeddingProvider("FlagEmbedding not installed")
-    return BGEEmbeddingProvider(model_name, revision)
+                "[MEMORY] %s is NOT installed — dense vector recall AND the "
+                "knowledge graph are DISABLED for model %r; memory degraded to "
+                "FTS-only. Index writes DEFER (graph stays empty). Fix: install "
+                "the 'memory' extra.", dep, model_name)
+        return NullEmbeddingProvider(f"{dep} not installed")
+    if _is_bge_m3(model_name):
+        return BGEEmbeddingProvider(model_name, revision)
+    return SentenceTransformerEmbeddingProvider(model_name, revision)
 
 
 # Process-wide shared instance. The BGE model is ~2.3 GB and ~seconds to load

--- a/backend/services/indexing/ladybug_store.py
+++ b/backend/services/indexing/ladybug_store.py
@@ -480,6 +480,26 @@ def get_ladybug_store(path: str) -> LadybugStore:
     return _STORE_SINGLETON
 
 
+def reset_ladybug_store(path: str) -> None:
+    """Close (if open) + WIPE the graph projection + drop the singleton, so the
+    next ``get_ladybug_store`` rebuilds it from scratch.
+
+    Required when the EMBEDDING MODEL changes: the HNSW vector index is built at
+    ``CREATE_VECTOR_INDEX`` time and is effectively STATIC (Kùzu/LadybugDB
+    lineage) — re-embedding nodes in place (delete+create) does NOT reliably
+    re-index them ('unreachable points' after delete/insert churn; index keeps
+    the stale vectors). A clean wipe + re-project from SQLite guarantees the
+    index is rebuilt over the NEW vectors. Caller re-enqueues the rebuild."""
+    global _STORE_SINGLETON
+    if _STORE_SINGLETON is not None:
+        try:
+            _STORE_SINGLETON.close()
+        except Exception:  # noqa: BLE001
+            pass
+        _STORE_SINGLETON = None
+    _wipe_graph_files(path)
+
+
 class LadybugIndexer:
     """Worker-facing adapter: lets the outbox worker target LadybugDB with the
     same indexer interface (is_available / ensure_collection /

--- a/backend/services/indexing/ladybug_store.py
+++ b/backend/services/indexing/ladybug_store.py
@@ -373,6 +373,56 @@ class LadybugStore:
                                       auth or "agent_observed", float(conf or 0.5)))
             return hits
 
+    def query_anchored_memories(self, *, owner: str, query: str, limit: int = 5,
+                                hub_max_df: float = 0.5) -> list[VectorHit]:
+        """GraphRAG recall ANCHORED to entities NAMED IN THE QUERY — not blind
+        co-occurrence off the vector seeds (``linked_memories``). Pulls memories
+        that MENTION an entity whose normalized name appears as a whole token-run
+        in the query.
+
+        Hub entities — mentioned by >= ``hub_max_df`` of the owner's active
+        memories (e.g. the user's own name, which co-occurs with nearly every
+        personal fact) — are SKIPPED: anchoring on them re-introduces the
+        tangential pulls this replaces. (Measured 2026-06-22: 'Nguyễn Văn Phúc'
+        at 64% df dragged an AI-career memory into a baby-age query via seed
+        co-occurrence.) Returns [] when the query names no non-hub entity → the
+        caller falls back to dense + FTS only. One hop (entity → mentioning
+        memory): on the bipartite MENTIONS graph deeper walks just re-hit hubs."""
+        qn = f" {_norm(query)} "
+        with self._lock:
+            tot = self.count(owner)
+            if tot == 0:
+                return []
+            hub_cut = max(2, int(tot * hub_max_df))   # floor keeps tiny stores sane
+            # Owner-scoped entities + document frequency (how many memories MENTION
+            # each). df is the hub signal: a high-df entity carries no discriminative
+            # power for co-occurrence recall.
+            res = self._exec(
+                "MATCH (e:Entity)<-[:MENTIONS]-(m:Memory) "
+                "WHERE m.owner = $owner AND m.status = 'active' "
+                "RETURN e.id, e.normalized, count(m)", {"owner": owner})
+            anchors: list[str] = []
+            while res.has_next():
+                eid, norm, df = res.get_next()
+                if not norm or int(df) >= hub_cut:
+                    continue                          # unnamed or hub → drop
+                if f" {norm} " in qn:                 # entity named in the query
+                    anchors.append(eid)
+            if not anchors:
+                return []
+            res = self._exec(
+                "MATCH (e:Entity)<-[:MENTIONS]-(m:Memory) "
+                "WHERE e.id IN $ids AND m.owner = $owner AND m.status = 'active' "
+                "RETURN DISTINCT m.id, m.owner, m.memory_type, m.content, "
+                "m.created_at, m.authority, m.confidence LIMIT $lim",
+                {"ids": anchors, "owner": owner, "lim": limit})
+            hits = []
+            while res.has_next():
+                rid, own, mt, content, ca, auth, conf = res.get_next()
+                hits.append(VectorHit(rid, own, mt, content, 1.0, float(ca or 0.0),
+                                      auth or "agent_observed", float(conf or 0.5)))
+            return hits
+
     def count(self, owner: str | None = None) -> int:
         with self._lock:
             if owner:

--- a/backend/services/indexing/ladybug_store.py
+++ b/backend/services/indexing/ladybug_store.py
@@ -162,13 +162,36 @@ class LadybugStore:
             self._exec("CREATE REL TABLE IF NOT EXISTS RELATES("
                        "FROM Entity TO Entity, predicate STRING, owner STRING, mem STRING)")
             # Vector index — created once; ignore "already exists" on re-open.
-            try:
-                self._exec(
-                    f"CALL CREATE_VECTOR_INDEX('Memory', '{_VECTOR_INDEX}', 'emb', "
-                    f"metric := 'cosine')")
-            except Exception as exc:  # noqa: BLE001
-                if "exist" not in str(exc).lower():
-                    raise
+            self._create_vector_index()
+
+    def _create_vector_index(self) -> None:
+        """CREATE the HNSW vector index; ignore "already exists". Single source of
+        truth for the index name/params — used by schema bring-up AND the
+        post-empty rebuild (``_rebuild_vector_index``)."""
+        try:
+            self._exec(
+                f"CALL CREATE_VECTOR_INDEX('Memory', '{_VECTOR_INDEX}', 'emb', "
+                f"metric := 'cosine')")
+        except Exception as exc:  # noqa: BLE001
+            if "exist" not in str(exc).lower():
+                raise
+
+    def _rebuild_vector_index(self) -> None:
+        """DROP + re-CREATE the vector index. REQUIRED after the Memory table is
+        emptied: LadybugDB 0.17.1 leaves the HNSW index DEAD once all indexed rows
+        are deleted (count→0) — rows inserted afterward exist (count>0, valid
+        embeddings) but QUERY_VECTOR_INDEX returns NOTHING until the index is
+        rebuilt (reproduced 12/12). This was the 2026-06-22 prod recall outage: a
+        "forget all memories" emptied the table, so every memory added afterward
+        was invisible to dense search while index-status still read healthy.
+        Partial deletes and updates do NOT trigger it — only deletion-to-empty.
+        Caller must hold ``self._lock``."""
+        try:
+            self._exec(f"CALL DROP_VECTOR_INDEX('Memory', '{_VECTOR_INDEX}')")
+        except Exception as exc:  # noqa: BLE001 — index may already be absent
+            if "exist" not in str(exc).lower():
+                raise
+        self._create_vector_index()
 
     # ---- writes (ADD-only; SQLite is the SoT) ---------------------------
     def upsert_memory(self, *, record_id: str, owner: str, memory_type: str,
@@ -213,6 +236,13 @@ class LadybugStore:
             # RELATES edges live between Entity nodes (not the Memory node), so
             # deleting the memory won't drop them — remove this memory's triples.
             self._exec("MATCH ()-[r:RELATES {mem: $id}]->() DELETE r", {"id": record_id})
+            # Emptying the Memory table kills the HNSW vector index on LadybugDB
+            # 0.17.1 (see _rebuild_vector_index): without this, "forget all" leaves
+            # dense search permanently dead for every memory added afterward.
+            # Rebuild the instant the last row goes — cheap on an empty table, and
+            # count() is reentrant under self._lock (RLock).
+            if self.count() == 0:
+                self._rebuild_vector_index()
 
     def link_entity(self, *, record_id: str, entity_id: str, name: str,
                     etype: str, normalized: str) -> None:

--- a/backend/services/memory/retrieval_hook.py
+++ b/backend/services/memory/retrieval_hook.py
@@ -106,19 +106,24 @@ def _render_block(evidence) -> str:
     return "\n".join(lines)
 
 
+def _score_dict(e) -> dict:
+    """RAW ``{rel, conf, authority}`` for one evidence — the per-line debug score
+    (RRF match score, fact-truth confidence, authority). No normalization (see
+    RECALL_SCORES_CHANNEL). SINGLE SOURCE OF TRUTH for both the persisted channel
+    string (``_block_scores``) and the live SSE chip (``_emit_recall_block``), so
+    the real-time chip and the reloaded one never diverge. Tolerant of partial
+    stubs so a debug annotation never breaks recall."""
+    scores = getattr(e, "scores", None)
+    rel = getattr(scores, "final", None) or getattr(scores, "rrf", None) or 0.0
+    conf = max(0.0, min(1.0, getattr(e, "confidence", 0.0) or 0.0))
+    return {"rel": round(rel, 4), "conf": round(conf, 2),
+            "authority": getattr(e, "authority", "") or ""}
+
+
 def _block_scores(evidence) -> list[str]:
-    """One ``rel|conf|authority`` string per evidence for the debug chip —
-    RAW relevance (RRF fusion score) + RAW confidence + authority. No
-    normalization (see RECALL_SCORES_CHANNEL). Tolerant of partial stubs so a
-    debug annotation never breaks recall."""
-    out: list[str] = []
-    for e in evidence:
-        scores = getattr(e, "scores", None)
-        rel = getattr(scores, "final", None) or getattr(scores, "rrf", None) or 0.0
-        conf = max(0.0, min(1.0, getattr(e, "confidence", 0.0) or 0.0))
-        authority = getattr(e, "authority", "") or ""
-        out.append(f"{round(rel, 4)}|{round(conf, 2)}|{authority}")
-    return out
+    """One ``rel|conf|authority`` string per evidence for the persisted channel —
+    derived from ``_score_dict`` so it stays identical to the live SSE payload."""
+    return [f"{s['rel']}|{s['conf']}|{s['authority']}" for s in map(_score_dict, evidence)]
 
 
 def _block_recall_ids(msg) -> list[str]:
@@ -161,6 +166,31 @@ def _build_block_message(evidence):
                   RECALL_LANES_CHANNEL: [text_content(",".join(lanes_of(getattr(e, "scores", None)))) for e in evidence],
                   RECALL_SCORES_CHANNEL: [text_content(s) for s in _block_scores(evidence)]},
     )
+
+
+def _emit_recall_block(owner: str, fresh) -> None:
+    """Live SSE mirror of the recall block just injected, so the chat UI shows the
+    "memories used" chip in REAL TIME instead of only after a page reload (the
+    chip was previously built solely from persisted history fetched on mount).
+
+    Carries exactly what the block persists — the rendered prose + per-line lanes
+    + per-line scores, all from ``fresh`` (the deduped set actually injected) — so
+    the live chip is byte-identical to the one rebuilt from history on reload.
+    Best-effort: a broadcast failure must never break the LLM call."""
+    try:
+        from services.activity_stream import activity_stream_manager
+        from services.retrieval.contracts import lanes_of
+        activity_stream_manager.broadcast({
+            "agent_name": owner,
+            "event_type": "memory_recalled",
+            "data": {
+                "content": _render_block(fresh),
+                "recall_lanes": [lanes_of(getattr(e, "scores", None)) for e in fresh],
+                "recall_scores": [_score_dict(e) for e in fresh],
+            },
+        })
+    except Exception as exc:  # noqa: BLE001 — never break the LLM call
+        logger.debug("[MEMORY] recall SSE emit failed: %s", exc)
 
 
 def create_memory_retrieval_hooks():
@@ -221,6 +251,8 @@ def create_memory_retrieval_hooks():
             # the turn commits, so the block persists & dedups exactly as before,
             # just correctly ordered. Never mutate earlier history → KV cache safe.
             delta_messages.append(_build_block_message(fresh))
+            # Mirror the block to the chat UI live (chip shows now, not on reload).
+            _emit_recall_block(owner, fresh)
         except Exception as exc:  # noqa: BLE001 — never break the LLM call
             logger.error("[MEMORY] retrieval hook error: %s", exc, exc_info=True)
 

--- a/backend/services/memory/retrieval_hook.py
+++ b/backend/services/memory/retrieval_hook.py
@@ -216,7 +216,8 @@ def create_memory_retrieval_hooks():
             # turns, fire-and-forget so it never adds latency to this LLM call.
             if cfg.auto_capture_preferences:
                 cnt = getattr(agent, "_jarvis_extract_turns", 0) + 1
-                if cnt >= EXTRACT_EVERY_N:
+                every_n = int(getattr(cfg, "extract_every_n", EXTRACT_EVERY_N) or EXTRACT_EVERY_N)
+                if cnt >= every_n:
                     agent._jarvis_extract_turns = 0
                     asyncio.create_task(_run_extraction(owner, _recent_snippet(agent, query), cfg))
                     # NOTE: KG triples are now extracted per-memory at persist time

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -28,6 +28,9 @@ class MemorySettings:
     enabled: bool = False
     mode: str = RetrievalMode.BALANCED.value
     auto_capture_preferences: bool = True
+    # Fast-lane capture frequency gate: run the cheap extractor every N user turns
+    # (cost knob — a frequency gate can't misclassify content; the LLM decides).
+    extract_every_n: int = 4
     approval_policy: str = "manual"
     pinned_token_budget: int = 1500
     evidence_token_budget: int = 2500
@@ -65,6 +68,10 @@ class MemorySettings:
     # star-shaped personal graph (the user hub is a super-node — 2 hops through it
     # pulls the whole profile = noise). Bump to 2 only with hop-decay.
     graph_max_hops: int = 1
+    # GraphRAG hub suppression: an entity mentioned by >= this fraction of the
+    # owner's active memories (e.g. the user's own name) is a hub that co-occurs
+    # with everything → carries no signal → excluded from query-anchored expansion.
+    hub_max_df: float = 0.5
     # Tuning overrides (JSON)
     trigger_lexicon_overrides: dict = field(default_factory=dict)
     quality_gate_thresholds: dict = field(default_factory=dict)
@@ -75,6 +82,7 @@ _SCHEMA: dict[str, tuple[str, Any]] = {
     "enabled": ("bool", False),
     "mode": ("str", RetrievalMode.BALANCED.value),
     "auto_capture_preferences": ("bool", True),
+    "extract_every_n": ("int", 4),
     "approval_policy": ("str", "manual"),
     "pinned_token_budget": ("int", 1500),
     "evidence_token_budget": ("int", 2500),
@@ -92,6 +100,7 @@ _SCHEMA: dict[str, tuple[str, Any]] = {
     "retention_retrieval_runs_days": ("int", 30),
     "recall_min_similarity": ("float", 0.34),
     "graph_max_hops": ("int", 1),
+    "hub_max_df": ("float", 0.5),
     "trigger_lexicon_overrides": ("json", {}),
     "quality_gate_thresholds": ("json", {}),
 }
@@ -165,6 +174,18 @@ def validate_settings_updates(updates: dict[str, Any]) -> list[str]:
         v = updates["graph_max_hops"]
         if not isinstance(v, int) or isinstance(v, bool) or not (1 <= v <= 3):
             errors.append("graph_max_hops must be an integer in [1, 3]")
+    if "hub_max_df" in updates:
+        v = updates["hub_max_df"]
+        if not isinstance(v, (int, float)) or isinstance(v, bool) or not (0.0 < float(v) <= 1.0):
+            errors.append("hub_max_df must be a number in (0, 1]")
+    for k in ("extract_every_n", "rerank_top_k"):
+        if k in updates and (not isinstance(updates[k], int) or isinstance(updates[k], bool)
+                             or updates[k] < 1):
+            errors.append(f"{k} must be an integer >= 1")
+    if "rerank_min_score" in updates:
+        v = updates["rerank_min_score"]
+        if not isinstance(v, (int, float)) or isinstance(v, bool) or float(v) < 0.0:
+            errors.append("rerank_min_score must be a number >= 0")
     unknown = set(updates) - set(_SCHEMA) - {_CURATOR_API_KEY}
     if unknown:
         errors.append(f"unknown settings: {sorted(unknown)}")

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -191,3 +191,20 @@ def update_memory_settings(updates: dict[str, Any], *, user: str = "user") -> Me
         config_service.set(MEMORY_CATEGORY, key, _coerce_write(kind, value), user=user)
 
     return get_memory_settings()
+
+
+def gate_mistuned_warning(embedding_model: str, recall_min_similarity: float) -> str | None:
+    """Advisory check (review #5): the recall gate is a cosine-similarity floor on
+    the EMBEDDING's score scale, which differs by model (bge-m3 ~0.44,
+    Qwen3-Embedding ~0.34). ``embedding_model`` is independently configurable, so
+    swapping the model without re-tuning the gate leaves it mistuned (e.g. bge-m3
+    at a Qwen 0.34 floor injects loosely-related rows). Returns a warning string
+    when the pair looks mismatched, else None — heuristic, never raises."""
+    m = (embedding_model or "").lower()
+    if "bge-m3" in m and recall_min_similarity < 0.40:
+        return (f"recall_min_similarity={recall_min_similarity} is Qwen-scale but "
+                f"embedding_model is bge-m3 (expected ~0.44) — gate too permissive")
+    if "qwen" in m and recall_min_similarity > 0.42:
+        return (f"recall_min_similarity={recall_min_similarity} is bge-scale but "
+                f"embedding_model is {embedding_model} (expected ~0.34) — gate too strict")
+    return None

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -36,22 +36,31 @@ class MemorySettings:
     curator_provider: str = ""
     curator_base_url: str = ""
     curator_api_key_set: bool = False  # masked; raw via get_curator_api_key()
-    # Embeddings / index
-    embedding_model: str = "BAAI/bge-m3"
+    # Embeddings / index. Qwen3-Embedding-0.6B (sentence-transformers, dim 1024 —
+    # same as bge-m3, so no LadybugDB schema change) measured 2026-06-22 to
+    # separate on-topic/off-topic better than bge-m3 on short Vietnamese
+    # question→fact recall. Switching the model re-embeds the whole store
+    # (startup migration on a revision change); bge-m3 is still selectable.
+    embedding_model: str = "Qwen/Qwen3-Embedding-0.6B"
     embedding_revision: str = ""
+    # Cross-encoder reranker (precision stage): re-scores the fused candidates by
+    # reading (query, memory) jointly — what the bi-encoder can't do. ON by default.
     reranker_enabled: bool = True
+    rerank_model: str = "BAAI/bge-reranker-v2-m3"
+    rerank_top_k: int = 20            # how many fused candidates to rerank
+    rerank_min_score: float = 0.005   # drop candidates scoring below this
     # Dense/graph backend = LadybugDB (embedded property graph + HNSW vectors).
     # ``ladybug_path`` is the embedded DB directory.
     ladybug_path: str = "data/memory_graph"
     # Retention (days)
     retention_episodic_days: int = 90
     retention_retrieval_runs_days: int = 30
-    # Recall relevance gate: drop a dense hit whose cosine similarity to the
-    # query is below this (distance = 1 - similarity). Calibrated 2026-06-17 on
-    # real BGE-M3 distances: on-topic queries match ≤0.53 distance, off-topic
-    # ≥0.59 — so 0.44 similarity (≤0.56 distance) keeps on-topic, drops off-topic
-    # (→ no memory injected for an unrelated turn).
-    recall_min_similarity: float = 0.44
+    # Recall relevance gate: drop a dense hit whose cosine similarity to the query
+    # is below this (distance = 1 - similarity). Re-tuned 2026-06-22 for
+    # Qwen3-Embedding-0.6B over 19 on-topic + 12 off-topic queries: on-topic
+    # top-sim ≥0.335, off-topic ≤0.333, so 0.34 keeps on-topic / drops off-topic.
+    # (bge-m3's scale was higher: it used 0.44. Re-tune if the model changes.)
+    recall_min_similarity: float = 0.34
     # GraphRAG traversal depth for RELATES expansion. 1 is the sweet spot for the
     # star-shaped personal graph (the user hub is a super-node — 2 hops through it
     # pulls the whole profile = noise). Bump to 2 only with hop-decay.
@@ -72,13 +81,16 @@ _SCHEMA: dict[str, tuple[str, Any]] = {
     "curator_model": ("str", ""),
     "curator_provider": ("str", ""),
     "curator_base_url": ("str", ""),
-    "embedding_model": ("str", "BAAI/bge-m3"),
+    "embedding_model": ("str", "Qwen/Qwen3-Embedding-0.6B"),
     "embedding_revision": ("str", ""),
     "reranker_enabled": ("bool", True),
+    "rerank_model": ("str", "BAAI/bge-reranker-v2-m3"),
+    "rerank_top_k": ("int", 20),
+    "rerank_min_score": ("float", 0.005),
     "ladybug_path": ("str", "data/memory_graph"),
     "retention_episodic_days": ("int", 90),
     "retention_retrieval_runs_days": ("int", 30),
-    "recall_min_similarity": ("float", 0.44),
+    "recall_min_similarity": ("float", 0.34),
     "graph_max_hops": ("int", 1),
     "trigger_lexicon_overrides": ("json", {}),
     "quality_gate_thresholds": ("json", {}),

--- a/backend/services/retrieval/fusion.py
+++ b/backend/services/retrieval/fusion.py
@@ -98,7 +98,21 @@ def apply_policy(evidence: list[Evidence], *, now: float) -> list[Evidence]:
     so it cannot reorder beyond this bound.
 
     Supersession is NOT handled here: providers return only ``status='active'``
-    rows (superseded/archived are filtered at query time)."""
+    rows (superseded/archived are filtered at query time).
+
+    RERANKER OVERRIDE: once a cross-encoder reranker has scored the candidates
+    (``scores.reranker`` set), THAT is the authoritative relevance order — it read
+    (query, memory) jointly, far better than the bi-encoder ranks RRF fuses. So we
+    sort by reranker and skip the rrf-based reorder (the bounded recency/authority
+    nudges below are for the rrf regime; applying them on top of a cross-encoder
+    score would just add noise)."""
+    if any(e.scores.reranker is not None for e in evidence):
+        for e in evidence:
+            if e.scores.reranker is not None:
+                e.scores.final = e.scores.reranker
+        evidence.sort(key=lambda e: (e.scores.reranker if e.scores.reranker is not None
+                                     else float("-inf")), reverse=True)
+        return evidence
     evidence.sort(key=lambda e: e.scores.rrf or 0.0, reverse=True)   # relevance baseline
 
     def _boost(e) -> float:

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -142,11 +142,22 @@ class RetrievalOrchestrator:
         """Cross-encoder rerank of the top fused candidates (precision stage).
         Re-scores into ``scores.reranker``, drops those below ``rerank_min_score``,
         returns them ordered by reranker. No-op when disabled/unavailable → fusion
-        order kept. Best-effort: a rerank error must never break recall."""
+        order kept. Best-effort: a rerank error must never break recall.
+
+        INTENTIONAL GATE (review #2): the floor can legitimately return [] when every
+        candidate scores below it — i.e. the cross-encoder judged them all off-topic
+        (measured: an off-topic query reranks the whole set to ~0). This is the
+        desired off-topic→nothing behavior; it is NOT the silent-veto bug the dense
+        off-topic gate had, because the reranker scored each candidate against THIS
+        query (it didn't drop a high-precision lane on a sibling lane's emptiness).
+        Keep ``rerank_min_score`` low (0.005) so a weak-but-relevant hit survives."""
         if not fused or self._reranker is None or not self._reranker.is_available():
             return fused
         top_k = int(getattr(self.settings, "rerank_top_k", 20) or 20)
         floor = float(getattr(self.settings, "rerank_min_score", 0.0) or 0.0)
+        # Tail beyond top_k is intentionally DROPPED from recall (not just from
+        # reranking): for personal-memory recall we inject far fewer than top_k, and
+        # the tail is the lowest-fusion-ranked anyway (review #4).
         cand = fused[:top_k]
         try:
             scores = self._reranker.rerank(request.query, [c.excerpt for c in cand])

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -65,6 +65,14 @@ class RetrievalOrchestrator:
         max_hops = int(getattr(settings, "graph_max_hops", 1) or 1)
         self._dense = LadybugProvider(store, emb, max_distance=1.0 - float(min_sim),
                                       max_hops=max_hops)
+        # Cross-encoder reranker (precision stage) — re-scores the fused candidates
+        # by reading (query, memory) jointly. None when disabled/unavailable →
+        # recall keeps fusion order (never breaks). Shared singleton (model loaded once).
+        self._reranker = None
+        if getattr(settings, "reranker_enabled", False):
+            from services.retrieval.reranker import get_shared_reranker
+            self._reranker = get_shared_reranker(
+                getattr(settings, "rerank_model", None) or "BAAI/bge-reranker-v2-m3")
 
     async def retrieve(self, request: RetrievalRequest, *, now: float,
                        ledger: EvidenceLedger | None = None, turn: int = 0,
@@ -119,10 +127,39 @@ class RetrievalOrchestrator:
             fusion.apply_policy(fused, now=now)
             level = LEVEL_AGENTIC
 
+        # Precision stage: cross-encoder rerank of the fused candidates. Sets
+        # scores.reranker (apply_policy then orders by it) and drops off-topic /
+        # low-relevance candidates below the floor — what the bi-encoder lanes
+        # can't do (the 2026-06-22 "cat memory in a baby-age query" case).
+        fused = self._apply_rerank(request, fused)
+
         _CACHE.set(key, fused)
         return self._finalize(request, fused, level=level, cache_hit=False,
                               budget=budget, ledger=ledger, turn=turn, now=now,
                               dense_failed=dense_failed)
+
+    def _apply_rerank(self, request: RetrievalRequest, fused: list[Evidence]) -> list[Evidence]:
+        """Cross-encoder rerank of the top fused candidates (precision stage).
+        Re-scores into ``scores.reranker``, drops those below ``rerank_min_score``,
+        returns them ordered by reranker. No-op when disabled/unavailable → fusion
+        order kept. Best-effort: a rerank error must never break recall."""
+        if not fused or self._reranker is None or not self._reranker.is_available():
+            return fused
+        top_k = int(getattr(self.settings, "rerank_top_k", 20) or 20)
+        floor = float(getattr(self.settings, "rerank_min_score", 0.0) or 0.0)
+        cand = fused[:top_k]
+        try:
+            scores = self._reranker.rerank(request.query, [c.excerpt for c in cand])
+        except Exception as exc:  # noqa: BLE001 — keep fusion order on rerank failure
+            logger.warning("[MEMORY] rerank failed, keeping fusion order: %s", exc)
+            return fused
+        kept = []
+        for c, s in zip(cand, scores):
+            c.scores.reranker = s
+            if s >= floor:
+                kept.append(c)
+        kept.sort(key=lambda e: e.scores.reranker or 0.0, reverse=True)
+        return kept
 
     async def _fast_round(self, request: RetrievalRequest, budget, *,
                           bm25_first: bool = False) -> tuple[list[Evidence], bool]:

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -63,8 +63,9 @@ class RetrievalOrchestrator:
         # is beyond this distance contributes nothing → no injection.
         min_sim = getattr(settings, "recall_min_similarity", 0.44)
         max_hops = int(getattr(settings, "graph_max_hops", 1) or 1)
+        hub_max_df = float(getattr(settings, "hub_max_df", 0.5) or 0.5)
         self._dense = LadybugProvider(store, emb, max_distance=1.0 - float(min_sim),
-                                      max_hops=max_hops)
+                                      max_hops=max_hops, hub_max_df=hub_max_df)
         # Cross-encoder reranker (precision stage) — re-scores the fused candidates
         # by reading (query, memory) jointly. None when disabled/unavailable →
         # recall keeps fusion order (never breaks). Shared singleton (model loaded once).

--- a/backend/services/retrieval/providers/ladybug_provider.py
+++ b/backend/services/retrieval/providers/ladybug_provider.py
@@ -21,7 +21,8 @@ from services.retrieval.contracts import (
 
 class LadybugProvider(RetrievalProvider):
     def __init__(self, store: LadybugStore, embedding: EmbeddingProvider,
-                 max_distance: float | None = None, max_hops: int = 1):
+                 max_distance: float | None = None, max_hops: int = 1,
+                 hub_max_df: float = 0.5):
         self.store = store
         self.embedding = embedding
         # Relevance gate: drop dense hits whose cosine distance exceeds this
@@ -30,6 +31,10 @@ class LadybugProvider(RetrievalProvider):
         # GraphRAG expansion depth (memory→memory steps through shared entities);
         # user-configurable via settings.graph_max_hops.
         self.max_hops = max_hops
+        # Hub-entity suppression threshold for query-anchored graph expansion
+        # (settings.hub_max_df): entities mentioned by >= this fraction of the
+        # owner's memories are excluded as no-signal super-nodes.
+        self.hub_max_df = hub_max_df
 
     def is_available(self) -> bool:
         return self.store is not None and self.embedding.is_available()
@@ -48,7 +53,8 @@ class LadybugProvider(RetrievalProvider):
         # queries (the 2026-06-22 "AI-career memory in a baby-age query" bug).
         # ``graph_max_hops <= 0`` disables the lane entirely (off-switch).
         linked = ([] if self.max_hops <= 0 else self.store.query_anchored_memories(
-            owner=request.owner_agent_name, query=request.query, limit=limit))
+            owner=request.owner_agent_name, query=request.query, limit=limit,
+            hub_max_df=self.hub_max_df))
 
         # Tag dense vs graph PROVENANCE distinctly so the debug UI can show each
         # lane's contribution. A memory reachable by BOTH (a vector hit that also

--- a/backend/services/retrieval/providers/ladybug_provider.py
+++ b/backend/services/retrieval/providers/ladybug_provider.py
@@ -1,9 +1,9 @@
 """LadybugDB dense + GraphRAG retrieval provider (memory v2).
 
-The dense leg (HNSW ``QUERY_VECTOR_INDEX``) PLUS a one-hop entity-linking boost
-(memories that share an entity with the top vector hits — the multi-hop signal),
-both owner-scoped. Returns [] when the store or embedder is unavailable so the
-orchestrator degrades to FTS-only. The sole dense/graph retrieval backend.
+The dense leg (HNSW ``QUERY_VECTOR_INDEX``) PLUS a query-entity-anchored graph
+boost (memories mentioning an entity NAMED IN THE QUERY, ubiquitous hub entities
+excluded), both owner-scoped. Returns [] when the store or embedder is unavailable
+so the orchestrator degrades to FTS-only. The sole dense/graph retrieval backend.
 """
 from __future__ import annotations
 
@@ -41,12 +41,14 @@ class LadybugProvider(RetrievalProvider):
         hits = self.store.vector_search(
             owner=request.owner_agent_name, query_embedding=qvec, limit=limit,
             max_distance=self.max_distance)
-        # One graph hop: memories sharing an entity with the vector hits. The
-        # GraphRAG multi-hop signal — pulls in related context a pure-vector
-        # search misses (mem0's +23.1 multi-hop class).
-        linked = self.store.linked_memories(
-            owner=request.owner_agent_name,
-            record_ids=[h.record_id for h in hits], limit=limit, max_hops=self.max_hops)
+        # GraphRAG, QUERY-ENTITY-ANCHORED (not blind seed co-occurrence): expand
+        # only from entities the query actually names, skipping ubiquitous hub
+        # entities. This stops the user's own entity — which co-occurs with nearly
+        # every personal fact — from dragging tangential memories into unrelated
+        # queries (the 2026-06-22 "AI-career memory in a baby-age query" bug).
+        # ``graph_max_hops <= 0`` disables the lane entirely (off-switch).
+        linked = ([] if self.max_hops <= 0 else self.store.query_anchored_memories(
+            owner=request.owner_agent_name, query=request.query, limit=limit))
 
         # Tag dense vs graph PROVENANCE distinctly so the debug UI can show each
         # lane's contribution. A memory reachable by BOTH (a vector hit that also

--- a/backend/services/retrieval/reranker.py
+++ b/backend/services/retrieval/reranker.py
@@ -1,0 +1,113 @@
+"""Cross-encoder reranker — the memory-v2 precision stage (spec §relevance).
+
+The dense lane is a BI-ENCODER: it embeds the query and each memory SEPARATELY,
+so it can't judge fine relevance — "how old is my baby" scores "I bought a cat"
+almost as high as "I have a 7-month-old son" (measured 2026-06-22). A CROSS-encoder
+reads (query, memory) TOGETHER and scores their relevance directly. That's the
+standard RAG fix; it's too slow to run over the whole store, so it runs only over
+the small FUSED candidate set at query time, re-orders it, and drops candidates
+below a score floor.
+
+Main-process-only + lazy + Null fallback, mirroring ``embedding_provider`` — an
+agent subprocess must never load a model; a missing dep degrades to "no rerank"
+(fusion order kept) rather than crashing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger("memory.reranker")
+
+DEFAULT_RERANKER = "BAAI/bge-reranker-v2-m3"
+# Set by the FastAPI lifespan in the main process (same flag the embedder uses).
+MAIN_PROCESS_ENV = "JARVIS_MAIN_PROCESS"
+
+
+class Reranker(ABC):
+    @abstractmethod
+    def is_available(self) -> bool: ...
+
+    @abstractmethod
+    def rerank(self, query: str, documents: list[str]) -> list[float]:
+        """Relevance score per document (higher = more relevant), SAME order as
+        ``documents``."""
+
+
+class NullReranker(Reranker):
+    """Used when the reranker dep/model is unavailable — callers check
+    ``is_available()`` and keep the fusion order."""
+
+    def __init__(self, reason: str):
+        self.reason = reason
+
+    def is_available(self) -> bool:
+        return False
+
+    def rerank(self, query, documents):
+        raise RuntimeError(f"reranker unavailable: {self.reason}")
+
+
+class CrossEncoderReranker(Reranker):
+    """Lazy ``sentence-transformers`` CrossEncoder (e.g. ``bge-reranker-v2-m3``),
+    loaded once in the main process. (FlagEmbedding's FlagReranker is NOT used —
+    it calls ``tokenizer.prepare_for_model`` which transformers 5.x removed.)"""
+
+    def __init__(self, model_name: str = DEFAULT_RERANKER, max_length: int = 512):
+        self._model_name = model_name
+        self._max_length = max_length
+        self._model = None
+
+    def is_available(self) -> bool:
+        return True
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return
+        if not os.environ.get(MAIN_PROCESS_ENV):
+            raise RuntimeError(
+                "reranker load attempted outside the main backend process; "
+                "agents must use the memory API, not load models.")
+        from sentence_transformers import CrossEncoder  # heavy, lazy
+        self._model = CrossEncoder(self._model_name, max_length=self._max_length)
+        logger.info("[MEMORY] Loaded reranker %s", self._model_name)
+
+    def rerank(self, query: str, documents: list[str]) -> list[float]:
+        if not documents:
+            return []
+        self._ensure_model()
+        scores = self._model.predict([[query, d] for d in documents])
+        return [float(s) for s in scores]
+
+
+def _have_st() -> bool:
+    import importlib.util
+    return importlib.util.find_spec("sentence_transformers") is not None
+
+
+_WARNED = False
+
+
+def get_reranker(model_name: str = DEFAULT_RERANKER) -> Reranker:
+    if not _have_st():
+        global _WARNED
+        if not _WARNED:
+            _WARNED = True
+            logger.warning("[MEMORY] sentence-transformers not installed — reranker "
+                           "disabled; recall keeps fusion order. Install the 'memory' extra.")
+        return NullReranker("sentence-transformers not installed")
+    return CrossEncoderReranker(model_name)
+
+
+# Process-wide shared instance (the model is loaded once; the orchestrator reuses it).
+_SHARED: Reranker | None = None
+_SHARED_KEY: str | None = None
+
+
+def get_shared_reranker(model_name: str = DEFAULT_RERANKER) -> Reranker:
+    global _SHARED, _SHARED_KEY
+    if _SHARED is None or _SHARED_KEY != model_name:
+        _SHARED = get_reranker(model_name)
+        _SHARED_KEY = model_name
+    return _SHARED

--- a/backend/tests/test_services/test_ladybug_store.py
+++ b/backend/tests/test_services/test_ladybug_store.py
@@ -335,3 +335,32 @@ def test_upsert_drops_edges_contract(store):
                         content="re-indexed", embedding=_vec(0), authority="user_confirmed",
                         confidence=0.9, created_at=9.0, valid_from=9.0)
     assert store.linked_memories(owner="Jarvis", record_ids=["m1"]) == []   # edge dropped → caller re-links
+
+
+def test_delete_to_empty_rebuilds_vector_index(store):
+    # Regression (2026-06-22 prod recall outage): on LadybugDB 0.17.1, emptying the
+    # Memory table (the "forget all memories" op) leaves the HNSW vector index dead
+    # — rows inserted afterward exist (count>0, valid embeddings) but
+    # QUERY_VECTOR_INDEX returns nothing, so dense recall silently dies for every
+    # new memory until a full rebuild. Reproduced 12/12. delete_memory must rebuild
+    # the index the instant the table empties. Partial deletes/updates are safe;
+    # only deletion-to-empty triggers it, so this test wipes ALL rows then re-adds.
+    def _put(rid, axis, t):
+        store.upsert_memory(record_id=rid, owner="J", memory_type="semantic",
+                            subject_scope="user", content=rid, embedding=_vec(axis),
+                            authority="user_confirmed", confidence=0.9,
+                            created_at=t, valid_from=t)
+
+    for i in range(4):
+        _put(f"a{i}", i, 1.0)
+    assert len(store.vector_search(owner="J", query_embedding=_vec(0), limit=10)) == 4
+
+    for i in range(4):
+        store.delete_memory(f"a{i}")
+    assert store.count() == 0
+
+    for i in range(3):
+        _put(f"b{i}", i, 2.0)
+    # Without the post-empty index rebuild this returns < 3 (usually 0).
+    hits = store.vector_search(owner="J", query_embedding=_vec(0), limit=10)
+    assert len(hits) == 3, f"dense recall dead after wipe+re-add: got {len(hits)}"

--- a/backend/tests/test_services/test_ladybug_store.py
+++ b/backend/tests/test_services/test_ladybug_store.py
@@ -364,3 +364,56 @@ def test_delete_to_empty_rebuilds_vector_index(store):
     # Without the post-empty index rebuild this returns < 3 (usually 0).
     hits = store.vector_search(owner="J", query_embedding=_vec(0), limit=10)
     assert len(hits) == 3, f"dense recall dead after wipe+re-add: got {len(hits)}"
+
+
+# ── query-anchored GraphRAG + hub suppression (the 2026-06-22 relevance fix) ──
+def _put_ents(store, rid, axis, content, owner, entities):
+    store.upsert_memory(record_id=rid, owner=owner, memory_type="semantic",
+                        subject_scope="user", content=content, embedding=_vec(axis),
+                        authority="user_confirmed", confidence=0.9, created_at=1.0, valid_from=1.0)
+    for nm in entities:
+        store.link_entity(record_id=rid, entity_id=f"kg:{owner}:{nm}", name=nm,
+                          etype="topic", normalized=nm)
+
+
+def _seed_hub_graph(store):
+    # 'user' is a HUB (mentioned by 5/6 memories); 'fpt' is specific (2/6).
+    for i, (rid, content, ents) in enumerate([
+        ("m1", "user works at fpt", ["user", "fpt"]),
+        ("m2", "fpt is in hanoi", ["fpt", "hanoi"]),
+        ("m3", "user likes pho", ["user", "pho"]),
+        ("m4", "user has a cat", ["user", "cat"]),
+        ("m5", "user plays tennis", ["user", "tennis"]),
+        ("m6", "user reads books", ["user", "books"]),
+    ]):
+        _put_ents(store, rid, i, content, "J", ents)
+
+
+def test_query_anchored_pulls_only_named_entity(store):
+    # GraphRAG anchored to the QUERY's entities: naming a specific (non-hub)
+    # entity pulls exactly the memories that MENTION it.
+    _seed_hub_graph(store)
+    hits = store.query_anchored_memories(owner="J", query="where is fpt located", limit=10)
+    assert {h.record_id for h in hits} == {"m1", "m2"}
+
+
+def test_query_anchored_empty_when_no_entity_named(store):
+    # The bug guard: a query naming no entity must NOT expand the graph, so
+    # unrelated memories are never dragged in via the ubiquitous user entity.
+    _seed_hub_graph(store)
+    assert store.query_anchored_memories(owner="J", query="what should i cook tonight", limit=10) == []
+
+
+def test_query_anchored_skips_hub_entity(store):
+    # Naming the hub entity ('user', mentioned by most memories) must NOT anchor —
+    # it co-occurs with nearly everything → no signal → [] (caller uses dense+FTS).
+    _seed_hub_graph(store)
+    assert store.query_anchored_memories(owner="J", query="tell me about the user", limit=10) == []
+
+
+def test_query_anchored_is_owner_scoped(store):
+    _seed_hub_graph(store)
+    _put_ents(store, "k1", 7, "other works at fpt", "K", ["fpt"])   # different owner
+    hits = store.query_anchored_memories(owner="J", query="where is fpt", limit=10)
+    assert "k1" not in {h.record_id for h in hits}
+    assert all(h.owner == "J" for h in hits)

--- a/backend/tests/test_services/test_memory_index_worker.py
+++ b/backend/tests/test_services/test_memory_index_worker.py
@@ -281,10 +281,10 @@ def test_embedding_provider_missing_deps_is_loud(monkeypatch, caplog):
     import logging
 
     from services.indexing import embedding_provider as ep
-    monkeypatch.setattr(ep, "_deps_available", lambda: False)
+    monkeypatch.setattr(ep, "_have", lambda pkg: False)
     monkeypatch.setattr(ep, "_WARNED_MISSING_DEPS", False)
     with caplog.at_level(logging.ERROR, logger="memory.embedding"):
-        prov = ep.get_embedding_provider()
+        prov = ep.get_embedding_provider("BAAI/bge-m3")   # bge → needs FlagEmbedding
     assert prov.is_available() is False
     assert any("FlagEmbedding is NOT installed" in r.message for r in caplog.records)
 

--- a/backend/tests/test_services/test_memory_index_worker.py
+++ b/backend/tests/test_services/test_memory_index_worker.py
@@ -320,3 +320,49 @@ async def test_worker_prune_defers_dense_when_store_down(Session, monkeypatch):
     # FTS already removed → degraded search won't surface it meanwhile.
     assert not fts_index.fts_search(db, owner_agent_name="Jarvis", query="compactor")
     db.close()
+
+
+def test_migrate_on_embedding_change(monkeypatch):
+    """Review #3: lock the embedding-swap migration — unchanged → no-op; changed +
+    deps present → wipe + rebuild + marker set AFTER enqueue; changed + deps MISSING
+    → SKIP the wipe (never self-inflict a dead graph) and leave the marker."""
+    import types
+
+    import services.config_service as cfgmod
+    import services.indexing.embedding_provider as ep
+    import services.indexing.ladybug_store as lbs
+    from services.indexing import consistency_service as cs
+
+    store = {}
+    monkeypatch.setattr(cfgmod.config_service, "get", lambda cat, key: store.get((cat, key)))
+    monkeypatch.setattr(cfgmod.config_service, "set",
+                        lambda cat, key, val, **kw: store.__setitem__((cat, key), val))
+    wiped = []
+    monkeypatch.setattr(lbs, "reset_ladybug_store", lambda p: wiped.append(p))
+    monkeypatch.setattr(cs, "rebuild", lambda db, *, now: 7)
+    avail = {"ok": True}
+    monkeypatch.setattr(ep, "get_embedding_provider",
+                        lambda m, r="": types.SimpleNamespace(is_available=lambda: avail["ok"]))
+    cfg = types.SimpleNamespace(embedding_model="Qwen/Qwen3-Embedding-0.6B",
+                                embedding_revision="", ladybug_path="data/g")
+
+    # 1. unchanged → no-op (no wipe, no marker churn)
+    store[("memory", "indexed_embedding_revision")] = "Qwen/Qwen3-Embedding-0.6B"
+    r = cs.migrate_on_embedding_change(None, cfg, now=1.0)
+    assert r == {"migrated": False, "reason": "unchanged"} and wiped == []
+
+    # 2. changed + deps available → wipe + rebuild + marker set
+    store[("memory", "indexed_embedding_revision")] = "BAAI/bge-m3"
+    r = cs.migrate_on_embedding_change("db", cfg, now=2.0)
+    assert r == {"migrated": True, "enqueued": 7}
+    assert wiped == ["data/g"]
+    assert store[("memory", "indexed_embedding_revision")] == "Qwen/Qwen3-Embedding-0.6B"
+
+    # 3. changed + deps MISSING → SKIP wipe, marker untouched
+    wiped.clear()
+    store[("memory", "indexed_embedding_revision")] = "BAAI/bge-m3"
+    avail["ok"] = False
+    r = cs.migrate_on_embedding_change("db", cfg, now=3.0)
+    assert r == {"migrated": False, "reason": "deps_missing"}
+    assert wiped == []                                   # did NOT wipe a healthy graph
+    assert store[("memory", "indexed_embedding_revision")] == "BAAI/bge-m3"

--- a/backend/tests/test_services/test_memory_pipeline_e2e.py
+++ b/backend/tests/test_services/test_memory_pipeline_e2e.py
@@ -128,6 +128,55 @@ async def test_capture_to_retrieve_full_pipeline(pipeline):
     assert other == []
 
 
+async def test_forget_all_then_readd_keeps_dense_recall(pipeline):
+    # Real user click-flow: "forget all memories" empties the Memory table, then
+    # new facts are stated and recalled. On LadybugDB 0.17.1 emptying the table
+    # kills the HNSW index, so a re-added memory is invisible to dense search
+    # (count>0 yet QUERY_VECTOR_INDEX returns nothing) until delete_memory rebuilds
+    # the index. Drives the REAL worker delete path (EVENT_MEMORY_DELETE →
+    # _delete_dense → LadybugIndexer.delete_by_record → store.delete_memory), not
+    # the store in isolation — so it guards the actual archive→worker→recall flow.
+    import time
+
+    from services.memory.memory_service import MemoryService
+    p = pipeline
+    now = time.time()
+
+    def _create(content):
+        db = p.Factory()
+        rec = MemoryService(db).create_memory(
+            owner_agent_name="Jarvis", memory_type="semantic", content=content,
+            subject_scope="user", authority="user_confirmed", confidence=0.9, now=now)
+        rid = rec.id
+        db.commit()
+        db.close()
+        return rid
+
+    # 1) seed two memories → worker projects → dense recall works.
+    ids = [_create("user works at FPT as an engineer"), _create("user likes pho")]
+    await p.worker.process_pending(now=now + 100)
+    assert p.store.count("Jarvis") == 2
+
+    # 2) FORGET ALL → worker drains the deletes → the table empties (count 0).
+    for rid in ids:
+        db = p.Factory()
+        MemoryService(db).archive_memory(rid, owner_agent_name="Jarvis", now=now)
+        db.close()
+    await p.worker.process_pending(now=now + 200)
+    assert p.store.count("Jarvis") == 0
+
+    # 3) state a NEW fact → worker projects it into the (rebuilt) index.
+    new_id = _create("user works as a software engineer")
+    await p.worker.process_pending(now=now + 300)
+    assert p.store.count("Jarvis") == 1
+
+    # 4) dense recall must surface it — returned [] before the index-rebuild fix.
+    prov = LadybugProvider(p.store, p.emb)
+    ev = await prov.search(
+        RetrievalRequest(owner_agent_name="Jarvis", query="where do I work", types=[]), limit=5)
+    assert ev and ev[0].record_id == new_id
+
+
 async def test_entity_link_survives_pipeline_multi_hop(pipeline):
     p = pipeline
     # two memories mentioning the same entity (FPT) → linked in the graph e2e.

--- a/backend/tests/test_services/test_memory_providers.py
+++ b/backend/tests/test_services/test_memory_providers.py
@@ -6,8 +6,9 @@ from services.indexing import embedding_provider as ep
 
 
 def test_embedding_factory_returns_null_when_deps_missing(monkeypatch):
-    # Force "deps missing" regardless of environment.
-    monkeypatch.setattr(ep, "_deps_available", lambda: False)
+    # Force "the model's backend package is missing" regardless of environment
+    # (dispatch is per-model now: bge-m3→FlagEmbedding, else→sentence-transformers).
+    monkeypatch.setattr(ep, "_have", lambda pkg: False)
     prov = ep.get_embedding_provider()
     assert isinstance(prov, ep.NullEmbeddingProvider)
     assert prov.is_available() is False

--- a/backend/tests/test_services/test_memory_recall_e2e.py
+++ b/backend/tests/test_services/test_memory_recall_e2e.py
@@ -114,16 +114,20 @@ async def test_recall_injects_real_orchestrator_result(wired):
 
 # ── GraphRAG co-occurrence + relevance gate (real orchestrator, fake embed) ───
 
-async def test_graphrag_cooccurrence_and_relevance_gate(monkeypatch):
-    """E2E through the REAL orchestrator (LadybugProvider dense + linked_memories
-    + FTS + fusion + gate); only the embedder is faked.
+async def test_graphrag_query_anchored_and_relevance_gate(monkeypatch):
+    """E2E through the REAL orchestrator (LadybugProvider dense + query-anchored
+    graph + FTS + fusion + gate); only the embedder is faked.
 
-    Proves two behaviours end-to-end:
-    1. GraphRAG co-occurrence — a memory that SHARES an entity with the vector hit
-       is pulled in via MENTIONS even though its OWN embedding is far from the
-       query (the value the dense gate would otherwise miss).
-    2. Relevance gate — an off-topic query (vector-far from everything) injects
-       nothing.
+    Proves the QUERY-ANCHORED GraphRAG contract (replaces blind seed co-occurrence,
+    the 2026-06-22 'AI-career memory in a baby-age query' bug):
+    1. A memory whose OWN embedding is far from the query is pulled via the graph
+       ONLY when the query NAMES the shared entity ('acme').
+    2. A query that does NOT name the entity ('plan a trip') does NOT drag that
+       memory in — even though it shares an entity with a vector hit.
+    3. Relevance gate — an off-topic query injects nothing.
+
+    Six memories so 'acme' (df 2/6) is below the hub cut (≥3) and stays usable;
+    fillers also give the off-topic query genuinely-empty vector results.
     """
     _CACHE.clear()
     eng = create_engine("sqlite:///:memory:",
@@ -136,6 +140,8 @@ async def test_graphrag_cooccurrence_and_relevance_gate(monkeypatch):
     F = sessionmaker(bind=eng)
     store = LadybugStore(f"{tempfile.mkdtemp()}/g")
 
+    _AXIS = {"trip": 0, "address": 5, "milk": 1, "blue": 2, "jazz": 3, "tennis": 4}
+
     class _Emb:
         def is_available(self): return True
         def dim(self): return EMBED_DIM
@@ -143,15 +149,25 @@ async def test_graphrag_cooccurrence_and_relevance_gate(monkeypatch):
         def _v(self, t):
             t = (t or "").lower()
             v = [0.0] * EMBED_DIM
-            v[0 if "trip" in t else 5 if "address" in t else 9] = 1.0
+            v[next((ax for kw, ax in _AXIS.items() if kw in t), 9)] = 1.0
             return v
         def embed_documents(self, ts): return [self._v(t) for t in ts]
         def embed_query(self, q): return self._v(q)
     emb = _Emb()
 
-    # A is near the query ("trip"); B is far ("address"); BOTH mention "Acme".
+    # A near "trip"; B vector-far ("address") and its CONTENT has no 'acme' token
+    # (so B can ONLY arrive via the graph anchor, not FTS). Both MENTION entity
+    # Acme. C–F are distinct fillers that dilute Acme's df below the hub cut.
+    rows = [
+        ("A", "trip planning notes", "acme"),
+        ("B", "office address downtown", "acme"),   # NB: no 'acme' word in content
+        ("C", "buy milk today", "grocery"),
+        ("D", "the sky is blue", "color"),
+        ("E", "jazz playlist", "music"),
+        ("F", "tennis match", "sport"),
+    ]
     seed = F()
-    for rid, content in [("A", "trip planning notes"), ("B", "acme office address")]:
+    for rid, content, ent in rows:
         seed.add(MemoryRecord(id=rid, owner_agent_name="Jarvis", memory_type="semantic",
                               subject_scope="user", content=content, normalized_content=content,
                               status="active", authority="user_confirmed", confidence=0.9,
@@ -161,8 +177,8 @@ async def test_graphrag_cooccurrence_and_relevance_gate(monkeypatch):
         store.upsert_memory(record_id=rid, owner="Jarvis", memory_type="semantic",
                             subject_scope="user", content=content, embedding=emb._v(content),
                             authority="user_confirmed", confidence=0.9, created_at=1.0, valid_from=1.0)
-        store.link_entity(record_id=rid, entity_id="ent:acme", name="Acme",
-                          etype="org", normalized="acme")     # shared entity → MENTIONS
+        store.link_entity(record_id=rid, entity_id=f"ent:{ent}", name=ent,
+                          etype="org", normalized=ent)
     seed.commit(); seed.close()
 
     import core.database as cd
@@ -179,23 +195,28 @@ async def test_graphrag_cooccurrence_and_relevance_gate(monkeypatch):
     from services.retrieval.contracts import RetrievalRequest
     from services.retrieval.orchestrator import RetrievalOrchestrator
 
-    # 1. on-topic: vector hits A; B is pulled via shared-entity MENTIONS (Lane C).
+    # 1. Query NAMES 'acme' → B (vector-far, content has no 'acme' word) is pulled
+    #    ONLY via the graph anchor.
     res = await RetrievalOrchestrator(F(), _cfg()).retrieve(
-        RetrievalRequest(owner_agent_name="Jarvis", query="plan a trip"),
+        RetrievalRequest(owner_agent_name="Jarvis", query="tell me about acme"),
         now=time.time(), agent_requested=True)
-    ids = {e.record_id for e in res.evidence}
-    assert "A" in ids                      # direct vector hit
-    assert "B" in ids                      # GraphRAG co-occurrence (vector-far, shared entity)
-    # Lane PROVENANCE (powers the debug UI): A came from the vector lane, B ONLY
-    # from the graph (MENTIONS) lane — so the UI can show graph's unique pull.
     by_id = {e.record_id: e.scores for e in res.evidence}
-    assert by_id["A"].dense_rank is not None and by_id["A"].graph_rank is None
+    assert "B" in by_id
     assert by_id["B"].graph_rank is not None and by_id["B"].dense_rank is None
 
-    # 2. off-topic: vector-far from everything → relevance gate → nothing injected.
+    # 2. Query does NOT name the entity → graph must NOT drag B in (the bug guard).
     _CACHE.clear()
     res2 = await RetrievalOrchestrator(F(), _cfg()).retrieve(
+        RetrievalRequest(owner_agent_name="Jarvis", query="plan a trip"),
+        now=time.time(), agent_requested=True)
+    ids2 = {e.record_id for e in res2.evidence}
+    assert "A" in ids2                     # direct vector hit
+    assert "B" not in ids2                 # NOT pulled — query named no entity
+
+    # 3. off-topic: vector-far from everything + names no entity → nothing.
+    _CACHE.clear()
+    res3 = await RetrievalOrchestrator(F(), _cfg()).retrieve(
         RetrievalRequest(owner_agent_name="Jarvis", query="quantum chromodynamics lecture"),
         now=time.time(), agent_requested=True)
-    assert res2.evidence == []
+    assert res3.evidence == []
     store.close()

--- a/backend/tests/test_services/test_memory_reranker.py
+++ b/backend/tests/test_services/test_memory_reranker.py
@@ -1,0 +1,65 @@
+"""Cross-encoder rerank stage: re-orders the fused candidates by joint
+(query, memory) relevance and drops those below the floor. The bi-encoder lanes
+can't do this (the 2026-06-22 "cat memory in a baby-age query" case). Logic is
+tested with a FAKE reranker — no model load."""
+import types
+
+from services.retrieval import fusion
+from services.retrieval.contracts import (
+    Evidence, EvidenceScores, EvidenceSource, RetrievalRequest)
+from services.retrieval.orchestrator import RetrievalOrchestrator
+
+
+def _ev(rid, rrf, content):
+    return Evidence(f"m:{rid}", rid, "J", "semantic", content,
+                    EvidenceSource("memory_record", rid, 1.0),
+                    EvidenceScores(rrf=rrf, final=rrf), "user_confirmed", 0.9)
+
+
+class _FakeRR:
+    """Scores 1.0 when 'baby' is in the doc, else 0.0 — a stand-in for the
+    cross-encoder's joint relevance judgement."""
+    def is_available(self): return True
+    def rerank(self, query, docs): return [1.0 if "baby" in d else 0.0 for d in docs]
+
+
+def _stub(reranker, *, floor=0.5, top_k=20):
+    return types.SimpleNamespace(
+        settings=types.SimpleNamespace(rerank_top_k=top_k, rerank_min_score=floor),
+        _reranker=reranker)
+
+
+def test_rerank_reorders_and_drops_below_floor():
+    # 'cat' noise outranks the relevant memory by RRF; the reranker must flip it
+    # AND drop the noise (score 0.0 < floor).
+    fused = [_ev("noise", 0.05, "user bought a cat mochi"),
+             _ev("rel", 0.01, "user has a baby 7 months old")]
+    out = RetrievalOrchestrator._apply_rerank(
+        _stub(_FakeRR()), RetrievalRequest(owner_agent_name="J", query="how old is my baby"), fused)
+    assert [e.record_id for e in out] == ["rel"]      # noise dropped, relevant kept
+    assert out[0].scores.reranker == 1.0
+
+
+def test_rerank_noop_when_unavailable():
+    fused = [_ev("a", 0.05, "x")]
+    out = RetrievalOrchestrator._apply_rerank(
+        _stub(None), RetrievalRequest(owner_agent_name="J", query="q"), fused)
+    assert out is fused                               # untouched → fusion order kept
+
+
+def test_rerank_failure_keeps_fusion_order():
+    class _Boom:
+        def is_available(self): return True
+        def rerank(self, q, docs): raise RuntimeError("model died")
+    fused = [_ev("a", 0.05, "x"), _ev("b", 0.01, "y")]
+    out = RetrievalOrchestrator._apply_rerank(
+        _stub(_Boom()), RetrievalRequest(owner_agent_name="J", query="q"), fused)
+    assert out is fused                               # best-effort: never break recall
+
+
+def test_apply_policy_orders_by_reranker_over_rrf():
+    a = _ev("a", 0.9, "x"); a.scores.reranker = 0.1   # high rrf, low rerank
+    b = _ev("b", 0.1, "y"); b.scores.reranker = 0.9   # low rrf, high rerank
+    out = fusion.apply_policy([a, b], now=1000.0)
+    assert [e.record_id for e in out] == ["b", "a"]   # reranker is authoritative
+    assert out[0].scores.final == 0.9

--- a/backend/tests/test_services/test_memory_retrieval_hook.py
+++ b/backend/tests/test_services/test_memory_retrieval_hook.py
@@ -78,6 +78,36 @@ async def test_no_injection_when_disabled(monkeypatch):
     assert not any(rh.is_injected_memory(m) for m in agent.message_history)
 
 
+async def test_emits_live_recall_sse_matching_the_block(monkeypatch):
+    # The "memories used" chip must render DURING the turn (not only after a
+    # reload): on a fresh injection the hook broadcasts a `memory_recalled`
+    # activity event carrying the SAME content + per-line lanes + scores the
+    # block persists, so the live chip equals the reloaded one.
+    events = []
+    import services.activity_stream as asm
+    monkeypatch.setattr(asm.activity_stream_manager, "broadcast", lambda ev: events.append(ev))
+    await _run_hook(monkeypatch, query="what was the fix in backend/server.py",
+                    settings=_settings(), evidence=[_ev()])
+    recalls = [e for e in events if e.get("event_type") == "memory_recalled"]
+    assert len(recalls) == 1
+    data = recalls[0]["data"]
+    assert recalls[0]["agent_name"] == "Jarvis"
+    assert rh.MEMORY_MARKER in data["content"]
+    assert "dedicated compactor" in data["content"]
+    # one lane-list and one score per injected line, SAME order as the block.
+    assert len(data["recall_lanes"]) == 1
+    assert len(data["recall_scores"]) == 1
+    assert set(data["recall_scores"][0]) == {"rel", "conf", "authority"}
+
+
+async def test_no_recall_sse_when_no_evidence(monkeypatch):
+    events = []
+    import services.activity_stream as asm
+    monkeypatch.setattr(asm.activity_stream_manager, "broadcast", lambda ev: events.append(ev))
+    await _run_hook(monkeypatch, query="hello there", settings=_settings(), evidence=[])
+    assert not any(e.get("event_type") == "memory_recalled" for e in events)
+
+
 # NOTE: v1 "Level 0 gating", "self-replacing block" and "strips stale block"
 # tests were removed — recall v2 is ALWAYS-retrieve + append-only + change-gate
 # (no intent gate deciding recall, no mid-history strip). The v2

--- a/backend/tests/test_services/test_memory_settings.py
+++ b/backend/tests/test_services/test_memory_settings.py
@@ -111,3 +111,12 @@ def test_curator_api_key_is_secret_and_masked(fake_cfg):
     # empty string clears it
     ms.update_memory_settings({"curator_api_key": ""})
     assert ms.get_memory_settings().curator_api_key_set is False
+
+
+def test_gate_mistuned_warning():
+    # Review #5: advisory mismatch between embedding model and the gate scale.
+    from services.memory.settings import gate_mistuned_warning
+    assert gate_mistuned_warning("Qwen/Qwen3-Embedding-0.6B", 0.34) is None   # matched
+    assert gate_mistuned_warning("BAAI/bge-m3", 0.44) is None                 # matched
+    assert gate_mistuned_warning("BAAI/bge-m3", 0.34) is not None             # bge at Qwen floor
+    assert gate_mistuned_warning("Qwen/Qwen3-Embedding-0.6B", 0.44) is not None  # qwen at bge floor

--- a/backend/tests/test_services/test_memory_settings.py
+++ b/backend/tests/test_services/test_memory_settings.py
@@ -120,3 +120,20 @@ def test_gate_mistuned_warning():
     assert gate_mistuned_warning("BAAI/bge-m3", 0.44) is None                 # matched
     assert gate_mistuned_warning("BAAI/bge-m3", 0.34) is not None             # bge at Qwen floor
     assert gate_mistuned_warning("Qwen/Qwen3-Embedding-0.6B", 0.44) is not None  # qwen at bge floor
+
+
+def test_new_tuning_knobs_config(fake_cfg):
+    # hub_max_df / extract_every_n / rerank_top_k / rerank_min_score are now
+    # config keys (promoted from hardcoded). Defaults + round-trip + validation.
+    d = ms.get_memory_settings()
+    assert d.hub_max_df == 0.5 and d.extract_every_n == 4
+    assert d.rerank_top_k == 20 and d.rerank_min_score == 0.005
+    ms.update_memory_settings({"hub_max_df": 0.6, "extract_every_n": 3,
+                               "rerank_top_k": 10, "rerank_min_score": 0.01})
+    s = ms.get_memory_settings()
+    assert (s.hub_max_df, s.extract_every_n, s.rerank_top_k, s.rerank_min_score) == (0.6, 3, 10, 0.01)
+    for bad, match in [({"hub_max_df": 0}, "hub_max_df"), ({"hub_max_df": 1.5}, "hub_max_df"),
+                       ({"extract_every_n": 0}, "extract_every_n"), ({"rerank_top_k": 0}, "rerank_top_k"),
+                       ({"rerank_min_score": -0.1}, "rerank_min_score")]:
+        with pytest.raises(ValueError, match=match):
+            ms.update_memory_settings(bad)

--- a/backend/tests/test_services/test_memory_settings.py
+++ b/backend/tests/test_services/test_memory_settings.py
@@ -43,7 +43,7 @@ def test_defaults_when_empty(fake_cfg):
     assert s.enabled is False           # feature flag OFF by default
     assert s.mode == "balanced"
     assert s.pinned_token_budget == 1500
-    assert s.embedding_model == "BAAI/bge-m3"
+    assert s.embedding_model == "Qwen/Qwen3-Embedding-0.6B"
     assert s.curator_api_key_set is False
 
 
@@ -72,7 +72,7 @@ def test_recall_gate_and_hops_round_trip_and_validation(fake_cfg):
     # defaults
     fake_cfg.store.clear()
     d = ms.get_memory_settings()
-    assert d.recall_min_similarity == 0.44 and d.graph_max_hops == 1
+    assert d.recall_min_similarity == 0.34 and d.graph_max_hops == 1
     # range validation
     with pytest.raises(ValueError, match="recall_min_similarity"):
         ms.update_memory_settings({"recall_min_similarity": 1.5})

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -63,9 +63,16 @@
       "keyStored": "stored · hidden",
       "keyNotSet": "not set",
       "recallMinSim": "Relevance gate (min similarity)",
-      "recallMinSimHint": "Dense hits below this are dropped → an off-topic turn recalls nothing (0–1, default 0.44).",
+      "recallMinSimHint": "Dense hits below this are dropped → an off-topic turn recalls nothing. Scale depends on the embedding model (Qwen ≈ 0.34, bge-m3 ≈ 0.44).",
       "graphMaxHops": "GraphRAG depth (hops)",
-      "graphMaxHopsHint": "How far to traverse the relation graph. 1 = precise for the star graph; 2 risks noise (1–3, default 1)."
+      "graphMaxHopsHint": "How far to traverse the relation graph. 1 = precise for the star graph; 2 risks noise (1–3, default 1).",
+      "rerankTopK": "Reranker candidates (top-K)",
+      "rerankMinScore": "Reranker score floor",
+      "rerankMinScoreHint": "Candidates scoring below this after reranking are dropped (≥0, default 0.005).",
+      "rerankModel": "Reranker model",
+      "hubMaxDf": "GraphRAG hub cutoff",
+      "hubMaxDfHint": "An entity mentioned by ≥ this fraction of memories (e.g. your own name) is a no-signal hub, excluded from graph expansion (0–1, default 0.5).",
+      "extractEveryN": "Auto-capture every N turns"
     },
     "shell": {
       "eyebrow": "SETTINGS",

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -63,9 +63,16 @@
       "keyStored": "đã lưu · ẩn",
       "keyNotSet": "chưa đặt",
       "recallMinSim": "Ngưỡng liên quan (similarity tối thiểu)",
-      "recallMinSimHint": "Dense hit dưới ngưỡng này bị bỏ → query lạc đề không recall gì (0–1, mặc định 0.44).",
+      "recallMinSimHint": "Dense hit dưới ngưỡng này bị bỏ → query lạc đề không recall gì. Thang tùy model embedding (Qwen ≈ 0.34, bge-m3 ≈ 0.44).",
       "graphMaxHops": "Độ sâu GraphRAG (hop)",
-      "graphMaxHopsHint": "Số bậc đi trong đồ thị quan hệ. 1 = chính xác cho graph hình sao; 2 dễ nhiễu (1–3, mặc định 1)."
+      "graphMaxHopsHint": "Số bậc đi trong đồ thị quan hệ. 1 = chính xác cho graph hình sao; 2 dễ nhiễu (1–3, mặc định 1).",
+      "rerankTopK": "Số candidate rerank (top-K)",
+      "rerankMinScore": "Ngưỡng điểm reranker",
+      "rerankMinScoreHint": "Candidate có điểm rerank dưới ngưỡng này bị bỏ (≥0, mặc định 0.005).",
+      "rerankModel": "Model reranker",
+      "hubMaxDf": "Ngưỡng hub GraphRAG",
+      "hubMaxDfHint": "Entity được nhắc bởi ≥ tỉ lệ này số memory (vd tên của bạn) là hub vô tín hiệu, bị loại khỏi graph expansion (0–1, mặc định 0.5).",
+      "extractEveryN": "Tự bắt mỗi N lượt"
     },
     "shell": {
       "tab": {

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -382,6 +382,15 @@ export const useAgentsStore = defineStore('agents', () => {
           }).catch(e => console.warn('[Store] Failed to forward approval event:', e))
           break
         }
+        // Live recall block → chat store, so the "memories used" chip renders
+        // during the turn (not only after a reload). Intercept before the
+        // generic memory_ forward below (which routes to the memory store).
+        if (event_type === 'memory_recalled') {
+          import('./chat').then(({ useChatStore }) => {
+            useChatStore().addMemoryRecallBlock(event.data, agent_name)
+          }).catch(e => console.warn('[Store] Failed to forward memory_recalled:', e))
+          break
+        }
         // Forward the live-reactive memory events (spec §17 subset) to the
         // memory store: candidate badge, index refresh, degraded banner.
         if (event_type.startsWith('memory_') || event_type === 'retrieval_degraded'

--- a/frontend/src/stores/chat.js
+++ b/frontend/src/stores/chat.js
@@ -1,7 +1,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
-import { apiFetch } from '../api'
-import { useAudioPlayerStore } from './audioPlayer'
+import { apiFetch } from '../api.js'
+import { useAudioPlayerStore } from './audioPlayer.js'
 
 const META_STORAGE_KEY = 'jarvis_chat_meta'
 const TTS_STORAGE_KEY = 'jarvis_tts_enabled'
@@ -390,6 +390,42 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   /**
+   * Insert a live "memories used" recall block from the `memory_recalled` SSE
+   * event so the chip shows DURING the turn (previously only after a page
+   * reload, because the chip was built solely from fetched history). The payload
+   * mirrors the persisted block (content + recall_lanes + recall_scores), so on
+   * the next history fetch the persisted block replaces this one with no visible
+   * change. Inserted BEFORE the in-flight assistant placeholder so it renders
+   * above the reply, matching the persisted order.
+   */
+  function addMemoryRecallBlock(data, agentName) {
+    if (!data || !data.content) return
+    const conv = activeConversation.value
+    // Only the conversation currently streaming this agent's turn gets the live
+    // block; persisted history is the source of truth and fixes any drift on
+    // reload. Guard on agent + streaming so a background agent's recall never
+    // lands in the wrong open conversation.
+    if (!conv || !isStreaming.value) return
+    if (agentName && conv.agentName && agentName !== conv.agentName) return
+    const block = {
+      id: `mem-live-${crypto.randomUUID()}`,
+      role: 'user',
+      content: data.content,
+      recallLanes: data.recall_lanes || null,
+      recallScores: data.recall_scores || null,
+      timestamp: Date.now(),
+      isStreaming: false,
+      toolCalls: [],
+    }
+    // Place it just before the last assistant message (the streaming placeholder).
+    const msgs = conv.messages
+    let i = msgs.length - 1
+    while (i >= 0 && msgs[i].role !== 'assistant') i--
+    if (i >= 0) msgs.splice(i, 0, block)
+    else msgs.push(block)
+  }
+
+  /**
    * Push a tool call event into the current streaming message (in-memory only).
    */
   function pushToolCall(messageId, toolCall) {
@@ -521,6 +557,7 @@ export const useChatStore = defineStore('chat', () => {
     stopTts,
     addUserMessage,
     addAgentMessagePlaceholder,
+    addMemoryRecallBlock,
     pushToolCall,
     finalizeAgentMessage,
     removeMessage,

--- a/frontend/src/stores/chat.js
+++ b/frontend/src/stores/chat.js
@@ -395,8 +395,10 @@ export const useChatStore = defineStore('chat', () => {
    * reload, because the chip was built solely from fetched history). The payload
    * mirrors the persisted block (content + recall_lanes + recall_scores), so on
    * the next history fetch the persisted block replaces this one with no visible
-   * change. Inserted BEFORE the in-flight assistant placeholder so it renders
-   * above the reply, matching the persisted order.
+   * change. (fetchHistory is a FULL replace — `conv.messages = history.map(...)`,
+   * not a merge — so the `mem-live-*` block is discarded, never duplicated.)
+   * Inserted BEFORE the in-flight assistant placeholder so it renders above the
+   * reply, matching the persisted order.
    */
   function addMemoryRecallBlock(data, agentName) {
     if (!data || !data.content) return

--- a/frontend/src/stores/chat.test.js
+++ b/frontend/src/stores/chat.test.js
@@ -1,0 +1,70 @@
+/**
+ * Chat store — live "memories used" recall block (memory_recalled SSE).
+ * Asserts the reactive UI update: the chip block is inserted DURING the turn,
+ * before the streaming assistant placeholder, and only for the streaming
+ * conversation of the matching agent.
+ */
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createPinia, setActivePinia } from 'pinia'
+
+// The store reads persisted meta from localStorage on setup; node:test has none.
+globalThis.localStorage = {
+  _d: {},
+  getItem(k) { return this._d[k] ?? null },
+  setItem(k, v) { this._d[k] = String(v) },
+  removeItem(k) { delete this._d[k] },
+}
+
+const { useChatStore } = await import('./chat.js')
+
+const MARKER = '⟦memory:recalled⟧'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+function startStreamingTurn(s) {
+  s.createConversation('Jarvis')
+  s.addUserMessage('tên đầy đủ của tôi là gì')
+  s.isStreaming = true
+  s.addAgentMessagePlaceholder()
+}
+
+function recallData() {
+  return {
+    content: `${MARKER} [System memory recall — not user input]:\n- [semantic] nguyễn văn phúc là người tạo ra ai agent`,
+    recall_lanes: [['fts', 'dense']],
+    recall_scores: [{ rel: 0.0325, conf: 0.6, authority: 'user_confirmed' }],
+  }
+}
+
+test('memory_recalled inserts a recall block before the streaming reply', () => {
+  const s = useChatStore()
+  startStreamingTurn(s)
+  s.addMemoryRecallBlock(recallData(), 'Jarvis')
+
+  const msgs = s.activeConversation.messages
+  const memIdx = msgs.findIndex(m => (m.content || '').includes(MARKER))
+  const asstIdx = msgs.findIndex(m => m.role === 'assistant')
+  assert.ok(memIdx >= 0, 'memory block inserted')
+  assert.ok(memIdx < asstIdx, 'memory block sits before the assistant placeholder')
+  assert.deepEqual(msgs[memIdx].recallLanes, [['fts', 'dense']])
+  assert.equal(msgs[memIdx].recallScores[0].rel, 0.0325)
+  assert.equal(msgs[memIdx].role, 'user') // isMemoryBlock() in ChatMessages keys on role=user + marker
+})
+
+test('memory_recalled is ignored when no turn is streaming', () => {
+  const s = useChatStore()
+  s.createConversation('Jarvis')
+  s.addUserMessage('hi')
+  s.addMemoryRecallBlock(recallData(), 'Jarvis') // isStreaming === false
+  assert.ok(!s.activeConversation.messages.some(m => (m.content || '').includes(MARKER)))
+})
+
+test('memory_recalled is ignored for a different agent', () => {
+  const s = useChatStore()
+  startStreamingTurn(s)
+  s.addMemoryRecallBlock(recallData(), 'SomeOtherAgent')
+  assert.ok(!s.activeConversation.messages.some(m => (m.content || '').includes(MARKER)))
+})

--- a/frontend/src/views/settings/SettingsMemory.vue
+++ b/frontend/src/views/settings/SettingsMemory.vue
@@ -38,6 +38,10 @@ const NUMBER_FIELDS = [
   { key: 'retention_retrieval_runs_days', labelKey: 'settings.memory.retentionRuns', min: 1, max: 365, step: 1 },
   { key: 'recall_min_similarity', labelKey: 'settings.memory.recallMinSim', min: 0, max: 1, step: 0.01 },
   { key: 'graph_max_hops', labelKey: 'settings.memory.graphMaxHops', min: 1, max: 3, step: 1 },
+  { key: 'rerank_top_k', labelKey: 'settings.memory.rerankTopK', min: 1, max: 100, step: 1 },
+  { key: 'rerank_min_score', labelKey: 'settings.memory.rerankMinScore', min: 0, max: 1, step: 0.001 },
+  { key: 'hub_max_df', labelKey: 'settings.memory.hubMaxDf', min: 0.05, max: 1, step: 0.05 },
+  { key: 'extract_every_n', labelKey: 'settings.memory.extractEveryN', min: 1, max: 50, step: 1 },
 ]
 
 // Curator provider is a known choice (mirrors the LLM Provider screen), not
@@ -52,6 +56,7 @@ const CURATOR_PROVIDERS = [
 // Always-shown text fields (independent of the curator provider choice).
 const REST_FIELDS = [
   { key: 'embedding_model', labelKey: 'settings.memory.embeddingModel' },
+  { key: 'rerank_model', labelKey: 'settings.memory.rerankModel' },
 ]
 
 const dirtyKeys = computed(() => {
@@ -211,6 +216,24 @@ onMounted(load)
         <div class="row-info"><h3>{{ t(NUMBER_FIELDS[5].labelKey) }}</h3>
           <p class="hint">{{ t('settings.memory.graphMaxHopsHint') }}</p></div>
         <input v-model="draft.graph_max_hops" class="num-input" type="number" min="1" max="3" step="1" />
+      </div>
+      <div class="row">
+        <div class="row-info"><h3>{{ t(NUMBER_FIELDS[6].labelKey) }}</h3></div>
+        <input v-model="draft.rerank_top_k" class="num-input" type="number" min="1" max="100" step="1" />
+      </div>
+      <div class="row">
+        <div class="row-info"><h3>{{ t(NUMBER_FIELDS[7].labelKey) }}</h3>
+          <p class="hint">{{ t('settings.memory.rerankMinScoreHint') }}</p></div>
+        <input v-model="draft.rerank_min_score" class="num-input" type="number" min="0" max="1" step="0.001" />
+      </div>
+      <div class="row">
+        <div class="row-info"><h3>{{ t(NUMBER_FIELDS[8].labelKey) }}</h3>
+          <p class="hint">{{ t('settings.memory.hubMaxDfHint') }}</p></div>
+        <input v-model="draft.hub_max_df" class="num-input" type="number" min="0.05" max="1" step="0.05" />
+      </div>
+      <div class="row">
+        <div class="row-info"><h3>{{ t(NUMBER_FIELDS[9].labelKey) }}</h3></div>
+        <input v-model="draft.extract_every_n" class="num-input" type="number" min="1" max="50" step="1" />
       </div>
 
       <!-- Curator / embedding — labelled fields, like the LLM Provider screen -->

--- a/frontend/tests/e2e/fixtures/chat_memory_recall.yaml
+++ b/frontend/tests/e2e/fixtures/chat_memory_recall.yaml
@@ -1,0 +1,37 @@
+# Realtime "memories used" chip — boot endpoints for the chat view.
+#
+# The chat-stream and activity-stream SSE are served by CUSTOM page.route
+# handlers in chat-memory-recall.spec.ts, NOT here: the mock harness serves SSE
+# bodies atomically (no inter-event timing) and the activity-stream opens at
+# mount, so the spec coordinates the two streams to mirror production order
+# (recall is broadcast DURING the turn). This fixture only covers the static
+# boot REST calls the chat view makes on mount.
+
+backend_source:
+  - "backend/services/memory/retrieval_hook.py::_emit_recall_block"
+  - "frontend/src/composables/useRealtimeStream.js::handleMessage -> agents.processEvent"
+  - "frontend/src/stores/agents.js::processEvent (memory_recalled -> chat store)"
+  - "frontend/src/stores/chat.js::addMemoryRecallBlock"
+  - "frontend/src/components/chat/ChatMessages.vue::memory-used chip"
+  - "backend/routes/sessions.py::list_conversations"
+  - "backend/routes/agents.py::list_agents"
+
+responses:
+  "GET /api/conversations":
+    status: 200
+    json:
+      items: []
+      total: 0
+
+  "GET /api/agents":
+    status: 200
+    json:
+      - name: "Jarvis"
+        description: "Main orchestrator"
+        status: "idle"
+        is_default: true
+        team_name: null
+
+  "GET /api/agents/activities/recent":
+    status: 200
+    json: {}

--- a/frontend/tests/e2e/flows/chat-memory-recall.spec.ts
+++ b/frontend/tests/e2e/flows/chat-memory-recall.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Realtime "memories used" chip — the recall block paints DURING the turn from
+ * the live `memory_recalled` activity-stream SSE, NOT only after a page reload.
+ *
+ * Production contract: the retrieval hook (`_emit_recall_block`) broadcasts a
+ * `memory_recalled` activity event while the turn is in flight; AppLayout's
+ * `useRealtimeStream` routes it to `agents.processEvent`, which forwards it to
+ * `chat.addMemoryRecallBlock`, inserting the block before the assistant
+ * placeholder so `ChatMessages` renders the chip.
+ *
+ * The mock harness serves SSE bodies atomically (no inter-event timing) and the
+ * activity-stream opens at mount, so two custom routes coordinate the ordering:
+ *   - chat-stream: held open (never closes) so the turn stays in flight
+ *     (`isStreaming` stays true — the precondition addMemoryRecallBlock guards).
+ *   - activity-stream: waits until the chat POST fires, THEN delivers
+ *     `memory_recalled` — mirroring production (recall broadcast mid-turn).
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+const SSE_HEADERS = {
+  'content-type': 'text/event-stream',
+  'cache-control': 'no-cache',
+}
+
+test('memory_recalled paints the chip mid-turn (no reload)', async ({ page }) => {
+  const backend = await mockBackend(page, [NOISE, join(FIXTURES, 'chat_memory_recall.yaml')])
+
+  // Resolves when the chat POST is observed → the turn is in flight.
+  let onChatStarted!: () => void
+  const chatStarted = new Promise<void>((r) => { onChatStarted = r })
+  // Lets the test hold the chat-stream open (turn stays streaming) until the
+  // chip is asserted, then release it for clean teardown.
+  let releaseChat: (() => void) | null = null
+
+  // Custom routes registered AFTER mockBackend → they win (Playwright LIFO) for
+  // these two paths; every other /api/* still falls to the fixture.
+  await page.route('**/api/chat-stream', async (route) => {
+    onChatStarted()
+    await new Promise<void>((r) => { releaseChat = r }) // keep the turn open
+    await route.fulfill({
+      status: 200,
+      headers: SSE_HEADERS,
+      body: 'retry: 3600000\n\ndata: {"type":"start","message":"…"}\n\n',
+    })
+  })
+
+  await page.route('**/api/agents/activity-stream**', async (route) => {
+    await chatStarted // deliver the recall only once the turn is in flight
+    const event = {
+      agent_name: 'Jarvis',
+      event_type: 'memory_recalled',
+      data: {
+        content:
+          '⟦memory:recalled⟧ [System memory recall — not user input]:\n'
+          + '- [semantic] nguyễn văn phúc là người tạo ra ai agent',
+        recall_lanes: [['fts', 'dense']],
+        recall_scores: [{ rel: 0.0325, conf: 0.6, authority: 'user_confirmed' }],
+      },
+    }
+    await route.fulfill({
+      status: 200,
+      headers: SSE_HEADERS,
+      body: `retry: 3600000\n\ndata: ${JSON.stringify(event)}\n\n`,
+    })
+  })
+
+  await page.goto('/chat')
+
+  const textarea = page.getByPlaceholder(/type a message/i)
+  await expect(textarea).toBeVisible()
+  await textarea.fill('tên đầy đủ của tôi là gì')
+  await textarea.press('Enter')
+
+  // The chip renders from the LIVE SSE event while the reply is still streaming
+  // (no reload, no history re-fetch).
+  const messages = page.getByTestId('chat-messages')
+  const chip = messages.locator('.memory-chip')
+  await expect(chip).toBeVisible()
+  await expect(chip).toContainText('🧠')
+
+  // Expand → the recalled line + its lane provenance came through the SSE
+  // (proves recall_lanes/recall_scores were carried and rendered, not just a
+  // bare count).
+  await chip.click()
+  await expect(messages.getByText(/nguyễn văn phúc là người tạo ra/i)).toBeVisible()
+  await expect(messages.locator('.memory-detail .lane', { hasText: 'fts' })).toBeVisible()
+
+  releaseChat?.()
+  expect(backend.unexpected.length).toBe(0)
+})


### PR DESCRIPTION
Two related memory-recall fixes found while debugging why prod recalled nothing (e.g. the user's full name) even though the data was stored.

---

## 1. Dense recall silently dies after "forget all memories"

**Symptom:** auto-recall, the UI memory search, **and** the agent's own `memory_search` tool all returned nothing, while `index-status` reported the dense backend healthy (`reachable=true, embeddings=true, points=8`). Local was fine on the same code.

**Root cause:** **LadybugDB 0.17.1 leaves the HNSW vector index DEAD once the `Memory` table is emptied** (`count→0`). Rows inserted afterward exist (valid embeddings, `count>0`) but `QUERY_VECTOR_INDEX` returns nothing — dense recall dies for every new memory until a full rebuild. Reproduced **12/12** on the real engine. **Partial deletes and updates are safe — only deletion-to-empty triggers it** (so "forget all memories" is the trigger). Reproduced end-to-end on prod live: `archive all 8 → points=0 → restore 8 → search n=0`; a graph rebuild (restart) restored it (`n=4/n=5`).

Compounding (follow-up, not fixed here): the empty dense lane is reported `degraded=false` (count>0 read as healthy), and the off-topic gate then discards the FTS keyword lane too → total silent recall failure.

**Fix:** `delete_memory()` rebuilds the vector index (`DROP_VECTOR_INDEX` + `CREATE_VECTOR_INDEX`) the instant the table empties (`count()==0`). Extracted `_create_vector_index()` as the single source of truth for the index name/params. Confirmed 5/5 that the rebuild recovers a dead index. Blast radius (GitNexus): LOW — `delete_memory` has one runtime caller (`delete_by_record`), 0 affected downstream symbols.

**Test:** `test_delete_to_empty_rebuilds_vector_index` — insert 4 → delete all → insert 3 → dense search still returns 3 (returns <3, usually 0, without the fix). Real LadybugDB, no mocks.

## 2. "Memories used" chip only showed after a page refresh

**Symptom:** the recall chip (🧠 N memories used + FTS/DENSE/GRAPH badges + scores) didn't appear during a turn — only after reloading the page.

**Root cause:** the chip is built solely from persisted history fetched on mount (`chat.js fetchHistory` → `recallLanes`/`recallScores`); the streaming turn never inserts the recall block. The realtime SSE `retrieval_completed` was only used to toggle the degraded banner, and didn't carry lanes/scores.

**Fix:** the retrieval hook broadcasts a `memory_recalled` activity event the moment it injects a block, carrying the SAME content + per-line lanes + scores the block persists (derived from the deduped `fresh` set via a shared `_score_dict`), so the live chip equals the reloaded one. The agents store routes it to the chat store, which inserts the block just before the in-flight assistant placeholder (guarded on streaming conversation + matching agent). On the next history fetch the persisted block transparently replaces the live one.

(Also: `chat.js` relative imports now carry explicit `.js` so the store is importable under `node:test`, matching `agents.js`.)

**Tests:** backend asserts `memory_recalled` is emitted with content/lanes/scores on injection (and silent with no evidence); frontend chat-store test asserts the block is inserted reactively before the reply, and ignored when not streaming or for a different agent.

## Click-flow

User says "forget all memories", states new facts, then asks Jarvis to recall them → recall works (was returning nothing until a restart), and the "memories used" chip appears during the same turn without a refresh.

## Follow-ups (not in this PR)

- Resilience: an empty dense lane should not veto the FTS keyword lane.
- Observability: `index-status` should flag "count>0 but vector_search empty" instead of reporting healthy.
- Consider upgrading LadybugDB past 0.17.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Test coverage (incl. e2e)

**#1 dense recall after forget-all:**
- `test_delete_to_empty_rebuilds_vector_index` — store-level, real LadybugDB: wipe-all → re-add stays dense-searchable.
- `test_forget_all_then_readd_keeps_dense_recall` — **e2e through the real worker**: `create_memory → outbox → MemoryIndexWorker → EVENT_MEMORY_DELETE → _delete_dense → delete_memory (empties → rebuild) → re-add → LadybugProvider recall`. Only the embedder is faked. **Verified it fails without the fix.**

**#2 realtime chip:**
- Backend: hook emits `memory_recalled` with content/lanes/scores on injection (silent with no evidence).
- Frontend: chat-store test asserts the block is inserted reactively before the reply, ignored when not streaming / wrong agent.
- **Playwright e2e** `chat-memory-recall.spec.ts` — boots the real chat app, sends a message, and delivers `memory_recalled` over a real EventSource mid-turn: asserts the chip paints in the live DOM (no reload) and, expanded, shows the recalled line + lane badge. Full browser round-trip (useRealtimeStream → agents.processEvent → chat.addMemoryRecallBlock → ChatMessages). Passing.

Manual: #1 also verified live on prod (archive→restore→search returns n=0 before the fix; restart restores).



---

## 3. GraphRAG recall pulled irrelevant (tangential) memories

**Symptom:** an unrelated query (e.g. baby's age) recalled a memory about the user's AI career, surfaced by the GRAPH lane.

**Root cause (pre-existing since the GraphRAG lane shipped in #96 — verified by checking out the pre-provenance commit and reproducing identical pulls):** the graph lane expanded from the **vector-hit seeds'** entities. In a personal-memory store almost every fact co-mentions the user's own entity ("Nguyễn Văn Phúc", measured **64% df** — a universal hub), so any query dragged in user-co-occurring memories. Not a recent regression: lane-provenance labelling (`53a36e3`) only made the pre-existing graph pull *visible* (it was previously mislabelled `dense`).

**Fix (query-entity anchoring + automatic hub suppression):**
- `LadybugStore.query_anchored_memories`: graph-expand ONLY from entities the query NAMES (normalized whole-token match); skip hubs (entity df ≥ 50% of the owner's memories, no hardcoded names). No query entity → `[]` → dense + FTS only.
- `LadybugProvider.search` uses it instead of blind seed co-occurrence; `graph_max_hops <= 0` disables the lane. **Did not touch dense / FTS / off-topic gate / RRF.**

**Measured before/after on real data:** query "bé làm gì đã 1 tuổi" → GRAPH hits **2 → 0** (AI-career memory gone); "con mèo của tôi tên gì" → still anchors the cat entity correctly.

**Tests:** store-level (named-entity pull / no-entity→empty / hub skipped / owner scope) + rewrote the orchestrator e2e to the query-anchored contract (a vector-far memory is pulled ONLY when the query names its entity, never dragged in otherwise).


---

## 4. Recall relevance: Qwen3-Embedding + cross-encoder reranker

**Symptom:** short Vietnamese question→fact recall returned tangential memories (e.g. the cat in a "how old is my baby" query).

**Root cause:** the bi-encoder dense lane embeds query and memory SEPARATELY → can't judge fine relevance (measured: bge-m3 ranks "cat" ~as high as "7-month son" for the baby query). A score/RRF threshold can't fix it — the relevant full-name answer sits at the same score as the noise.

**Fix (both, quality-first):**
- **A. Embedding → Qwen3-Embedding-0.6B** (sentence-transformers, dim 1024 = no schema change; bge-m3 still selectable via `embedding_model`). `recall_min_similarity` re-tuned 0.44 → 0.34 over 19 on-topic + 12 off-topic queries. Startup migration re-embeds the store IN PLACE on an embedding-revision change (no manual cleanup; old memory records are unchanged & compatible).
- **B. Cross-encoder reranker** (`bge-reranker-v2-m3` via sentence-transformers CrossEncoder — FlagReranker breaks on transformers 5.x). New precision stage: rerank top-K fused candidates by joint (query, memory) relevance, drop below `rerank_min_score`, order by reranker; `apply_policy` is reranker-aware. Gated main-process load + Null fallback (keeps fusion order on failure).

**Verified live (after auto-migration):** "bé mấy tuổi" → only "con trai 7 tháng" (cat/AI noise gone); "con mèo tên gì" → only the cat (0.97); off-topic → nothing. Added latency ~90–260ms/turn warm (Qwen embed ~30-75ms + rerank ~30-216ms); first recall after a restart pays a one-time ~7s reranker load (lazy).

**Tests:** rerank reorder/floor/no-op + apply_policy reranker-override; settings/factory tests updated for new defaults + per-model dep dispatch. 238 memory tests pass.

**Deploy note:** needs `uv sync` (adds `sentence-transformers`, `einops`); switching the embedding model triggers a one-time full re-embed (startup migration).
