### PR TITLE
ci(deploy): widen health-check window for cold-start model download

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,17 +111,30 @@ jobs:
           # can verify the process is up without needing a bearer token.
           # /api/setup/status would work pre-master-key (dev mode) but starts
           # returning 401 once core_auth.JARVIS_API_KEY is populated.
-          echo "Waiting for backend to start (up to 120s)..."
-          for i in $(seq 1 24); do
+          # 360s window: a FIRST deploy with a new embedding/reranker model
+          # downloads ~1.2GB from HF Hub AND re-embeds the store at boot, which
+          # blocks startup well past the old 120s (the v2.7.0 Qwen swap false-
+          # failed here while the backend was in fact coming up). A crashed
+          # container fails fast below, so the long window only ever waits on a
+          # genuinely-slow-but-healthy boot.
+          echo "Waiting for backend to start (up to 360s; first deploy downloads models)..."
+          for i in $(seq 1 72); do
             code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/setup/auth/probe || echo 000)
             if [ "$code" = "200" ]; then
               echo "✅ Backend up after $((i*5))s (auth/probe=200)"
               break
             fi
-            echo "  Attempt $i/24 — auth/probe=$code, waiting 5s..."
+            # Fast-fail on a real crash instead of waiting out the whole window.
+            if docker compose ps jarvis-backend 2>/dev/null | grep -qiE "exit|dead"; then
+              echo "❌ jarvis-backend exited (crash) — failing fast."
+              docker compose ps
+              docker compose logs --tail=150 jarvis-backend
+              exit 1
+            fi
+            echo "  Attempt $i/72 — auth/probe=$code, waiting 5s..."
             sleep 5
-            if [ "$i" -eq 24 ]; then
-              echo "⚠️ Backend not ready after 120s — collecting logs..."
+            if [ "$i" -eq 72 ]; then
+              echo "⚠️ Backend not ready after 360s — collecting logs..."
               echo "--- Docker containers status ---"
               docker compose ps
               echo ""


### PR DESCRIPTION
## Why
v2.7.0's deploy **false-failed** the Health Check: `auth/probe` returned `000` for all 24×5s=120s attempts, then `exit 1` — **but prod actually came up** (it serves `200` now). The first deploy with the new **Qwen embedding/reranker** downloads ~1.2GB from HF Hub (unauthenticated → rate-limited) AND re-embeds the store at boot, which blocks the event loop past 120s, so uvicorn doesn't accept connections until it finishes.

## Change
- Health-check window **120s → 360s** (`seq 1 72`) — covers the cold-start model download + re-embed.
- **Fast-fail** if `jarvis-backend` has exited (a real crash), so the longer window only ever waits on a genuinely-slow-but-healthy boot, never on a crash.

## Follow-ups (not here, larger)
- **Don't block the event loop**: the worker loads the model + embeds synchronously → freezes uvicorn during the call (also the per-recall latency stall). Offload to a thread executor.
- **Pre-bake the Qwen models** into the image (no runtime download), and/or set **`HF_TOKEN`** to avoid HF rate-limiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)