### PR TITLE
feat(memory): faster reranker default + download-progress UI + per-tool tool results

### DIFF
--- a/backend/routes/memory_settings.py
+++ b/backend/routes/memory_settings.py
@@ -39,7 +39,9 @@ def _kick_reranker_warm(model_name: str) -> None:
         loop = None
 
     def on_progress(state: str, pct: int) -> None:
-        ev = {"event_type": "reranker_model_loading", "state": state,
+        # ``memory_`` prefix so the frontend's activity-stream router forwards it
+        # to the memory store (agents.js gates forwarding on event_type.startsWith).
+        ev = {"event_type": "memory_reranker_loading", "state": state,
               "progress": pct, "model": model_name}
         if loop is not None:
             loop.call_soon_threadsafe(activity_stream_manager.broadcast, ev)

--- a/backend/routes/memory_settings.py
+++ b/backend/routes/memory_settings.py
@@ -6,7 +6,9 @@ masked on read. Audit history / export still flow through config_service.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
+import threading
 from dataclasses import asdict
 from typing import Any
 
@@ -14,10 +16,38 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from core.auth import verify_api_key
+from services.activity_stream import activity_stream_manager
 from services.memory.settings import get_memory_settings, update_memory_settings
 
 logger = logging.getLogger("memory_settings_api")
 router = APIRouter(prefix="/api/memory", tags=["memory"])
+
+
+def _kick_reranker_warm(model_name: str) -> None:
+    """After a rerank-model switch, download + warm the new model in a daemon
+    thread and stream progress to the activity SSE — so the UI shows a progress
+    bar instead of the FIRST recall silently hanging on the download/load.
+
+    The warm runs off the event loop (it blocks); progress is marshalled back
+    onto the loop with ``call_soon_threadsafe`` because ``broadcast`` touches
+    asyncio.Queues that are not thread-safe to write from another thread.
+    """
+    from services.retrieval.reranker import prefetch_and_warm
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    def on_progress(state: str, pct: int) -> None:
+        ev = {"event_type": "reranker_model_loading", "state": state,
+              "progress": pct, "model": model_name}
+        if loop is not None:
+            loop.call_soon_threadsafe(activity_stream_manager.broadcast, ev)
+        else:
+            activity_stream_manager.broadcast(ev)
+
+    threading.Thread(target=prefetch_and_warm, args=(model_name, on_progress),
+                     name="reranker-prefetch", daemon=True).start()
 
 
 class MemorySettingsPatch(BaseModel):
@@ -65,4 +95,9 @@ async def patch_settings(patch: MemorySettingsPatch) -> dict[str, Any]:
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     logger.info("[MEMORY] Settings updated: %s", sorted(updates))
+    # A rerank-model switch would otherwise download + load on the first recall
+    # (a multi-second silent hang). Pre-warm in the background and stream
+    # progress to the UI. Only when the reranker is actually enabled.
+    if "rerank_model" in updates and settings.reranker_enabled:
+        _kick_reranker_warm(settings.rerank_model)
     return asdict(settings)

--- a/backend/server.py
+++ b/backend/server.py
@@ -492,7 +492,7 @@ async def lifespan(app: FastAPI):
             if getattr(_mem_cfg, "reranker_enabled", False):
                 from services.retrieval.reranker import get_shared_reranker
                 get_shared_reranker(
-                    getattr(_mem_cfg, "rerank_model", None) or "Qwen/Qwen3-Reranker-0.6B"
+                    getattr(_mem_cfg, "rerank_model", None) or "BAAI/bge-reranker-v2-m3"
                 ).warm_async()
                 logger.info("[MEMORY] reranker eager-warm kicked off (background)")
     except Exception:

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -55,10 +55,12 @@ class MemorySettings:
     # evenly. Qwen3 (better gate spread, slower) still selectable. NOTE: an earlier
     # 2026-06-23 note claimed bge "compressed scores near 0 (ungateable)" — that was
     # raw-logit; the CrossEncoder.predict path used here is sigmoid (0..1). VALIDATED
-    # 2026-06-28 on the real VI store: on-topic answers score 0.016–0.99 (all above
-    # the 0.001 floor → kept), off-topic/off-keyword < 0.001 (dropped), off-topic
-    # QUERIES score ~0 across the board (no injection). So rerank_min_score gates
-    # correctly — no silent recall loss from the bge switch.
+    # 2026-06-28 with a 27-query VI labelled sweep on the real store (and regressed
+    # by tests/test_eval/test_rerank_gate_eval.py on a synthetic profile): at the
+    # 0.001 floor recall(on-topic)=1.00 and clear-off-topic suppression=1.00; raising
+    # to 0.005 already drops recall to 0.94. Residual: off-topic KEYWORD-overlap
+    # (e.g. "Angular latest version") still leaks — a scalar floor can't catch
+    # topical overlap (needs intent/LLM, deferred), same as the old reranker.
     rerank_model: str = "BAAI/bge-reranker-v2-m3"
     # 5 keeps recall < ~1s on CPU: each candidate is a forward pass, so cost scales
     # with this. The fused pool is small for personal memory; 5 covers the relevant

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -54,9 +54,11 @@ class MemorySettings:
     # docs/rerank-latency-issue.md). bge-v2-m3 is ~0.8s @ 8 docs and handles VI+EN
     # evenly. Qwen3 (better gate spread, slower) still selectable. NOTE: an earlier
     # 2026-06-23 note claimed bge "compressed scores near 0 (ungateable)" — that was
-    # raw-logit; the CrossEncoder.predict path used here is sigmoid (0..1), measured
-    # 0.99 on-topic / 0.00 off in a sanity test, so rerank_min_score still gates.
-    # Re-validate the gate on real VI queries if recall looks off.
+    # raw-logit; the CrossEncoder.predict path used here is sigmoid (0..1). VALIDATED
+    # 2026-06-28 on the real VI store: on-topic answers score 0.016–0.99 (all above
+    # the 0.001 floor → kept), off-topic/off-keyword < 0.001 (dropped), off-topic
+    # QUERIES score ~0 across the board (no injection). So rerank_min_score gates
+    # correctly — no silent recall loss from the bge switch.
     rerank_model: str = "BAAI/bge-reranker-v2-m3"
     # 5 keeps recall < ~1s on CPU: each candidate is a forward pass, so cost scales
     # with this. The fused pool is small for personal memory; 5 covers the relevant

--- a/backend/services/memory/settings.py
+++ b/backend/services/memory/settings.py
@@ -48,12 +48,20 @@ class MemorySettings:
     # memory) relevance — the bi-encoder can't. ON by default. It is a RANKER, not
     # a precision GATE: see rerank_min_score.
     reranker_enabled: bool = True
-    # Qwen3-Reranker-0.6B (causal LM, yes/no logit) measured 2026-06-23 to rank the
-    # direct answer FIRST on the live Vietnamese store and give a usable score
-    # spread, where bge-reranker-v2-m3 compressed everything near 0 (ungateable,
-    # mis-ranked). bge still selectable. Slower (autoregressive) but worth it.
-    rerank_model: str = "Qwen/Qwen3-Reranker-0.6B"
-    rerank_top_k: int = 20            # how many fused candidates to rerank
+    # Default bge-reranker-v2-m3: a multilingual cross-encoder (one forward + head)
+    # ~10x cheaper on CPU than Qwen3-Reranker-0.6B (a 600M causal LM measured at
+    # ~0.87s/candidate → ~17s recall on the CPU-only prod; see
+    # docs/rerank-latency-issue.md). bge-v2-m3 is ~0.8s @ 8 docs and handles VI+EN
+    # evenly. Qwen3 (better gate spread, slower) still selectable. NOTE: an earlier
+    # 2026-06-23 note claimed bge "compressed scores near 0 (ungateable)" — that was
+    # raw-logit; the CrossEncoder.predict path used here is sigmoid (0..1), measured
+    # 0.99 on-topic / 0.00 off in a sanity test, so rerank_min_score still gates.
+    # Re-validate the gate on real VI queries if recall looks off.
+    rerank_model: str = "BAAI/bge-reranker-v2-m3"
+    # 5 keeps recall < ~1s on CPU: each candidate is a forward pass, so cost scales
+    # with this. The fused pool is small for personal memory; 5 covers the relevant
+    # head. (Was 20 — ~17s with the old Qwen3 reranker.)
+    rerank_top_k: int = 5             # how many fused candidates to rerank
     # Drop candidates scoring below this. With bge-reranker this had to be 0.0 (it
     # compressed every Vietnamese score near 0 — a floor couldn't separate on-topic
     # from off-keyword without killing recall). Qwen3-Reranker fixes that: measured
@@ -116,8 +124,8 @@ _SCHEMA: dict[str, tuple[str, Any]] = {
     "embedding_model": ("str", "Qwen/Qwen3-Embedding-0.6B"),
     "embedding_revision": ("str", ""),
     "reranker_enabled": ("bool", True),
-    "rerank_model": ("str", "Qwen/Qwen3-Reranker-0.6B"),
-    "rerank_top_k": ("int", 20),
+    "rerank_model": ("str", "BAAI/bge-reranker-v2-m3"),
+    "rerank_top_k": ("int", 5),
     "rerank_min_score": ("float", 0.001),
     "ladybug_path": ("str", "data/memory_graph"),
     "retention_episodic_days": ("int", 90),

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -74,7 +74,7 @@ class RetrievalOrchestrator:
         if getattr(settings, "reranker_enabled", False):
             from services.retrieval.reranker import get_shared_reranker
             self._reranker = get_shared_reranker(
-                getattr(settings, "rerank_model", None) or "Qwen/Qwen3-Reranker-0.6B")
+                getattr(settings, "rerank_model", None) or "BAAI/bge-reranker-v2-m3")
 
     async def retrieve(self, request: RetrievalRequest, *, now: float,
                        ledger: EvidenceLedger | None = None, turn: int = 0,

--- a/backend/services/retrieval/reranker.py
+++ b/backend/services/retrieval/reranker.py
@@ -20,7 +20,7 @@ from abc import ABC, abstractmethod
 
 logger = logging.getLogger("memory.reranker")
 
-DEFAULT_RERANKER = "Qwen/Qwen3-Reranker-0.6B"
+DEFAULT_RERANKER = "BAAI/bge-reranker-v2-m3"
 # Set by the FastAPI lifespan in the main process (same flag the embedder uses).
 MAIN_PROCESS_ENV = "JARVIS_MAIN_PROCESS"
 

--- a/backend/services/retrieval/reranker.py
+++ b/backend/services/retrieval/reranker.py
@@ -329,10 +329,18 @@ def prefetch_and_warm(model_name: str, on_progress) -> None:
             logger.info("[MEMORY] reranker prefetch skipped/failed (%s) — trying load", exc)
 
         _emit("loading", max(state["last_pct"], 99))
-        reranker = get_shared_reranker(model_name)
+        # Build + warm a FRESH instance, then publish it to the shared singleton
+        # ONLY after warm() succeeds. If we swapped _SHARED first (via
+        # get_shared_reranker) an orchestrator constructed during the warm window
+        # would grab the unwarmed model and pay the load on the request path — the
+        # exact hang this function exists to remove. Until we publish, recalls keep
+        # using the current _SHARED (the old, already-warm model).
+        global _SHARED, _SHARED_KEY
+        reranker = get_reranker(model_name)
         reranker.warm()                       # blocks until weights are in RAM
         if not reranker.is_available():
             raise RuntimeError("reranker unavailable after load (missing dep?)")
+        _SHARED, _SHARED_KEY = reranker, model_name   # atomic publish, post-warm
         _emit("ready", 100)
         logger.info("[MEMORY] reranker '%s' downloaded + warmed", model_name)
     except Exception as exc:  # noqa: BLE001 — surface one error event, never crash

--- a/backend/services/retrieval/reranker.py
+++ b/backend/services/retrieval/reranker.py
@@ -270,3 +270,74 @@ def get_shared_reranker(model_name: str = DEFAULT_RERANKER) -> Reranker:
         _SHARED = get_reranker(model_name)
         _SHARED_KEY = model_name
     return _SHARED
+
+
+def prefetch_and_warm(model_name: str, on_progress) -> None:
+    """Download (with byte-level progress) then load a reranker model into the
+    shared singleton, so the FIRST recall after a model switch never pays the
+    download/load on the request path.
+
+    ``on_progress(state, pct)`` is called with state in
+    ``downloading|loading|ready|error`` and an integer 0..100. The download %
+    is real (aggregated bytes); ``loading`` is indeterminate (pct stays at the
+    last download value). Best-effort: any failure ends in a single ``error``.
+
+    MUST run OFF the event loop (it blocks on network + a model load). The
+    callback is the only side-channel — it is expected to be thread-safe
+    (the API hook marshals it back onto the loop).
+    """
+    state = {"done": 0, "total": 0, "last_pct": -1}
+
+    def _emit(st: str, pct: int) -> None:
+        # Throttle: only fire when the integer pct actually advances, so a
+        # chunked download doesn't flood the SSE channel.
+        if st == "downloading" and pct == state["last_pct"]:
+            return
+        state["last_pct"] = pct
+        try:
+            on_progress(st, pct)
+        except Exception:  # noqa: BLE001 — progress is best-effort, never break the warm
+            logger.debug("[MEMORY] reranker progress callback failed", exc_info=True)
+
+    try:
+        _emit("downloading", 0)
+        try:
+            from huggingface_hub import snapshot_download
+            from tqdm.auto import tqdm as _tqdm
+
+            # Aggregate byte progress across HF's per-file bars. Only count the
+            # byte bars (unit == 'B'); HF's outer "Fetching N files" bar uses
+            # unit 'it' and would otherwise pollute the denominator.
+            class _ProgressTqdm(_tqdm):
+                def __init__(self, *a, **k):
+                    super().__init__(*a, **k)
+                    if self.unit == "B":
+                        state["total"] += (self.total or 0)
+
+                def update(self, n=1):
+                    r = super().update(n)
+                    if self.unit == "B" and state["total"]:
+                        state["done"] += n
+                        _emit("downloading",
+                              min(99, int(state["done"] * 100 / state["total"])))
+                    return r
+
+            snapshot_download(repo_id=model_name, tqdm_class=_ProgressTqdm)
+        except Exception as exc:  # noqa: BLE001 — already cached / offline / hub error
+            # Not fatal: the files may already be cached, in which case the
+            # load below still succeeds. Log and move on to the load phase.
+            logger.info("[MEMORY] reranker prefetch skipped/failed (%s) — trying load", exc)
+
+        _emit("loading", max(state["last_pct"], 99))
+        reranker = get_shared_reranker(model_name)
+        reranker.warm()                       # blocks until weights are in RAM
+        if not reranker.is_available():
+            raise RuntimeError("reranker unavailable after load (missing dep?)")
+        _emit("ready", 100)
+        logger.info("[MEMORY] reranker '%s' downloaded + warmed", model_name)
+    except Exception as exc:  # noqa: BLE001 — surface one error event, never crash
+        logger.warning("[MEMORY] reranker prefetch_and_warm failed: %s", exc)
+        try:
+            on_progress("error", 0)
+        except Exception:  # noqa: BLE001
+            pass

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -636,21 +636,30 @@ class SessionService:
                 if et == "tool_call":
                     pending = a
                 elif et == "tool_result" and pending is not None:
-                    tools_info = pending["data"].get("tools", []) or []
                     result_data = a["data"] or {}
+                    # Prefer the RESULT event's tool list — each entry carries its
+                    # OWN result_preview after the per-tool fix. Fall back to the
+                    # call event's tools + the batch-level preview for rows persisted
+                    # before the fix (where every tool shared the first result).
+                    tools_info = result_data.get("tools") or pending["data"].get("tools", []) or []
+                    batch_preview = result_data.get("result_preview")
                     for tool in tools_info:
                         if isinstance(tool, dict):
                             tool_name = tool.get("name", "unknown")
                             tool_args = tool.get("args", {}) or {}
+                            preview = tool.get("result_preview")
+                            if preview is None:
+                                preview = batch_preview
                         else:
                             tool_name = str(tool)
                             tool_args = {}
+                            preview = batch_preview
                         out.append({
                             "tool": tool_name,
                             "args": tool_args,
                             "status": "done",
                             "duration_ms": result_data.get("duration_ms"),
-                            "result_preview": result_data.get("result_preview"),
+                            "result_preview": preview,
                         })
                     pending = None
             return out

--- a/backend/services/sse_progress.py
+++ b/backend/services/sse_progress.py
@@ -336,25 +336,59 @@ def _extract_tool_info(message: PromptMessageExtended) -> list[dict]:
                             args = json.loads(raw_args)
                         except (json.JSONDecodeError, TypeError):
                             args = {"raw": raw_args[:200]}
-                tools.append({"name": name, "args": {k: str(v) for k, v in args.items()}})
+                tools.append({"id": tool_id, "name": name,
+                              "args": {k: str(v) for k, v in args.items()}})
             except Exception:
-                tools.append({"name": str(tool_id)[:20], "args": {}})
+                tools.append({"id": tool_id, "name": str(tool_id)[:20], "args": {}})
     return tools
 
 
-def _extract_result_preview(message: PromptMessageExtended) -> Optional[str]:
-    """Extract a brief preview of tool results."""
+def _extract_results_by_id(message: PromptMessageExtended) -> tuple[dict[str, str], list[str]]:
+    """Map each tool_result to its tool_id (and keep call order for a positional
+    fallback). A turn can run SEVERAL tools; the previous code returned only the
+    FIRST result and broadcast it for the whole batch, so every tool card showed
+    the first tool's output (e.g. ``get_current_time`` displayed ``memory_remember``'s
+    result). Per-id mapping fixes that."""
+    by_id: dict[str, str] = {}
+    order: list[str] = []
     try:
         if message.tool_results:
             for tool_id, result in message.tool_results.items():
+                text = ""
                 if result.content:
                     for block in result.content:
-                        text = getattr(block, 'text', None)
-                        if text:
-                            return text.strip()
+                        t = getattr(block, 'text', None)
+                        if t:
+                            text = t.strip()
+                            break
+                by_id[tool_id] = text
+                order.append(text)
     except Exception:
         pass
-    return None
+    return by_id, order
+
+
+def _attach_per_tool_results(tools_done: list[dict],
+                             message: PromptMessageExtended) -> Optional[str]:
+    """Attach each tool's OWN result to it (matched by id; positional fallback
+    when ids don't line up), MUTATING ``tools_done`` in place. Returns the
+    batch-level preview (first non-empty) for legacy single-tool consumers.
+
+    Fixes the bug where a multi-tool turn broadcast ONE preview (the first
+    tool's) for every tool, so e.g. ``get_current_time`` rendered
+    ``memory_remember``'s result."""
+    by_id, ordered = _extract_results_by_id(message)
+    matched = False
+    for tinfo in tools_done:
+        rp = by_id.get(tinfo.get("id"))
+        if rp is not None:
+            matched = True
+        tinfo["result_preview"] = rp
+    if not matched and ordered:           # ids didn't align → positional
+        for i, tinfo in enumerate(tools_done):
+            tinfo["result_preview"] = ordered[i] if i < len(ordered) else None
+    return next((t.get("result_preview") for t in tools_done
+                 if t.get("result_preview")), None)
 
 
 def _make_message(agent_display: str, event_type: str, details: str = "") -> str:
@@ -516,10 +550,11 @@ def create_progress_hooks(request_id: str, session_id: str | None = None) -> Too
         start = _tool_start_times.pop(agent_name, None)
         duration_ms = int((time.time() - start) * 1000) if start else None
         
-        # Get result preview
-        result_preview = _extract_result_preview(message)
-        
+        # Per-tool results — a turn can run SEVERAL tools, so each tool gets ITS
+        # OWN result (see _attach_per_tool_results); the returned value is the
+        # legacy batch-level preview for single-tool consumers.
         tools_done = _tool_names.pop(agent_name, [])
+        result_preview = _attach_per_tool_results(tools_done, message)
         tool_str = ", ".join(t["name"] for t in tools_done) if tools_done else "tools"
         
         # chat-stream progress event for the chat UI's per-tool progress widget.

--- a/backend/services/sse_progress.py
+++ b/backend/services/sse_progress.py
@@ -378,15 +378,14 @@ def _attach_per_tool_results(tools_done: list[dict],
     tool's) for every tool, so e.g. ``get_current_time`` rendered
     ``memory_remember``'s result."""
     by_id, ordered = _extract_results_by_id(message)
-    matched = False
-    for tinfo in tools_done:
+    # Per-tool: prefer the id match; fall back to call-order position for any tool
+    # whose id didn't line up (handles a partial-id-match turn, not just the
+    # all-or-nothing case).
+    for i, tinfo in enumerate(tools_done):
         rp = by_id.get(tinfo.get("id"))
-        if rp is not None:
-            matched = True
+        if rp is None and i < len(ordered):
+            rp = ordered[i]
         tinfo["result_preview"] = rp
-    if not matched and ordered:           # ids didn't align → positional
-        for i, tinfo in enumerate(tools_done):
-            tinfo["result_preview"] = ordered[i] if i < len(ordered) else None
     return next((t.get("result_preview") for t in tools_done
                  if t.get("result_preview")), None)
 

--- a/backend/tests/test_eval/test_rerank_gate_eval.py
+++ b/backend/tests/test_eval/test_rerank_gate_eval.py
@@ -1,0 +1,95 @@
+"""Tune/regress the rerank_min_score floor for the default reranker on a
+multi-case Vietnamese labelled set.
+
+Opt-in (``memory_eval`` marker) — loads the real cross-encoder, so it's skipped
+unless sentence-transformers + the model are present. Synthetic profile corpus
+(no real PII; vi+en code-switching is a core feature, VI fixtures are allowed).
+
+Guards the decision in services/memory/settings.py: with bge-reranker-v2-m3 the
+0.001 floor keeps ALL on-topic answers and drops ALL clear off-topic queries.
+A reranker/floor change that breaks recall or off-topic suppression fails here.
+"""
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.memory_eval
+
+_ST = importlib.util.find_spec("sentence_transformers") is not None
+_MODEL = "BAAI/bge-reranker-v2-m3"
+_FLOOR = 0.001
+
+# Synthetic profile (mirrors the kinds of facts personal memory stores).
+_CORPUS = [
+    "Người dùng tên là An.",                                  # 0
+    "Người dùng tên đầy đủ là Trần Hoàng An.",                # 1
+    "Người dùng sinh năm 1990.",                              # 2
+    "Người dùng làm software engineer tại FPT.",              # 3
+    "Công việc chính là phát triển web frontend với React.",  # 4
+    "Địa chỉ công ty là số 10 Lê Lợi, Quận 1, TP HCM.",       # 5
+    "Người dùng đã có gia đình.",                             # 6
+    "Người dùng có một bé gái tên là Bông.",                  # 7
+    "Bé Bông được 2 tuổi.",                                   # 8
+    "Buổi sáng người dùng đi làm lúc 7h.",                    # 9
+    "Người dùng thích leo núi và đã đến Fansipan, Tà Xùa.",   # 10
+    "Người dùng đam mê nhiếp ảnh.",                           # 11
+]
+
+def _i(*kw):
+    return {i for i, d in enumerate(_CORPUS) if all(k.lower() in d.lower() for k in kw)}
+
+# (query, relevant indices). Empty = off-topic-clear (nothing should be kept).
+_ON_TOPIC = [
+    ("tôi tên là gì", _i("tên là An") | _i("tên đầy đủ")),
+    ("tên đầy đủ của tôi", _i("tên đầy đủ")),
+    ("tôi sinh năm nào", _i("sinh năm")),
+    ("tôi làm nghề gì", _i("software engineer") | _i("frontend")),
+    ("tôi làm ở công ty nào", _i("FPT")),
+    ("công ty tôi ở đâu", _i("địa chỉ công ty") | _i("Lê Lợi")),
+    ("con tôi tên gì", _i("Bông") - _i("2 tuổi")),
+    ("con tôi mấy tuổi", _i("2 tuổi")),
+    ("sáng tôi đi làm lúc mấy giờ", _i("7h")),
+    ("tôi code bằng gì", _i("React")),
+    ("sở thích của tôi", _i("leo núi") | _i("nhiếp ảnh")),
+    ("kể về gia đình tôi", _i("gia đình") | _i("Bông")),
+]
+_OFF_TOPIC = [
+    "thời tiết hôm nay thế nào",
+    "giá vàng hôm nay bao nhiêu",
+    "công thức nấu phở bò",
+    "thủ đô nước Pháp là gì",
+    "cách cài docker trên ubuntu",
+]
+
+
+@pytest.fixture(scope="module")
+def reranker():
+    if not _ST:
+        pytest.skip("sentence-transformers not installed")
+    from services.retrieval.reranker import get_reranker
+    r = get_reranker(_MODEL)
+    try:
+        r.warm()
+    except Exception as exc:  # noqa: BLE001 — model not downloadable in this env
+        pytest.skip(f"reranker model unavailable: {exc}")
+    return r
+
+
+def test_floor_keeps_all_on_topic(reranker):
+    """At the 0.001 floor every on-topic query keeps >= 1 relevant memory."""
+    misses = []
+    for q, rel in _ON_TOPIC:
+        s = reranker.rerank(q, _CORPUS)
+        if not any(s[i] >= _FLOOR for i in rel):
+            misses.append((q, max((s[i] for i in rel), default=0.0)))
+    assert not misses, f"on-topic recall dropped below floor: {misses}"
+
+
+def test_floor_drops_all_clear_off_topic(reranker):
+    """At the 0.001 floor every clear off-topic query injects nothing."""
+    leaks = []
+    for q in _OFF_TOPIC:
+        s = reranker.rerank(q, _CORPUS)
+        if any(x >= _FLOOR for x in s):
+            leaks.append((q, max(s)))
+    assert not leaks, f"clear off-topic leaked above floor: {leaks}"

--- a/backend/tests/test_services/test_memory_reranker.py
+++ b/backend/tests/test_services/test_memory_reranker.py
@@ -109,7 +109,9 @@ def test_get_reranker_dispatches_by_model(monkeypatch):
     monkeypatch.setattr(rr, "_have_st", lambda: True)
     assert isinstance(rr.get_reranker("Qwen/Qwen3-Reranker-0.6B"), rr.Qwen3Reranker)
     assert isinstance(rr.get_reranker("BAAI/bge-reranker-v2-m3"), rr.CrossEncoderReranker)
-    assert rr.DEFAULT_RERANKER.startswith("Qwen/")
+    # Default is now bge-reranker-v2-m3 (CrossEncoder path) — faster on CPU.
+    assert rr.DEFAULT_RERANKER == "BAAI/bge-reranker-v2-m3"
+    assert isinstance(rr.get_reranker(), rr.CrossEncoderReranker)
 
 
 def test_get_reranker_falls_back_when_lib_missing(monkeypatch):

--- a/backend/tests/test_services/test_memory_reranker.py
+++ b/backend/tests/test_services/test_memory_reranker.py
@@ -155,3 +155,49 @@ def test_qwen3_reranker_scoring_math():
         assert abs(s - 1.0 / (1.0 + math.exp(-i))) < 1e-4
     assert scores == sorted(scores)                # monotonic in row order (order preserved)
     assert r.rerank("q", []) == []                 # empty → empty
+
+
+# ── prefetch_and_warm: progress reporting for the Settings download UI ──
+
+def test_prefetch_and_warm_emits_phases_in_order(monkeypatch):
+    """Reports downloading → loading → ready so the UI can show a progress bar
+    instead of the first recall hanging on the model download."""
+    import huggingface_hub
+    from services.retrieval import reranker as rr
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **k: "/tmp/cache")
+
+    class _Fake:
+        def warm(self):  # already-cached → instant
+            pass
+        def is_available(self):
+            return True
+
+    monkeypatch.setattr(rr, "get_shared_reranker", lambda name: _Fake())
+
+    events = []
+    rr.prefetch_and_warm("some/model", lambda st, pct: events.append((st, pct)))
+    states = [s for s, _ in events]
+    assert states[0] == "downloading"
+    assert "loading" in states
+    assert states[-1] == "ready"
+    assert events[-1][1] == 100
+
+
+def test_prefetch_and_warm_emits_error_on_load_failure(monkeypatch):
+    import huggingface_hub
+    from services.retrieval import reranker as rr
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **k: "/tmp/cache")
+
+    class _Bad:
+        def warm(self):
+            raise RuntimeError("boom")
+        def is_available(self):
+            return False
+
+    monkeypatch.setattr(rr, "get_shared_reranker", lambda name: _Bad())
+
+    events = []
+    rr.prefetch_and_warm("some/model", lambda st, pct: events.append((st, pct)))
+    assert events[-1][0] == "error"

--- a/backend/tests/test_services/test_memory_reranker.py
+++ b/backend/tests/test_services/test_memory_reranker.py
@@ -175,7 +175,7 @@ def test_prefetch_and_warm_emits_phases_in_order(monkeypatch):
         def is_available(self):
             return True
 
-    monkeypatch.setattr(rr, "get_shared_reranker", lambda name: _Fake())
+    monkeypatch.setattr(rr, "get_reranker", lambda name: _Fake())  # prefetch builds via get_reranker, publishes _SHARED post-warm
 
     events = []
     rr.prefetch_and_warm("some/model", lambda st, pct: events.append((st, pct)))
@@ -198,7 +198,7 @@ def test_prefetch_and_warm_emits_error_on_load_failure(monkeypatch):
         def is_available(self):
             return False
 
-    monkeypatch.setattr(rr, "get_shared_reranker", lambda name: _Bad())
+    monkeypatch.setattr(rr, "get_reranker", lambda name: _Bad())
 
     events = []
     rr.prefetch_and_warm("some/model", lambda st, pct: events.append((st, pct)))

--- a/backend/tests/test_services/test_memory_settings.py
+++ b/backend/tests/test_services/test_memory_settings.py
@@ -127,7 +127,7 @@ def test_new_tuning_knobs_config(fake_cfg):
     # config keys (promoted from hardcoded). Defaults + round-trip + validation.
     d = ms.get_memory_settings()
     assert d.hub_max_df == 0.5 and d.extract_every_n == 4
-    assert d.rerank_top_k == 20 and d.rerank_min_score == 0.001
+    assert d.rerank_top_k == 5 and d.rerank_min_score == 0.001
     ms.update_memory_settings({"hub_max_df": 0.6, "extract_every_n": 3,
                                "rerank_top_k": 10, "rerank_min_score": 0.01})
     s = ms.get_memory_settings()

--- a/backend/tests/test_services/test_sse_progress.py
+++ b/backend/tests/test_services/test_sse_progress.py
@@ -104,3 +104,53 @@ class TestCreateProgressHooks:
         assert hooks.after_llm_call is not None
         assert hooks.before_tool_call is not None
         assert hooks.after_tool_call is not None
+
+
+class TestPerToolResults:
+    """Each tool in a multi-tool turn must carry ITS OWN result_preview.
+
+    Regression: get_current_time rendered memory_remember's result because the
+    whole batch shared the first tool's preview."""
+
+    @staticmethod
+    def _msg(results: dict):
+        # PromptMessageExtended-like: tool_results = {id: result-with-content}
+        from types import SimpleNamespace
+        tr = {tid: SimpleNamespace(content=[SimpleNamespace(text=txt)])
+              for tid, txt in results.items()}
+        return SimpleNamespace(tool_results=tr)
+
+    def test_extract_results_by_id_keeps_each_result(self):
+        from services.sse_progress import _extract_results_by_id
+        by_id, order = _extract_results_by_id(self._msg({
+            "call-1": '{"candidate_id":"abc"}',
+            "call-2": "2026-06-27T17:00:00",
+        }))
+        assert by_id["call-1"] == '{"candidate_id":"abc"}'
+        assert by_id["call-2"] == "2026-06-27T17:00:00"
+        assert order == ['{"candidate_id":"abc"}', "2026-06-27T17:00:00"]
+
+    def test_attach_matches_by_id(self):
+        from services.sse_progress import _attach_per_tool_results
+        tools = [{"id": "call-1", "name": "memory_remember"},
+                 {"id": "call-2", "name": "get_current_time"}]
+        batch = _attach_per_tool_results(tools, self._msg({
+            "call-1": "MEM-RESULT", "call-2": "TIME-RESULT"}))
+        assert tools[0]["result_preview"] == "MEM-RESULT"
+        assert tools[1]["result_preview"] == "TIME-RESULT"   # NOT the memory result
+        assert batch == "MEM-RESULT"                          # legacy = first non-empty
+
+    def test_attach_positional_fallback_when_ids_mismatch(self):
+        from services.sse_progress import _attach_per_tool_results
+        tools = [{"id": "x1", "name": "a"}, {"id": "x2", "name": "b"}]
+        _attach_per_tool_results(tools, self._msg({"y1": "A", "y2": "B"}))
+        assert tools[0]["result_preview"] == "A"
+        assert tools[1]["result_preview"] == "B"
+
+    def test_attach_no_results_leaves_none(self):
+        from types import SimpleNamespace
+        from services.sse_progress import _attach_per_tool_results
+        tools = [{"id": "call-1", "name": "a"}]
+        batch = _attach_per_tool_results(tools, SimpleNamespace(tool_results=None))
+        assert tools[0]["result_preview"] is None
+        assert batch is None

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -70,6 +70,10 @@
       "rerankMinScore": "Reranker score floor",
       "rerankMinScoreHint": "Candidates scoring below this after reranking are dropped (≥0, default 0.005).",
       "rerankModel": "Reranker model",
+      "rerankDownloading": "Downloading reranker {model}…",
+      "rerankLoading": "Loading {model} into memory…",
+      "rerankReady": "Reranker {model} is ready",
+      "rerankLoadError": "Failed to load reranker {model}",
       "hubMaxDf": "GraphRAG hub cutoff",
       "hubMaxDfHint": "An entity mentioned by ≥ this fraction of memories (e.g. your own name) is a no-signal hub, excluded from graph expansion (0–1, default 0.5).",
       "extractEveryN": "Auto-capture every N turns"

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -70,6 +70,10 @@
       "rerankMinScore": "Ngưỡng điểm reranker",
       "rerankMinScoreHint": "Candidate có điểm rerank dưới ngưỡng này bị bỏ (≥0, mặc định 0.005).",
       "rerankModel": "Model reranker",
+      "rerankDownloading": "Đang tải reranker {model}…",
+      "rerankLoading": "Đang nạp {model} vào bộ nhớ…",
+      "rerankReady": "Reranker {model} đã sẵn sàng",
+      "rerankLoadError": "Tải reranker {model} thất bại",
       "hubMaxDf": "Ngưỡng hub GraphRAG",
       "hubMaxDfHint": "Entity được nhắc bởi ≥ tỉ lệ này số memory (vd tên của bạn) là hub vô tín hiệu, bị loại khỏi graph expansion (0–1, mặc định 0.5).",
       "extractEveryN": "Tự bắt mỗi N lượt"

--- a/frontend/src/stores/agents.js
+++ b/frontend/src/stores/agents.js
@@ -151,6 +151,14 @@ export const useAgentsStore = defineStore('agents', () => {
    */
   function processEvent(event) {
     const { agent_name, event_type } = event
+    // GLOBAL memory events (memory_indexed, memory_reranker_loading) carry no
+    // agent_name. Forward them to the memory store BEFORE the per-agent guard
+    // below, which would otherwise drop every agent-less event on the floor.
+    if (!agent_name && event_type && event_type.startsWith('memory_')) {
+      import('./memory').then(({ useMemoryStore }) => useMemoryStore().processMemoryEvent(event))
+        .catch((e) => console.warn('[Store] Failed to forward global memory event:', e))
+      return
+    }
     if (!agent_name || !event_type) return
 
     pushEvent(event)

--- a/frontend/src/stores/memory.js
+++ b/frontend/src/stores/memory.js
@@ -14,6 +14,9 @@ export const useMemoryStore = defineStore('memory', () => {
   const degradedByAgent = ref({})
   // bumped whenever something is indexed → views can re-fetch index-status
   const indexTick = ref(0)
+  // Live reranker download/load progress after a model switch (Settings → Memory).
+  // null when idle; { state: downloading|loading|ready|error, progress, model }.
+  const rerankerLoad = ref(null)
 
   function isDegraded(agent) {
     return Boolean(degradedByAgent.value[agent])
@@ -24,6 +27,14 @@ export const useMemoryStore = defineStore('memory', () => {
     // handle it BEFORE the per-agent guard so the drain hint reaches the panels.
     if (event.event_type === 'memory_indexed') {
       indexTick.value += 1
+      return
+    }
+    // Reranker model swap progress — also GLOBAL (no agent). Drives the progress
+    // bar on the Memory settings page so the model download isn't a silent hang.
+    if (event.event_type === 'reranker_model_loading') {
+      rerankerLoad.value = {
+        state: event.state, progress: event.progress ?? 0, model: event.model,
+      }
       return
     }
     const agent = event.agent_name
@@ -43,7 +54,7 @@ export const useMemoryStore = defineStore('memory', () => {
   }
 
   return {
-    degradedByAgent, indexTick,
+    degradedByAgent, indexTick, rerankerLoad,
     isDegraded, processMemoryEvent,
   }
 })

--- a/frontend/src/stores/memory.js
+++ b/frontend/src/stores/memory.js
@@ -31,7 +31,8 @@ export const useMemoryStore = defineStore('memory', () => {
     }
     // Reranker model swap progress — also GLOBAL (no agent). Drives the progress
     // bar on the Memory settings page so the model download isn't a silent hang.
-    if (event.event_type === 'reranker_model_loading') {
+    // (memory_ prefix so agents.js forwards it here — see processEvent gate.)
+    if (event.event_type === 'memory_reranker_loading') {
       rerankerLoad.value = {
         state: event.state, progress: event.progress ?? 0, model: event.model,
       }

--- a/frontend/src/stores/memory.test.js
+++ b/frontend/src/stores/memory.test.js
@@ -42,19 +42,19 @@ test('events without agent_name are ignored', () => {
   assert.deepEqual(s.degradedByAgent, {})
 })
 
-test('reranker_model_loading drives the global rerankerLoad progress', () => {
+test('memory_reranker_loading drives the global rerankerLoad progress', () => {
   // GLOBAL event (no agent_name) — must be handled before the per-agent guard,
   // like memory_indexed, so the Settings progress bar updates.
   const s = useMemoryStore()
   assert.equal(s.rerankerLoad, null)
-  s.processMemoryEvent({ event_type: 'reranker_model_loading', state: 'downloading', progress: 42, model: 'itdainb/PhoRanker' })
+  s.processMemoryEvent({ event_type: 'memory_reranker_loading', state: 'downloading', progress: 42, model: 'itdainb/PhoRanker' })
   assert.deepEqual(s.rerankerLoad, { state: 'downloading', progress: 42, model: 'itdainb/PhoRanker' })
-  s.processMemoryEvent({ event_type: 'reranker_model_loading', state: 'ready', progress: 100, model: 'itdainb/PhoRanker' })
+  s.processMemoryEvent({ event_type: 'memory_reranker_loading', state: 'ready', progress: 100, model: 'itdainb/PhoRanker' })
   assert.equal(s.rerankerLoad.state, 'ready')
 })
 
-test('reranker_model_loading defaults progress to 0 when omitted', () => {
+test('memory_reranker_loading defaults progress to 0 when omitted', () => {
   const s = useMemoryStore()
-  s.processMemoryEvent({ event_type: 'reranker_model_loading', state: 'loading', model: 'x' })
+  s.processMemoryEvent({ event_type: 'memory_reranker_loading', state: 'loading', model: 'x' })
   assert.equal(s.rerankerLoad.progress, 0)
 })

--- a/frontend/src/stores/memory.test.js
+++ b/frontend/src/stores/memory.test.js
@@ -41,3 +41,20 @@ test('events without agent_name are ignored', () => {
   s.processMemoryEvent({ event_type: 'retrieval_degraded' })
   assert.deepEqual(s.degradedByAgent, {})
 })
+
+test('reranker_model_loading drives the global rerankerLoad progress', () => {
+  // GLOBAL event (no agent_name) — must be handled before the per-agent guard,
+  // like memory_indexed, so the Settings progress bar updates.
+  const s = useMemoryStore()
+  assert.equal(s.rerankerLoad, null)
+  s.processMemoryEvent({ event_type: 'reranker_model_loading', state: 'downloading', progress: 42, model: 'itdainb/PhoRanker' })
+  assert.deepEqual(s.rerankerLoad, { state: 'downloading', progress: 42, model: 'itdainb/PhoRanker' })
+  s.processMemoryEvent({ event_type: 'reranker_model_loading', state: 'ready', progress: 100, model: 'itdainb/PhoRanker' })
+  assert.equal(s.rerankerLoad.state, 'ready')
+})
+
+test('reranker_model_loading defaults progress to 0 when omitted', () => {
+  const s = useMemoryStore()
+  s.processMemoryEvent({ event_type: 'reranker_model_loading', state: 'loading', model: 'x' })
+  assert.equal(s.rerankerLoad.progress, 0)
+})

--- a/frontend/src/utils/toolEvents.js
+++ b/frontend/src/utils/toolEvents.js
@@ -53,6 +53,10 @@ export function expandToolDone(event) {
     command: event.message || 'result',
     isResult: true,
     duration,
-    resultPreview: event.result_preview || null,
+    // Each tool's OWN result — the backend now sends `tools[*].result_preview`.
+    // Previously every tool inherited the batch-level `event.result_preview`
+    // (the first tool's output), so e.g. get_current_time showed memory_remember's
+    // result. Fall back to the batch field for older single-tool events.
+    resultPreview: t.result_preview ?? event.result_preview ?? null,
   }))
 }

--- a/frontend/src/utils/toolEvents.test.js
+++ b/frontend/src/utils/toolEvents.test.js
@@ -89,6 +89,36 @@ test('expandToolDone yields one result entry per tool in the batch', () => {
   }
 })
 
+test('expandToolDone gives each tool its OWN result_preview (per-tool fix)', () => {
+  // Regression: time-service showed memory_remember's result because every tool
+  // in the batch inherited the single event.result_preview (the first result).
+  // Now each tools[*] carries its own result_preview.
+  const event = {
+    type: 'tool_done',
+    tools: [
+      { name: 'memory_server__memory_remember', result_preview: '{"candidate_id":"abc"}' },
+      { name: 'time-service__get_current_time', result_preview: '2026-06-27T17:00:00' },
+    ],
+    duration_ms: 1000,
+    result_preview: '{"candidate_id":"abc"}',
+  }
+  const out = expandToolDone(event)
+  assert.equal(out.length, 2)
+  assert.equal(out[0].resultPreview, '{"candidate_id":"abc"}')
+  assert.equal(out[1].resultPreview, '2026-06-27T17:00:00') // NOT the memory result
+})
+
+test('expandToolDone falls back to batch result_preview when a tool lacks its own', () => {
+  const event = {
+    type: 'tool_done',
+    tools: [{ name: 'a' }, { name: 'b', result_preview: 'B-own' }],
+    result_preview: 'batch',
+  }
+  const out = expandToolDone(event)
+  assert.equal(out[0].resultPreview, 'batch') // no own → batch (legacy rows)
+  assert.equal(out[1].resultPreview, 'B-own') // own preferred
+})
+
 test('expandToolDone omits duration when duration_ms missing', () => {
   const event = { type: 'tool_done', tools: [{ name: 'x' }] }
   const out = expandToolDone(event)

--- a/frontend/src/views/settings/SettingsMemory.vue
+++ b/frontend/src/views/settings/SettingsMemory.vue
@@ -11,11 +11,32 @@
  * key eye-toggle + stored/not-set badge, `--primary` toggles and buttons.
  * Copy via i18n (useLang().t) — English base, Vietnamese overlay.
  */
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { apiFetch, ApiError } from '../../api'
 import { useLang } from '../../composables/useLang.js'
+import { useMemoryStore } from '../../stores/memory'
 
 const { t } = useLang()
+const memStore = useMemoryStore()
+
+// Live reranker download/load progress (driven by the global activity SSE →
+// memory store). Shown as a progress bar after a rerank-model switch so the
+// model download isn't a silent multi-second hang on the first recall.
+const rerankerLoad = computed(() => memStore.rerankerLoad)
+const rerankLoadLabel = computed(() => {
+  const rl = rerankerLoad.value
+  if (!rl) return ''
+  const m = rl.model || ''
+  if (rl.state === 'downloading') return t('settings.memory.rerankDownloading', { model: m })
+  if (rl.state === 'loading') return t('settings.memory.rerankLoading', { model: m })
+  if (rl.state === 'ready') return t('settings.memory.rerankReady', { model: m })
+  return t('settings.memory.rerankLoadError', { model: m })
+})
+// Auto-dismiss the "ready" confirmation after a few seconds; keep "error" so the
+// user actually notices it (cleared on the next switch).
+watch(() => rerankerLoad.value?.state, (s) => {
+  if (s === 'ready') setTimeout(() => { memStore.rerankerLoad = null }, 4000)
+})
 
 const loading = ref(true)
 const saving = ref(false)
@@ -284,6 +305,24 @@ onMounted(load)
           <label>{{ t(f.labelKey) }}</label>
           <input v-model="draft[f.key]" class="text-input" type="text" />
         </div>
+
+        <!-- Reranker model download/load progress (live SSE) — appears after a
+             rerank-model switch so the download is visible, not a silent hang. -->
+        <div v-if="rerankerLoad" class="rerank-load" :class="rerankerLoad.state" aria-live="polite">
+          <div class="rl-head">
+            <span class="rl-label">
+              <span v-if="rerankerLoad.state === 'ready'" class="rl-icon">✓</span>
+              <span v-else-if="rerankerLoad.state === 'error'" class="rl-icon">⚠</span>
+              <span v-else class="rl-spin"></span>
+              {{ rerankLoadLabel }}
+            </span>
+            <span v-if="rerankerLoad.state === 'downloading'" class="rl-pct">{{ rerankerLoad.progress }}%</span>
+          </div>
+          <div v-if="rerankerLoad.state === 'downloading' || rerankerLoad.state === 'loading'" class="rl-track">
+            <div class="rl-fill" :class="{ indet: rerankerLoad.state === 'loading' }"
+                 :style="rerankerLoad.state === 'downloading' ? { width: rerankerLoad.progress + '%' } : null"></div>
+          </div>
+        </div>
       </div>
 
       <div class="actions">
@@ -370,6 +409,27 @@ code { background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: 3px;
 .btn:disabled { opacity: .5; cursor: not-allowed; }
 .ok { color: var(--success); font-size: 13px; }
 .dirty { color: var(--text-dim); font-size: 12px; }
+
+/* Reranker model download/load progress */
+.rerank-load { margin-top: 14px; padding: 12px 14px; border-radius: var(--r-md, 8px);
+  background: var(--bg-3); border: 1px solid var(--border-strong); }
+.rerank-load.ready { border-color: var(--success); }
+.rerank-load.error { border-color: var(--danger); }
+.rl-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.rl-label { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text); }
+.rl-pct { font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); }
+.rl-icon { font-size: 14px; }
+.rerank-load.ready .rl-icon { color: var(--success); }
+.rerank-load.error .rl-icon { color: var(--danger); }
+.rl-spin { width: 13px; height: 13px; flex-shrink: 0; border: 2px solid var(--border-strong);
+  border-top-color: var(--primary); border-radius: 50%; animation: rl-spin .7s linear infinite; }
+@keyframes rl-spin { to { transform: rotate(360deg); } }
+.rl-track { margin-top: 10px; height: 6px; border-radius: 999px; background: var(--bg-4);
+  overflow: hidden; }
+.rl-fill { height: 100%; background: var(--primary); border-radius: 999px; transition: width .2s ease; }
+/* Indeterminate sweep while loading weights into RAM (no byte %). */
+.rl-fill.indet { width: 40%; animation: rl-indet 1.1s ease-in-out infinite; }
+@keyframes rl-indet { 0% { margin-left: -40%; } 100% { margin-left: 100%; } }
 
 @media (max-width: 768px) {
   .row { flex-direction: column; align-items: stretch; }


### PR DESCRIPTION
## What & why

The agent reranker was the dominant recall cost on the CPU-only deployment and
the chat/memory UX around it had two bugs. This PR makes recall fast by default,
makes a reranker-model switch visible, and fixes per-tool result display.

Investigation notes (measured, on the prod CPU): `docs/rerank-latency-issue.md`.

### 1. Faster reranker default (`feat`)
- Default reranker: **`Qwen/Qwen3-Reranker-0.6B` → `BAAI/bge-reranker-v2-m3`**.
  Qwen3-Reranker is a 600M causal LM measured at **~0.87s/candidate** on CPU →
  ~17s recall for a one-line query. bge-reranker-v2-m3 is a multilingual
  cross-encoder (one forward + head), ~10× cheaper on CPU, handles VI+EN evenly.
- **`rerank_top_k` 20 → 5** — each candidate is a forward pass, so cost scales
  with this; 5 covers the relevant head for personal memory and keeps recall
  well under ~1s.
- Updated dataclass + `_SCHEMA` defaults, `DEFAULT_RERANKER`, and the
  orchestrator/lifespan fallbacks. Qwen3 stays selectable via Settings.

### 2. Realtime reranker-model download progress (`feat`)
Switching the rerank model used to download + load lazily on the FIRST recall —
a multi-second silent hang. Now:
- `reranker.prefetch_and_warm(model, on_progress)` — `snapshot_download` with a
  byte-aggregating tqdm → real % → load → ready (or error). Off the request path.
- `patch_settings` kicks the prefetch in a daemon thread on a `rerank_model`
  change and streams progress to the activity SSE
  (`call_soon_threadsafe`, since broadcast touches non-thread-safe queues).
- `SettingsMemory` shows a progress bar (download % / indeterminate load / ready
  ✓ / error ⚠); recalls during the load keep the old model / fusion order so
  chat never blocks. Full en/vi i18n.

### 3. Per-tool result in the "tools used" panel (`fix`)
A multi-tool turn rendered the FIRST tool's result on every card
(`get_current_time` showed `memory_remember`'s output) because the `tool_done`
SSE carried one batch-level `result_preview`. Now each tool carries its own
result (matched by `tool_id`, positional fallback); FE + the chat-history reload
read per-tool, falling back to the batch field for older rows.

### 4. Global memory SSE routing (`fix`)
`agents.js` dropped agent-less events at the `!agent_name` guard before the
`memory_*` forward gate (so `memory_indexed` and the new
`memory_reranker_loading` never reached the store). Forward agent-less `memory_*`
events before that guard.

## Tests
- Backend: `test_memory_reranker` (prefetch progress phases + dispatch),
  `test_memory_settings` (new defaults), `test_sse_progress` (per-tool mapping +
  positional fallback), `test_memory_retrieval_core` updated. Full memory/sse/
  session sweep **344 passed**.
- Frontend: `toolEvents` (per-tool + fallback), `memory` store
  (`memory_reranker_loading`), `agents` store — **32 passed**. `vite build` clean.

## Manual click-flow
1. Settings → Memory → change Reranker model to a not-yet-cached model → Save →
   a progress bar shows download % → loading → ready ✓; chat stays responsive.
2. Chat a turn that runs ≥2 tools → expand "tools used" → each tool shows ITS
   OWN result.
3. Toggle En/Vi → both panels translate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
