### PR TITLE
fix(ui): brand page title "Jarvis" (drop "Jarvis v2" / "My Jarvis")

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="My Jarvis — AI Agents Dashboard" />
+    <meta name="description" content="Jarvis — AI Agents Dashboard" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <title>My Jarvis</title>
+    <title>Jarvis</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/components/AppLayout.vue
+++ b/frontend/src/components/AppLayout.vue
@@ -125,8 +125,8 @@ useSSEConnection(buildSSEUrl('/api/scheduler/stream'), {
       if (data.type === 'new_notification') {
         unreadCount.value += 1
         document.title = unreadCount.value > 0
-          ? `(${unreadCount.value}) ${route.meta.title || 'Dashboard'} — My Jarvis`
-          : `${route.meta.title || 'Dashboard'} — My Jarvis`
+          ? `(${unreadCount.value}) ${route.meta.title || 'Dashboard'} — Jarvis`
+          : `${route.meta.title || 'Dashboard'} — Jarvis`
       }
     } catch (_) {}
   },

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -162,7 +162,7 @@ const router = createRouter({
 
 // Update page title
 router.afterEach((to) => {
-  document.title = `${to.meta.title || 'Dashboard'} — Jarvis v2`
+  document.title = `${to.meta.title || 'Dashboard'} — Jarvis`
 })
 
 export default router


### PR DESCRIPTION
The browser tab read **"… — Jarvis v2"** (`router.js`) while `index.html` and the unread-count title used **"My Jarvis"** — three different brand strings. "v2" was a dev-era leftover, not user-facing branding.

Unified all title + meta strings to **"Jarvis"** (matches the sidebar "Jarvis" + README), so the tab now reads **"Chat — Jarvis"**.

Files: `frontend/index.html` (`<title>` + meta description), `frontend/src/router.js` (afterEach title), `frontend/src/components/AppLayout.vue` (unread-count title).

Build: `✓ built`. No logic change. Ships to prod on the next `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)