### PR TITLE
feat(memory): Qwen3 reranker + recall tuning + realtime saved chip + rrf/rerank score split

### DIFF
--- a/backend/agent.py
+++ b/backend/agent.py
@@ -332,6 +332,11 @@ else:
       call memory_remember to persist it (it self-gates / awaits approval).
     - Use memory_search whenever personalization would improve the answer
       (e.g. trip planning → search for the user's transport, family, budget).
+    - PHRASE the query as a SHORT, NATURAL question that names the subject
+      ("what is the user's job?"), NOT a pile of abstract keywords — recall is
+      embedding-based, so a keyword-stuffed query matches nothing. For a broad
+      need, run SEVERAL focused searches (job, skills, certifications) and merge,
+      rather than one long catch-all query.
 
     OUTPUT FORMAT RULES:
     - Use Markdown when appropriate (heading, bullet, table, code block).

--- a/backend/services/memory/candidate_service.py
+++ b/backend/services/memory/candidate_service.py
@@ -103,6 +103,9 @@ def create_candidate(
         return cand                                  # await curator decision
     if requires_approval:
         _create_approval_row(cand)
+        # Live chat chip: surface the pending memory IN CONTEXT (with inline
+        # approve/reject) instead of leaving it silent until the Approvals tab.
+        _emit_saved(cand, status="pending")
         return cand
     # Deterministic, unambiguous → persist now.
     _persist_from_candidate(db, cand, CandidateStatus.AUTO_APPROVED.value,
@@ -138,6 +141,7 @@ def reject_candidate(db: Session, candidate_id: str, *, now: float | None = None
     cand.resolution_json = json.dumps({"reason": reason}) if reason else None
     db.commit()
     _emit("memory_candidate_rejected", cand)
+    _emit_saved(cand, status="rejected")    # live chat chip: pending → dismissed
     if not _from_approval:
         _close_linked_approval(candidate_id, "reject")
     return cand
@@ -252,6 +256,9 @@ def _persist_from_candidate(db, cand, status, *, now, changed_by="system",
     cand.resolved_at = now
     db.commit()
     _emit("memory_candidate_approved", cand)
+    # Live chat chip: this candidate is now an ACTIVE memory (covers BOTH the
+    # auto-approved path and a human approval) → tell the chat the moment it lands.
+    _emit_saved(cand, status="saved", record_id=(rec.id if rec is not None else None))
 
     # SINGLE-SOURCE graph projection: extract this memory's triples (→ RELATES +
     # MENTIONS) off the hot path, for EVERY lane incl. the agent's free-text
@@ -307,4 +314,36 @@ def _emit(event_type: str, cand: MemoryCandidate) -> None:
             "data": {"candidate_id": cand.id, "candidate_type": cand.candidate_type},
         })
     except Exception:  # noqa: BLE001
+        pass
+
+
+def _emit_saved(cand: MemoryCandidate, *, status: str, record_id: str | None = None) -> None:
+    """Live SSE for the CHAT "memory saved" chip — so the user knows the moment
+    Jarvis stores something, in context, instead of discovering it later in the
+    Memory tab. Distinct from ``_emit`` (which feeds the Memory tab) so the two
+    surfaces stay decoupled, mirroring how recall has its own ``memory_recalled``.
+
+    ``status``: ``saved`` (auto-approved OR human-approved → now active),
+    ``pending`` (manual policy / secret / high-risk → awaiting approval), or
+    ``rejected``. The chat store keys items by ``candidate_id`` so a later
+    transition (pending→saved/rejected) updates the SAME chip in place. Secrets
+    are MASKED here too — the cleartext never rides the SSE bus into the chat."""
+    try:
+        from services.activity_stream import activity_stream_manager
+        payload = json.loads(cand.payload_json or "{}")
+        raw = payload.get("content", "") or ""
+        sensitive = has_secret(raw)
+        activity_stream_manager.broadcast({
+            "agent_name": cand.owner_agent_name, "event_type": "memory_saved",
+            "message": "memory_saved", "timestamp": cand.resolved_at or cand.created_at,
+            "data": {
+                "candidate_id": cand.id,
+                "record_id": record_id,
+                "content": "🔒 hidden secret" if sensitive else raw,
+                "memory_type": payload.get("memory_type", "semantic"),
+                "status": status,
+                "sensitive": sensitive,
+            },
+        })
+    except Exception:  # noqa: BLE001 — never break a write over a UI mirror
         pass

--- a/backend/services/memory/candidate_service.py
+++ b/backend/services/memory/candidate_service.py
@@ -345,5 +345,5 @@ def _emit_saved(cand: MemoryCandidate, *, status: str, record_id: str | None = N
                 "sensitive": sensitive,
             },
         })
-    except Exception:  # noqa: BLE001 — never break a write over a UI mirror
-        pass
+    except Exception as exc:  # noqa: BLE001 — never break a write over a UI mirror
+        logger.debug("[MEMORY] memory_saved SSE emit failed: %s", exc)

--- a/backend/services/memory/retrieval_hook.py
+++ b/backend/services/memory/retrieval_hook.py
@@ -107,23 +107,32 @@ def _render_block(evidence) -> str:
 
 
 def _score_dict(e) -> dict:
-    """RAW ``{rel, conf, authority}`` for one evidence — the per-line debug score
-    (RRF match score, fact-truth confidence, authority). No normalization (see
-    RECALL_SCORES_CHANNEL). SINGLE SOURCE OF TRUTH for both the persisted channel
-    string (``_block_scores``) and the live SSE chip (``_emit_recall_block``), so
-    the real-time chip and the reloaded one never diverge. Tolerant of partial
-    stubs so a debug annotation never breaks recall."""
+    """RAW per-line debug score for one evidence: the REAL RRF fusion score AND
+    the cross-encoder reranker score, kept SEPARATE (they answer different
+    questions — rrf = lane-fusion rank, rerank = joint (query,memory) relevance,
+    which is the authoritative post-rerank order and can be ~1.0 when the query
+    nearly restates the memory). Plus fact-truth confidence + authority. No
+    normalization (see RECALL_SCORES_CHANNEL). Either score is ``None`` when its
+    stage didn't run. SINGLE SOURCE OF TRUTH for both the persisted channel string
+    (``_block_scores``) and the live SSE chip (``_emit_recall_block``), so the
+    real-time chip and the reloaded one never diverge. Tolerant of partial stubs."""
     scores = getattr(e, "scores", None)
-    rel = getattr(scores, "final", None) or getattr(scores, "rrf", None) or 0.0
+    rrf = getattr(scores, "rrf", None)
+    rerank = getattr(scores, "reranker", None)
     conf = max(0.0, min(1.0, getattr(e, "confidence", 0.0) or 0.0))
-    return {"rel": round(rel, 4), "conf": round(conf, 2),
-            "authority": getattr(e, "authority", "") or ""}
+    return {"rrf": round(rrf, 4) if rrf is not None else None,
+            "rerank": round(rerank, 4) if rerank is not None else None,
+            "conf": round(conf, 2), "authority": getattr(e, "authority", "") or ""}
 
 
 def _block_scores(evidence) -> list[str]:
-    """One ``rel|conf|authority`` string per evidence for the persisted channel —
-    derived from ``_score_dict`` so it stays identical to the live SSE payload."""
-    return [f"{s['rel']}|{s['conf']}|{s['authority']}" for s in map(_score_dict, evidence)]
+    """One ``rrf|rerank|conf|authority`` string per evidence for the persisted
+    channel — derived from ``_score_dict`` so it stays identical to the live SSE
+    payload. An empty field means that score was absent (e.g. no reranker)."""
+    def _f(v):
+        return "" if v is None else v
+    return [f"{_f(s['rrf'])}|{_f(s['rerank'])}|{s['conf']}|{s['authority']}"
+            for s in map(_score_dict, evidence)]
 
 
 def _block_recall_ids(msg) -> list[str]:

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -75,10 +75,12 @@ class MemorySettings:
     retention_retrieval_runs_days: int = 30
     # Recall relevance gate: drop a dense hit whose cosine similarity to the query
     # is below this (distance = 1 - similarity). RECALL-oriented, NOT precision.
-    # Grid-searched 2026-06-23 with the real Qwen3-Embedding + bge reranker over a
-    # 78-query labelled set (on-topic clear/indirect + off-topic clear/keyword-
-    # overlap, real memories): on-topic recall@5 is a FLAT 100% across [0.05, 0.39]
-    # and only falls off from 0.40 (the cliff). The dense gate therefore does NOT
+    # Grid-searched 2026-06-23 with the real Qwen3-Embedding over a 78-query
+    # labelled set (on-topic clear/indirect + off-topic clear/keyword-overlap, real
+    # memories): on-topic recall@5 is a FLAT 100% across [0.05, 0.39] and only falls
+    # off from 0.40 (the cliff). This is a DENSE-lane property measured PRE-rerank-
+    # gate (the gate applies before reranking), so it holds regardless of which
+    # reranker ships — the bge→Qwen3 swap does not move it. The dense gate does NOT
     # bound recall anywhere in that band — it is a candidate-pool / false-positive
     # knob. 0.30 sits mid-plateau: ~0.10 margin below the 0.40 cliff (robust to
     # unseen / semantic-only phrasings the labelled set under-represents) while

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -50,23 +50,23 @@ class MemorySettings:
     # memory) relevance — the bi-encoder can't. ON by default. It is a RANKER, not
     # a precision GATE: see rerank_min_score.
     reranker_enabled: bool = True
-    rerank_model: str = "BAAI/bge-reranker-v2-m3"
+    # Qwen3-Reranker-0.6B (causal LM, yes/no logit) measured 2026-06-23 to rank the
+    # direct answer FIRST on the live Vietnamese store and give a usable score
+    # spread, where bge-reranker-v2-m3 compressed everything near 0 (ungateable,
+    # mis-ranked). bge still selectable. Slower (autoregressive) but worth it.
+    rerank_model: str = "Qwen/Qwen3-Reranker-0.6B"
     rerank_top_k: int = 20            # how many fused candidates to rerank
-    # Drop candidates scoring below this. Grid-searched 2026-06-23 (real reranker,
-    # 78-query labelled set): the reranker score CANNOT separate on-topic from
-    # off-topic-keyword — on-topic-INDIRECT targets score as low as 0.0000 ("Repo
-    # trợ lý tôi làm nằm ở đâu?" → 0.0000) while off-topic-keyword candidates score
-    # up to 0.44 (bge) / 0.98 (Qwen3-Reranker), because those queries are genuinely
-    # topically similar. Any floor > 0 that drops the off-topic noise ALSO drops
-    # ~20%+ of indirect-phrased on-topic recall (the original recall=0 failure mode
-    # — verified: floor 0.005 → on-topic recall@5 drops 100%→80%). So the floor is
-    # 0.0: the reranker only ORDERS; the dense gate controls recall/precision.
-    # Off-topic-keyword false-positives (a topically-related memory injected for a
-    # general question) are an ACCEPTED trade — mild noise the LLM ignores. The
-    # real fix is an upstream personal-intent gate (deferred), NOT this floor:
-    # an instruction-tuned reranker was tested and did NOT help (it rates topical
-    # relevance, which is the wrong question — "is it NEEDED?" needs reasoning).
-    rerank_min_score: float = 0.0
+    # Drop candidates scoring below this. With bge-reranker this had to be 0.0 (it
+    # compressed every Vietnamese score near 0 — a floor couldn't separate on-topic
+    # from off-keyword without killing recall). Qwen3-Reranker fixes that: measured
+    # live 2026-06-23, real on-topic answers score >= 0.003 (e.g. "where do I work"
+    # → Techcombank 0.245) while off-keyword / general-knowledge candidates score
+    # <= 0.0009 ("Angular latest version" → 0.0002). So 0.001 cleanly gates: it
+    # drops off-keyword noise (the q2/q3 acceptance cases → 0 memory) while keeping
+    # the direct answers (q1/q4/q7), which now also rank #1. Residual: a real memory
+    # the reranker scores high for the WRONG query (the con/Milo adversarial pair)
+    # still leaks — no scalar floor catches that (needs intent/LLM, deferred).
+    rerank_min_score: float = 0.001
     # Dense/graph backend = LadybugDB (embedded property graph + HNSW vectors).
     # ``ladybug_path`` is the embedded DB directory.
     ladybug_path: str = "data/memory_graph"
@@ -116,9 +116,9 @@ _SCHEMA: dict[str, tuple[str, Any]] = {
     "embedding_model": ("str", "Qwen/Qwen3-Embedding-0.6B"),
     "embedding_revision": ("str", ""),
     "reranker_enabled": ("bool", True),
-    "rerank_model": ("str", "BAAI/bge-reranker-v2-m3"),
+    "rerank_model": ("str", "Qwen/Qwen3-Reranker-0.6B"),
     "rerank_top_k": ("int", 20),
-    "rerank_min_score": ("float", 0.0),
+    "rerank_min_score": ("float", 0.001),
     "ladybug_path": ("str", "data/memory_graph"),
     "retention_episodic_days": ("int", 90),
     "retention_retrieval_runs_days": ("int", 30),

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -46,12 +46,27 @@ class MemorySettings:
     # (startup migration on a revision change); bge-m3 is still selectable.
     embedding_model: str = "Qwen/Qwen3-Embedding-0.6B"
     embedding_revision: str = ""
-    # Cross-encoder reranker (precision stage): re-scores the fused candidates by
-    # reading (query, memory) jointly — what the bi-encoder can't do. ON by default.
+    # Cross-encoder reranker: re-ORDERS the fused candidates by joint (query,
+    # memory) relevance — the bi-encoder can't. ON by default. It is a RANKER, not
+    # a precision GATE: see rerank_min_score.
     reranker_enabled: bool = True
     rerank_model: str = "BAAI/bge-reranker-v2-m3"
     rerank_top_k: int = 20            # how many fused candidates to rerank
-    rerank_min_score: float = 0.005   # drop candidates scoring below this
+    # Drop candidates scoring below this. Grid-searched 2026-06-23 (real reranker,
+    # 78-query labelled set): the reranker score CANNOT separate on-topic from
+    # off-topic-keyword — on-topic-INDIRECT targets score as low as 0.0000 ("Repo
+    # trợ lý tôi làm nằm ở đâu?" → 0.0000) while off-topic-keyword candidates score
+    # up to 0.44 (bge) / 0.98 (Qwen3-Reranker), because those queries are genuinely
+    # topically similar. Any floor > 0 that drops the off-topic noise ALSO drops
+    # ~20%+ of indirect-phrased on-topic recall (the original recall=0 failure mode
+    # — verified: floor 0.005 → on-topic recall@5 drops 100%→80%). So the floor is
+    # 0.0: the reranker only ORDERS; the dense gate controls recall/precision.
+    # Off-topic-keyword false-positives (a topically-related memory injected for a
+    # general question) are an ACCEPTED trade — mild noise the LLM ignores. The
+    # real fix is an upstream personal-intent gate (deferred), NOT this floor:
+    # an instruction-tuned reranker was tested and did NOT help (it rates topical
+    # relevance, which is the wrong question — "is it NEEDED?" needs reasoning).
+    rerank_min_score: float = 0.0
     # Dense/graph backend = LadybugDB (embedded property graph + HNSW vectors).
     # ``ladybug_path`` is the embedded DB directory.
     ladybug_path: str = "data/memory_graph"
@@ -59,11 +74,20 @@ class MemorySettings:
     retention_episodic_days: int = 90
     retention_retrieval_runs_days: int = 30
     # Recall relevance gate: drop a dense hit whose cosine similarity to the query
-    # is below this (distance = 1 - similarity). Re-tuned 2026-06-22 for
-    # Qwen3-Embedding-0.6B over 19 on-topic + 12 off-topic queries: on-topic
-    # top-sim ≥0.335, off-topic ≤0.333, so 0.34 keeps on-topic / drops off-topic.
-    # (bge-m3's scale was higher: it used 0.44. Re-tune if the model changes.)
-    recall_min_similarity: float = 0.34
+    # is below this (distance = 1 - similarity). RECALL-oriented, NOT precision.
+    # Grid-searched 2026-06-23 with the real Qwen3-Embedding + bge reranker over a
+    # 78-query labelled set (on-topic clear/indirect + off-topic clear/keyword-
+    # overlap, real memories): on-topic recall@5 is a FLAT 100% across [0.05, 0.39]
+    # and only falls off from 0.40 (the cliff). The dense gate therefore does NOT
+    # bound recall anywhere in that band — it is a candidate-pool / false-positive
+    # knob. 0.30 sits mid-plateau: ~0.10 margin below the 0.40 cliff (robust to
+    # unseen / semantic-only phrasings the labelled set under-represents) while
+    # trimming more off-topic-clear noise than a very low gate. The old 0.34 sat
+    # right at the cliff; bge-m3's scale was higher (~0.44 — gate_mistuned_warning
+    # flags the mismatch). NOTE: off-topic-KEYWORD rejection is intentionally NOT
+    # solved here — the reranker scores topical similarity, which those queries
+    # genuinely have; see rerank_min_score.
+    recall_min_similarity: float = 0.30
     # GraphRAG traversal depth for RELATES expansion. 1 is the sweet spot for the
     # star-shaped personal graph (the user hub is a super-node — 2 hops through it
     # pulls the whole profile = noise). Bump to 2 only with hop-decay.
@@ -94,11 +118,11 @@ _SCHEMA: dict[str, tuple[str, Any]] = {
     "reranker_enabled": ("bool", True),
     "rerank_model": ("str", "BAAI/bge-reranker-v2-m3"),
     "rerank_top_k": ("int", 20),
-    "rerank_min_score": ("float", 0.005),
+    "rerank_min_score": ("float", 0.0),
     "ladybug_path": ("str", "data/memory_graph"),
     "retention_episodic_days": ("int", 90),
     "retention_retrieval_runs_days": ("int", 30),
-    "recall_min_similarity": ("float", 0.34),
+    "recall_min_similarity": ("float", 0.30),
     "graph_max_hops": ("int", 1),
     "hub_max_df": ("float", 0.5),
     "trigger_lexicon_overrides": ("json", {}),

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -73,7 +73,7 @@ class RetrievalOrchestrator:
         if getattr(settings, "reranker_enabled", False):
             from services.retrieval.reranker import get_shared_reranker
             self._reranker = get_shared_reranker(
-                getattr(settings, "rerank_model", None) or "BAAI/bge-reranker-v2-m3")
+                getattr(settings, "rerank_model", None) or "Qwen/Qwen3-Reranker-0.6B")
 
     async def retrieve(self, request: RetrievalRequest, *, now: float,
                        ledger: EvidenceLedger | None = None, turn: int = 0,

--- a/backend/services/retrieval/reranker.py
+++ b/backend/services/retrieval/reranker.py
@@ -83,10 +83,12 @@ class CrossEncoderReranker(Reranker):
 
 # Query-side instruction for Qwen3-Reranker — the personal-relevance framing.
 # Measured 2026-06-23 head-to-head on the live Vietnamese store: Qwen3-Reranker
-# ranks the direct answer #1 ("where do I work" → Techcombank 0.167) where
+# ranks the direct answer #1 ("where do I work" → Techcombank 0.245 live) where
 # bge-reranker-v2-m3 buried it at 0.0013, and gives a usable score SPREAD (so a
-# floor can gate) — bge compressed every score near 0, ungateable. Slower
-# (autoregressive) but worth it for the ranking + precision gain.
+# floor can gate) — bge compressed every score near 0, ungateable. The cost is
+# latency: one batched forward pass of a 0.6B LM over the candidates (~1.2–1.4s
+# p50/p95 end-to-end on CPU, vs bge's classification head) — accelerated to
+# cuda/mps when present. Worth it for the ranking + precision gain.
 QWEN_RERANK_INSTRUCT = (
     "The user is searching their OWN personal memory. A document is relevant ONLY "
     "if it states a personal fact about the user needed to answer this specific "
@@ -108,6 +110,7 @@ class Qwen3Reranker(Reranker):
         self._tok = None
         self._yes = self._no = None
         self._pre = self._suf = None
+        self._device = "cpu"
 
     def is_available(self) -> bool:
         return True
@@ -119,9 +122,16 @@ class Qwen3Reranker(Reranker):
             raise RuntimeError(
                 "reranker load attempted outside the main backend process; "
                 "agents must use the memory API, not load models.")
+        import torch
         from transformers import AutoModelForCausalLM, AutoTokenizer  # heavy, lazy
+        # Use an accelerator when present (the 0.6B forward dominates recall
+        # latency on CPU); fp16 there, fp32 on CPU for numerical safety.
+        self._device = ("cuda" if torch.cuda.is_available()
+                        else "mps" if torch.backends.mps.is_available() else "cpu")
+        dtype = torch.float16 if self._device != "cpu" else torch.float32
         self._tok = AutoTokenizer.from_pretrained(self._model_name, padding_side="left")
-        self._model = AutoModelForCausalLM.from_pretrained(self._model_name).eval()
+        self._model = (AutoModelForCausalLM.from_pretrained(self._model_name, dtype=dtype)
+                       .to(self._device).eval())
         self._yes = self._tok.convert_tokens_to_ids("yes")
         self._no = self._tok.convert_tokens_to_ids("no")
         # The fixed system/assistant scaffold around each (instruct, query, doc).
@@ -133,7 +143,8 @@ class Qwen3Reranker(Reranker):
         self._suf = self._tok.encode(
             "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
             add_special_tokens=False)
-        logger.info("[MEMORY] Loaded reranker %s (Qwen3 yes/no logit)", self._model_name)
+        logger.info("[MEMORY] Loaded reranker %s (Qwen3 yes/no logit, device=%s)",
+                    self._model_name, self._device)
 
     def rerank(self, query: str, documents: list[str]) -> list[float]:
         if not documents:
@@ -149,10 +160,12 @@ class Qwen3Reranker(Reranker):
         ]
         ml = max(len(s) for s in seqs)
         pad = self._tok.pad_token_id or 0
-        ids = torch.tensor([[pad] * (ml - len(s)) + s for s in seqs])      # left-pad
-        att = torch.tensor([[0] * (ml - len(s)) + [1] * len(s) for s in seqs])
+        dev = self._device
+        ids = torch.tensor([[pad] * (ml - len(s)) + s for s in seqs], device=dev)   # left-pad
+        att = torch.tensor([[0] * (ml - len(s)) + [1] * len(s) for s in seqs], device=dev)
         with torch.no_grad():
-            logits = self._model(input_ids=ids, attention_mask=att).logits[:, -1, :]
+            logits = self._model(input_ids=ids, attention_mask=att).logits[:, -1, :].float()
+        # P(yes) from the softmax over the [no, yes] next-token logits.
         probs = torch.softmax(torch.stack([logits[:, self._no], logits[:, self._yes]], 1), 1)[:, 1]
         return [float(p) for p in probs]
 

--- a/backend/services/retrieval/reranker.py
+++ b/backend/services/retrieval/reranker.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 
 logger = logging.getLogger("memory.reranker")
 
-DEFAULT_RERANKER = "BAAI/bge-reranker-v2-m3"
+DEFAULT_RERANKER = "Qwen/Qwen3-Reranker-0.6B"
 # Set by the FastAPI lifespan in the main process (same flag the embedder uses).
 MAIN_PROCESS_ENV = "JARVIS_MAIN_PROCESS"
 
@@ -81,6 +81,86 @@ class CrossEncoderReranker(Reranker):
         return [float(s) for s in scores]
 
 
+# Query-side instruction for Qwen3-Reranker — the personal-relevance framing.
+# Measured 2026-06-23 head-to-head on the live Vietnamese store: Qwen3-Reranker
+# ranks the direct answer #1 ("where do I work" → Techcombank 0.167) where
+# bge-reranker-v2-m3 buried it at 0.0013, and gives a usable score SPREAD (so a
+# floor can gate) — bge compressed every score near 0, ungateable. Slower
+# (autoregressive) but worth it for the ranking + precision gain.
+QWEN_RERANK_INSTRUCT = (
+    "The user is searching their OWN personal memory. A document is relevant ONLY "
+    "if it states a personal fact about the user needed to answer this specific "
+    "question about themselves; a general-knowledge question that merely mentions "
+    "a keyword is NOT relevant.")
+
+
+class Qwen3Reranker(Reranker):
+    """Qwen3-Reranker scored via the yes/no NEXT-TOKEN logit — a causal LM, NOT a
+    SequenceClassification cross-encoder, so it can't use the CrossEncoder path.
+    Instruction-aware. Lazy + main-process-only, like the embedder."""
+
+    def __init__(self, model_name: str, max_length: int = 512,
+                 instruct: str = QWEN_RERANK_INSTRUCT):
+        self._model_name = model_name
+        self._max_length = max_length
+        self._instruct = instruct
+        self._model = None
+        self._tok = None
+        self._yes = self._no = None
+        self._pre = self._suf = None
+
+    def is_available(self) -> bool:
+        return True
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return
+        if not os.environ.get(MAIN_PROCESS_ENV):
+            raise RuntimeError(
+                "reranker load attempted outside the main backend process; "
+                "agents must use the memory API, not load models.")
+        from transformers import AutoModelForCausalLM, AutoTokenizer  # heavy, lazy
+        self._tok = AutoTokenizer.from_pretrained(self._model_name, padding_side="left")
+        self._model = AutoModelForCausalLM.from_pretrained(self._model_name).eval()
+        self._yes = self._tok.convert_tokens_to_ids("yes")
+        self._no = self._tok.convert_tokens_to_ids("no")
+        # The fixed system/assistant scaffold around each (instruct, query, doc).
+        self._pre = self._tok.encode(
+            "<|im_start|>system\nJudge whether the Document meets the requirements "
+            "based on the Query and the Instruct provided. Note that the answer can "
+            "only be \"yes\" or \"no\".<|im_end|>\n<|im_start|>user\n",
+            add_special_tokens=False)
+        self._suf = self._tok.encode(
+            "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n",
+            add_special_tokens=False)
+        logger.info("[MEMORY] Loaded reranker %s (Qwen3 yes/no logit)", self._model_name)
+
+    def rerank(self, query: str, documents: list[str]) -> list[float]:
+        if not documents:
+            return []
+        self._ensure_model()
+        import torch
+        seqs = [
+            self._pre + self._tok.encode(
+                f"<Instruct>: {self._instruct}\n<Query>: {query}\n<Document>: {d}",
+                add_special_tokens=False, max_length=self._max_length, truncation=True)
+            + self._suf
+            for d in documents
+        ]
+        ml = max(len(s) for s in seqs)
+        pad = self._tok.pad_token_id or 0
+        ids = torch.tensor([[pad] * (ml - len(s)) + s for s in seqs])      # left-pad
+        att = torch.tensor([[0] * (ml - len(s)) + [1] * len(s) for s in seqs])
+        with torch.no_grad():
+            logits = self._model(input_ids=ids, attention_mask=att).logits[:, -1, :]
+        probs = torch.softmax(torch.stack([logits[:, self._no], logits[:, self._yes]], 1), 1)[:, 1]
+        return [float(p) for p in probs]
+
+
+def _is_qwen(model_name: str) -> bool:
+    return "qwen" in (model_name or "").lower()
+
+
 def _have_st() -> bool:
     import importlib.util
     return importlib.util.find_spec("sentence_transformers") is not None
@@ -97,6 +177,10 @@ def get_reranker(model_name: str = DEFAULT_RERANKER) -> Reranker:
             logger.warning("[MEMORY] sentence-transformers not installed — reranker "
                            "disabled; recall keeps fusion order. Install the 'memory' extra.")
         return NullReranker("sentence-transformers not installed")
+    # Dispatch by model: Qwen3-Reranker is a causal LM (yes/no logit); bge & other
+    # cross-encoders use the sentence-transformers CrossEncoder path.
+    if _is_qwen(model_name):
+        return Qwen3Reranker(model_name)
     return CrossEncoderReranker(model_name)
 
 

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -151,9 +151,12 @@ def _recall_lanes_from_channels(msg: Dict) -> Optional[List[List[str]]]:
 
 
 def _recall_scores_from_channels(msg: Dict) -> Optional[List[Dict]]:
-    """Read the ``jarvis:recall_scores`` channel — one ``{rel, conf, authority}``
-    per recalled line (RAW values; see RECALL_SCORES_CHANNEL). ``None`` if absent
-    (not a recall block, or recalled before this shipped)."""
+    """Read the ``jarvis:recall_scores`` channel — one
+    ``{rrf, rerank, conf, authority}`` per recalled line (RAW values; see
+    RECALL_SCORES_CHANNEL). ``None`` if absent (not a recall block, or recalled
+    before this shipped). Back-compat: older blocks stored a 3-field
+    ``rel|conf|authority`` where ``rel`` was the post-rerank ``final`` score — map
+    it onto ``rerank`` so reloaded old chips still render."""
     from services.memory.retrieval_hook import RECALL_SCORES_CHANNEL
     entries = (msg.get("channels") or {}).get(RECALL_SCORES_CHANNEL)
     if not entries:
@@ -161,13 +164,21 @@ def _recall_scores_from_channels(msg: Dict) -> Optional[List[Dict]]:
     out: List[Dict] = []
     for c in entries:
         text = c.get("text", "") if isinstance(c, dict) else ""
-        rel_s, _sep, rest = text.partition("|")
-        conf_s, _sep2, authority = rest.partition("|")
-        out.append({
-            "rel": _safe_float(rel_s),
-            "conf": _safe_float(conf_s),
-            "authority": authority,
-        })
+        parts = text.split("|")
+        if len(parts) >= 4:                       # rrf|rerank|conf|authority
+            out.append({
+                "rrf": _safe_float(parts[0]),
+                "rerank": _safe_float(parts[1]),
+                "conf": _safe_float(parts[2]),
+                "authority": parts[3],
+            })
+        else:                                     # legacy rel|conf|authority
+            out.append({
+                "rrf": None,
+                "rerank": _safe_float(parts[0] if parts else ""),
+                "conf": _safe_float(parts[1] if len(parts) > 1 else ""),
+                "authority": parts[2] if len(parts) > 2 else "",
+            })
     return out
 
 

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -155,8 +155,9 @@ def _recall_scores_from_channels(msg: Dict) -> Optional[List[Dict]]:
     ``{rrf, rerank, conf, authority}`` per recalled line (RAW values; see
     RECALL_SCORES_CHANNEL). ``None`` if absent (not a recall block, or recalled
     before this shipped). Back-compat: older blocks stored a 3-field
-    ``rel|conf|authority`` where ``rel`` was the post-rerank ``final`` score — map
-    it onto ``rerank`` so reloaded old chips still render."""
+    ``rel|conf|authority`` where ``rel`` was a single conflated score (``final or
+    rrf`` — could be either). We can't know which, so keep it as a NEUTRAL ``rel``
+    and let the chip render "score …" rather than mislabel it rrf or rerank."""
     from services.memory.retrieval_hook import RECALL_SCORES_CHANNEL
     entries = (msg.get("channels") or {}).get(RECALL_SCORES_CHANNEL)
     if not entries:
@@ -175,7 +176,8 @@ def _recall_scores_from_channels(msg: Dict) -> Optional[List[Dict]]:
         else:                                     # legacy rel|conf|authority
             out.append({
                 "rrf": None,
-                "rerank": _safe_float(parts[0] if parts else ""),
+                "rerank": None,
+                "rel": _safe_float(parts[0] if parts else ""),   # neutral → "score"
                 "conf": _safe_float(parts[1] if len(parts) > 1 else ""),
                 "authority": parts[2] if len(parts) > 2 else "",
             })

--- a/backend/tests/test_services/test_memory_candidate.py
+++ b/backend/tests/test_services/test_memory_candidate.py
@@ -27,6 +27,60 @@ def _payload(content="answer in Vietnamese", **kw):
     return base
 
 
+@pytest.fixture()
+def saved_events(monkeypatch):
+    """Capture the live `memory_saved` SSE the chat chip consumes."""
+    import services.activity_stream as asm
+    evs = []
+    monkeypatch.setattr(asm.activity_stream_manager, "broadcast",
+                        lambda ev: evs.append(ev))
+    return evs                        # live list, grows as events fire
+
+
+def _saved(evs):
+    return [e for e in evs if e.get("event_type") == "memory_saved"]
+
+
+def test_memory_saved_event_auto(db, saved_events):
+    c = cnd.create_candidate(db, owner_agent_name="Jarvis", candidate_type="preference",
+                             payload=_payload(), now=100.0)
+    saved = _saved(saved_events)
+    assert len(saved) == 1
+    d = saved[0]["data"]
+    assert d["status"] == "saved" and d["candidate_id"] == c.id and d["record_id"]
+    assert d["content"] == "answer in Vietnamese" and d["sensitive"] is False
+
+
+def test_memory_saved_event_pending_then_approved(db, saved_events):
+    c = cnd.create_candidate(db, owner_agent_name="Jarvis", candidate_type="fact",
+                             payload=_payload(content="we picked Postgres", memory_type="semantic"),
+                             now=100.0, requires_approval=True)
+    saved = _saved(saved_events)
+    assert [e["data"]["status"] for e in saved] == ["pending"]
+    assert saved[0]["data"]["record_id"] is None      # not active yet
+    cnd.approve_candidate(db, c.id, now=200.0)
+    saved = _saved(saved_events)
+    assert saved[-1]["data"]["status"] == "saved" and saved[-1]["data"]["record_id"]
+    assert saved[-1]["data"]["candidate_id"] == c.id   # SAME id → chip updates in place
+
+
+def test_memory_saved_event_rejected(db, saved_events):
+    c = cnd.create_candidate(db, owner_agent_name="Jarvis", candidate_type="fact",
+                             payload=_payload(content="we picked Postgres", memory_type="semantic"),
+                             now=100.0, requires_approval=True)
+    cnd.reject_candidate(db, c.id, now=200.0)
+    assert _saved(saved_events)[-1]["data"]["status"] == "rejected"
+
+
+def test_memory_saved_event_masks_secret(db, saved_events):
+    # A secret forces approval (pending) AND must never ride the SSE in cleartext.
+    cnd.create_candidate(db, owner_agent_name="Jarvis", candidate_type="fact",
+                         payload=_payload(content="db password: hunter2secret"), now=100.0)
+    d = _saved(saved_events)[0]["data"]
+    assert d["status"] == "pending" and d["sensitive"] is True
+    assert "hunter2secret" not in d["content"] and "🔒" in d["content"]
+
+
 def test_deterministic_candidate_auto_persists(db):
     c = cnd.create_candidate(db, owner_agent_name="Jarvis", candidate_type="preference",
                              payload=_payload(), now=100.0)

--- a/backend/tests/test_services/test_memory_recall_hook.py
+++ b/backend/tests/test_services/test_memory_recall_hook.py
@@ -215,7 +215,8 @@ def test_recall_lanes_channel_survives_to_display(tmp_path):
 
     def _ev_scored(rid, excerpt, *, authority="user_confirmed", confidence=0.9, **ranks):
         sc = EvidenceScores(**ranks)
-        sc.final = 0.03 if ranks.get("dense_rank") else 0.016   # raw RRF-ish
+        sc.rrf = 0.03 if ranks.get("dense_rank") else 0.016        # raw RRF fusion
+        sc.reranker = 0.88 if ranks.get("dense_rank") else 0.21    # cross-encoder
         return Evidence(
             evidence_id=f"{evidence_kind('semantic')}:{rid}", record_id=rid,
             owner_agent_name="Jarvis", memory_type="semantic", excerpt=excerpt,
@@ -239,9 +240,10 @@ def test_recall_lanes_channel_survives_to_display(tmp_path):
     lines = [l for l in display[0]["content"].split("\n") if l.startswith("- ")]
     assert len(lines) == len(lanes) == 2
 
-    # RAW scores ride the same way (no %): rel = RRF, conf = fact-truth, authority.
+    # RAW scores ride the same way (no %): rrf = lane fusion, rerank = cross-encoder,
+    # conf = fact-truth, authority. Both scores survive persist→display separately.
     scores = display[0]["recall_scores"]
     assert scores == [
-        {"rel": 0.03, "conf": 0.9, "authority": "user_confirmed"},
-        {"rel": 0.016, "conf": 0.6, "authority": "inferred"},
+        {"rrf": 0.03, "rerank": 0.88, "conf": 0.9, "authority": "user_confirmed"},
+        {"rrf": 0.016, "rerank": 0.21, "conf": 0.6, "authority": "inferred"},
     ]

--- a/backend/tests/test_services/test_memory_reranker.py
+++ b/backend/tests/test_services/test_memory_reranker.py
@@ -72,3 +72,36 @@ def test_get_reranker_dispatches_by_model():
     assert isinstance(rr.get_reranker("Qwen/Qwen3-Reranker-0.6B"), rr.Qwen3Reranker)
     assert isinstance(rr.get_reranker("BAAI/bge-reranker-v2-m3"), rr.CrossEncoderReranker)
     assert rr.DEFAULT_RERANKER.startswith("Qwen/")
+
+
+def test_qwen3_reranker_scoring_math():
+    # Covers the yes/no-logit scaffold WITHOUT weights: left-pad to max len, take
+    # the LAST-token logits, softmax over [no, yes], return P(yes) per doc IN ORDER.
+    import math
+    import types
+    import torch
+    from services.retrieval import reranker as rr
+    r = rr.Qwen3Reranker("Qwen/fake")
+    r._yes, r._no = 1, 0           # token ids for "yes"/"no"
+    r._pre, r._suf = [9], [9]
+    r._device = "cpu"
+
+    class _Tok:
+        pad_token_id = 0
+        def encode(self, text, **kw): return [7] * (len(text) % 4 + 1)   # varied lengths
+
+    class _Model:
+        def __call__(self, input_ids, attention_mask):
+            b, t = input_ids.shape
+            lg = torch.zeros(b, t, 10)
+            for i in range(b):
+                lg[i, -1, 1] = float(i)          # yes-logit = row index → P(yes)=sigmoid(i)
+            return types.SimpleNamespace(logits=lg)
+
+    r._tok, r._model = _Tok(), _Model()           # bypass _ensure_model (model is set)
+    scores = r.rerank("q", ["a", "bb", "ccc", "dddd"])
+    assert len(scores) == 4                        # one score per doc, same order
+    for i, s in enumerate(scores):                 # softmax([0, i])[1] == sigmoid(i)
+        assert abs(s - 1.0 / (1.0 + math.exp(-i))) < 1e-4
+    assert scores == sorted(scores)                # monotonic in row order (order preserved)
+    assert r.rerank("q", []) == []                 # empty → empty

--- a/backend/tests/test_services/test_memory_reranker.py
+++ b/backend/tests/test_services/test_memory_reranker.py
@@ -63,3 +63,12 @@ def test_apply_policy_orders_by_reranker_over_rrf():
     out = fusion.apply_policy([a, b], now=1000.0)
     assert [e.record_id for e in out] == ["b", "a"]   # reranker is authoritative
     assert out[0].scores.final == 0.9
+
+
+def test_get_reranker_dispatches_by_model():
+    # qwen name → causal-LM Qwen3Reranker; anything else → CrossEncoder. (Lazy:
+    # constructing does NOT load the model, so this needs no weights.)
+    from services.retrieval import reranker as rr
+    assert isinstance(rr.get_reranker("Qwen/Qwen3-Reranker-0.6B"), rr.Qwen3Reranker)
+    assert isinstance(rr.get_reranker("BAAI/bge-reranker-v2-m3"), rr.CrossEncoderReranker)
+    assert rr.DEFAULT_RERANKER.startswith("Qwen/")

--- a/backend/tests/test_services/test_memory_retrieval_hook.py
+++ b/backend/tests/test_services/test_memory_retrieval_hook.py
@@ -97,7 +97,7 @@ async def test_emits_live_recall_sse_matching_the_block(monkeypatch):
     # one lane-list and one score per injected line, SAME order as the block.
     assert len(data["recall_lanes"]) == 1
     assert len(data["recall_scores"]) == 1
-    assert set(data["recall_scores"][0]) == {"rel", "conf", "authority"}
+    assert set(data["recall_scores"][0]) == {"rrf", "rerank", "conf", "authority"}
 
 
 async def test_no_recall_sse_when_no_evidence(monkeypatch):

--- a/backend/tests/test_services/test_memory_settings.py
+++ b/backend/tests/test_services/test_memory_settings.py
@@ -127,7 +127,7 @@ def test_new_tuning_knobs_config(fake_cfg):
     # config keys (promoted from hardcoded). Defaults + round-trip + validation.
     d = ms.get_memory_settings()
     assert d.hub_max_df == 0.5 and d.extract_every_n == 4
-    assert d.rerank_top_k == 20 and d.rerank_min_score == 0.0
+    assert d.rerank_top_k == 20 and d.rerank_min_score == 0.001
     ms.update_memory_settings({"hub_max_df": 0.6, "extract_every_n": 3,
                                "rerank_top_k": 10, "rerank_min_score": 0.01})
     s = ms.get_memory_settings()

--- a/backend/tests/test_services/test_memory_settings.py
+++ b/backend/tests/test_services/test_memory_settings.py
@@ -72,7 +72,7 @@ def test_recall_gate_and_hops_round_trip_and_validation(fake_cfg):
     # defaults
     fake_cfg.store.clear()
     d = ms.get_memory_settings()
-    assert d.recall_min_similarity == 0.34 and d.graph_max_hops == 1
+    assert d.recall_min_similarity == 0.30 and d.graph_max_hops == 1
     # range validation
     with pytest.raises(ValueError, match="recall_min_similarity"):
         ms.update_memory_settings({"recall_min_similarity": 1.5})
@@ -127,7 +127,7 @@ def test_new_tuning_knobs_config(fake_cfg):
     # config keys (promoted from hardcoded). Defaults + round-trip + validation.
     d = ms.get_memory_settings()
     assert d.hub_max_df == 0.5 and d.extract_every_n == 4
-    assert d.rerank_top_k == 20 and d.rerank_min_score == 0.005
+    assert d.rerank_top_k == 20 and d.rerank_min_score == 0.0
     ms.update_memory_settings({"hub_max_df": 0.6, "extract_every_n": 3,
                                "rerank_top_k": 10, "rerank_min_score": 0.01})
     s = ms.get_memory_settings()

--- a/backend/tools/memory_server.py
+++ b/backend/tools/memory_server.py
@@ -49,7 +49,15 @@ def memory_search(query: str, types: list[str] | None = None,
     """Search YOUR durable memory (episodic history, decisions, preferences,
     procedures). Returns {"memories": [{"id", "type", "text"}, ...]} ordered by
     relevance — ``text`` is the content to use; pass ``id`` to memory_fetch for
-    the full source. ``types`` optionally restricts to e.g. ["episodic","semantic"]."""
+    the full source. ``types`` optionally restricts to e.g. ["episodic","semantic"].
+
+    QUERY PHRASING (matters — recall is embedding-based): write ``query`` as a
+    SHORT, NATURAL question that NAMES the subject, the way a person asks it
+    ("what is the user's job?", "the user's cat's name"). Do NOT stuff abstract
+    keywords ("profession goal learning skills current user") — a keyword pile
+    embeds far from the concrete stored facts and returns nothing. For a BROAD
+    need, issue SEVERAL focused searches (one concept each: job, skills,
+    certifications) and merge — not one long catch-all query."""
     owner = _owner()
     if not owner:
         return {"error": "no bound agent identity; memory unavailable"}

--- a/frontend/src/components/chat/ChatMessages.vue
+++ b/frontend/src/components/chat/ChatMessages.vue
@@ -5,6 +5,7 @@ import { parseYoutubeTags, youtubeEmbedUrl } from '../../utils/youtubeTags'
 import { normalizeTs } from '../../utils/timeFormat.js'
 import { useVoiceSession } from '../../composables/useVoiceSession.js'
 import { useLang } from '../../composables/useLang'
+import { useChatStore } from '../../stores/chat'
 import MarkdownRenderer from '../MarkdownRenderer.vue'
 
 /**
@@ -36,6 +37,14 @@ const expandedRows = reactive({})
 const { isMobile } = useBreakpoint()
 const voice = useVoiceSession()
 const { t } = useLang()
+const chat = useChatStore()
+
+// ── Memory-SAVED chip (live capture: auto-saved or pending approval) ──
+// Distinct from the recall chip: blocks carry `isMemorySaved` + a `memorySaved`
+// array of {candidateId, content, memoryType, status, recordId}. Rejected items
+// are hidden; counts drive the collapsed summary.
+function savedVisible(msg) { return (msg.memorySaved || []).filter(it => it.status !== 'rejected') }
+function savedCount(msg, status) { return (msg.memorySaved || []).filter(it => it.status === status).length }
 
 function toggleTools(msgId) { expandedTools[msgId] = !expandedTools[msgId] }
 function toggleRow(msgId, idx) { expandedRows[`${msgId}-${idx}`] = !expandedRows[`${msgId}-${idx}`] }
@@ -248,6 +257,30 @@ function parsedAgentContent(content) {
               <span v-if="scoreFor(msg, i)" class="mscore" :title="t('memory.scoreHint')">
                 {{ scoreLabel(scoreFor(msg, i))
                 }}<span v-if="isVerified(scoreFor(msg, i))" class="ok">✓</span>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- ── MEMORY-SAVED CHIP (live capture: auto-saved or pending) ──── -->
+        <div v-else-if="msg.isMemorySaved" class="row row-memory">
+          <button class="memory-chip saved" @click="toggleMemory(msg.id)">
+            <span v-if="savedCount(msg, 'saved')">✏️ {{ savedCount(msg, 'saved') }} {{ t('memory.saved.remembered') }}</span>
+            <span v-if="savedCount(msg, 'pending')">{{ savedCount(msg, 'saved') ? ' · ' : '' }}⏳ {{ savedCount(msg, 'pending') }} {{ t('memory.saved.pending') }}</span>
+            <span class="mc-chevron" :class="{ expanded: !!expandedMemory[msg.id] }">▾</span>
+          </button>
+          <div v-if="expandedMemory[msg.id]" class="memory-detail">
+            <div v-for="it in savedVisible(msg)" :key="it.candidateId" class="memory-line saved-line"
+                 :class="{ archived: it.status === 'archived' }">
+              <span class="lane" :class="it.status === 'pending' ? 'lane-graph' : 'lane-dense'">{{ it.memoryType }}</span>
+              {{ it.content }}
+              <span class="saved-actions">
+                <button v-if="it.status === 'saved'" class="saved-btn undo" @click="chat.archiveSavedMemory(it)">↩ {{ t('memory.saved.undo') }}</button>
+                <template v-else-if="it.status === 'pending'">
+                  <button class="saved-btn approve" @click="chat.approveSavedMemory(it)">✓ {{ t('memory.saved.approve') }}</button>
+                  <button class="saved-btn reject" @click="chat.rejectSavedMemory(it)">✗ {{ t('memory.saved.reject') }}</button>
+                </template>
+                <span v-else-if="it.status === 'archived'" class="archived-tag">{{ t('memory.saved.archived') }}</span>
               </span>
             </div>
           </div>
@@ -785,4 +818,20 @@ function parsedAgentContent(content) {
 .mscore { font-size: 10px; color: var(--text-faint); font-family: var(--font-mono, monospace);
   white-space: nowrap; margin-left: 4px; cursor: help; }
 .mscore .ok { color: var(--success, #16a34a); margin-left: 2px; font-weight: 700; }
+
+/* ── Memory-saved chip (live capture) — green-tinted to read as WRITE, vs the
+   indigo recall chip (READ). Pending items keep an amber cue via the actions. */
+.memory-chip.saved { background: color-mix(in srgb, var(--success, #16a34a) 12%, transparent);
+  color: var(--success, #16a34a); border-color: color-mix(in srgb, var(--success, #16a34a) 35%, transparent); }
+.memory-chip.saved:hover { background: color-mix(in srgb, var(--success, #16a34a) 20%, transparent); }
+.saved-line { display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap; }
+.saved-line.archived { opacity: .5; text-decoration: line-through; }
+.saved-actions { margin-left: auto; display: inline-flex; gap: 6px; white-space: nowrap; }
+.saved-btn { font-size: 11px; padding: 1px 8px; border-radius: var(--r-full); cursor: pointer;
+  border: 1px solid var(--border-strong); background: var(--bg-3); color: var(--text-dim); }
+.saved-btn:hover { background: var(--bg-4); }
+.saved-btn.approve { color: var(--success, #16a34a); border-color: color-mix(in srgb, var(--success, #16a34a) 40%, transparent); }
+.saved-btn.reject { color: var(--danger, #dc2626); border-color: color-mix(in srgb, var(--danger, #dc2626) 40%, transparent); }
+.saved-btn.undo { color: var(--text-faint); }
+.archived-tag { font-size: 11px; color: var(--text-faint); margin-left: auto; }
 </style>

--- a/frontend/src/components/chat/ChatMessages.vue
+++ b/frontend/src/components/chat/ChatMessages.vue
@@ -76,6 +76,18 @@ function memoryGraphCount(msg) {
 const VERIFIED_AUTHORITIES = ['user_confirmed', 'tool_verified']
 function scoreFor(msg, i) { return (msg.recallScores && msg.recallScores[i]) || null }
 function isVerified(s) { return !!s && VERIFIED_AUTHORITIES.includes(s.authority) }
+// Show rrf (lane fusion) and rerank (cross-encoder) SEPARATELY — they answer
+// different questions and diverge a lot (rerank ~1.0 on a near-verbatim restate).
+// `rel` fallback keeps any pre-split cached block rendering until its next reload.
+function scoreLabel(s) {
+  if (!s) return ''
+  const p = []
+  if (s.rrf != null) p.push(`rrf ${s.rrf}`)
+  if (s.rerank != null) p.push(`rerank ${s.rerank}`)
+  if (s.rrf == null && s.rerank == null && s.rel != null) p.push(`score ${s.rel}`)
+  if (s.conf != null) p.push(`conf ${s.conf}`)
+  return p.join(' · ')
+}
 
 // Auto-scroll to bottom on new messages
 watch(
@@ -234,7 +246,7 @@ function parsedAgentContent(content) {
                     :title="t('memory.lane.' + ln)">{{ ln }}</span>
               {{ line }}
               <span v-if="scoreFor(msg, i)" class="mscore" :title="t('memory.scoreHint')">
-                rrf {{ scoreFor(msg, i).rel }} · conf {{ scoreFor(msg, i).conf
+                {{ scoreLabel(scoreFor(msg, i))
                 }}<span v-if="isVerified(scoreFor(msg, i))" class="ok">✓</span>
               </span>
             </div>

--- a/frontend/src/components/chat/ChatMessages.vue
+++ b/frontend/src/components/chat/ChatMessages.vue
@@ -264,21 +264,21 @@ function parsedAgentContent(content) {
 
         <!-- ── MEMORY-SAVED CHIP (live capture: auto-saved or pending) ──── -->
         <div v-else-if="msg.isMemorySaved" class="row row-memory">
-          <button class="memory-chip saved" @click="toggleMemory(msg.id)">
-            <span v-if="savedCount(msg, 'saved')">✏️ {{ savedCount(msg, 'saved') }} {{ t('memory.saved.remembered') }}</span>
-            <span v-if="savedCount(msg, 'pending')">{{ savedCount(msg, 'saved') ? ' · ' : '' }}⏳ {{ savedCount(msg, 'pending') }} {{ t('memory.saved.pending') }}</span>
+          <button class="memory-chip" :class="savedCount(msg, 'pending') ? 'chip-pending' : 'chip-saved'"
+                  @click="toggleMemory(msg.id)">
+            <span v-if="savedCount(msg, 'saved')">🧠 {{ savedCount(msg, 'saved') }} {{ t('memory.saved.remembered') }}</span>
+            <span v-if="savedCount(msg, 'pending')">{{ savedCount(msg, 'saved') ? ' · ' : '' }}{{ savedCount(msg, 'pending') }} {{ t('memory.saved.pending') }}</span>
             <span class="mc-chevron" :class="{ expanded: !!expandedMemory[msg.id] }">▾</span>
           </button>
           <div v-if="expandedMemory[msg.id]" class="memory-detail">
             <div v-for="it in savedVisible(msg)" :key="it.candidateId" class="memory-line saved-line"
                  :class="{ archived: it.status === 'archived' }">
-              <span class="lane" :class="it.status === 'pending' ? 'lane-graph' : 'lane-dense'">{{ it.memoryType }}</span>
-              {{ it.content }}
+              <span class="mtype">[{{ it.memoryType }}]</span> {{ it.content }}
               <span class="saved-actions">
-                <button v-if="it.status === 'saved'" class="saved-btn undo" @click="chat.archiveSavedMemory(it)">↩ {{ t('memory.saved.undo') }}</button>
+                <button v-if="it.status === 'saved'" class="s-btn ghost" @click="chat.archiveSavedMemory(it)">{{ t('memory.saved.undo') }}</button>
                 <template v-else-if="it.status === 'pending'">
-                  <button class="saved-btn approve" @click="chat.approveSavedMemory(it)">✓ {{ t('memory.saved.approve') }}</button>
-                  <button class="saved-btn reject" @click="chat.rejectSavedMemory(it)">✗ {{ t('memory.saved.reject') }}</button>
+                  <button class="s-btn primary" @click="chat.approveSavedMemory(it)">{{ t('memory.saved.approve') }}</button>
+                  <button class="s-btn ghost" @click="chat.rejectSavedMemory(it)">{{ t('memory.saved.reject') }}</button>
                 </template>
                 <span v-else-if="it.status === 'archived'" class="archived-tag">{{ t('memory.saved.archived') }}</span>
               </span>
@@ -819,19 +819,25 @@ function parsedAgentContent(content) {
   white-space: nowrap; margin-left: 4px; cursor: help; }
 .mscore .ok { color: var(--success, #16a34a); margin-left: 2px; font-weight: 700; }
 
-/* ── Memory-saved chip (live capture) — green-tinted to read as WRITE, vs the
-   indigo recall chip (READ). Pending items keep an amber cue via the actions. */
-.memory-chip.saved { background: color-mix(in srgb, var(--success, #16a34a) 12%, transparent);
-  color: var(--success, #16a34a); border-color: color-mix(in srgb, var(--success, #16a34a) 35%, transparent); }
-.memory-chip.saved:hover { background: color-mix(in srgb, var(--success, #16a34a) 20%, transparent); }
+/* ── Memory-saved chip (live capture). Reuses the recall chip base (.memory-chip)
+   and tints by STATE with the design-system semantic tokens — success (saved) /
+   warning (pending, needs review). Hover fills the colour, mirroring .btn.danger
+   in AgentMemoryPanel. Action buttons reuse that same .btn pattern. */
+.memory-chip.chip-saved { background: var(--success-bg); color: var(--success); border-color: var(--success); }
+.memory-chip.chip-saved:hover { background: var(--success); color: #fff; }
+.memory-chip.chip-pending { background: var(--warning-bg); color: var(--warning); border-color: var(--warning); }
+.memory-chip.chip-pending:hover { background: var(--warning); color: #fff; }
 .saved-line { display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap; }
 .saved-line.archived { opacity: .5; text-decoration: line-through; }
+.mtype { color: var(--text-faint); font-family: var(--font-mono, monospace); }
 .saved-actions { margin-left: auto; display: inline-flex; gap: 6px; white-space: nowrap; }
-.saved-btn { font-size: 11px; padding: 1px 8px; border-radius: var(--r-full); cursor: pointer;
-  border: 1px solid var(--border-strong); background: var(--bg-3); color: var(--text-dim); }
-.saved-btn:hover { background: var(--bg-4); }
-.saved-btn.approve { color: var(--success, #16a34a); border-color: color-mix(in srgb, var(--success, #16a34a) 40%, transparent); }
-.saved-btn.reject { color: var(--danger, #dc2626); border-color: color-mix(in srgb, var(--danger, #dc2626) 40%, transparent); }
-.saved-btn.undo { color: var(--text-faint); }
+/* Mirrors AgentMemoryPanel's .btn / .btn.primary / .btn.ghost (same tokens,
+   tightened for the inline chip context). */
+.s-btn { background: transparent; color: var(--text-dim); border: 1px solid var(--border-strong);
+  border-radius: var(--r-md); padding: 2px 10px; font-size: 11px; cursor: pointer; transition: all .15s; }
+.s-btn:hover { color: var(--text); background: rgba(255,255,255,0.04); }
+.s-btn.primary { background: var(--primary); color: #fff; border-color: var(--primary); }
+.s-btn.primary:hover { background: var(--primary-hover); border-color: var(--primary-hover); }
+.s-btn.ghost { border-color: transparent; }
 .archived-tag { font-size: 11px; color: var(--text-faint); margin-left: auto; }
 </style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -607,7 +607,15 @@
     "recentRetrievals": "Recent searches",
     "confirmDelete": "Permanently delete this memory?",
     "graph": "Memory graph",
-    "restore": "Restore"
+    "restore": "Restore",
+    "saved": {
+      "remembered": "remembered",
+      "pending": "pending review",
+      "undo": "Undo",
+      "approve": "Approve",
+      "reject": "Dismiss",
+      "archived": "removed"
+    }
   },
   "chat": {
     "memoryUsed": "memories used",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -581,7 +581,7 @@
       "dense": "Vector (semantic) match",
       "graph": "Knowledge-graph co-occurrence (MENTIONS) — surfaced via a shared entity"
     },
-    "scoreHint": "rrf = raw fusion relevance score (higher = better query match). conf = confidence the fact is true (0–1). ✓ = verified (user-confirmed or tool-verified).",
+    "scoreHint": "rrf = raw lane-fusion rank score (keyword + vector). rerank = cross-encoder joint (query, memory) relevance — the authoritative order, near 1.0 when the query nearly restates the memory. conf = confidence the fact is true (0–1). ✓ = verified (user-confirmed or tool-verified).",
     "approvalReason": {
       "unverified_evidence": "Needs review even with auto-save on: the evidence for this memory couldn't be verified against your messages, so it wasn't auto-saved.",
       "secret": "Needs review: this looks like sensitive/secret content, which is never auto-saved."

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -558,7 +558,7 @@
       "dense": "Khớp vector (ngữ nghĩa)",
       "graph": "Đồng xuất hiện trên đồ thị tri thức (MENTIONS) — kéo về qua entity chung"
     },
-    "scoreHint": "rrf = điểm khớp truy xuất thô (cao = khớp câu hỏi hơn). conf = độ tin fact đúng (0–1). ✓ = đã xác minh (user xác nhận hoặc tool kiểm chứng).",
+    "scoreHint": "rrf = điểm gộp lane thô (keyword + vector). rerank = điểm cross-encoder chấm chung (query, memory) — thứ tự quyết định, gần 1.0 khi câu hỏi gần như lặp lại memory. conf = độ tin fact đúng (0–1). ✓ = đã xác minh (user xác nhận hoặc tool kiểm chứng).",
     "approvalReason": {
       "unverified_evidence": "Vẫn cần duyệt dù đã bật tự lưu: không xác minh được bằng chứng cho ký ức này trong tin nhắn của bạn, nên nó không được tự lưu.",
       "secret": "Cần duyệt: nội dung có vẻ nhạy cảm/bí mật, loại này không bao giờ tự lưu."

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -584,7 +584,15 @@
     "recentRetrievals": "Lần tìm gần đây",
     "confirmDelete": "Xóa vĩnh viễn ký ức này?",
     "graph": "Đồ thị ký ức",
-    "restore": "Khôi phục"
+    "restore": "Khôi phục",
+    "saved": {
+      "remembered": "đã nhớ",
+      "pending": "chờ duyệt",
+      "undo": "Bỏ nhớ",
+      "approve": "Duyệt",
+      "reject": "Bỏ",
+      "archived": "đã bỏ"
+    }
   },
   "chat": {
     "memoryUsed": "ký ức đã dùng",

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -391,6 +391,15 @@ export const useAgentsStore = defineStore('agents', () => {
           }).catch(e => console.warn('[Store] Failed to forward memory_recalled:', e))
           break
         }
+        // Live "memory saved/pending" chip → chat store, so the user knows the
+        // moment Jarvis stores or proposes a memory (with inline undo/approve).
+        // The Memory tab still refreshes via its own memory_indexed tick.
+        if (event_type === 'memory_saved') {
+          import('./chat').then(({ useChatStore }) => {
+            useChatStore().addMemorySavedBlock(event.data, agent_name)
+          }).catch(e => console.warn('[Store] Failed to forward memory_saved:', e))
+          break
+        }
         // Forward the live-reactive memory events (spec §17 subset) to the
         // memory store: candidate badge, index refresh, degraded banner.
         if (event_type.startsWith('memory_') || event_type === 'retrieval_degraded'

--- a/frontend/src/stores/chat.js
+++ b/frontend/src/stores/chat.js
@@ -364,6 +364,9 @@ export const useChatStore = defineStore('chat', () => {
       content,
       timestamp: Date.now(),
     })
+    // A new user turn starts a fresh "memory saved" group, so saves triggered by
+    // THIS turn batch into one chip (and don't append to the previous turn's).
+    conv._savedBlockId = null
     // Update title from first user message
     if (conv.messages.filter(m => m.role === 'user').length === 1) {
       conv.title = content.length > 40 ? content.slice(0, 40) + '...' : content
@@ -425,6 +428,91 @@ export const useChatStore = defineStore('chat', () => {
     while (i >= 0 && msgs[i].role !== 'assistant') i--
     if (i >= 0) msgs.splice(i, 0, block)
     else msgs.push(block)
+  }
+
+  /**
+   * Live "memory saved" chip from the `memory_saved` SSE event — so the user
+   * KNOWS the moment Jarvis stores something (auto-approved) or proposes one
+   * (pending), in context, with inline undo/approve/reject — instead of only
+   * discovering it later in the Memory tab. Items are keyed by `candidateId`, so
+   * a later transition (pending→saved/rejected) updates the SAME item in place.
+   * This block is a session-only NOTIFICATION (not LLM context, not persisted to
+   * chat history) — the durable record lives in the Memory tab; on reload the
+   * chip is simply gone. Auto-capture lands AFTER the reply (async), so no
+   * isStreaming guard — saves group into the current turn's chip at the tail.
+   */
+  function addMemorySavedBlock(data, agentName) {
+    if (!data || !data.candidate_id) return
+    const conv = activeConversation.value
+    if (!conv) return
+    if (agentName && conv.agentName && agentName !== conv.agentName) return
+    // Transition: update the existing item in place (status / arriving record_id).
+    for (const m of conv.messages) {
+      if (!m.memorySaved) continue
+      const it = m.memorySaved.find(x => x.candidateId === data.candidate_id)
+      if (it) {
+        it.status = data.status
+        if (data.record_id) it.recordId = data.record_id
+        return
+      }
+    }
+    if (data.status === 'rejected' || !data.content) return  // nothing to surface
+    const item = {
+      candidateId: data.candidate_id,
+      recordId: data.record_id || null,
+      content: data.content,
+      memoryType: data.memory_type || 'semantic',
+      status: data.status,            // 'saved' | 'pending'
+      sensitive: !!data.sensitive,
+    }
+    let block = conv._savedBlockId
+      ? conv.messages.find(m => m.id === conv._savedBlockId)
+      : null
+    if (!block) {
+      block = {
+        id: `mem-saved-${crypto.randomUUID()}`,
+        role: 'system',
+        isMemorySaved: true,
+        memorySaved: [],
+        timestamp: Date.now(),
+      }
+      conv.messages.push(block)
+      conv._savedBlockId = block.id
+    }
+    block.memorySaved.push(item)
+  }
+
+  // Inline chip actions. Optimistic (flip status now); the resulting SSE is
+  // idempotent (keyed by candidateId) so a confirming echo is a no-op.
+  async function archiveSavedMemory(item) {
+    const conv = activeConversation.value
+    if (!conv || !item || !item.recordId) return
+    const prev = item.status
+    item.status = 'archived'
+    try {
+      await apiFetch(`/api/agents/${encodeURIComponent(conv.agentName)}/memories/${item.recordId}/archive`,
+        { method: 'POST' })
+    } catch (e) { item.status = prev; console.warn('[chat] archive memory failed:', e) }
+  }
+  async function approveSavedMemory(item) {
+    const conv = activeConversation.value
+    if (!conv || !item || !item.candidateId) return
+    const prev = item.status
+    item.status = 'saved'
+    try {
+      await apiFetch(`/api/agents/${encodeURIComponent(conv.agentName)}/memory-candidates/${item.candidateId}/approve`,
+        { method: 'POST' })
+    } catch (e) { item.status = prev; console.warn('[chat] approve memory failed:', e) }
+  }
+  async function rejectSavedMemory(item) {
+    const conv = activeConversation.value
+    if (!conv || !item || !item.candidateId) return
+    const prev = item.status
+    item.status = 'rejected'
+    try {
+      await apiFetch(`/api/agents/${encodeURIComponent(conv.agentName)}/memory-candidates/${item.candidateId}/reject`,
+        { method: 'POST' })
+    } catch (e) { item.status = prev; console.warn('[chat] reject memory failed:', e) }
   }
 
   /**
@@ -560,6 +648,10 @@ export const useChatStore = defineStore('chat', () => {
     addUserMessage,
     addAgentMessagePlaceholder,
     addMemoryRecallBlock,
+    addMemorySavedBlock,
+    archiveSavedMemory,
+    approveSavedMemory,
+    rejectSavedMemory,
     pushToolCall,
     finalizeAgentMessage,
     removeMessage,

--- a/frontend/src/stores/chat.test.js
+++ b/frontend/src/stores/chat.test.js
@@ -35,7 +35,7 @@ function recallData() {
   return {
     content: `${MARKER} [System memory recall — not user input]:\n- [semantic] nguyễn văn phúc là người tạo ra ai agent`,
     recall_lanes: [['fts', 'dense']],
-    recall_scores: [{ rel: 0.0325, conf: 0.6, authority: 'user_confirmed' }],
+    recall_scores: [{ rrf: 0.0325, rerank: 0.9993, conf: 0.6, authority: 'user_confirmed' }],
   }
 }
 
@@ -50,7 +50,8 @@ test('memory_recalled inserts a recall block before the streaming reply', () => 
   assert.ok(memIdx >= 0, 'memory block inserted')
   assert.ok(memIdx < asstIdx, 'memory block sits before the assistant placeholder')
   assert.deepEqual(msgs[memIdx].recallLanes, [['fts', 'dense']])
-  assert.equal(msgs[memIdx].recallScores[0].rel, 0.0325)
+  assert.equal(msgs[memIdx].recallScores[0].rrf, 0.0325)
+  assert.equal(msgs[memIdx].recallScores[0].rerank, 0.9993)
   assert.equal(msgs[memIdx].role, 'user') // isMemoryBlock() in ChatMessages keys on role=user + marker
 })
 

--- a/frontend/src/stores/chat.test.js
+++ b/frontend/src/stores/chat.test.js
@@ -69,3 +69,59 @@ test('memory_recalled is ignored for a different agent', () => {
   s.addMemoryRecallBlock(recallData(), 'SomeOtherAgent')
   assert.ok(!s.activeConversation.messages.some(m => (m.content || '').includes(MARKER)))
 })
+
+// ── memory_saved live chip (auto-save + pending approval) ──
+function saved(id, status, extra = {}) {
+  return { candidate_id: id, content: `fact ${id}`, memory_type: 'semantic', status, ...extra }
+}
+function savedBlock(s) { return s.activeConversation.messages.find(m => m.isMemorySaved) }
+
+test('memory_saved inserts a chip; same-turn saves batch into one block', () => {
+  const s = useChatStore()
+  s.createConversation('Jarvis')
+  s.addUserMessage('tôi tên Phúc, landing page là x')
+  s.addMemorySavedBlock(saved('c1', 'saved', { record_id: 'r1' }), 'Jarvis')
+  s.addMemorySavedBlock(saved('c2', 'saved', { record_id: 'r2' }), 'Jarvis')
+  const blocks = s.activeConversation.messages.filter(m => m.isMemorySaved)
+  assert.equal(blocks.length, 1, 'one block for the turn')
+  assert.equal(blocks[0].memorySaved.length, 2, 'both items batched')
+  assert.equal(blocks[0].memorySaved[0].recordId, 'r1')
+})
+
+test('memory_saved transition pending→saved updates the same item in place', () => {
+  const s = useChatStore()
+  s.createConversation('Jarvis')
+  s.addUserMessage('số thẻ của tôi là ...')
+  s.addMemorySavedBlock(saved('c1', 'pending'), 'Jarvis')
+  assert.equal(savedBlock(s).memorySaved[0].status, 'pending')
+  s.addMemorySavedBlock(saved('c1', 'saved', { record_id: 'r9' }), 'Jarvis')
+  assert.equal(savedBlock(s).memorySaved.length, 1, 'no duplicate item')
+  assert.equal(savedBlock(s).memorySaved[0].status, 'saved')
+  assert.equal(savedBlock(s).memorySaved[0].recordId, 'r9')
+})
+
+test('memory_saved rejected for a never-seen candidate is ignored', () => {
+  const s = useChatStore()
+  s.createConversation('Jarvis')
+  s.addUserMessage('hi')
+  s.addMemorySavedBlock(saved('cX', 'rejected'), 'Jarvis')
+  assert.equal(savedBlock(s), undefined)
+})
+
+test('a new user turn starts a fresh saved block', () => {
+  const s = useChatStore()
+  s.createConversation('Jarvis')
+  s.addUserMessage('turn 1')
+  s.addMemorySavedBlock(saved('a', 'saved', { record_id: 'r' }), 'Jarvis')
+  s.addUserMessage('turn 2')
+  s.addMemorySavedBlock(saved('b', 'saved', { record_id: 'r' }), 'Jarvis')
+  assert.equal(s.activeConversation.messages.filter(m => m.isMemorySaved).length, 2)
+})
+
+test('memory_saved is ignored for a different agent', () => {
+  const s = useChatStore()
+  s.createConversation('Jarvis')
+  s.addUserMessage('hi')
+  s.addMemorySavedBlock(saved('c1', 'saved', { record_id: 'r' }), 'SomeOtherAgent')
+  assert.equal(savedBlock(s), undefined)
+})

--- a/frontend/tests/e2e/flows/chat-memory-saved.spec.ts
+++ b/frontend/tests/e2e/flows/chat-memory-saved.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Realtime "memory saved" chip — when Jarvis stores (auto-approved) or proposes
+ * (pending approval) a memory, the user SEES it in context via the live
+ * `memory_saved` activity-stream SSE, with inline undo / approve / reject —
+ * instead of only discovering it later in the Memory tab.
+ *
+ * Production contract: candidate_service._emit_saved broadcasts `memory_saved`
+ * (status saved | pending | rejected); useRealtimeStream → agents.processEvent →
+ * chat.addMemorySavedBlock inserts/updates the chip; ChatMessages renders it.
+ *
+ * Mirrors chat-memory-recall.spec: chat-stream held open so the conversation is
+ * active; activity-stream delivers the saved events once the turn is in flight.
+ */
+
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+const SSE_HEADERS = {
+  'content-type': 'text/event-stream',
+  'cache-control': 'no-cache',
+}
+
+test('memory_saved paints the chip mid-turn with inline actions', async ({ page }) => {
+  const backend = await mockBackend(page, [NOISE, join(FIXTURES, 'chat_memory_recall.yaml')])
+
+  let onChatStarted!: () => void
+  const chatStarted = new Promise<void>((r) => { onChatStarted = r })
+  let releaseChat: (() => void) | null = null
+
+  // Resolves when the inline "Approve" click POSTs to the candidate route.
+  let onApproved!: () => void
+  const approved = new Promise<void>((r) => { onApproved = r })
+
+  await page.route('**/api/chat-stream', async (route) => {
+    onChatStarted()
+    await new Promise<void>((r) => { releaseChat = r }) // keep the conversation active
+    await route.fulfill({
+      status: 200,
+      headers: SSE_HEADERS,
+      body: 'retry: 3600000\n\ndata: {"type":"start","message":"…"}\n\n',
+    })
+  })
+
+  // Two saved events in one body: one AUTO-saved, one PENDING approval.
+  await page.route('**/api/agents/activity-stream**', async (route) => {
+    await chatStarted
+    const ev = (data: object) => ({ agent_name: 'Jarvis', event_type: 'memory_saved', data })
+    const saved = ev({
+      candidate_id: 'c1', record_id: 'r1', status: 'saved',
+      memory_type: 'semantic', content: 'Phúc là chủ nhân của OmnigentX Jarvis', sensitive: false,
+    })
+    const pending = ev({
+      candidate_id: 'c2', record_id: null, status: 'pending',
+      memory_type: 'semantic', content: 'số thẻ ngân hàng của tôi', sensitive: false,
+    })
+    await route.fulfill({
+      status: 200,
+      headers: SSE_HEADERS,
+      body: `retry: 3600000\n\ndata: ${JSON.stringify(saved)}\n\ndata: ${JSON.stringify(pending)}\n\n`,
+    })
+  })
+
+  // Inline approve → real POST to the candidate approve route (assert it fires).
+  await page.route('**/api/agents/Jarvis/memory-candidates/c2/approve', async (route) => {
+    onApproved()
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"approved"}' })
+  })
+
+  await page.goto('/chat')
+
+  const textarea = page.getByPlaceholder(/type a message/i)
+  await expect(textarea).toBeVisible()
+  await textarea.fill('tôi tên Phúc, đây là số thẻ của tôi')
+  await textarea.press('Enter')
+
+  // Chip paints live, summarising BOTH states (✏️ saved + ⏳ pending).
+  const messages = page.getByTestId('chat-messages')
+  const chip = messages.locator('.memory-chip.saved')
+  await expect(chip).toBeVisible()
+  await expect(chip).toContainText('✏️')
+  await expect(chip).toContainText('⏳')
+
+  // Expand → both memories + their per-state actions.
+  await chip.click()
+  await expect(messages.getByText(/Phúc là chủ nhân của OmnigentX/i)).toBeVisible()
+  await expect(messages.locator('.saved-btn.undo')).toBeVisible()       // auto-saved → undo
+  const approveBtn = messages.locator('.saved-btn.approve')
+  await expect(approveBtn).toBeVisible()                                // pending → approve
+
+  // Inline approve hits the real candidate route (approve-in-context).
+  await approveBtn.click()
+  await approved
+
+  releaseChat?.()
+  expect(backend.unexpected.length).toBe(0)
+})

--- a/frontend/tests/e2e/flows/chat-memory-saved.spec.ts
+++ b/frontend/tests/e2e/flows/chat-memory-saved.spec.ts
@@ -79,18 +79,19 @@ test('memory_saved paints the chip mid-turn with inline actions', async ({ page 
   await textarea.fill('tôi tên Phúc, đây là số thẻ của tôi')
   await textarea.press('Enter')
 
-  // Chip paints live, summarising BOTH states (✏️ saved + ⏳ pending).
+  // Chip paints live. A mixed batch (1 saved + 1 pending) takes the warning
+  // (pending) tint — `chip-pending` — and keeps the 🧠 memory motif.
   const messages = page.getByTestId('chat-messages')
-  const chip = messages.locator('.memory-chip.saved')
+  const chip = messages.locator('.memory-chip.chip-pending')
   await expect(chip).toBeVisible()
-  await expect(chip).toContainText('✏️')
-  await expect(chip).toContainText('⏳')
+  await expect(chip).toContainText('🧠')
 
-  // Expand → both memories + their per-state actions.
+  // Expand → both memories + their per-state actions (design-system .btn pattern:
+  // approve = primary, undo/reject = ghost).
   await chip.click()
   await expect(messages.getByText(/Phúc là chủ nhân của OmnigentX/i)).toBeVisible()
-  await expect(messages.locator('.saved-btn.undo')).toBeVisible()       // auto-saved → undo
-  const approveBtn = messages.locator('.saved-btn.approve')
+  await expect(messages.locator('.s-btn.ghost').first()).toBeVisible()  // auto-saved → undo
+  const approveBtn = messages.locator('.s-btn.primary')
   await expect(approveBtn).toBeVisible()                                // pending → approve
 
   // Inline approve hits the real candidate route (approve-in-context).


### PR DESCRIPTION
Stacked on #100. Four related memory changes, developed/measured incrementally on the live Vietnamese store. (The original title was just the threshold tuning; this body reflects everything that actually ships — per review.)

## 1. Reranker swap — bge-reranker-v2-m3 → Qwen3-Reranker-0.6B
Live head-to-head (2026-06-23, real store) showed **bge is the precision bottleneck**: it compressed every Vietnamese score near 0, so the correct "where do I work" answer scored **0.0013** (buried at #2) — no floor could gate, and ranking was wrong (direct answer ranked behind name/entity matches). An earlier "Qwen worse" result was a synthetic-query artifact.

**Qwen3-Reranker-0.6B** (causal LM scored via the **yes/no next-token logit**, not a SequenceClassification cross-encoder → new `Qwen3Reranker` class, dispatched by model name) ranks the direct answer **#1 @ 0.245** and gives a usable spread (answers ≥0.003, off-keyword ≤0.0009). bge still selectable. Auto-selects cuda/mps/cpu (fp16 on accelerator): **warm rerank ~0.44s on mps**, ~1.2–1.4s p50/p95 CPU end-to-end — a real latency cost on the recall hot path, accepted for the quality gain.

## 2. Threshold tuning
- `recall_min_similarity` 0.34→**0.30** — grid-searched (78-query labelled set, Qwen3-Embedding): on-topic recall@5 is flat 100% across [0.05, 0.39]; 0.34 sat at the 0.40 cliff. DENSE-lane property measured **pre-rerank-gate** (independent of the reranker).
- `rerank_min_score` 0.0→**0.001** — viable only because Qwen gives a spread bge couldn't.

**Live acceptance:** "Angular latest version?" 5 leaked memories → **0**; math → 0; "where do I work?" answer #1; archived "where is my child?" → 0. **Residual:** a memory the reranker scores high for the WRONG query (con/Milo adversarial) still leaks — no scalar floor catches it (intent/LLM, deferred).

## 3. Recall-score split (UI)
The "memories used" chip rendered `final` but labelled it `rrf`; after reranking `final` = the reranker score (≈1.0 on a near-verbatim restate), so it showed the cross-encoder score under the wrong name while the real RRF (~0.03) was never shown. Now persists + renders **rrf and rerank separately**, with legacy 3-field back-compat (old blocks render a neutral "score").

## 4. Realtime "memory saved" chip (user-facing feature)
Recall already shows a live chip; **saving was silent** until the user opened the Memory tab. New `memory_saved` SSE (`_emit_saved`, 3 lifecycle points; secrets masked) → `chat.addMemorySavedBlock` → a Vue chip (design-system tokens: success=saved, warning=pending) with **inline undo / approve / reject**, covering BOTH approval cases (auto-approved vs manual/secret pending), with in-place pending→saved/rejected transitions. Session-only notification (not LLM context, not persisted). Bilingual + Playwright e2e.

## Tests
~55 backend memory tests (settings, candidate `memory_saved` incl. secret-mask, reranker dispatch + scoring-math, recall score-split round-trip) + frontend store unit + 2 Playwright e2e (recall + saved chips), all passing.

## Follow-ups (not here)
- con/Milo adversarial & deep ranking → needs a stronger signal (intent gate / LLM judge).
- Persist the saved chip across reload (currently ephemeral; needs candidate↔session linkage).
- `retrieval_runs.rerank_ms`/`total_ms` telemetry records 0 (pre-existing gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
