### PR TITLE
fix(memory): recover LadybugDB from wal_record.cpp WAL assertion + CHECKPOINT on shutdown

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -832,7 +832,17 @@ async def lifespan(app: FastAPI):
             await memory_index_task
         except asyncio.CancelledError:
             pass
-    
+
+    # CHECKPOINT LadybugDB AFTER the index worker stops writing — flushes the WAL
+    # so a graceful stop never leaves a dirty WAL for the next boot to choke on
+    # (the wal_record.cpp UNREACHABLE_CODE corruption). Best-effort, no-op if the
+    # graph was never opened.
+    try:
+        from services.indexing.ladybug_store import checkpoint_shared_store
+        checkpoint_shared_store()
+    except Exception:  # noqa: BLE001 — never block shutdown on the disposable index
+        logger.debug("[MEMORY] LadybugDB shutdown checkpoint skipped", exc_info=True)
+
     # Shutdown spawn event socket server
     if event_socket_server:
         await event_socket_server.stop()

--- a/backend/services/indexing/ladybug_store.py
+++ b/backend/services/indexing/ladybug_store.py
@@ -122,11 +122,19 @@ class LadybugStore:
         try:
             db = ladybug.Database(path)
         except RuntimeError as exc:
-            # Match ONLY Ladybug's exact corrupt-WAL signature — a broad
-            # "wal"/"corrupt" substring could wipe a healthy graph on an
+            # Match Ladybug's WAL-replay corruption — BOTH known signatures:
+            #   * the old "Corrupted wal file" message, and
+            #   * the newer assertion that surfaces as
+            #     'Assertion failed in file ".../storage/wal/wal_record.cpp" ...
+            #      UNREACHABLE_CODE' when an ungraceful exit left a dirty WAL.
+            # (Matching only the old string left prod stuck "FTS-only" — the
+            # assertion never triggered the self-heal. See ladybugdb/kuzu WAL
+            # recovery: rm the wal / rebuild.) Stay SPECIFIC to WAL replay so a
+            # broad "wal"/"corrupt" substring can't wipe a healthy graph on an
             # unrelated transient/lock error. Quarantine (not delete) so a
             # misfire is recoverable; the startup migration rebuilds from SQLite.
-            if "corrupted wal file" not in str(exc).lower():
+            _msg = str(exc).lower()
+            if not ("corrupted wal" in _msg or "wal_record.cpp" in _msg):
                 raise
             logger.error("[MEMORY] LadybugDB corrupt WAL (%s) — quarantining the "
                          "disposable graph to <path>*.corrupt; the startup "
@@ -458,7 +466,25 @@ class LadybugStore:
                 n["kind"] = "subject" if nid in subjects else "object"
             return {"nodes": list(nodes.values()), "edges": edges}
 
+    def checkpoint(self) -> None:
+        """Flush the WAL into the main DB file so the NEXT open replays nothing.
+
+        The dirty-WAL corruption (wal_record.cpp UNREACHABLE_CODE) happens when a
+        process exits without checkpointing; running CHECKPOINT before a graceful
+        stop is the documented prevention. Best-effort — a checkpoint failure must
+        never block shutdown."""
+        con = getattr(self, "_con", None)
+        if con is None:
+            return
+        with self._lock:
+            try:
+                con.execute("CHECKPOINT")
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[ladybug] CHECKPOINT failed: %s", exc)
+
     def close(self) -> None:
+        # CHECKPOINT first so an ungraceful next boot doesn't replay a dirty WAL.
+        self.checkpoint()
         with self._lock:
             for obj in (getattr(self, "_con", None), getattr(self, "_db", None)):
                 close = getattr(obj, "close", None)
@@ -478,6 +504,18 @@ def get_ladybug_store(path: str) -> LadybugStore:
     if _STORE_SINGLETON is None:
         _STORE_SINGLETON = LadybugStore(path)
     return _STORE_SINGLETON
+
+
+def checkpoint_shared_store() -> None:
+    """CHECKPOINT the open singleton (no-op if none) on graceful shutdown so the
+    WAL is flushed before the process exits — prevents the dirty-WAL corruption
+    that otherwise bricks dense recall on the next boot. Best-effort."""
+    if _STORE_SINGLETON is not None:
+        try:
+            _STORE_SINGLETON.checkpoint()
+            logger.info("[MEMORY] LadybugDB checkpoint on shutdown — WAL flushed")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[MEMORY] LadybugDB shutdown checkpoint failed: %s", exc)
 
 
 def reset_ladybug_store(path: str) -> None:

--- a/backend/tests/test_services/test_ladybug_store.py
+++ b/backend/tests/test_services/test_ladybug_store.py
@@ -80,6 +80,47 @@ def test_open_self_heals_corrupt_wal(monkeypatch, tmp_path):
         store.close()
 
 
+def test_open_self_heals_wal_replay_assertion(monkeypatch, tmp_path):
+    # Regression (2026-06-25 prod incident): in ladybug 0.17.x the dirty-WAL
+    # failure surfaces as a wal_record.cpp UNREACHABLE_CODE ASSERTION, not the
+    # old "Corrupted wal file" message — so the self-heal silently never fired
+    # and prod sat "FTS-only / semantic search degraded" across restarts. The
+    # matcher must catch this signature too.
+    import ladybug
+
+    from services.indexing import ladybug_store as ls
+
+    path = str(tmp_path / "graph")
+    real_db = ladybug.Database
+    calls = {"n": 0}
+    wiped = {"n": 0}
+
+    def flaky_db(p=None, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError(
+                'Assertion failed in file "/__w/ladybug/ladybug/src/storage/wal/'
+                'wal_record.cpp" on line 76: UNREACHABLE_CODE')
+        return real_db(p, **kw)
+
+    monkeypatch.setattr(ladybug, "Database", flaky_db)
+    real_q = ls._quarantine_graph_files
+
+    def spy_quarantine(p):
+        wiped["n"] += 1
+        real_q(p)
+
+    monkeypatch.setattr(ls, "_quarantine_graph_files", spy_quarantine)
+
+    store = ls.LadybugStore(path)        # assertion → quarantine → retry → ok
+    try:
+        assert calls["n"] == 2
+        assert wiped["n"] == 1
+        assert store.count() == 0
+    finally:
+        store.close()
+
+
 def test_open_reraises_non_corruption_error(monkeypatch, tmp_path):
     # M2: the self-heal must match ONLY Ladybug's exact corrupt-WAL signature —
     # a transient/lock error (or any message merely containing "wal"/"corrupt")


### PR DESCRIPTION
Prod: **"Semantic index (LadybugDB) unavailable — semantic search degraded, FTS-only"** across every restart.

## Root cause
An ungraceful exit (container SIGKILL on deploy) leaves a **dirty WAL**. The next `ladybug.Database(path)` open replays it and — in ladybug 0.17.x — fails with an **assertion**: `Assertion failed in file ".../storage/wal/wal_record.cpp" on line 76: UNREACHABLE_CODE` (NOT the old `"Corrupted wal file"` string). Our self-heal in `LadybugStore._open` matched **only the old message**, so it re-raised → `ladybug migration check failed` → the disposable index stayed dead. SQLite (the real data, 13 records on prod) was always intact.

Confirmed against the official guidance ([GitNexus #1480](https://github.com/abhigyanpatwari/GitNexus/issues/1480) — same `wal_record.cpp:76` error; [Kùzu #4013](https://github.com/kuzudb/kuzu/issues/4013) — checkpoint-before-close).

## Fix (LadybugDB is a rebuildable projection; SQLite is SoT)
1. **`_open` recovery** — broaden the match to also catch the assertion (`"wal_record.cpp" in msg`), kept **specific** so an unrelated lock/transient error still propagates (`test_open_reraises_non_corruption_error` still green). On match → quarantine the graph + reopen empty → startup migration rebuilds from SQLite. **→ prod auto-recovers on the next boot; no manual `rm *.wal`.**
2. **Prevention** — `LadybugStore.checkpoint()` runs `CHECKPOINT` (documented WAL flush); `close()` checkpoints first; the lifespan **shutdown** calls `checkpoint_shared_store()` after the index worker stops → a graceful stop leaves a **clean WAL**.

## Verify
- `test_ladybug_store` **24 pass**, incl. new `test_open_self_heals_wal_replay_assertion` (the exact prod signature) + the existing reraise-on-unrelated-error guard.
- `py_compile` clean; `checkpoint()` smoke-tested on a real store.

**Deploying this PR fixes prod on boot** (the broadened self-heal finally fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)