### PR TITLE
perf(memory): reranker never blocks the chat flow — background warm + skip-until-ready (+ pre-bake recipe)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@
 # System deps (apt + npm + uv + gitnexus) live in the public base image so CI
 # doesn't re-run apt-get / npm install on every build. Rebuild + bump the tag
 # only when Dockerfile.base changes — see Dockerfile.base header for steps.
+# NOTE: bump to :1.4.0 ONLY after building + pushing that base (it pre-bakes the
+# Qwen3 embedder+reranker — see Dockerfile.base 1.4.0). Until then 1.3.0 is live;
+# the lazy reranker warm is handled at runtime (server lifespan eager-warm).
 ARG BASE_IMAGE=omnigentx/jarvis-backend-base:1.3.0
 FROM ${BASE_IMAGE} AS base
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,10 +2,9 @@
 # System deps (apt + npm + uv + gitnexus) live in the public base image so CI
 # doesn't re-run apt-get / npm install on every build. Rebuild + bump the tag
 # only when Dockerfile.base changes — see Dockerfile.base header for steps.
-# NOTE: bump to :1.4.0 ONLY after building + pushing that base (it pre-bakes the
-# Qwen3 embedder+reranker — see Dockerfile.base 1.4.0). Until then 1.3.0 is live;
-# the lazy reranker warm is handled at runtime (server lifespan eager-warm).
-ARG BASE_IMAGE=omnigentx/jarvis-backend-base:1.3.0
+# 1.4.0 pre-bakes the Qwen3 embedder + reranker (see Dockerfile.base 1.4.0), so
+# the memory models load from the image — no runtime download on first chat/deploy.
+ARG BASE_IMAGE=omnigentx/jarvis-backend-base:1.4.0
 FROM ${BASE_IMAGE} AS base
 
 # ─── Stage 2: Python dependencies (cached unless pyproject/lock/fast-agent change) ───

--- a/backend/Dockerfile.base
+++ b/backend/Dockerfile.base
@@ -30,14 +30,16 @@
 #   docker push omnigentx/jarvis-backend-base:${VERSION}
 #
 # Version log:
-#   1.4.0 — swap the pre-baked default models bge-m3 → Qwen3 (the new memory
-#           defaults): Qwen3-Embedding-0.6B + Qwen3-Reranker-0.6B (~2.4GB total).
+#   1.4.0 — ADD the new default memory models alongside bge-m3:
+#           Qwen3-Embedding-0.6B + Qwen3-Reranker-0.6B (~2.4GB more).
 #           WHY: the reranker is a 0.6B causal LM that loaded lazily on the FIRST
 #           chat (~65s cold download+load on CPU), blocking the turn before any
 #           tool call; and the HF cache lives in the container layer, so EVERY
 #           deploy re-downloaded it. Baking both here = no runtime download; the
 #           lifespan also eager-warms the reranker so the first chat never blocks.
-#           bge-m3 is no longer the default → downloads on first use if selected.
+#           bge-m3 is kept (still selectable as a non-default embedding_model).
+#           Built as a thin overlay on 1.3.0 (FROM base:1.3.0 + the hf download
+#           below) since the host is arm64; this from-scratch recipe is equivalent.
 #   1.3.0 — pre-download the default embedding model (BAAI/bge-m3, ~2.3GB) into
 #           the HF cache so the memory dense lane + knowledge graph load INSTANTLY
 #           at runtime (no first-request download, survives container recreate).
@@ -104,8 +106,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uvx /bin/uvx
 RUN uvx --from "scrapling[ai]" scrapling install \
     && rm -rf /root/.cache/uv
 
-# Pre-download the DEFAULT memory models (Qwen3-Embedding-0.6B + Qwen3-Reranker-0.6B,
-# ~2.4GB total) into the HF cache so the dense lane, knowledge graph, AND the
+# Pre-download the memory models (bge-m3 + the new defaults Qwen3-Embedding-0.6B +
+# Qwen3-Reranker-0.6B) into the HF cache so the dense lane, knowledge graph, AND the
 # precision reranker load INSTANTLY at runtime — no first-request download, and it
 # survives container recreation (baked into this layer, exactly like the Playwright
 # browsers above). Critical for the reranker: it's a 0.6B causal LM whose lazy
@@ -119,6 +121,7 @@ RUN uvx --from "scrapling[ai]" scrapling install \
 # cache path. Both models are public (no HF_TOKEN needed; pass one as a build
 # secret if rate-limited).
 ENV HF_HOME=/root/.cache/huggingface
-RUN uvx --from huggingface_hub hf download Qwen/Qwen3-Embedding-0.6B \
+RUN uvx --from huggingface_hub hf download BAAI/bge-m3 \
+    && uvx --from huggingface_hub hf download Qwen/Qwen3-Embedding-0.6B \
     && uvx --from huggingface_hub hf download Qwen/Qwen3-Reranker-0.6B \
     && rm -rf /root/.cache/uv

--- a/backend/Dockerfile.base
+++ b/backend/Dockerfile.base
@@ -30,6 +30,14 @@
 #   docker push omnigentx/jarvis-backend-base:${VERSION}
 #
 # Version log:
+#   1.4.0 — swap the pre-baked default models bge-m3 → Qwen3 (the new memory
+#           defaults): Qwen3-Embedding-0.6B + Qwen3-Reranker-0.6B (~2.4GB total).
+#           WHY: the reranker is a 0.6B causal LM that loaded lazily on the FIRST
+#           chat (~65s cold download+load on CPU), blocking the turn before any
+#           tool call; and the HF cache lives in the container layer, so EVERY
+#           deploy re-downloaded it. Baking both here = no runtime download; the
+#           lifespan also eager-warms the reranker so the first chat never blocks.
+#           bge-m3 is no longer the default → downloads on first use if selected.
 #   1.3.0 — pre-download the default embedding model (BAAI/bge-m3, ~2.3GB) into
 #           the HF cache so the memory dense lane + knowledge graph load INSTANTLY
 #           at runtime (no first-request download, survives container recreate).
@@ -96,17 +104,21 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uvx /bin/uvx
 RUN uvx --from "scrapling[ai]" scrapling install \
     && rm -rf /root/.cache/uv
 
-# Pre-download the DEFAULT embedding model (BAAI/bge-m3, ~2.3GB) into the HF cache
-# so the memory subsystem's dense lane + knowledge graph load INSTANTLY at runtime
-# — no first-request download, and it survives container recreation (baked into
-# this layer, exactly like the Playwright browsers above). It's a large, STABLE
-# runtime asset, so the base is the right home: built once, every app image
-# inherits it, app builds stay fast. FlagEmbedding (the loader) stays an app dep
-# (Dockerfile deps stage, `--extra memory`); a different `embedding_model` in
-# settings still works — it just downloads on first use (only the default is
+# Pre-download the DEFAULT memory models (Qwen3-Embedding-0.6B + Qwen3-Reranker-0.6B,
+# ~2.4GB total) into the HF cache so the dense lane, knowledge graph, AND the
+# precision reranker load INSTANTLY at runtime — no first-request download, and it
+# survives container recreation (baked into this layer, exactly like the Playwright
+# browsers above). Critical for the reranker: it's a 0.6B causal LM whose lazy
+# first-load otherwise stalls the FIRST chat ~65s on CPU (and re-downloads every
+# deploy, since the cache is in the container layer, not a volume). These are
+# large, STABLE runtime assets, so the base is the right home: built once, every
+# app image inherits it, app builds stay fast. transformers + sentence-transformers
+# (the loaders) stay app deps (`--extra memory`); a non-default `embedding_model` /
+# `rerank_model` still works — it just downloads on first use (only defaults are
 # pre-baked). HF_HOME is pinned so the build and the root runtime agree on the
-# cache path. bge-m3 is public (no HF_TOKEN needed; pass one as a build secret if
-# rate-limited).
+# cache path. Both models are public (no HF_TOKEN needed; pass one as a build
+# secret if rate-limited).
 ENV HF_HOME=/root/.cache/huggingface
-RUN uvx --from huggingface_hub hf download BAAI/bge-m3 \
+RUN uvx --from huggingface_hub hf download Qwen/Qwen3-Embedding-0.6B \
+    && uvx --from huggingface_hub hf download Qwen/Qwen3-Reranker-0.6B \
     && rm -rf /root/.cache/uv

--- a/backend/server.py
+++ b/backend/server.py
@@ -485,6 +485,16 @@ async def lifespan(app: FastAPI):
             if _gw:
                 logger.warning("[MEMORY] recall gate may be mistuned for the embedding "
                                "model: %s", _gw)
+            # Eager-warm the reranker OFF the request path. It's a 0.6B causal LM
+            # whose first cold-load is slow (~tens of s on CPU). Warming it in a
+            # daemon thread at boot means the FIRST chat never blocks on it — the
+            # recall path keeps fusion order until it's ready (see _apply_rerank).
+            if getattr(_mem_cfg, "reranker_enabled", False):
+                from services.retrieval.reranker import get_shared_reranker
+                get_shared_reranker(
+                    getattr(_mem_cfg, "rerank_model", None) or "Qwen/Qwen3-Reranker-0.6B"
+                ).warm_async()
+                logger.info("[MEMORY] reranker eager-warm kicked off (background)")
     except Exception:
         logger.exception("Failed to start memory index worker")
 

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -154,6 +154,14 @@ class RetrievalOrchestrator:
         Keep ``rerank_min_score`` low (0.005) so a weak-but-relevant hit survives."""
         if not fused or self._reranker is None or not self._reranker.is_available():
             return fused
+        # NEVER block a recall turn on the reranker's cold load. The 0.6B causal
+        # LM's first load is slow (~tens of s on CPU); if it isn't warm yet, kick
+        # off a one-shot background load and keep fusion order for THIS turn. The
+        # lifespan eager-warms it at boot, so this skip window is normally empty —
+        # it only catches a turn that races the warm right after startup.
+        if hasattr(self._reranker, "is_loaded") and not self._reranker.is_loaded():
+            self._reranker.warm_async()
+            return fused
         top_k = int(getattr(self.settings, "rerank_top_k", 20) or 20)
         floor = float(getattr(self.settings, "rerank_min_score", 0.0) or 0.0)
         # Tail beyond top_k is intentionally DROPPED from recall (not just from

--- a/backend/services/retrieval/reranker.py
+++ b/backend/services/retrieval/reranker.py
@@ -34,6 +34,40 @@ class Reranker(ABC):
         """Relevance score per document (higher = more relevant), SAME order as
         ``documents``."""
 
+    def is_loaded(self) -> bool:
+        """True once the model is warm in memory. Default True (no lazy cost);
+        only the lazy LM rerankers override it. The recall path checks this so it
+        NEVER blocks a turn on a cold model load — it skips to fusion order until
+        the model is warm."""
+        return True
+
+    def warm(self) -> None:
+        """Block-load the model. Call OFF the request path (boot / background)."""
+
+    def warm_async(self) -> None:
+        """Kick off a ONE-SHOT background load — idempotent, non-blocking. Safe to
+        call from a request path: returns immediately, the model loads in a daemon
+        thread, and the caller keeps fusion order until ``is_loaded()`` flips."""
+        if self.is_loaded():
+            return
+        import threading
+        lock = self.__dict__.setdefault("_warm_lock", threading.Lock())
+        with lock:
+            if self.__dict__.get("_warming") or self.is_loaded():
+                return
+            self.__dict__["_warming"] = True
+
+        def _bg() -> None:
+            try:
+                self.warm()
+                logger.info("[MEMORY] reranker warm complete (background)")
+            except Exception as exc:  # noqa: BLE001 — warm is best-effort
+                logger.warning("[MEMORY] reranker background warm failed: %s", exc)
+            finally:
+                self.__dict__["_warming"] = False
+
+        threading.Thread(target=_bg, name="reranker-warm", daemon=True).start()
+
 
 class NullReranker(Reranker):
     """Used when the reranker dep/model is unavailable — callers check
@@ -61,6 +95,12 @@ class CrossEncoderReranker(Reranker):
 
     def is_available(self) -> bool:
         return True
+
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    def warm(self) -> None:
+        self._ensure_model()
 
     def _ensure_model(self):
         if self._model is not None:
@@ -114,6 +154,12 @@ class Qwen3Reranker(Reranker):
 
     def is_available(self) -> bool:
         return True
+
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    def warm(self) -> None:
+        self._ensure_model()
 
     def _ensure_model(self):
         if self._model is not None:

--- a/backend/tests/test_services/test_memory_reranker.py
+++ b/backend/tests/test_services/test_memory_reranker.py
@@ -57,6 +57,36 @@ def test_rerank_failure_keeps_fusion_order():
     assert out is fused                               # best-effort: never break recall
 
 
+def test_rerank_skips_and_warms_when_model_not_loaded_yet():
+    """The cold reranker must NEVER block a recall turn: until is_loaded() flips,
+    recall keeps fusion order and a ONE-SHOT background warm is kicked off — the
+    first chat after a fresh boot can't hang on the ~tens-of-seconds CPU load."""
+    calls = {"warm": 0, "rerank": 0}
+
+    class _Cold:
+        def is_available(self): return True
+        def is_loaded(self): return False
+        def warm_async(self): calls["warm"] += 1
+        def rerank(self, q, docs): calls["rerank"] += 1; return [0.0] * len(docs)
+
+    fused = [_ev("a", 0.05, "x"), _ev("b", 0.01, "y")]
+    out = RetrievalOrchestrator._apply_rerank(
+        _stub(_Cold()), RetrievalRequest(owner_agent_name="J", query="q"), fused)
+    assert out is fused              # fusion order kept — no reorder, no block
+    assert calls["warm"] == 1        # background warm kicked off
+    assert calls["rerank"] == 0      # rerank NOT called (would cold-load → block)
+
+
+def test_qwen3_warm_async_is_nonblocking_and_idempotent():
+    from services.retrieval.reranker import Qwen3Reranker
+    rr = Qwen3Reranker("Qwen/Qwen3-Reranker-0.6B")
+    assert rr.is_loaded() is False
+    rr.warm_async()                  # returns immediately; bg thread can't load
+    rr.warm_async()                  # idempotent — no second thread, no raise
+    import time; time.sleep(0.2)     # let the bg thread fail fast (not main process)
+    assert rr.is_loaded() is False   # never loaded here, and never blocked/crashed
+
+
 def test_apply_policy_orders_by_reranker_over_rrf():
     a = _ev("a", 0.9, "x"); a.scores.reranker = 0.1   # high rrf, low rerank
     b = _ev("b", 0.1, "y"); b.scores.reranker = 0.9   # low rrf, high rerank


### PR DESCRIPTION
Fixes the **~65s hang on the first chat after each deploy**. Diagnosed live on prod (SSH): request `13:32:37` → `Loaded reranker Qwen/Qwen3-Reranker-0.6B (device=cpu)` `13:33:42` = **65s of cold load blocking the recall hook** before any tool/LLM call. The reranker (0.6B causal LM, added #102) loaded **lazily on first recall**, on CPU, and re-downloads every deploy (HF cache is in the container layer, not a volume).

## Tier 1 — keep the cost OFF the main flow (ships via normal CD, fixes the hang alone)
- `reranker.py`: `is_loaded()` / `warm()` / `warm_async()` (one-shot daemon-thread load, idempotent, non-blocking).
- `server.py` lifespan: **eager-warm the reranker in the background at boot**.
- `orchestrator._apply_rerank`: if not warm yet → kick off `warm_async()` and keep **fusion order** for that turn. A recall turn **never blocks** on the cold load. Skip window is normally empty (boot warm wins the race); defensive `hasattr` guard for duck-typed rerankers.
- Tests: skip-and-warm-when-cold; `warm_async` non-blocking + idempotent. **43 affected tests pass.**

→ Result: the first chat keeps fusion order for the few seconds until warm, then rerank kicks in. **No hang**, even without Tier 2.

## Tier 2 — pre-bake (recipe only; needs base build+push to activate)
- `Dockerfile.base` **1.4.0**: pre-bake `Qwen3-Embedding-0.6B` + `Qwen3-Reranker-0.6B` (replacing now-non-default bge-m3) → no runtime download, survives container recreate → boot warm becomes ~seconds.
- `Dockerfile`: ARG **kept at 1.3.0**. ⚠️ Bump to `1.4.0` **only after** `docker build -f Dockerfile.base -t omnigentx/jarvis-backend-base:1.4.0 . && docker push` — otherwise the next deploy cannot pull the base. Tier 1 stands alone until then.

## Verify
- Backend: reranker + retrieval + recall-hook suites green (43 passed). `py_compile` OK.
- No deploy-breaking change (ARG stays 1.3.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)