### PR TITLE
feat: Telegram & Zalo messaging gateways (images + slash commands)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ docs/memory-v2-plan.md
 docs/oss-i18n-backlog.md
 docs/memory-impl/
 scripts/scan_vietnamese.py
+
+# Local model overlays (per-user model capability declarations)
+backend/.fast-agent/model-overlays/

--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -926,6 +926,31 @@ class CommunicationRecord(Base):
     created_at = Column(Float, nullable=False, default=lambda: datetime.now().timestamp(), index=True)
 
 
+class GatewayChat(Base):
+    """Maps an external messaging chat (Telegram/Zalo/…) to a backend chat
+    session so every inbound message from the same chat continues the SAME
+    conversation across restarts.
+
+    This is the single source of truth for the chat→session binding. The
+    backend ``SessionManager`` owns session *existence*; this table is only an
+    index into it, and ``services.gateways.session_map`` reconciles against
+    ``resume_and_send``'s returned id so the two never silently diverge (a
+    deleted backend session re-binds to a fresh one on the next message).
+    """
+    __tablename__ = "gateway_chats"
+    __table_args__ = (
+        UniqueConstraint("platform", "chat_id", name="uq_gateway_chat"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    platform = Column(String(30), nullable=False, index=True)   # telegram | zalo | …
+    chat_id = Column(String(100), nullable=False, index=True)   # platform chat id (string-normalized)
+    session_id = Column(String(100), nullable=False)            # backend SessionManager id
+    agent_name = Column(String(100), nullable=False)            # agent that answers this chat
+    created_at = Column(Float, nullable=False, default=lambda: datetime.now().timestamp())
+    updated_at = Column(Float, nullable=False, default=lambda: datetime.now().timestamp())
+
+
 def get_db():
     """Dependency for getting database session."""
     db = SessionLocal()

--- a/backend/fastagent.secrets.yaml.example
+++ b/backend/fastagent.secrets.yaml.example
@@ -30,3 +30,7 @@ openai:
 
 google:
   api_key: ""
+
+# Messaging gateways (Telegram / Zalo) are configured in the UI, not here —
+# Settings → Messaging Gateways. Tokens are stored encrypted in the DB and
+# applied live (no restart). See backend/services/gateways/README.md.

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -29,6 +29,7 @@ from routes.team_templates_factory import router as team_templates_factory_route
 from routes.context_compaction import router as context_compaction_router
 from routes.memory_settings import router as memory_settings_router
 from routes.memory import router as memory_router
+from routes.gateways import router as gateways_router
 
 all_routers: list[APIRouter] = [
     auth_router,
@@ -59,4 +60,5 @@ all_routers: list[APIRouter] = [
     context_compaction_router,
     memory_settings_router,
     memory_router,
+    gateways_router,
 ]

--- a/backend/routes/gateways.py
+++ b/backend/routes/gateways.py
@@ -1,0 +1,68 @@
+"""HTTP routes for the messaging-gateways Settings panel.
+
+Config read/write goes through the generic ``/api/settings`` endpoints
+(category ``gateways``) — those already handle encryption, history, and the
+change events that trigger live reload. This module only adds the two things
+settings can't: live runtime **status** and a **test-connection** probe.
+"""
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from core.auth import verify_api_key
+from services.gateways.registry import GATEWAY_REGISTRY
+
+logger = logging.getLogger("gateways_api")
+router = APIRouter(prefix="/api/gateways", tags=["gateways"])
+
+
+class TestBody(BaseModel):
+    # Optional: when omitted/blank, the already-saved token is tested (so the
+    # user can re-verify a stored token without re-typing it).
+    token: str | None = Field(default=None, max_length=500)
+
+
+@router.get("", dependencies=[Depends(verify_api_key)])
+async def gateway_status():
+    """Per-platform config + live status (enabled/running/connected/bot/error)."""
+    import services.shared_state as state
+
+    mgr = getattr(state, "gateway_manager", None)
+    if mgr is None:
+        # Manager not started (e.g. very early boot) — report registered
+        # platforms as all-off so the UI still renders.
+        return {"gateways": [
+            {"platform": name, "enabled": False, "running": False,
+             "connected": False, "bot_username": None, "last_error": None,
+             "agent": "Jarvis", "allow_count": 0, "has_token": False}
+            for name in GATEWAY_REGISTRY
+        ]}
+    return {"gateways": mgr.status()}
+
+
+@router.post("/{platform}/test", dependencies=[Depends(verify_api_key)])
+async def test_connection(platform: str, body: TestBody):
+    """Validate a bot token via the platform's ``getMe``.
+
+    Tests the token in the request body, or — when none is given — the token
+    already saved for this platform (so the user can re-verify without
+    re-typing the secret).
+    """
+    cls = GATEWAY_REGISTRY.get(platform)
+    if cls is None:
+        raise HTTPException(status_code=404, detail=f"Unknown platform: {platform!r}")
+    probe = getattr(cls, "probe", None)
+    if probe is None:
+        raise HTTPException(status_code=400, detail=f"{platform} does not support token testing")
+
+    token = (body.token or "").strip()
+    if not token:
+        # Fall back to the stored token (soft-fail on a stale/undecryptable row).
+        from services.config_service import config_service
+        from services.secret_utils import safe_get_or_none
+        token = (safe_get_or_none(config_service, "gateways", f"{platform}_token") or "").strip()
+    if not token:
+        return {"ok": False, "error": "No token to test — enter one first."}
+
+    return await probe(token)

--- a/backend/server.py
+++ b/backend/server.py
@@ -810,13 +810,33 @@ async def lifespan(app: FastAPI):
                 logger.warning("MCP server tools: background discovery failed: %s", e)
         
         asyncio.create_task(_discover_uncached_servers())
-        
+
+        # Start external messaging gateways (Telegram / Zalo). Opt-in: reads
+        # the `gateways:` section of fastagent.secrets.yaml; does nothing unless
+        # a gateway is enabled with a token. Started last so agent_app + all
+        # background services it dispatches into are already live.
+        gateway_manager = None
+        try:
+            from services.gateways import GatewayManager
+            gateway_manager = GatewayManager(state.agent_app)
+            gateway_manager.start()
+            state.gateway_manager = gateway_manager
+        except Exception:
+            logger.exception("Failed to start messaging gateways")
+
         print(f"\n{'═' * 50}")
         print(f"🚀 Jarvis backend ready | agents={len(fast.agents)} | mcp_cached={len(cached_servers)}")
         print(f"{'═' * 50}\n")
-        
+
         yield
-    
+
+    # Shutdown messaging gateways (stop polling loops + close HTTP clients)
+    if gateway_manager:
+        try:
+            await gateway_manager.stop()
+        except Exception:
+            logger.exception("Error stopping messaging gateways")
+
     # Shutdown reload loop
     reload_task.cancel()
     try:

--- a/backend/services/gateways/README.md
+++ b/backend/services/gateways/README.md
@@ -1,0 +1,102 @@
+# Messaging gateways
+
+Connect external chat platforms (Telegram, Zalo, …) to the Jarvis agent.
+Inbound message → agent run → reply back in the same chat. Long-polling, so
+**no public domain / webhook is required** — the bot holds an outbound
+`getUpdates` request open and the platform returns the instant a message
+arrives.
+
+## Layers
+
+```
+BaseGateway (base.py)          orchestration: allow-list → typing → dispatch → reply → error
+  └─ BotApiGateway (bot_api.py)  shared Telegram-style HTTP long-poll transport
+       ├─ TelegramGateway        array updates + update_id offset, sendChatAction typing
+       └─ ZaloGateway            single update + 408 timeout, no typing
+
+GatewayManager (manager.py)    lifecycle + the ONE bridge to the agent runtime
+session_map.py                 (platform, chat_id) → backend session_id  [SSoT, DB-backed]
+config.py                      loads `gateways:` from fastagent.secrets.yaml
+registry.py                    name → gateway class
+```
+
+## How a message flows
+
+1. `BotApiGateway.run()` long-polls `getUpdates` and normalizes each update to
+   an `InboundMessage`.
+2. `BaseGateway.handle_inbound()` gates on `allow_from`, shows "typing…", then
+   calls the manager's dispatcher.
+3. `GatewayManager._dispatch()` looks up the chat's bound session, calls
+   `session_service.resume_and_send(...)`, and **upserts the session id it gets
+   back** — so the binding self-heals if the backend session was deleted.
+4. The reply is chunked (≤3900 chars) and sent via `sendMessage`.
+
+Agent runs are globally serialized by `session_service`'s lock, so concurrent
+gateways + the web UI never interleave turns.
+
+## Adding a platform
+
+Telegram-style Bot API (most chat apps): subclass `BotApiGateway`, set
+`api_base` / `typing_method`, implement `_poll()`. ~20 lines — see `zalo.py`.
+
+Anything else (WebSocket, webhook, SDK): subclass `BaseGateway` directly and
+implement `run()` + `send_text()`.
+
+Then add one line to `GATEWAY_REGISTRY` in `registry.py` and a config block in
+`fastagent.secrets.yaml`. Nothing else changes.
+
+## Config
+
+Stored in `config_service` (the DB, category `gateways`), edited from the UI:
+**Settings → Messaging Gateways**. Keys per platform: `<p>_enabled`,
+`<p>_token` (encrypted secret), `<p>_allow_from` (JSON array), `<p>_agent`.
+
+Writes go through `/api/settings/bulk`, which emits a change event;
+`GatewayManager` subscribes and **live-reloads** (stop → reload → start,
+debounced) — no restart. `routes/gateways.py` adds `GET /api/gateways`
+(status) and `POST /api/gateways/{platform}/test` (validate a token via
+`getMe`). Disabled by default; empty `allow_from` ignores everyone until you
+add user ids (`["*"]` to allow all).
+
+## Inbound images
+
+Photos are downloaded and passed to the agent as multimodal input. Telegram:
+`getFile` → file URL → base64. Zalo: the photo arrives as a CDN URL in
+`message.photo_url` (not `photo`), fetched directly; its `image/jpg` content
+type is normalized to `image/jpeg`. The caption (if any) becomes the message
+text. Stickers / other media are skipped (cursor still advances).
+
+**Vision model required.** The image only reaches the LLM if the answering
+model is vision-capable. fast-agent strips image content for models it doesn't
+recognize (unknown models default to text-only → "Missing capability: vision").
+For a custom/proxy model (e.g. a 9router combo) declare its capabilities with a
+local overlay — gitignored, per-user — at
+`backend/.fast-agent/model-overlays/<name>.yaml`:
+
+```yaml
+name: openai.coding-agent   # must equal the model string you use (default_model)
+provider: openai
+model: coding-agent          # wire name sent to the provider
+metadata:
+  tokenizes: [text/plain, image/jpeg, image/png, image/webp]
+```
+
+## Slash commands (typed in the chat)
+
+Handled in `commands.py` before the agent runs (only for allow-listed users;
+unknown `/...` falls through to the agent):
+
+- `/new` (`/reset`, `/clear`) — start a fresh conversation.
+- `/agent <name>` — switch the answering agent for *this* chat (stored in the
+  binding); no arg shows the current agent + the list.
+- `/help` — list commands.
+
+`/stop` is intentionally absent: the poll loop is sequential and blocks on the
+agent reply, so it cannot receive a message to interrupt mid-run.
+
+## Scope / roadmap
+
+- One synchronous reply per message (no streaming edits). Streaming would hang
+  off the activity stream — deferred to keep this simple and rate-limit-safe.
+- Webhook transport is not implemented (long-polling covers local/NAT setups).
+- Outbound media (bot → user images) not implemented; inbound only.

--- a/backend/services/gateways/README.md
+++ b/backend/services/gateways/README.md
@@ -89,10 +89,19 @@ unknown `/...` falls through to the agent):
 - `/new` (`/reset`, `/clear`) — start a fresh conversation.
 - `/agent <name>` — switch the answering agent for *this* chat (stored in the
   binding); no arg shows the current agent + the list.
+- `/whoami` (`/id`) — show your user id.
 - `/help` — list commands.
 
 `/stop` is intentionally absent: the poll loop is sequential and blocks on the
 agent reply, so it cannot receive a message to interrupt mid-run.
+
+## Secure onboarding (no `*` needed)
+
+An **unauthorized** sender never reaches the agent — the bot replies with ONLY
+their user id and a "not authorized" notice. So the owner keeps `allow_from`
+empty (deny-all, the safe default), messages the bot, reads their id from the
+reply, and adds it. You never have to open `["*"]` just to discover an id.
+(Same idea as openclaw/hermes pairing.)
 
 ## Scope / roadmap
 

--- a/backend/services/gateways/__init__.py
+++ b/backend/services/gateways/__init__.py
@@ -1,0 +1,14 @@
+"""External messaging gateways (Telegram, Zalo, …).
+
+See ``README.md`` in this package for the architecture and how to add a
+platform. Public surface:
+
+  * :class:`~services.gateways.manager.GatewayManager` — lifecycle + dispatch.
+  * :class:`~services.gateways.base.BaseGateway` — implement to add a platform.
+  * :data:`~services.gateways.registry.GATEWAY_REGISTRY` — register it.
+"""
+from .base import BaseGateway, InboundMessage
+from .manager import GatewayManager
+from .registry import GATEWAY_REGISTRY
+
+__all__ = ["BaseGateway", "InboundMessage", "GatewayManager", "GATEWAY_REGISTRY"]

--- a/backend/services/gateways/base.py
+++ b/backend/services/gateways/base.py
@@ -1,0 +1,180 @@
+"""Gateway abstraction — connect external messaging platforms to Jarvis.
+
+A *gateway* bridges one external chat platform (Telegram, Zalo, …) to the
+agent runtime. The design splits two concerns so adding a platform is cheap
+and the agent-facing logic lives in exactly one place:
+
+  * **Transport** (subclass responsibility): how to *receive* messages from
+    the platform (``run``) and how to *send* a reply (``send_text``). This is
+    the only part that differs per platform.
+
+  * **Orchestration** (this base class, ``handle_inbound``): allow-list gate →
+    typing indicator → hand the message to the agent via the injected
+    ``dispatcher`` → deliver the reply → on failure, log loudly *and* tell the
+    user (never a silent swallow).
+
+To add a new platform: subclass :class:`BaseGateway` (or
+:class:`~services.gateways.bot_api.BotApiGateway` for any Telegram-style Bot
+API), implement the transport methods, and register it in
+``services.gateways.registry``. Nothing else in the codebase changes.
+"""
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, List, Optional, Sequence
+
+logger = logging.getLogger("gateways")
+
+# A dispatcher runs the agent for one inbound message and returns the reply
+# text. The GatewayManager supplies the real implementation (wired to
+# session_service); gateways stay ignorant of how the agent is run.
+Dispatcher = Callable[["InboundMessage"], Awaitable[str]]
+
+
+@dataclass(slots=True)
+class InboundMessage:
+    """A platform message normalized to the minimal shape the agent needs.
+
+    ``chat_id`` and ``user_id`` are kept as strings so every platform (Telegram
+    uses ints, Zalo uses strings) shares one representation — the session map
+    and allow-list compare strings, never mixed types.
+    """
+    platform: str
+    chat_id: str
+    user_id: str
+    text: str
+    raw: Any = field(default=None, repr=False)  # original payload, for debugging
+    # Platform-specific handles for attached media (e.g. Telegram file_ids),
+    # resolved to bytes by the gateway's fetch_media() AFTER the allow-list gate
+    # so we never download for unauthorized senders.
+    media_refs: List[dict] = field(default_factory=list)
+    # Downloaded media, ready for the agent: [{filename, content_type, data_b64}].
+    files_data: List[dict] = field(default_factory=list)
+
+
+class BaseGateway(abc.ABC):
+    """Abstract base for a messaging gateway.
+
+    Subclasses implement the transport (:meth:`run`, :meth:`send_text`, and
+    optionally :meth:`send_typing`). The orchestration in
+    :meth:`handle_inbound` is shared and must not be overridden.
+
+    Args:
+        name: platform identifier (``"telegram"``, ``"zalo"``).
+        dispatcher: async callable that runs the agent and returns reply text.
+        allow_from: user ids permitted to drive the agent. ``["*"]`` opts in to
+            allowing everyone (explicit and visible in config); an empty list
+            denies all (safe default — an unconfigured token cannot be abused).
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        dispatcher: Dispatcher,
+        allow_from: Optional[Sequence[Any]] = None,
+    ) -> None:
+        self.name = name
+        self._dispatcher = dispatcher
+        # Normalize to strings once so membership tests never compare int vs str.
+        self._allow_from = {str(u) for u in (allow_from or [])}
+        self._open_to_all = "*" in self._allow_from
+
+    # ── Transport: subclasses MUST implement ──────────────────────────────
+
+    @abc.abstractmethod
+    async def run(self) -> None:
+        """Long-running receive loop. Must exit cleanly on ``CancelledError``."""
+
+    @abc.abstractmethod
+    async def send_text(self, chat_id: str, text: str) -> None:
+        """Deliver ``text`` to ``chat_id`` on the platform."""
+
+    async def send_typing(self, chat_id: str) -> None:
+        """Optional 'typing…' indicator. No-op unless the platform supports it."""
+        return None
+
+    async def stop(self) -> None:
+        """Release transport resources. Default no-op — the manager also cancels
+        the ``run`` task, so a gateway with nothing to close needs no override."""
+        return None
+
+    def update_runtime(self, *, allow_from: Optional[Sequence[Any]], dispatcher: Dispatcher) -> None:
+        """Apply allow-list / dispatcher changes to a RUNNING gateway in place.
+
+        Lets the manager honour an allow-list or answering-agent edit without
+        tearing down and reconnecting the transport — which, for long-polling
+        Bot APIs, would otherwise trigger a transient 409 while the old
+        connection is still held server-side.
+        """
+        self._allow_from = {str(u) for u in (allow_from or [])}
+        self._open_to_all = "*" in self._allow_from
+        self._dispatcher = dispatcher
+
+    async def fetch_media(self, media_refs: List[dict]) -> List[dict]:
+        """Download attached media into agent-ready ``files_data`` dicts.
+
+        Default: no media support (returns nothing). Platforms that carry media
+        (Telegram photos, …) override this to resolve their refs to bytes. Called
+        from :meth:`handle_inbound` AFTER the allow-list gate.
+        """
+        return []
+
+    # ── Orchestration: shared, do NOT override ────────────────────────────
+
+    def is_allowed(self, user_id: str) -> bool:
+        """Allow-list gate. Empty list ⇒ deny all; ``"*"`` ⇒ allow all."""
+        return self._open_to_all or str(user_id) in self._allow_from
+
+    async def handle_inbound(self, msg: InboundMessage) -> None:
+        """Run one message end-to-end: gate → typing → agent → reply.
+
+        Errors are logged with a traceback AND surfaced to the user as a short
+        message — the receive loop keeps running (one bad turn must not kill the
+        gateway), but the failure is never swallowed silently.
+        """
+        if not self.is_allowed(msg.user_id):
+            # Not an error — an unauthorized sender. Log at info so an operator
+            # can see who to add to allow_from, but do not reply (avoid leaking
+            # the bot's existence / inviting probing).
+            logger.info(
+                "[%s] ignored message from unauthorized user_id=%s chat_id=%s",
+                self.name, msg.user_id, msg.chat_id,
+            )
+            return
+
+        try:
+            await self.send_typing(msg.chat_id)
+            # Resolve any attached media to bytes (post allow-gate). A media
+            # failure must not drop the whole message — fall back to text-only.
+            if msg.media_refs:
+                try:
+                    msg.files_data = await self.fetch_media(msg.media_refs)
+                except Exception:
+                    logger.exception("[%s] media fetch failed chat_id=%s — "
+                                     "continuing text-only", self.name, msg.chat_id)
+            reply = await self._dispatcher(msg)
+            if reply and reply.strip():
+                await self.send_text(msg.chat_id, reply)
+            else:
+                # The agent returned nothing — tell the user rather than leave
+                # them staring at a silent chat.
+                await self.send_text(msg.chat_id, "(no response)")
+        except Exception:
+            logger.exception(
+                "[%s] failed handling message chat_id=%s", self.name, msg.chat_id
+            )
+            # Best-effort user-facing error; if even this send fails it is logged
+            # by send_text's own error path, so nothing is hidden.
+            try:
+                await self.send_text(
+                    msg.chat_id,
+                    "⚠️ Something went wrong handling your message. Please try again.",
+                )
+            except Exception:
+                logger.exception(
+                    "[%s] failed to deliver error notice chat_id=%s",
+                    self.name, msg.chat_id,
+                )

--- a/backend/services/gateways/base.py
+++ b/backend/services/gateways/base.py
@@ -136,13 +136,26 @@ class BaseGateway(abc.ABC):
         gateway), but the failure is never swallowed silently.
         """
         if not self.is_allowed(msg.user_id):
-            # Not an error — an unauthorized sender. Log at info so an operator
-            # can see who to add to allow_from, but do not reply (avoid leaking
-            # the bot's existence / inviting probing).
+            # Unauthorized sender → reply with ONLY their id, never the agent.
+            # This is the secure-onboarding pattern (cf. openclaw/hermes pairing):
+            # the owner can keep allow_from empty (deny-all, safe), message the
+            # bot, read their own id from this reply, and add it — without ever
+            # opening "*". A stranger who finds the bot gets just their id; they
+            # cannot reach the agent or any data.
             logger.info(
-                "[%s] ignored message from unauthorized user_id=%s chat_id=%s",
+                "[%s] unauthorized user_id=%s chat_id=%s — replying id only",
                 self.name, msg.user_id, msg.chat_id,
             )
+            try:
+                await self.send_text(
+                    msg.chat_id,
+                    "🔒 You're not authorized to use this bot.\n"
+                    f"Your user id: {msg.user_id}\n"
+                    "Ask the owner to add it to the allow-list "
+                    "(Settings → Messaging Gateways).",
+                )
+            except Exception:
+                logger.exception("[%s] failed to send unauthorized notice", self.name)
             return
 
         try:

--- a/backend/services/gateways/bot_api.py
+++ b/backend/services/gateways/bot_api.py
@@ -1,0 +1,285 @@
+"""Shared transport for Telegram-style Bot APIs (Telegram, Zalo).
+
+Both Telegram and Zalo expose nearly identical HTTP Bot APIs:
+
+  * URL shape ``{base}/bot{token}/{method}`` with a JSON POST body.
+  * Response envelope ``{"ok": bool, "result": ..., "error_code", "description"}``.
+  * ``sendMessage`` takes ``{chat_id, text}``.
+
+They differ only in:
+
+  * base URL,
+  * the long-poll model (Telegram returns an *array* of updates keyed by an
+    ``update_id`` offset; Zalo returns a *single* update and signals "no
+    updates" with HTTP-style ``error_code`` 408),
+  * the per-update JSON field paths,
+  * whether a typing indicator method exists.
+
+``BotApiGateway`` implements everything common; a concrete platform overrides
+the four hook methods below. This is why adding another Telegram-clone is ~20
+lines (see :mod:`services.gateways.telegram` / :mod:`services.gateways.zalo`).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, List, Optional, Sequence
+
+import httpx
+
+from .base import BaseGateway, Dispatcher, InboundMessage
+
+logger = logging.getLogger("gateways")
+
+# Telegram/Zalo hard cap is 4096 chars; stay under it with headroom for the
+# "(1/3)" style continuation prefix we add when splitting.
+_MAX_CHARS = 3900
+_POLL_TIMEOUT_S = 30  # long-poll: server holds the request open this long
+# Pause before retrying after a benign 409 self-overlap (see run()).
+_CONFLICT_RETRY_DELAY = 1.0
+
+
+class BotApiError(Exception):
+    """A non-ok Bot API response. ``error_code`` 408 means 'poll timed out'."""
+
+    def __init__(self, message: str, error_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+    @property
+    def is_poll_timeout(self) -> bool:
+        return self.error_code == 408
+
+
+def chunk_text(text: str, limit: int = _MAX_CHARS) -> List[str]:
+    """Split ``text`` into platform-sized chunks, preferring line boundaries.
+
+    Kept module-level and pure so it is trivially unit-testable without any
+    network or gateway instance.
+    """
+    if len(text) <= limit:
+        return [text]
+    chunks: List[str] = []
+    remaining = text
+    while len(remaining) > limit:
+        # Prefer to break at the last newline within the window; fall back to a
+        # hard cut so a single very long line still gets delivered.
+        cut = remaining.rfind("\n", 0, limit)
+        if cut <= 0:
+            cut = limit
+        chunks.append(remaining[:cut])
+        remaining = remaining[cut:].lstrip("\n")
+    if remaining:
+        chunks.append(remaining)
+    return chunks
+
+
+class BotApiGateway(BaseGateway):
+    """Long-polling gateway for a Telegram-style Bot API.
+
+    Args mirror :class:`BaseGateway` plus the platform endpoint config.
+    """
+
+    # Subclasses set these.
+    api_base: str = ""
+    # Method name used for the typing indicator, or None if unsupported.
+    typing_method: Optional[str] = None
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        token: str,
+        dispatcher: Dispatcher,
+        allow_from: Optional[Sequence[Any]] = None,
+        client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        super().__init__(name=name, dispatcher=dispatcher, allow_from=allow_from)
+        self._token = token
+        # Allow injection of a pre-built client for tests (no real network).
+        self._client = client or httpx.AsyncClient(timeout=_POLL_TIMEOUT_S + 15)
+        self._owns_client = client is None
+        self._stop = asyncio.Event()
+        # Live status surfaced to the Settings UI (read via GatewayManager.status).
+        self.connected = False
+        self.bot_username: Optional[str] = None
+        self.last_error: Optional[str] = None
+
+    # ── HTTP plumbing ─────────────────────────────────────────────────────
+
+    def _url(self, method: str) -> str:
+        return f"{self.api_base}/bot{self._token}/{method}"
+
+    def _redact(self, msg: str) -> str:
+        """Strip the bot token from any message before it is stored/shown.
+
+        Defence in depth: error strings (httpx URLs, timeouts) can embed the
+        full ``bot<token>`` URL; that token must never reach a log or the UI.
+        """
+        if self._token and self._token in msg:
+            return msg.replace(self._token, "***")
+        return msg
+
+    async def _call(self, method: str, body: Optional[dict] = None) -> Any:
+        """POST to the Bot API and unwrap the ``{ok, result}`` envelope.
+
+        We parse the JSON envelope ourselves instead of ``raise_for_status()``:
+        Telegram/Zalo return a proper ``{ok, error_code, description}`` body even
+        on 4xx (e.g. 409 Conflict), so this surfaces the real reason — and,
+        critically, never raises an ``httpx`` error whose message embeds the
+        token-bearing URL.
+        """
+        resp = await self._client.post(self._url(method), json=body or {})
+        try:
+            data = resp.json()
+        except ValueError:
+            # Non-JSON error body — report the status without leaking the URL.
+            raise BotApiError(f"{self.name} HTTP {resp.status_code}", error_code=resp.status_code)
+        if not data.get("ok", False):
+            raise BotApiError(
+                data.get("description") or f"{self.name} API error: {method}",
+                error_code=data.get("error_code") or resp.status_code,
+            )
+        return data.get("result")
+
+    # ── Platform hooks: subclasses override ───────────────────────────────
+
+    async def _poll(self) -> List[InboundMessage]:
+        """Fetch the next batch of updates and normalize them.
+
+        Returns an empty list on a poll timeout (no new messages).
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _display_name(get_me_result: dict) -> str:
+        """Human-readable bot name from a ``getMe`` result. Override per platform."""
+        return (
+            get_me_result.get("username")
+            or get_me_result.get("name")
+            or get_me_result.get("first_name")
+            or "bot"
+        )
+
+    @classmethod
+    async def probe(cls, token: str) -> dict:
+        """Validate a token via ``getMe`` without starting the gateway.
+
+        Returns ``{"ok": True, "name": <bot name>}`` or
+        ``{"ok": False, "error": <message>}``. Used by the Test-connection
+        endpoint so the user can verify a token before saving it.
+        """
+        def _safe(msg: str) -> str:
+            return msg.replace(token, "***") if token and token in msg else msg
+
+        client = httpx.AsyncClient(timeout=15)
+        try:
+            resp = await client.post(f"{cls.api_base}/bot{token}/getMe", json={})
+            # Parse the envelope directly — Telegram returns {ok, description} even
+            # on 401, and raise_for_status would leak the token-bearing URL.
+            try:
+                data = resp.json()
+            except ValueError:
+                return {"ok": False, "error": f"HTTP {resp.status_code}"}
+            if not data.get("ok"):
+                return {"ok": False, "error": _safe(data.get("description") or "invalid token")}
+            return {"ok": True, "name": cls._display_name(data.get("result") or {})}
+        except Exception as e:  # network/timeout — surface to the UI, token-stripped
+            return {"ok": False, "error": _safe(str(e))}
+        finally:
+            await client.aclose()
+
+    # ── Transport API (BaseGateway) ───────────────────────────────────────
+
+    async def run(self) -> None:
+        """Long-poll loop with exponential backoff on transient errors."""
+        logger.info("[%s] gateway started (long-polling)", self.name)
+        # Identify the bot up-front so the UI can show "Connected as @name"
+        # immediately. A failure here (bad token) is non-fatal — the poll loop
+        # below will surface the same error and keep the last_error fresh.
+        try:
+            result = await self._call("getMe")
+            self.bot_username = self._display_name(result or {})
+            self.connected = True
+            self.last_error = None
+            logger.info("[%s] connected as %s", self.name, self.bot_username)
+        except Exception as e:
+            self.connected = False
+            self.last_error = self._redact(str(e))
+            logger.warning("[%s] getMe failed (will keep retrying): %s", self.name, self.last_error)
+
+        backoff = 1.0
+        while not self._stop.is_set():
+            try:
+                messages = await self._poll()
+                self.connected = True
+                self.last_error = None
+                backoff = 1.0  # reset after any successful poll
+                for msg in messages:
+                    # Serialize per-message handling; the agent itself is
+                    # globally serialized downstream (session_service lock), so
+                    # awaiting here keeps ordering and avoids interleaved turns.
+                    await self.handle_inbound(msg)
+                # Cooperative yield: real getUpdates blocks server-side for
+                # ~30s, but a misbehaving (or mocked) server that returns
+                # instantly on empty would otherwise spin this loop hot and
+                # starve the event loop. One yield per iteration keeps the
+                # scheduler fair at negligible cost.
+                await asyncio.sleep(0)
+            except asyncio.CancelledError:
+                break
+            except BotApiError as e:
+                if e.is_poll_timeout:
+                    continue  # normal: no updates within the long-poll window
+                if e.error_code == 409:
+                    # BENIGN self-conflict. Telegram returns 409 "terminated by
+                    # other getUpdates request" on the poll immediately following
+                    # a successful long-poll timeout — it hasn't fully released
+                    # OUR previous getUpdates yet. Verified with a single sole
+                    # client: 200/409 strictly alternate (delay + no-keepalive
+                    # don't change it), and every 409 is followed by a 200, so the
+                    # bot stays reachable and updates still arrive on the good
+                    # polls. Do NOT flip connected / set last_error (that made the
+                    # UI flap red) and do NOT grow backoff — just pause briefly and
+                    # retry; the next poll succeeds.
+                    logger.debug("[%s] getUpdates 409 self-overlap — brief retry", self.name)
+                    await self._sleep_backoff(_CONFLICT_RETRY_DELAY)
+                    continue
+                logger.warning("[%s] API error while polling: %s", self.name, self._redact(str(e)))
+                self.connected = False
+                self.last_error = self._redact(str(e))
+                await self._sleep_backoff(backoff)
+                backoff = min(backoff * 2, 60)
+            except Exception as e:
+                logger.exception("[%s] poll loop error; backing off %.0fs",
+                                 self.name, backoff)
+                self.connected = False
+                self.last_error = self._redact(str(e))
+                await self._sleep_backoff(backoff)
+                backoff = min(backoff * 2, 60)
+        logger.info("[%s] gateway stopped", self.name)
+
+    async def _sleep_backoff(self, seconds: float) -> None:
+        """Sleep that wakes immediately if stop() is requested."""
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            pass
+
+    async def send_text(self, chat_id: str, text: str) -> None:
+        for chunk in chunk_text(text):
+            await self._call("sendMessage", {"chat_id": chat_id, "text": chunk})
+
+    async def send_typing(self, chat_id: str) -> None:
+        if not self.typing_method:
+            return
+        try:
+            await self._call(self.typing_method, {"chat_id": chat_id, "action": "typing"})
+        except Exception:
+            # Typing is cosmetic — never let it break message handling.
+            logger.debug("[%s] typing indicator failed", self.name, exc_info=True)
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._owns_client:
+            await self._client.aclose()

--- a/backend/services/gateways/commands.py
+++ b/backend/services/gateways/commands.py
@@ -1,0 +1,86 @@
+"""Slash commands users can type in a gateway chat (Telegram / Zalo).
+
+A message that starts with ``/`` and names a known command is handled here and
+NOT forwarded to the agent. Unknown ``/...`` text is left alone (returns None) so
+it falls through to the agent — we don't hijack legitimate slash text.
+
+Why these three (and not ``/stop``): the gateway poll loop processes one message
+at a time and blocks on the agent's reply, so it can't *receive* a ``/stop``
+mid-run to interrupt — that command is unworkable in this transport and is
+intentionally omitted.
+
+To add a command: extend ``_COMMANDS`` (and ``_ALIASES``) — :func:`handle`,
+``/help``, and the tests pick it up.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
+
+# Canonical name → one-line help. Aliases map into these.
+_COMMANDS = {
+    "new": "start a new conversation (clears context)",
+    "agent": "switch the answering agent — /agent <name>",
+    "help": "show this list",
+}
+_ALIASES = {"reset": "new", "clear": "new"}
+
+
+@dataclass(slots=True)
+class CommandContext:
+    """Everything a command needs to run, supplied by the GatewayManager."""
+    current_agent: str
+    agent_names: List[str]
+    reset_conversation: Callable[[], None]   # /new
+    set_agent: Callable[[str], None]         # /agent
+
+
+def parse(text: str) -> Optional[Tuple[str, List[str]]]:
+    """Return ``(canonical_name, args)`` for a recognized command, else None."""
+    if not text or not text.startswith("/"):
+        return None
+    parts = text.strip().split()
+    name = parts[0][1:].lower()
+    name = _ALIASES.get(name, name)
+    if name not in _COMMANDS:
+        return None
+    return name, parts[1:]
+
+
+def help_text() -> str:
+    lines = ["Available commands:"]
+    for name, desc in _COMMANDS.items():
+        lines.append(f"/{name} — {desc}")
+    lines.append("(aliases: /reset, /clear = /new)")
+    return "\n".join(lines)
+
+
+def handle(text: str, ctx: CommandContext) -> Optional[str]:
+    """Execute a slash command and return the reply, or None if ``text`` is not
+    a recognized command (the caller then dispatches to the agent)."""
+    parsed = parse(text)
+    if parsed is None:
+        return None
+    name, args = parsed
+
+    if name == "new":
+        ctx.reset_conversation()
+        return "🆕 Started a new conversation — previous context cleared."
+
+    if name == "agent":
+        if not args:
+            return (f"Current agent: {ctx.current_agent}\n"
+                    f"Usage: /agent <name>\n"
+                    f"Available: {', '.join(ctx.agent_names)}")
+        target = args[0]
+        match = next((a for a in ctx.agent_names if a.lower() == target.lower()), None)
+        if match is None:
+            return (f"❌ Unknown agent '{target}'.\n"
+                    f"Available: {', '.join(ctx.agent_names)}")
+        ctx.set_agent(match)
+        return f"✅ Now answering with agent: {match}"
+
+    if name == "help":
+        return help_text()
+
+    return None  # unreachable (parse already gated), but explicit

--- a/backend/services/gateways/commands.py
+++ b/backend/services/gateways/commands.py
@@ -21,9 +21,10 @@ from typing import Callable, List, Optional, Tuple
 _COMMANDS = {
     "new": "start a new conversation (clears context)",
     "agent": "switch the answering agent — /agent <name>",
+    "whoami": "show your user id",
     "help": "show this list",
 }
-_ALIASES = {"reset": "new", "clear": "new"}
+_ALIASES = {"reset": "new", "clear": "new", "id": "whoami"}
 
 
 @dataclass(slots=True)
@@ -31,6 +32,7 @@ class CommandContext:
     """Everything a command needs to run, supplied by the GatewayManager."""
     current_agent: str
     agent_names: List[str]
+    user_id: str
     reset_conversation: Callable[[], None]   # /new
     set_agent: Callable[[str], None]         # /agent
 
@@ -79,6 +81,9 @@ def handle(text: str, ctx: CommandContext) -> Optional[str]:
                     f"Available: {', '.join(ctx.agent_names)}")
         ctx.set_agent(match)
         return f"✅ Now answering with agent: {match}"
+
+    if name == "whoami":
+        return f"Your user id: {ctx.user_id}"
 
     if name == "help":
         return help_text()

--- a/backend/services/gateways/config.py
+++ b/backend/services/gateways/config.py
@@ -1,0 +1,71 @@
+"""Gateway configuration — stored in ``config_service`` (the DB, single source).
+
+Config lives in the ``gateways`` category so it is editable from the Settings UI
+with no file editing and no restart: a write through ``/api/settings`` fires a
+``config_service`` change event, and :class:`GatewayManager` live-reloads
+(see ``manager.py``). Tokens are stored encrypted (``is_secret=True``).
+
+Per-platform keys (``<platform>`` is ``telegram`` / ``zalo`` / …):
+  ``<platform>_enabled``    "true" / "false"
+  ``<platform>_token``      bot token (secret)
+  ``<platform>_allow_from`` JSON array of user ids ("[]" = deny all, "[\"*\"]" = all)
+  ``<platform>_agent``      agent that answers (defaults to "Jarvis")
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+logger = logging.getLogger("gateways")
+
+
+@dataclass(slots=True)
+class GatewayConfig:
+    enabled: bool = False
+    token: str = ""
+    allow_from: List = field(default_factory=list)
+    agent: str = "Jarvis"
+
+
+def _parse_allow_from(raw: str | None) -> List:
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, list) else []
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Invalid allow_from JSON %r; treating as empty (deny all)", raw)
+        return []
+
+
+def load_gateway_configs() -> Dict[str, GatewayConfig]:
+    """Return ``{platform: GatewayConfig}`` for every registered platform.
+
+    Reads from ``config_service``. A platform with no rows yet comes back as a
+    disabled default — gateways are entirely opt-in.
+    """
+    from services.config_service import config_service
+    from services.secret_utils import safe_get_or_none
+
+    from .registry import GATEWAY_REGISTRY
+
+    out: Dict[str, GatewayConfig] = {}
+    for name in GATEWAY_REGISTRY:
+        enabled = (config_service.get("gateways", f"{name}_enabled") or "false").strip().lower() == "true"
+        # Token is a secret — soft-fail on a stale ciphertext so one corrupt row
+        # can't crash gateway startup (logged, not swallowed).
+        token = safe_get_or_none(
+            config_service, "gateways", f"{name}_token",
+            on_warn=lambda e, n=name: logger.warning("Gateway '%s' token unreadable: %s", n, e),
+        ) or ""
+        allow_from = _parse_allow_from(config_service.get("gateways", f"{name}_allow_from"))
+        agent = config_service.get("gateways", f"{name}_agent") or "Jarvis"
+        out[name] = GatewayConfig(
+            enabled=enabled,
+            token=token.strip(),
+            allow_from=allow_from,
+            agent=agent,
+        )
+    return out

--- a/backend/services/gateways/manager.py
+++ b/backend/services/gateways/manager.py
@@ -1,0 +1,272 @@
+"""GatewayManager — lifecycle, agent-facing dispatch, and live config reload.
+
+Two jobs:
+  * Turn an :class:`InboundMessage` into an agent run (the single bridge to the
+    runtime): resolve the chat's session, call ``resume_and_send``, persist the
+    (possibly new) binding.
+  * Track config: subscribe to ``config_service`` so edits made in the Settings
+    UI take effect WITHOUT a restart — a burst of per-key change events is
+    debounced into one stop-all → reload-config → start-all cycle.
+
+Started/stopped from ``server.py``'s lifespan, after ``state.agent_app`` exists.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable, Dict, List, Optional
+
+from . import session_map
+from .base import BaseGateway, InboundMessage
+from .config import GatewayConfig, load_gateway_configs
+from .registry import GATEWAY_REGISTRY
+
+logger = logging.getLogger("gateways")
+
+# Coalesce the burst of per-key events from one bulk settings save into a single
+# reload, fired this long after the last event.
+_RELOAD_DEBOUNCE_S = 0.3
+
+
+class GatewayManager:
+    def __init__(self, agent_app) -> None:
+        self.agent_app = agent_app
+        self._gateways: Dict[str, BaseGateway] = {}
+        self._tasks: Dict[str, asyncio.Task] = {}
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._unsubscribe: Optional[Callable[[], None]] = None
+        self._reload_handle: Optional[asyncio.TimerHandle] = None
+        # Last config applied per platform — lets reload restart ONLY what
+        # actually changed (avoids needless reconnects / transient 409s).
+        self._applied: Dict[str, GatewayConfig] = {}
+        # Serialize reloads. _apply() awaits _stop_one(); without this lock two
+        # overlapping reloads (e.g. several quick Saves) could interleave a
+        # stop and a start and ORPHAN a poller — two pollers on one bot then
+        # 409 each other forever ("terminated by other getUpdates request").
+        self._reload_lock = asyncio.Lock()
+
+    # ── Agent-facing dispatch (the single bridge to the runtime) ──────────
+
+    def _make_dispatcher(self, agent_name: str) -> Callable:
+        async def dispatch(msg: InboundMessage) -> str:
+            return await self._dispatch(msg, agent_name)
+        return dispatch
+
+    async def _dispatch(self, msg: InboundMessage, agent_name: str) -> str:
+        """Run the agent for one message and return its reply text.
+
+        First chance for a slash command (``/new``, ``/agent``, ``/help``) — if
+        it's one, we reply to it and never touch the agent. Otherwise the
+        load-bearing bit is session resolution: look up the chat's bound session
+        (may be stale/None), let ``resume_and_send`` decide existence and hand
+        back the authoritative id, then persist THAT — so the binding can never
+        silently point at a dead session.
+
+        The answering agent is per-chat: ``/agent`` stores a choice in the
+        binding; falls back to the gateway's configured ``agent_name``.
+        """
+        from services.shared_state import session_service
+
+        effective_agent = session_map.get_agent(msg.platform, msg.chat_id) or agent_name
+
+        # Slash command? Handle and return — do not run the agent.
+        reply = self._try_command(msg, effective_agent)
+        if reply is not None:
+            return reply
+
+        bound_session = session_map.lookup(msg.platform, msg.chat_id)
+
+        # Tag the turn so token usage is attributed to this chat (same
+        # ContextVar the chat/voice/cron paths set before sending).
+        from services.sse_progress import current_run_id
+        token = current_run_id.set(f"{msg.platform}:{msg.chat_id}")
+        try:
+            reply, real_session = await session_service.resume_and_send(
+                self.agent_app, msg.text, bound_session,
+                files_data=(msg.files_data or None), agent_name=effective_agent,
+            )
+        finally:
+            current_run_id.reset(token)
+
+        session_map.upsert(msg.platform, msg.chat_id, real_session, effective_agent)
+        return str(reply) if reply is not None else ""
+
+    def _try_command(self, msg: InboundMessage, effective_agent: str) -> Optional[str]:
+        """Run a slash command if the text is one; else return None."""
+        from . import commands
+
+        agent_names = list(getattr(self.agent_app, "_agents", {}).keys()) or ["Jarvis"]
+        ctx = commands.CommandContext(
+            current_agent=effective_agent,
+            agent_names=agent_names,
+            reset_conversation=lambda: session_map.delete(msg.platform, msg.chat_id),
+            set_agent=lambda name: session_map.set_agent(msg.platform, msg.chat_id, name),
+        )
+        return commands.handle(msg.text, ctx)
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    def start(self, configs: Optional[Dict[str, GatewayConfig]] = None) -> None:
+        """Launch enabled gateways and begin watching config for live edits."""
+        self._loop = asyncio.get_running_loop()
+        if self._unsubscribe is None:
+            from services.config_service import config_service
+            self._unsubscribe = config_service.subscribe(self._on_config_change)
+        configs = configs if configs is not None else load_gateway_configs()
+        for name in GATEWAY_REGISTRY:
+            cfg = configs.get(name, GatewayConfig())
+            self._applied[name] = cfg
+            if cfg.enabled:
+                self._start_one(name, cfg)
+        if not self._tasks:
+            logger.info("No messaging gateways enabled.")
+
+    def _running(self, name: str) -> bool:
+        task = self._tasks.get(name)
+        return bool(task and not task.done())
+
+    def _start_one(self, name: str, cfg: GatewayConfig) -> None:
+        # Defensive: never overwrite a live task without cancelling it, or the
+        # old poller keeps running orphaned (→ self-409). Should not trigger once
+        # reloads are serialized, but cheap insurance against a logic slip.
+        stale = self._tasks.get(name)
+        if stale and not stale.done():
+            logger.warning("Gateway '%s' start requested while still running — "
+                           "cancelling the stale poller first", name)
+            stale.cancel()
+        cls = GATEWAY_REGISTRY.get(name)
+        if cls is None:
+            logger.warning("Gateway '%s' is enabled but not registered; skipping", name)
+            return
+        if not cfg.token:
+            logger.warning("Gateway '%s' is enabled but has no token; skipping", name)
+            return
+        if not cfg.allow_from:
+            logger.warning(
+                "Gateway '%s' has empty allow_from — it will ignore ALL messages "
+                "until you add user ids (or [\"*\"] to allow all).", name,
+            )
+        gw = cls(
+            token=cfg.token,
+            dispatcher=self._make_dispatcher(cfg.agent),
+            allow_from=cfg.allow_from,
+        )
+        self._gateways[name] = gw
+        self._tasks[name] = asyncio.create_task(gw.run())
+        logger.info("Gateway '%s' started (agent=%s)", name, cfg.agent)
+
+    async def _stop_one(self, name: str) -> None:
+        gw = self._gateways.pop(name, None)
+        task = self._tasks.pop(name, None)
+        if gw:
+            try:
+                await gw.stop()
+            except Exception:
+                logger.exception("Error stopping gateway '%s'", name)
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("Gateway '%s' task ended with error", name)
+
+    async def stop(self) -> None:
+        """Full shutdown: stop watching config and stop every gateway."""
+        if self._unsubscribe:
+            self._unsubscribe()
+            self._unsubscribe = None
+        if self._reload_handle:
+            self._reload_handle.cancel()
+            self._reload_handle = None
+        for name in list(set(self._gateways) | set(self._tasks)):
+            await self._stop_one(name)
+
+    # ── Live config reload ────────────────────────────────────────────────
+
+    def _on_config_change(self, event) -> None:
+        """config_service listener (may run on any thread) — schedule a reload.
+
+        Only ``gateways`` edits matter; everything else is ignored. The actual
+        reload runs on the gateway event loop, debounced, so a bulk save's
+        many events collapse into one restart.
+        """
+        if getattr(event, "category", None) != "gateways":
+            return
+        loop = self._loop
+        if loop and loop.is_running():
+            loop.call_soon_threadsafe(self._schedule_reload)
+
+    def _schedule_reload(self) -> None:
+        if self._reload_handle:
+            self._reload_handle.cancel()
+        self._reload_handle = self._loop.call_later(
+            _RELOAD_DEBOUNCE_S, lambda: asyncio.create_task(self._reload())
+        )
+
+    async def _reload(self) -> None:
+        self._reload_handle = None
+        # Serialize: two overlapping _apply() runs could orphan a poller.
+        async with self._reload_lock:
+            await self._apply(load_gateway_configs())
+
+    async def _apply(self, configs: Dict[str, GatewayConfig]) -> None:
+        """Reconcile running gateways with the latest config, MINIMALLY.
+
+        Restart a poller only when it must reconnect — an ``enabled`` flip or a
+        token change. An allow-list / answering-agent edit is applied in place
+        so a benign save never drops the long-poll connection (which would cause
+        a transient 409 while the old connection is still held server-side).
+        """
+        for name in GATEWAY_REGISTRY:
+            new = configs.get(name, GatewayConfig())
+            old = self._applied.get(name, GatewayConfig())
+            self._applied[name] = new
+
+            if not new.enabled:
+                if self._running(name) or name in self._gateways:
+                    await self._stop_one(name)
+                    logger.info("Gateway '%s' disabled — stopped", name)
+                continue
+
+            if not self._running(name):
+                self._start_one(name, new)
+            elif new.token != old.token:
+                logger.info("Gateway '%s' token changed — reconnecting", name)
+                await self._stop_one(name)
+                self._start_one(name, new)
+            elif new.allow_from != old.allow_from or new.agent != old.agent:
+                gw = self._gateways.get(name)
+                if gw is not None:
+                    gw.update_runtime(
+                        allow_from=new.allow_from,
+                        dispatcher=self._make_dispatcher(new.agent),
+                    )
+                    logger.info(
+                        "Gateway '%s' updated in place (allow-list/agent) — no reconnect",
+                        name,
+                    )
+
+    # ── Status (for the Settings UI) ──────────────────────────────────────
+
+    def status(self) -> List[dict]:
+        """Per-platform config + live runtime status."""
+        configs = load_gateway_configs()
+        rows: List[dict] = []
+        for name in GATEWAY_REGISTRY:
+            cfg = configs.get(name, GatewayConfig())
+            gw = self._gateways.get(name)
+            task = self._tasks.get(name)
+            rows.append({
+                "platform": name,
+                "enabled": cfg.enabled,
+                "running": bool(task and not task.done()),
+                "connected": bool(getattr(gw, "connected", False)) if gw else False,
+                "bot_username": getattr(gw, "bot_username", None) if gw else None,
+                "last_error": getattr(gw, "last_error", None) if gw else None,
+                "agent": cfg.agent,
+                "allow_count": len(cfg.allow_from),
+                "has_token": bool(cfg.token),
+            })
+        return rows

--- a/backend/services/gateways/manager.py
+++ b/backend/services/gateways/manager.py
@@ -99,6 +99,7 @@ class GatewayManager:
         ctx = commands.CommandContext(
             current_agent=effective_agent,
             agent_names=agent_names,
+            user_id=msg.user_id,
             reset_conversation=lambda: session_map.delete(msg.platform, msg.chat_id),
             set_agent=lambda name: session_map.set_agent(msg.platform, msg.chat_id, name),
         )

--- a/backend/services/gateways/registry.py
+++ b/backend/services/gateways/registry.py
@@ -1,0 +1,18 @@
+"""Registry of available gateway platforms.
+
+Adding a platform = implement a :class:`~services.gateways.base.BaseGateway`
+subclass and add one line here. The manager and config loader discover it
+automatically — nothing else changes.
+"""
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import BaseGateway
+from .telegram import TelegramGateway
+from .zalo import ZaloGateway
+
+GATEWAY_REGISTRY: Dict[str, Type[BaseGateway]] = {
+    "telegram": TelegramGateway,
+    "zalo": ZaloGateway,
+}

--- a/backend/services/gateways/session_map.py
+++ b/backend/services/gateways/session_map.py
@@ -1,0 +1,117 @@
+"""Persistent chat→session binding for gateways (the SSoT index).
+
+Every inbound message from the same external chat must continue the *same*
+backend conversation, across restarts. This module is the single authoritative
+place that binds ``(platform, chat_id)`` to a backend ``session_id``.
+
+It deliberately does NOT decide whether a session still exists — the backend
+``SessionManager`` owns that. The dispatcher passes :func:`lookup`'s result into
+``resume_and_send`` (which creates a fresh session if the bound one is gone) and
+then calls :func:`upsert` with the id that came back, so the binding self-heals
+instead of silently pointing at a dead session.
+"""
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from core.database import GatewayChat, get_db_session
+
+
+def lookup(platform: str, chat_id: str) -> Optional[str]:
+    """Return the backend session_id bound to this chat, or ``None``."""
+    db = get_db_session()
+    try:
+        row = (
+            db.query(GatewayChat)
+            .filter_by(platform=platform, chat_id=str(chat_id))
+            .one_or_none()
+        )
+        return row.session_id if row else None
+    finally:
+        db.close()
+
+
+def get_agent(platform: str, chat_id: str) -> Optional[str]:
+    """Return the per-chat answering agent bound to this chat, or ``None``.
+
+    Set by the ``/agent`` command; lets a single gateway answer different chats
+    with different agents without a config change.
+    """
+    db = get_db_session()
+    try:
+        row = (
+            db.query(GatewayChat)
+            .filter_by(platform=platform, chat_id=str(chat_id))
+            .one_or_none()
+        )
+        return row.agent_name if row else None
+    finally:
+        db.close()
+
+
+def delete(platform: str, chat_id: str) -> None:
+    """Drop the chat→session binding so the next message starts a fresh
+    conversation (the ``/new`` command). Idempotent."""
+    db = get_db_session()
+    try:
+        db.query(GatewayChat).filter_by(platform=platform, chat_id=str(chat_id)).delete()
+        db.commit()
+    finally:
+        db.close()
+
+
+def set_agent(platform: str, chat_id: str, agent_name: str) -> None:
+    """Change the answering agent for this chat (``/agent``), keeping the bound
+    session if any. Creates a session-less row (``session_id=""``) when the chat
+    has no binding yet so the choice persists; the next message fills in the
+    real session id. ``""`` reads back as falsy in :func:`lookup`, so a fresh
+    session is created on that next turn."""
+    db = get_db_session()
+    try:
+        now = time.time()
+        row = (
+            db.query(GatewayChat)
+            .filter_by(platform=platform, chat_id=str(chat_id))
+            .one_or_none()
+        )
+        if row:
+            row.agent_name = agent_name
+            row.updated_at = now
+        else:
+            db.add(GatewayChat(
+                platform=platform, chat_id=str(chat_id),
+                session_id="", agent_name=agent_name,
+                created_at=now, updated_at=now,
+            ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def upsert(platform: str, chat_id: str, session_id: str, agent_name: str) -> None:
+    """Bind (or rebind) ``(platform, chat_id)`` to ``session_id``."""
+    db = get_db_session()
+    try:
+        now = time.time()
+        row = (
+            db.query(GatewayChat)
+            .filter_by(platform=platform, chat_id=str(chat_id))
+            .one_or_none()
+        )
+        if row:
+            row.session_id = session_id
+            row.agent_name = agent_name
+            row.updated_at = now
+        else:
+            db.add(GatewayChat(
+                platform=platform,
+                chat_id=str(chat_id),
+                session_id=session_id,
+                agent_name=agent_name,
+                created_at=now,
+                updated_at=now,
+            ))
+        db.commit()
+    finally:
+        db.close()

--- a/backend/services/gateways/telegram.py
+++ b/backend/services/gateways/telegram.py
@@ -114,7 +114,12 @@ class TelegramGateway(BotApiGateway):
                     "content_type": ref["content_type"],
                     "data_b64": base64.b64encode(resp.content).decode("ascii"),
                 })
-            except Exception:
-                logger.exception("[telegram] failed to download media file_id=%s",
-                                 ref.get("file_id"))
+            except Exception as e:
+                # The download URL embeds the bot token; raise_for_status() (and
+                # many httpx transport errors) put that full URL in the exception
+                # message. Redact it and do NOT log the raw traceback (exc_info),
+                # which would carry the token too — this is the one media path
+                # that bypasses _call's protection.
+                logger.error("[telegram] failed to download media file_id=%s: %s",
+                             ref.get("file_id"), self._redact(str(e)))
         return out

--- a/backend/services/gateways/telegram.py
+++ b/backend/services/gateways/telegram.py
@@ -1,0 +1,120 @@
+"""Telegram gateway — long-polling via the Bot API.
+
+Telegram's ``getUpdates`` returns an *array* of updates and uses an
+``update_id`` cursor: pass ``offset = max(update_id) + 1`` so each update is
+delivered exactly once and never replayed after a restart hiccup.
+
+Handles text and photos (incl. images sent as documents). A photo's caption
+becomes the message text, and the largest available size is downloaded and
+handed to the agent as multimodal input.
+
+Token: create a bot with @BotFather, put the token in ``fastagent.secrets.yaml``
+under ``gateways.telegram.token`` (see the example file).
+"""
+from __future__ import annotations
+
+import base64
+import logging
+from typing import List, Optional
+
+from .base import InboundMessage
+from .bot_api import BotApiGateway
+
+logger = logging.getLogger("gateways")
+
+# getFile works for files up to 20 MB; skip anything larger than this rather
+# than attempt a download that the Bot API will reject.
+_MAX_MEDIA_BYTES = 20 * 1024 * 1024
+
+
+class TelegramGateway(BotApiGateway):
+    api_base = "https://api.telegram.org"
+    typing_method = "sendChatAction"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(name="telegram", **kwargs)
+        self._offset = 0  # update_id cursor; 0 means "from the beginning"
+
+    async def _poll(self) -> List[InboundMessage]:
+        updates = await self._call(
+            "getUpdates",
+            {"offset": self._offset, "timeout": 30, "allowed_updates": ["message"]},
+        )
+        messages: List[InboundMessage] = []
+        for upd in updates or []:
+            # Always advance the cursor, even for updates we skip (stickers,
+            # edited messages, …) — otherwise getUpdates replays them forever.
+            self._offset = max(self._offset, int(upd["update_id"]) + 1)
+            inbound = self._to_inbound(upd)
+            if inbound is not None:
+                messages.append(inbound)
+        return messages
+
+    def _to_inbound(self, upd: dict) -> Optional[InboundMessage]:
+        msg = upd.get("message") or {}
+        chat = msg.get("chat") or {}
+        if "id" not in chat:
+            return None
+        sender = msg.get("from") or {}
+
+        # A photo message carries `caption` (not `text`) + a `photo` array of
+        # sizes; the last entry is the largest. An image can also arrive as a
+        # `document` with an image mime type.
+        media_refs: List[dict] = []
+        photos = msg.get("photo") or []
+        if photos:
+            largest = photos[-1]
+            media_refs.append({
+                "file_id": largest["file_id"],
+                "content_type": "image/jpeg",  # Telegram re-encodes photos to JPEG
+                "filename": "photo.jpg",
+                "file_size": largest.get("file_size", 0),
+            })
+        doc = msg.get("document") or {}
+        if doc and str(doc.get("mime_type", "")).startswith("image/"):
+            media_refs.append({
+                "file_id": doc["file_id"],
+                "content_type": doc["mime_type"],
+                "filename": doc.get("file_name") or "image",
+                "file_size": doc.get("file_size", 0),
+            })
+
+        text = msg.get("text") or msg.get("caption") or ""
+        # Nothing we can act on (no text, no image) → skip (sticker, location…).
+        if not text and not media_refs:
+            return None
+
+        return InboundMessage(
+            platform="telegram",
+            chat_id=str(chat["id"]),
+            user_id=str(sender.get("id", chat["id"])),
+            text=text,
+            raw=upd,
+            media_refs=media_refs,
+        )
+
+    async def fetch_media(self, media_refs: List[dict]) -> List[dict]:
+        """Resolve Telegram file_ids to base64 bytes via getFile + file download."""
+        out: List[dict] = []
+        for ref in media_refs:
+            if ref.get("file_size", 0) and ref["file_size"] > _MAX_MEDIA_BYTES:
+                logger.warning("[telegram] skipping media > 20MB (%s bytes)", ref["file_size"])
+                continue
+            try:
+                info = await self._call("getFile", {"file_id": ref["file_id"]})
+                file_path = (info or {}).get("file_path")
+                if not file_path:
+                    continue
+                # File download uses a DIFFERENT path: /file/bot<token>/<file_path>
+                url = f"{self.api_base}/file/bot{self._token}/{file_path}"
+                resp = await self._client.get(url)
+                resp.raise_for_status()
+                out.append({
+                    "filename": ref["filename"],
+                    "content_type": ref["content_type"],
+                    "data_b64": base64.b64encode(resp.content).decode("ascii"),
+                })
+            except Exception:
+                logger.exception("[telegram] failed to download media file_id=%s",
+                                 ref.get("file_id"))
+        return out

--- a/backend/services/gateways/zalo.py
+++ b/backend/services/gateways/zalo.py
@@ -1,0 +1,114 @@
+"""Zalo gateway — long-polling via the official Zalo Bot API.
+
+Zalo's Bot API mirrors Telegram's shape (``{base}/bot{token}/{method}``, the
+``{ok, result}`` envelope, ``sendMessage{chat_id, text}``) with two quirks:
+
+  * ``getUpdates`` returns a *single* update object, not an array, and has no
+    ``update_id`` offset cursor.
+  * "no updates within the poll window" comes back as ``error_code`` 408, which
+    :class:`BotApiGateway` already treats as a normal (non-error) timeout.
+
+Token: register a bot at https://bot.zaloplatforms.com, put the token in
+``fastagent.secrets.yaml`` under ``gateways.zalo.token``.
+
+API reference: https://bot.zaloplatforms.com/docs
+"""
+from __future__ import annotations
+
+import base64
+import logging
+from typing import List
+
+from .base import InboundMessage
+from .bot_api import BotApiGateway
+
+logger = logging.getLogger("gateways")
+
+_TEXT_EVENT = "message.text.received"
+_IMAGE_EVENT = "message.image.received"
+# Cap inbound media; Zalo image URLs are CDN links we fetch directly.
+_MAX_MEDIA_BYTES = 20 * 1024 * 1024
+# Zalo's CDN serves photos as ``image/jpg`` — a non-standard mime that the LLM
+# vision path (and fast-agent's supported-type check) rejects. Map to the
+# canonical ``image/jpeg`` so the image isn't silently dropped.
+_IMAGE_MIME_NORMALIZE = {"image/jpg": "image/jpeg"}
+
+
+class ZaloGateway(BotApiGateway):
+    api_base = "https://bot-api.zaloplatforms.com"
+    typing_method = None  # Zalo Bot API exposes no typing indicator
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(name="zalo", **kwargs)
+
+    @staticmethod
+    def _display_name(get_me_result: dict) -> str:
+        """Zalo's getMe returns the bot name under ``display_name`` /
+        ``account_name`` (NOT ``name``/``username`` like Telegram), e.g.
+        ``{"display_name": "Bot OmnigentxJarvis", "account_name": "bot.WbZlgxnx"}``."""
+        return (
+            get_me_result.get("display_name")
+            or get_me_result.get("account_name")
+            or "bot"
+        )
+
+    async def _poll(self) -> List[InboundMessage]:
+        # Zalo wants the timeout as a string and returns one update per call.
+        update = await self._call("getUpdates", {"timeout": "30"})
+        if not update:
+            return []
+        event = update.get("event_name")
+        msg = update.get("message") or {}
+        chat = msg.get("chat") or {}
+        if "id" not in chat:
+            return []
+        sender = msg.get("from") or {}
+
+        media_refs: List[dict] = []
+        if event == _IMAGE_EVENT:
+            # Verified against the live API: an image arrives as a public CDN URL
+            # in `photo_url` (NOT `photo` as some older docs claim), with the
+            # caption in `caption` (NOT `text` like Telegram).
+            photo = msg.get("photo_url") or msg.get("photo")
+            if isinstance(photo, str) and photo:
+                media_refs.append({"url": photo, "filename": "photo.jpg"})
+            text = msg.get("caption") or ""
+        elif event == _TEXT_EVENT:
+            text = msg.get("text") or ""
+        else:
+            return []  # sticker / unsupported
+
+        if not text and not media_refs:
+            return []
+        return [InboundMessage(
+            platform="zalo",
+            chat_id=str(chat["id"]),
+            user_id=str(sender.get("id", chat["id"])),
+            text=text,
+            raw=update,
+            media_refs=media_refs,
+        )]
+
+    async def fetch_media(self, media_refs: List[dict]) -> List[dict]:
+        """Download Zalo images directly from their CDN URL → base64."""
+        out: List[dict] = []
+        for ref in media_refs:
+            url = ref.get("url")
+            if not url:
+                continue
+            try:
+                resp = await self._client.get(url)
+                resp.raise_for_status()
+                if len(resp.content) > _MAX_MEDIA_BYTES:
+                    logger.warning("[zalo] skipping media > 20MB")
+                    continue
+                ct = (resp.headers.get("content-type") or "image/jpeg").split(";")[0].strip()
+                ct = _IMAGE_MIME_NORMALIZE.get(ct, ct) or "image/jpeg"
+                out.append({
+                    "filename": ref.get("filename", "photo.jpg"),
+                    "content_type": ct,
+                    "data_b64": base64.b64encode(resp.content).decode("ascii"),
+                })
+            except Exception:
+                logger.exception("[zalo] failed to download media url")
+        return out

--- a/backend/services/gateways/zalo.py
+++ b/backend/services/gateways/zalo.py
@@ -97,18 +97,34 @@ class ZaloGateway(BotApiGateway):
             if not url:
                 continue
             try:
-                resp = await self._client.get(url)
-                resp.raise_for_status()
-                if len(resp.content) > _MAX_MEDIA_BYTES:
-                    logger.warning("[zalo] skipping media > 20MB")
-                    continue
-                ct = (resp.headers.get("content-type") or "image/jpeg").split(";")[0].strip()
-                ct = _IMAGE_MIME_NORMALIZE.get(ct, ct) or "image/jpeg"
-                out.append({
-                    "filename": ref.get("filename", "photo.jpg"),
-                    "content_type": ct,
-                    "data_b64": base64.b64encode(resp.content).decode("ascii"),
-                })
+                # Stream so the size cap actually BOUNDS the work: reject on the
+                # Content-Length up front, and abort mid-read if the body crosses
+                # the cap anyway (header missing or under-reported) — never buffer
+                # an unbounded CDN response just to drop it afterwards.
+                async with self._client.stream("GET", url) as resp:
+                    resp.raise_for_status()
+                    declared = int(resp.headers.get("content-length") or 0)
+                    if declared > _MAX_MEDIA_BYTES:
+                        logger.warning("[zalo] skipping media > 20MB (content-length=%d)",
+                                       declared)
+                        continue
+                    chunks: List[bytes] = []
+                    total = 0
+                    async for chunk in resp.aiter_bytes():
+                        total += len(chunk)
+                        if total > _MAX_MEDIA_BYTES:
+                            break
+                        chunks.append(chunk)
+                    if total > _MAX_MEDIA_BYTES:
+                        logger.warning("[zalo] skipping media > 20MB")
+                        continue
+                    ct = (resp.headers.get("content-type") or "image/jpeg").split(";")[0].strip()
+                    ct = _IMAGE_MIME_NORMALIZE.get(ct, ct) or "image/jpeg"
+                    out.append({
+                        "filename": ref.get("filename", "photo.jpg"),
+                        "content_type": ct,
+                        "data_b64": base64.b64encode(b"".join(chunks)).decode("ascii"),
+                    })
             except Exception:
                 logger.exception("[zalo] failed to download media url")
         return out

--- a/backend/services/shared_state.py
+++ b/backend/services/shared_state.py
@@ -45,4 +45,5 @@ meeting_bridge = None  # MeetingEventBridge, wired in lifespan
 cron_scheduler = None  # CronScheduler instance, wired in lifespan
 current_conversation_id = None  # Active chat conversation_id (set during chat processing)
 stt_recorder = None  # services.stt_realtime.RealtimeSTTService, wired in lifespan
+gateway_manager = None  # services.gateways.GatewayManager, wired in lifespan
 

--- a/backend/tests/test_services/test_gateways.py
+++ b/backend/tests/test_services/test_gateways.py
@@ -1,0 +1,825 @@
+"""Tests for the messaging gateways (Telegram / Zalo).
+
+Coverage map:
+  * Unit — pure logic, no network: chunking, allow-list, handle_inbound
+    orchestration (happy / unauthorized / agent-error / empty), and the
+    Telegram + Zalo update parsers.
+  * Integration — REAL SQLite: the chat→session binding SSoT
+    (`session_map`) and `GatewayManager._dispatch` reconciliation
+    (create → reuse → self-heal when the bound session is gone).
+  * E2E — the full `BotApiGateway` long-poll loop running through REAL httpx
+    over a mock transport: getUpdates → parse → handle_inbound → sendMessage.
+    Only the external Telegram server is faked; the gateway code under test is
+    exercised for real.
+
+Gap stated explicitly (per CLAUDE.md item 4/5): the agent LLM run
+(`resume_and_send` → fast-agent → model) is NOT exercised here — it needs no
+network/keys to be meaningful and is already covered by the chat-path tests.
+The gateway↔session_service contract is faked at that single seam.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from core.database import Base, GatewayChat, engine, get_db_session
+from services.gateways import session_map
+from services.gateways.base import BaseGateway, InboundMessage
+from services.gateways.bot_api import BotApiError, chunk_text
+from services.gateways.config import GatewayConfig, load_gateway_configs
+from services.gateways.manager import GatewayManager
+from services.gateways.telegram import TelegramGateway
+from services.gateways.zalo import ZaloGateway
+
+
+@pytest.fixture(autouse=True)
+def _tables():
+    """Ensure the gateway_chats table exists in the isolated test DB."""
+    Base.metadata.create_all(bind=engine)
+    yield
+
+
+# ── Test doubles ───────────────────────────────────────────────────────────
+
+
+class RecordingGateway(BaseGateway):
+    """Minimal BaseGateway that records sends instead of hitting a network."""
+
+    def __init__(self, **kwargs):
+        super().__init__(name="fake", **kwargs)
+        self.sent: list[tuple[str, str]] = []
+        self.typing: list[str] = []
+
+    async def run(self):  # pragma: no cover - not exercised
+        return None
+
+    async def send_text(self, chat_id, text):
+        self.sent.append((chat_id, text))
+
+    async def send_typing(self, chat_id):
+        self.typing.append(chat_id)
+
+
+def _msg(text="hi", user_id="42", chat_id="100"):
+    return InboundMessage(platform="fake", chat_id=chat_id, user_id=user_id, text=text)
+
+
+# ── Unit: chunking ─────────────────────────────────────────────────────────
+
+
+def test_chunk_text_short_passthrough():
+    assert chunk_text("hello") == ["hello"]
+
+
+def test_chunk_text_splits_on_newline_and_respects_limit():
+    text = "a" * 50 + "\n" + "b" * 50
+    chunks = chunk_text(text, limit=60)
+    assert len(chunks) == 2
+    assert chunks[0] == "a" * 50
+    assert chunks[1] == "b" * 50
+    assert all(len(c) <= 60 for c in chunks)
+
+
+def test_chunk_text_hard_cuts_a_single_long_line():
+    text = "x" * 250
+    chunks = chunk_text(text, limit=100)
+    assert [len(c) for c in chunks] == [100, 100, 50]
+    assert "".join(chunks) == text
+
+
+# ── Unit: allow-list ───────────────────────────────────────────────────────
+
+
+def test_allowlist_empty_denies_all():
+    gw = RecordingGateway(dispatcher=None, allow_from=[])
+    assert gw.is_allowed("42") is False
+
+
+def test_allowlist_star_allows_all():
+    gw = RecordingGateway(dispatcher=None, allow_from=["*"])
+    assert gw.is_allowed("anyone") is True
+
+
+def test_allowlist_normalizes_int_and_str():
+    # config may carry ints; inbound ids are strings — must still match.
+    gw = RecordingGateway(dispatcher=None, allow_from=[42])
+    assert gw.is_allowed("42") is True
+    assert gw.is_allowed("43") is False
+
+
+# ── Unit: handle_inbound orchestration ─────────────────────────────────────
+
+
+async def test_handle_inbound_happy_path():
+    async def dispatcher(m):
+        return f"echo:{m.text}"
+
+    gw = RecordingGateway(dispatcher=dispatcher, allow_from=["42"])
+    await gw.handle_inbound(_msg(text="ping"))
+    assert gw.typing == ["100"]
+    assert gw.sent == [("100", "echo:ping")]
+
+
+async def test_handle_inbound_unauthorized_is_silent_and_skips_agent():
+    called = False
+
+    async def dispatcher(m):
+        nonlocal called
+        called = True
+        return "should not happen"
+
+    gw = RecordingGateway(dispatcher=dispatcher, allow_from=[])  # deny all
+    await gw.handle_inbound(_msg())
+    assert called is False
+    assert gw.sent == []  # no reply leaked to an unauthorized user
+
+
+async def test_handle_inbound_agent_error_notifies_user_not_silent():
+    async def dispatcher(m):
+        raise RuntimeError("boom")
+
+    gw = RecordingGateway(dispatcher=dispatcher, allow_from=["42"])
+    await gw.handle_inbound(_msg())  # must NOT raise out of the loop
+    assert len(gw.sent) == 1
+    assert "wrong" in gw.sent[0][1].lower()
+
+
+async def test_handle_inbound_empty_reply_tells_user():
+    async def dispatcher(m):
+        return "   "
+
+    gw = RecordingGateway(dispatcher=dispatcher, allow_from=["42"])
+    await gw.handle_inbound(_msg())
+    assert gw.sent == [("100", "(no response)")]
+
+
+# ── Unit: platform parsers ─────────────────────────────────────────────────
+
+
+async def test_telegram_poll_parses_and_advances_offset(monkeypatch):
+    gw = TelegramGateway(token="t", dispatcher=None, allow_from=[])
+    updates = [
+        {"update_id": 5, "message": {"text": "hello",
+                                     "chat": {"id": 111}, "from": {"id": 222}}},
+        {"update_id": 6, "message": {"sticker": "x",  # non-text → skipped
+                                     "chat": {"id": 111}, "from": {"id": 222}}},
+    ]
+
+    async def fake_call(method, body=None):
+        assert method == "getUpdates"
+        assert body["offset"] == 0  # first poll starts from beginning
+        return updates
+
+    monkeypatch.setattr(gw, "_call", fake_call)
+    msgs = await gw._poll()
+    assert len(msgs) == 1
+    assert msgs[0].platform == "telegram"
+    assert msgs[0].chat_id == "111"
+    assert msgs[0].user_id == "222"
+    assert msgs[0].text == "hello"
+    # Offset advanced past BOTH updates (incl. the skipped sticker), so they are
+    # never replayed.
+    assert gw._offset == 7
+    await gw.stop()
+
+
+# ── Media: photos / images ─────────────────────────────────────────────────
+
+
+async def test_telegram_parses_photo_with_caption(monkeypatch):
+    gw = TelegramGateway(token="t", dispatcher=None, allow_from=[])
+    updates = [{"update_id": 1, "message": {
+        "caption": "look at this",
+        "chat": {"id": 5}, "from": {"id": 9},
+        "photo": [{"file_id": "small", "file_size": 100},
+                  {"file_id": "big", "file_size": 2000}],
+    }}]
+
+    async def fake_call(method, body=None):
+        return updates
+
+    monkeypatch.setattr(gw, "_call", fake_call)
+    msgs = await gw._poll()
+    assert len(msgs) == 1
+    assert msgs[0].text == "look at this"           # caption becomes the text
+    assert msgs[0].media_refs[0]["file_id"] == "big"  # largest size chosen
+    assert msgs[0].media_refs[0]["content_type"] == "image/jpeg"
+    await gw.stop()
+
+
+async def test_telegram_fetch_media_downloads_base64():
+    def handler(req):
+        path = req.url.path
+        if path.endswith("/getFile"):
+            return httpx.Response(200, json={"ok": True, "result": {"file_path": "photos/x.jpg"}})
+        if "/file/bot" in path:  # the actual file download
+            return httpx.Response(200, content=b"JPEGBYTES")
+        return httpx.Response(200, json={"ok": True, "result": True})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gw = TelegramGateway(token="TKN", dispatcher=None, allow_from=[], client=client)
+    files = await gw.fetch_media([{
+        "file_id": "big", "content_type": "image/jpeg",
+        "filename": "photo.jpg", "file_size": 2000,
+    }])
+    assert len(files) == 1
+    assert files[0]["content_type"] == "image/jpeg"
+    import base64 as _b64
+    assert _b64.b64decode(files[0]["data_b64"]) == b"JPEGBYTES"
+    await gw.stop()
+
+
+async def test_handle_inbound_resolves_media_before_dispatch():
+    """handle_inbound must download media (post allow-gate) and hand it to the
+    dispatcher as files_data — the root fix for 'image not handled'."""
+    captured = {}
+
+    async def dispatcher(m):
+        captured["text"] = m.text
+        captured["files"] = m.files_data
+        return "ok"
+
+    class G(TelegramGateway):
+        async def fetch_media(self, refs):
+            return [{"filename": "photo.jpg", "content_type": "image/jpeg", "data_b64": "QQ=="}]
+        async def send_text(self, chat_id, text):
+            pass
+        async def send_typing(self, chat_id):
+            pass
+
+    gw = G(token="t", dispatcher=dispatcher, allow_from=["9"])
+    msg = InboundMessage(platform="telegram", chat_id="5", user_id="9",
+                         text="look", media_refs=[{"file_id": "big"}])
+    await gw.handle_inbound(msg)
+    assert captured["text"] == "look"
+    assert captured["files"] == [{"filename": "photo.jpg", "content_type": "image/jpeg", "data_b64": "QQ=="}]
+    await gw.stop()
+
+
+async def test_telegram_skips_unsupported_non_text_non_media(monkeypatch):
+    gw = TelegramGateway(token="t", dispatcher=None, allow_from=[])
+    updates = [{"update_id": 1, "message": {"sticker": {"file_id": "s"},
+                                            "chat": {"id": 5}, "from": {"id": 9}}}]
+
+    async def fake_call(method, body=None):
+        return updates
+
+    monkeypatch.setattr(gw, "_call", fake_call)
+    assert await gw._poll() == []  # sticker → skipped, but offset still advanced
+    assert gw._offset == 2
+    await gw.stop()
+
+
+async def test_zalo_poll_parses_text_event(monkeypatch):
+    gw = ZaloGateway(token="t", dispatcher=None, allow_from=[])
+
+    async def fake_call(method, body=None):
+        assert method == "getUpdates"
+        assert body == {"timeout": "30"}
+        return {
+            "event_name": "message.text.received",
+            "message": {"text": "xin chào",
+                        "chat": {"id": "abc", "chat_type": "PRIVATE"},
+                        "from": {"id": "u1"}},
+        }
+
+    monkeypatch.setattr(gw, "_call", fake_call)
+    msgs = await gw._poll()
+    assert len(msgs) == 1
+    assert msgs[0].platform == "zalo"
+    assert msgs[0].chat_id == "abc"
+    assert msgs[0].text == "xin chào"
+    await gw.stop()
+
+
+async def test_zalo_poll_parses_image_event(monkeypatch):
+    gw = ZaloGateway(token="t", dispatcher=None, allow_from=[])
+
+    async def fake_call(method, body=None):
+        # Real Zalo image update: URL in `photo_url`, caption in `caption`.
+        return {"event_name": "message.image.received", "message": {
+            "message_type": "CHAT_PHOTO",
+            "photo_url": "https://photo.zdn.vn/abc.jpg", "caption": "ai đây",
+            "chat": {"id": "c1"}, "from": {"id": "u1"}}}
+
+    monkeypatch.setattr(gw, "_call", fake_call)
+    msgs = await gw._poll()
+    assert len(msgs) == 1
+    assert msgs[0].text == "ai đây"  # caption becomes text
+    assert msgs[0].media_refs == [{"url": "https://photo.zdn.vn/abc.jpg", "filename": "photo.jpg"}]
+    await gw.stop()
+
+
+async def test_zalo_poll_skips_sticker_event(monkeypatch):
+    gw = ZaloGateway(token="t", dispatcher=None, allow_from=[])
+
+    async def fake_call(method, body=None):
+        return {"event_name": "message.sticker.received",
+                "message": {"sticker": "x", "chat": {"id": "c1"}, "from": {"id": "u1"}}}
+
+    monkeypatch.setattr(gw, "_call", fake_call)
+    assert await gw._poll() == []
+    await gw.stop()
+
+
+async def test_zalo_fetch_media_downloads_url():
+    def handler(req):
+        # Zalo CDN serves the non-standard "image/jpg" — must be normalized.
+        return httpx.Response(200, content=b"ZALOIMG", headers={"content-type": "image/jpg"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gw = ZaloGateway(token="t", dispatcher=None, allow_from=[], client=client)
+    files = await gw.fetch_media([{"url": "https://photo.zdn.vn/abc.jpg", "filename": "photo.jpg"}])
+    assert len(files) == 1
+    assert files[0]["content_type"] == "image/jpeg"  # normalized from image/jpg
+    import base64 as _b64
+    assert _b64.b64decode(files[0]["data_b64"]) == b"ZALOIMG"
+    await gw.stop()
+
+
+def test_display_name_per_platform():
+    # Telegram: username/first_name; Zalo: display_name/account_name.
+    assert TelegramGateway._display_name({"username": "tg_bot", "first_name": "X"}) == "tg_bot"
+    assert ZaloGateway._display_name(
+        {"display_name": "Bot OmnigentxJarvis", "account_name": "bot.WbZlgxnx"}
+    ) == "Bot OmnigentxJarvis"
+    assert ZaloGateway._display_name({"account_name": "bot.abc"}) == "bot.abc"
+    assert ZaloGateway._display_name({}) == "bot"
+
+
+def test_bot_api_error_408_is_poll_timeout():
+    assert BotApiError("timeout", error_code=408).is_poll_timeout is True
+    assert BotApiError("real", error_code=400).is_poll_timeout is False
+
+
+# ── Security: the bot token must never leak into errors ────────────────────
+
+
+async def test_call_409_surfaces_description_without_leaking_token():
+    """A 409 must yield the Telegram description + error_code, and the bot
+    token must NOT appear anywhere in the raised error (it would otherwise be
+    shown in the Settings UI banner)."""
+    def handler(req):
+        return httpx.Response(409, json={
+            "ok": False, "error_code": 409,
+            "description": "Conflict: terminated by other getUpdates request",
+        })
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gw = TelegramGateway(token="8407785561:SECRET_xyz", dispatcher=None,
+                         allow_from=[], client=client)
+    with pytest.raises(BotApiError) as ei:
+        await gw._call("getUpdates")
+    assert ei.value.error_code == 409
+    assert "Conflict" in str(ei.value)
+    assert "SECRET_xyz" not in str(ei.value)
+    await gw.stop()
+
+
+async def test_409_is_benign_keeps_connected_and_still_delivers():
+    """A 409 self-overlap must NOT flip connected→false / set last_error (that
+    made the UI flap red), and the bot must keep working — the next poll's
+    message is still delivered."""
+    sent = []
+    delivered = asyncio.Event()
+    seq = {"n": 0}
+
+    def handler(req):
+        p = req.url.path
+        if p.endswith("/getMe"):
+            return httpx.Response(200, json={"ok": True, "result": {"username": "b"}})
+        if p.endswith("/getUpdates"):
+            seq["n"] += 1
+            if seq["n"] == 1:  # benign self-conflict
+                return httpx.Response(409, json={
+                    "ok": False, "error_code": 409,
+                    "description": "Conflict: terminated by other getUpdates request"})
+            if seq["n"] == 2:  # a real message
+                return httpx.Response(200, json={"ok": True, "result": [{
+                    "update_id": 1,
+                    "message": {"text": "hi", "chat": {"id": 5}, "from": {"id": 9}}}]})
+            return httpx.Response(200, json={"ok": True, "result": []})
+        if p.endswith("/sendMessage"):
+            sent.append(json.loads(req.content))
+            delivered.set()
+            return httpx.Response(200, json={"ok": True, "result": {"message_id": "1"}})
+        return httpx.Response(200, json={"ok": True, "result": True})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    async def dispatcher(m):
+        return "ok"
+
+    gw = TelegramGateway(token="t", dispatcher=dispatcher, allow_from=["9"], client=client)
+    task = asyncio.create_task(gw.run())
+    try:
+        await asyncio.wait_for(delivered.wait(), timeout=6)
+    finally:
+        await gw.stop()
+        await task
+
+    assert gw.connected is True, "409 wrongly flipped connected to False (UI flap)"
+    assert gw.last_error is None, "409 wrongly set last_error"
+    assert sent and sent[0]["text"] == "ok"
+
+
+def test_redact_strips_token_from_message():
+    gw = TelegramGateway(token="TKN123:abc", dispatcher=None, allow_from=[])
+    leaked = "ConnectError for https://api.telegram.org/botTKN123:abc/getUpdates"
+    assert "TKN123:abc" not in gw._redact(leaked)
+    assert "bot***/getUpdates" in gw._redact(leaked)
+
+
+async def test_probe_invalid_token_does_not_leak(monkeypatch):
+    _patch_probe_transport(
+        monkeypatch,
+        lambda req: httpx.Response(401, json={"ok": False, "description": "Unauthorized"}),
+    )
+    res = await TelegramGateway.probe("MYTOKEN:secret")
+    assert res["ok"] is False
+    assert "MYTOKEN" not in res["error"]
+
+
+# ── Live reload: minimal restarts (anti-409 churn) ─────────────────────────
+
+
+async def test_apply_updates_allowlist_in_place_without_restart(monkeypatch):
+    """Changing only allow-list/agent must NOT restart the poller (a restart
+    would drop the long-poll and trigger a transient 409). A token change MUST
+    reconnect."""
+    import services.gateways.manager as m
+
+    class FakeGW(BaseGateway):
+        # The manager always constructs gateways with token=…; BaseGateway
+        # itself doesn't take it (only BotApiGateway does), so absorb it here.
+        def __init__(self, *, token=None, **kw):
+            super().__init__(name="telegram", **kw)
+            self.token = token
+        async def run(self):
+            await asyncio.Event().wait()  # run until cancelled
+        async def send_text(self, chat_id, text):
+            pass
+
+    monkeypatch.setitem(m.GATEWAY_REGISTRY, "telegram", FakeGW)
+
+    mgr = GatewayManager(agent_app=object())
+    mgr._loop = asyncio.get_running_loop()
+    mgr.start(configs={"telegram": GatewayConfig(enabled=True, token="t", allow_from=[1], agent="Jarvis")})
+    task1 = mgr._tasks["telegram"]
+    gw = mgr._gateways["telegram"]
+    assert gw.is_allowed("1") and not gw.is_allowed("2")
+
+    # allow-list change only → in place, SAME task, new allow-list live.
+    await mgr._apply({"telegram": GatewayConfig(enabled=True, token="t", allow_from=[1, 2], agent="Jarvis")})
+    assert mgr._tasks["telegram"] is task1, "poller was needlessly restarted"
+    assert gw.is_allowed("2"), "in-place allow-list update did not take effect"
+
+    # token change → MUST reconnect (new task).
+    await mgr._apply({"telegram": GatewayConfig(enabled=True, token="t2", allow_from=[1, 2], agent="Jarvis")})
+    assert mgr._tasks["telegram"] is not task1, "token change must reconnect"
+
+    # disable → stopped.
+    await mgr._apply({"telegram": GatewayConfig(enabled=False)})
+    assert "telegram" not in mgr._tasks
+    await mgr.stop()
+
+
+# ── Slash commands (gateway chat) ──────────────────────────────────────────
+
+
+def test_commands_parse_recognizes_and_aliases():
+    from services.gateways import commands
+    assert commands.parse("/new") == ("new", [])
+    assert commands.parse("/reset") == ("new", [])       # alias
+    assert commands.parse("/clear") == ("new", [])       # alias
+    assert commands.parse("/agent Personal") == ("agent", ["Personal"])
+    assert commands.parse("/help") == ("help", [])
+    assert commands.parse("/unknown") is None            # not a command → falls through
+    assert commands.parse("hello") is None               # plain text
+
+
+def test_commands_handle_new_agent_help():
+    from services.gateways import commands
+    calls = {"reset": 0, "agent": None}
+    ctx = commands.CommandContext(
+        current_agent="Jarvis",
+        agent_names=["Jarvis", "Personal"],
+        reset_conversation=lambda: calls.__setitem__("reset", calls["reset"] + 1),
+        set_agent=lambda n: calls.__setitem__("agent", n),
+    )
+    assert "new conversation" in commands.handle("/new", ctx).lower()
+    assert calls["reset"] == 1
+
+    assert "Personal" in commands.handle("/agent Personal", ctx)
+    assert calls["agent"] == "Personal"
+
+    assert "Unknown agent" in commands.handle("/agent Nope", ctx)
+
+    assert "/new" in commands.handle("/help", ctx) and "/agent" in commands.handle("/help", ctx)
+
+    assert commands.handle("just a normal message", ctx) is None
+
+
+async def test_dispatch_new_command_resets_without_running_agent(monkeypatch):
+    import services.shared_state as ss_mod
+
+    ran = {"n": 0}
+
+    class FakeSS:
+        async def resume_and_send(self, *a, **k):
+            ran["n"] += 1
+            return "agent reply", "s1"
+
+    monkeypatch.setattr(ss_mod, "session_service", FakeSS())
+
+    class App:
+        _agents = {"Jarvis": object(), "Personal": object()}
+
+    mgr = GatewayManager(agent_app=App())
+    session_map.upsert("fake", "cmd1", "sess-x", "Jarvis")  # existing binding
+
+    reply = await mgr._dispatch(_msg(text="/new", chat_id="cmd1"), "Jarvis")
+    assert "new conversation" in reply.lower()
+    assert ran["n"] == 0                                  # agent NOT invoked
+    assert session_map.lookup("fake", "cmd1") is None     # binding cleared
+
+
+async def test_dispatch_agent_command_sets_per_chat_agent(monkeypatch):
+    import services.shared_state as ss_mod
+
+    class FakeSS:
+        async def resume_and_send(self, agent_app, message, session_id, files_data=None, agent_name=None):
+            return f"answered by {agent_name}", "s2"
+
+    monkeypatch.setattr(ss_mod, "session_service", FakeSS())
+
+    class App:
+        _agents = {"Jarvis": object(), "Personal": object()}
+
+    mgr = GatewayManager(agent_app=App())
+
+    # /agent switches the per-chat agent (no agent run)
+    reply = await mgr._dispatch(_msg(text="/agent Personal", chat_id="cmd2"), "Jarvis")
+    assert "Personal" in reply
+    assert session_map.get_agent("fake", "cmd2") == "Personal"
+
+    # next normal message is answered by the chosen agent, not the default
+    reply2 = await mgr._dispatch(_msg(text="hi", chat_id="cmd2"), "Jarvis")
+    assert reply2 == "answered by Personal"
+
+
+async def test_start_one_never_orphans_a_running_poller(monkeypatch):
+    """If a start is requested while a poller is already running, the old task
+    must be cancelled — otherwise two pollers run on one bot and 409 each other
+    forever. Guards the root cause of the persistent-409 bug."""
+    import services.gateways.manager as m
+
+    class FakeGW(BaseGateway):
+        def __init__(self, *, token=None, **kw):
+            super().__init__(name="telegram", **kw)
+        async def run(self):
+            await asyncio.Event().wait()
+        async def send_text(self, chat_id, text):
+            pass
+
+    monkeypatch.setitem(m.GATEWAY_REGISTRY, "telegram", FakeGW)
+    mgr = GatewayManager(agent_app=object())
+    mgr._loop = asyncio.get_running_loop()
+    cfg = GatewayConfig(enabled=True, token="t", allow_from=[1], agent="Jarvis")
+
+    mgr._start_one("telegram", cfg)
+    t1 = mgr._tasks["telegram"]
+    mgr._start_one("telegram", cfg)  # again, while t1 still running
+    t2 = mgr._tasks["telegram"]
+
+    assert t1 is not t2
+    await asyncio.sleep(0)  # let the cancellation land
+    assert t1.cancelled() or t1.done(), "stale poller was orphaned (not cancelled)"
+    await mgr.stop()
+
+
+# ── Integration: config loader reads from config_service (REAL DB) ─────────
+
+
+def _clear_gateway_config():
+    """Remove all gateways/* rows so each config test starts clean."""
+    from services.config_service import config_service
+    for name in ("telegram", "zalo"):
+        for suffix in ("enabled", "token", "allow_from", "agent"):
+            config_service.set("gateways", f"{name}_{suffix}", None)
+
+
+def test_load_gateway_configs_defaults_when_unset():
+    _clear_gateway_config()
+    cfgs = load_gateway_configs()
+    # Every registered platform is present and disabled by default.
+    assert set(cfgs) == {"telegram", "zalo"}
+    assert cfgs["telegram"].enabled is False
+    assert cfgs["telegram"].token == ""
+    assert cfgs["telegram"].allow_from == []
+    assert cfgs["telegram"].agent == "Jarvis"
+
+
+def test_load_gateway_configs_reads_db_values():
+    from services.config_service import config_service
+    _clear_gateway_config()
+    config_service.set("gateways", "telegram_enabled", "true")
+    config_service.set("gateways", "telegram_token", "abc123", is_secret=True)
+    config_service.set("gateways", "telegram_allow_from", "[1, 2]")
+    config_service.set("gateways", "telegram_agent", "Personal")
+
+    cfgs = load_gateway_configs()
+    assert cfgs["telegram"].enabled is True
+    assert cfgs["telegram"].token == "abc123"   # decrypted from the secret row
+    assert cfgs["telegram"].allow_from == [1, 2]
+    assert cfgs["telegram"].agent == "Personal"
+    _clear_gateway_config()
+
+
+# ── Integration: session_map against REAL SQLite ───────────────────────────
+
+
+def test_session_map_upsert_lookup_and_rebind():
+    assert session_map.lookup("telegram", "c1") is None
+    session_map.upsert("telegram", "c1", "sess-A", "Jarvis")
+    assert session_map.lookup("telegram", "c1") == "sess-A"
+    # Rebind (e.g. the backend session was recreated) updates in place, no dup.
+    session_map.upsert("telegram", "c1", "sess-B", "Jarvis")
+    assert session_map.lookup("telegram", "c1") == "sess-B"
+    db = get_db_session()
+    try:
+        rows = db.query(GatewayChat).filter_by(platform="telegram", chat_id="c1").all()
+        assert len(rows) == 1  # UniqueConstraint(platform, chat_id) held
+    finally:
+        db.close()
+
+
+async def test_dispatch_creates_then_reuses_binding(monkeypatch):
+    """GatewayManager._dispatch must: pass the bound session to the agent,
+    persist the id it gets back, and reuse it next time — verified against the
+    REAL DB binding. The agent runtime is faked at the session_service seam.
+    """
+    import services.shared_state as ss_mod
+
+    created = {"n": 0}
+
+    class FakeSessionService:
+        async def resume_and_send(self, agent_app, message, session_id, files_data=None, agent_name=None):
+            # Mirror resume_and_send's contract: reuse the id if one is passed,
+            # otherwise mint a new one.
+            if session_id:
+                return f"reply to {message}", session_id
+            created["n"] += 1
+            return f"reply to {message}", f"new-sess-{created['n']}"
+
+    monkeypatch.setattr(ss_mod, "session_service", FakeSessionService())
+
+    mgr = GatewayManager(agent_app=object())
+
+    reply1 = await mgr._dispatch(_msg(text="first", chat_id="zz"), "Jarvis")
+    assert reply1 == "reply to first"
+    bound = session_map.lookup("fake", "zz")
+    assert bound == "new-sess-1"  # first turn minted + persisted a session
+
+    reply2 = await mgr._dispatch(_msg(text="second", chat_id="zz"), "Jarvis")
+    assert reply2 == "reply to second"
+    # Second turn reused the SAME session (no new mint) — the conversation
+    # continues instead of starting over.
+    assert session_map.lookup("fake", "zz") == "new-sess-1"
+    assert created["n"] == 1
+
+
+# ── E2E: full long-poll loop over REAL httpx (mock transport) ──────────────
+
+
+async def test_e2e_telegram_loop_poll_to_send():
+    """One inbound update flows through the real gateway loop and produces a
+    real sendMessage HTTP call. Only the Telegram server is mocked (httpx
+    MockTransport); BotApiGateway/TelegramGateway code is exercised for real.
+    """
+    sent_messages: list[dict] = []
+    delivered = asyncio.Event()
+    state = {"update_served": False}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        body = json.loads(request.content or b"{}")
+        if path.endswith("/getMe"):
+            return httpx.Response(200, json={"ok": True, "result": {"username": "jarvis_bot"}})
+        if path.endswith("/getUpdates"):
+            if not state["update_served"]:
+                state["update_served"] = True
+                return httpx.Response(200, json={"ok": True, "result": [{
+                    "update_id": 1,
+                    "message": {"text": "hello bot",
+                                "chat": {"id": 999}, "from": {"id": 7}},
+                }]})
+            # Subsequent polls: no new updates.
+            return httpx.Response(200, json={"ok": True, "result": []})
+        if path.endswith("/sendMessage"):
+            sent_messages.append(body)
+            delivered.set()
+            return httpx.Response(200, json={"ok": True, "result": {"message_id": "1"}})
+        # sendChatAction (typing) and anything else.
+        return httpx.Response(200, json={"ok": True, "result": True})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    async def dispatcher(m: InboundMessage) -> str:
+        return f"got: {m.text}"
+
+    gw = TelegramGateway(
+        token="TT", dispatcher=dispatcher, allow_from=["7"], client=client,
+    )
+    task = asyncio.create_task(gw.run())
+    try:
+        await asyncio.wait_for(delivered.wait(), timeout=3)
+    finally:
+        await gw.stop()
+        await task
+
+    assert sent_messages == [{"chat_id": "999", "text": "got: hello bot"}]
+
+
+# ── Test-connection probe (getMe over mocked httpx) ────────────────────────
+
+
+def _patch_probe_transport(monkeypatch, handler):
+    import services.gateways.bot_api as bot_api_mod
+    real_cls = httpx.AsyncClient
+
+    def fake_client(*a, **k):
+        return real_cls(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(bot_api_mod.httpx, "AsyncClient", fake_client)
+
+
+async def test_probe_valid_token_returns_name(monkeypatch):
+    _patch_probe_transport(
+        monkeypatch,
+        lambda req: httpx.Response(200, json={"ok": True, "result": {"username": "mybot"}}),
+    )
+    assert await TelegramGateway.probe("tok") == {"ok": True, "name": "mybot"}
+
+
+async def test_probe_invalid_token_returns_error(monkeypatch):
+    _patch_probe_transport(
+        monkeypatch,
+        lambda req: httpx.Response(200, json={"ok": False, "description": "bad token"}),
+    )
+    res = await ZaloGateway.probe("123456:ABCDEF")  # realistic token (no word collision)
+    assert res == {"ok": False, "error": "bad token"}
+
+
+# ── Live config reload + status ────────────────────────────────────────────
+
+
+def _clear_gateway_config_all():
+    from services.config_service import config_service
+    for name in ("telegram", "zalo"):
+        for suffix in ("enabled", "token", "allow_from", "agent"):
+            config_service.set("gateways", f"{name}_{suffix}", None)
+
+
+async def test_config_change_triggers_single_debounced_reload(monkeypatch):
+    """A burst of gateways/* edits (one bulk save) collapses into ONE reload;
+    non-gateways edits are ignored.
+    """
+    mgr = GatewayManager(agent_app=object())
+    mgr._loop = asyncio.get_running_loop()
+
+    reloads = []
+
+    async def fake_reload():
+        reloads.append(1)
+
+    monkeypatch.setattr(mgr, "_reload", fake_reload)
+
+    class Ev:
+        def __init__(self, category):
+            self.category = category
+
+    mgr._on_config_change(Ev("llm"))        # unrelated → ignored
+    mgr._on_config_change(Ev("gateways"))   # burst from one bulk save
+    mgr._on_config_change(Ev("gateways"))
+    mgr._on_config_change(Ev("gateways"))
+
+    await asyncio.sleep(0.5)  # let the debounce window elapse
+    assert reloads == [1], "expected exactly one coalesced reload"
+
+
+def test_status_reflects_db_config():
+    from services.config_service import config_service
+    _clear_gateway_config_all()
+    config_service.set("gateways", "zalo_enabled", "true")
+    config_service.set("gateways", "zalo_token", "tok", is_secret=True)
+    config_service.set("gateways", "zalo_allow_from", '["*"]')
+
+    rows = {r["platform"]: r for r in GatewayManager(agent_app=object()).status()}
+    assert rows["zalo"]["enabled"] is True
+    assert rows["zalo"]["has_token"] is True
+    assert rows["zalo"]["running"] is False  # not started in this test
+    assert rows["telegram"]["enabled"] is False
+    _clear_gateway_config_all()

--- a/backend/tests/test_services/test_gateways.py
+++ b/backend/tests/test_services/test_gateways.py
@@ -238,6 +238,30 @@ async def test_telegram_fetch_media_downloads_base64():
     await gw.stop()
 
 
+async def test_telegram_media_download_error_does_not_leak_token(caplog):
+    """A failed file download raises an HTTPStatusError whose message embeds the
+    token-bearing URL. It must be redacted before it reaches the log."""
+    import logging
+    TOKEN = "8407785561:SECRET_xyz"
+
+    def handler(req):
+        if req.url.path.endswith("/getFile"):
+            return httpx.Response(200, json={"ok": True, "result": {"file_path": "photos/x.jpg"}})
+        return httpx.Response(404, text="Not Found")  # the file download fails
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gw = TelegramGateway(token=TOKEN, dispatcher=None, allow_from=[], client=client)
+    with caplog.at_level(logging.ERROR):
+        files = await gw.fetch_media([{
+            "file_id": "f1", "content_type": "image/jpeg",
+            "filename": "photo.jpg", "file_size": 0,
+        }])
+    assert files == []
+    assert TOKEN not in caplog.text          # token must never reach the log
+    assert "f1" in caplog.text               # but the file_id is logged for debugging
+    await gw.stop()
+
+
 async def test_handle_inbound_resolves_media_before_dispatch():
     """handle_inbound must download media (post allow-gate) and hand it to the
     dispatcher as files_data — the root fix for 'image not handled'."""
@@ -343,6 +367,22 @@ async def test_zalo_fetch_media_downloads_url():
     assert files[0]["content_type"] == "image/jpeg"  # normalized from image/jpg
     import base64 as _b64
     assert _b64.b64decode(files[0]["data_b64"]) == b"ZALOIMG"
+    await gw.stop()
+
+
+async def test_zalo_fetch_media_rejects_oversized_before_buffering():
+    """The size cap must bound the work: a too-large Content-Length is rejected
+    up front (on the declared header), not after the body is buffered."""
+    def handler(req):
+        return httpx.Response(
+            200, content=b"x",
+            headers={"content-type": "image/jpeg", "content-length": str(21 * 1024 * 1024)},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    gw = ZaloGateway(token="t", dispatcher=None, allow_from=[], client=client)
+    files = await gw.fetch_media([{"url": "https://photo.zdn.vn/big.jpg", "filename": "photo.jpg"}])
+    assert files == []  # skipped on the declared Content-Length
     await gw.stop()
 
 

--- a/backend/tests/test_services/test_gateways.py
+++ b/backend/tests/test_services/test_gateways.py
@@ -123,7 +123,10 @@ async def test_handle_inbound_happy_path():
     assert gw.sent == [("100", "echo:ping")]
 
 
-async def test_handle_inbound_unauthorized_is_silent_and_skips_agent():
+async def test_handle_inbound_unauthorized_replies_id_and_skips_agent():
+    """Secure onboarding: an unauthorized sender never reaches the agent, but
+    gets ONLY their own id back so the owner can allow-list it without ever
+    opening '*'."""
     called = False
 
     async def dispatcher(m):
@@ -132,9 +135,12 @@ async def test_handle_inbound_unauthorized_is_silent_and_skips_agent():
         return "should not happen"
 
     gw = RecordingGateway(dispatcher=dispatcher, allow_from=[])  # deny all
-    await gw.handle_inbound(_msg())
-    assert called is False
-    assert gw.sent == []  # no reply leaked to an unauthorized user
+    await gw.handle_inbound(_msg(user_id="42", chat_id="100"))
+    assert called is False                       # agent NOT run
+    assert len(gw.sent) == 1
+    chat_id, text = gw.sent[0]
+    assert chat_id == "100"
+    assert "42" in text and "not authorized" in text.lower()
 
 
 async def test_handle_inbound_agent_error_notifies_user_not_silent():
@@ -496,6 +502,8 @@ def test_commands_parse_recognizes_and_aliases():
     assert commands.parse("/clear") == ("new", [])       # alias
     assert commands.parse("/agent Personal") == ("agent", ["Personal"])
     assert commands.parse("/help") == ("help", [])
+    assert commands.parse("/whoami") == ("whoami", [])
+    assert commands.parse("/id") == ("whoami", [])        # alias
     assert commands.parse("/unknown") is None            # not a command → falls through
     assert commands.parse("hello") is None               # plain text
 
@@ -506,6 +514,7 @@ def test_commands_handle_new_agent_help():
     ctx = commands.CommandContext(
         current_agent="Jarvis",
         agent_names=["Jarvis", "Personal"],
+        user_id="u123",
         reset_conversation=lambda: calls.__setitem__("reset", calls["reset"] + 1),
         set_agent=lambda n: calls.__setitem__("agent", n),
     )
@@ -516,6 +525,8 @@ def test_commands_handle_new_agent_help():
     assert calls["agent"] == "Personal"
 
     assert "Unknown agent" in commands.handle("/agent Nope", ctx)
+
+    assert "u123" in commands.handle("/whoami", ctx)       # /whoami returns the id
 
     assert "/new" in commands.handle("/help", ctx) and "/agent" in commands.handle("/help", ctx)
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -318,7 +318,7 @@
       "tokenSavedPlaceholder": "•••••••• saved — paste a new token to replace",
       "tokenHint": "Create a bot and get a token at",
       "allowLabel": "Allowed User IDs",
-      "allowHint": "Comma-separated numeric user ids allowed to chat. Empty = nobody (safe default). Use * to allow everyone.",
+      "allowHint": "Comma-separated user ids allowed to chat. Empty = nobody (safe default). To get your id: send /whoami to the bot (Telegram: also via @userinfobot). Avoid * (allows everyone).",
       "allowAllWarning": "Allowing EVERYONE. Anyone who messages this bot can drive the agent — including its shell, Gmail and IoT tools. Use only for testing; set specific user ids for real use.",
       "agentLabel": "Answering Agent",
       "testConnection": "Test Connection",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -319,6 +319,7 @@
       "tokenHint": "Create a bot and get a token at",
       "allowLabel": "Allowed User IDs",
       "allowHint": "Comma-separated numeric user ids allowed to chat. Empty = nobody (safe default). Use * to allow everyone.",
+      "allowAllWarning": "Allowing EVERYONE. Anyone who messages this bot can drive the agent — including its shell, Gmail and IoT tools. Use only for testing; set specific user ids for real use.",
       "agentLabel": "Answering Agent",
       "testConnection": "Test Connection",
       "testing": "Testing…",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -92,6 +92,7 @@
         "llm": "LLM Provider",
         "voice": "Voice",
         "services": "Services",
+        "gateways": "Messaging Gateways",
         "yaml": "YAML Config",
         "runningTmpl": "Running Templates",
         "compaction": "Context Compaction",
@@ -307,6 +308,30 @@
         "title": "More services",
         "desc": "(Firebase, Home Assistant…) will land here over time. For now they still live in the Services tab of the Setup Wizard."
       }
+    },
+    "gateways": {
+      "intro": "Connect a chat bot so you can talk to your agent from Telegram or Zalo. Changes apply live — no restart needed.",
+      "cardDesc": "Receive and reply to messages through {name}.",
+      "enable": "Enable {name}",
+      "tokenLabel": "Bot Token",
+      "tokenPlaceholder": "Paste your bot token",
+      "tokenSavedPlaceholder": "•••••••• saved — paste a new token to replace",
+      "tokenHint": "Create a bot and get a token at",
+      "allowLabel": "Allowed User IDs",
+      "allowHint": "Comma-separated numeric user ids allowed to chat. Empty = nobody (safe default). Use * to allow everyone.",
+      "agentLabel": "Answering Agent",
+      "testConnection": "Test Connection",
+      "testing": "Testing…",
+      "needTokenToTest": "Enter a token first",
+      "testOk": "Token valid — bot: {name}",
+      "testFail": "Token test failed",
+      "runtimeError": "Connection error",
+      "savedMsg": "Saved. Applying…",
+      "connectedAs": "Connected as {name}",
+      "connected": "Connected",
+      "connecting": "Connecting…",
+      "statusError": "Error",
+      "disabled": "Off"
     },
     "voice": {
       "providerSplit": "● PROVIDER SPLIT",

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -307,7 +307,7 @@
       "tokenSavedPlaceholder": "•••••••• đã lưu — dán token mới để thay",
       "tokenHint": "Tạo bot và lấy token tại",
       "allowLabel": "ID người dùng được phép",
-      "allowHint": "Danh sách id (số) cách nhau bởi dấu phẩy được phép chat. Để trống = không ai (mặc định an toàn). Dùng * để cho phép tất cả.",
+      "allowHint": "Danh sách id được phép chat, cách nhau bởi dấu phẩy. Để trống = không ai (mặc định an toàn). Cách lấy id: gõ /whoami trong chat với bot (Telegram: hoặc hỏi @userinfobot). Tránh dùng * (cho phép tất cả).",
       "allowAllWarning": "Đang cho phép TẤT CẢ. Bất kỳ ai nhắn bot đều điều khiển được agent — gồm cả shell, Gmail, IoT. Chỉ dùng để test; đặt id người dùng cụ thể khi dùng thật.",
       "agentLabel": "Agent trả lời",
       "testConnection": "Kiểm tra kết nối",

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -308,6 +308,7 @@
       "tokenHint": "Tạo bot và lấy token tại",
       "allowLabel": "ID người dùng được phép",
       "allowHint": "Danh sách id (số) cách nhau bởi dấu phẩy được phép chat. Để trống = không ai (mặc định an toàn). Dùng * để cho phép tất cả.",
+      "allowAllWarning": "Đang cho phép TẤT CẢ. Bất kỳ ai nhắn bot đều điều khiển được agent — gồm cả shell, Gmail, IoT. Chỉ dùng để test; đặt id người dùng cụ thể khi dùng thật.",
       "agentLabel": "Agent trả lời",
       "testConnection": "Kiểm tra kết nối",
       "testing": "Đang kiểm tra…",

--- a/frontend/src/locales/vi.json
+++ b/frontend/src/locales/vi.json
@@ -85,6 +85,7 @@
         "llm": "Nhà cung cấp LLM",
         "voice": "Giọng nói",
         "services": "Dịch vụ",
+        "gateways": "Cổng nhắn tin",
         "yaml": "Cấu hình YAML",
         "runningTmpl": "Mẫu đang chạy",
         "compaction": "Nén ngữ cảnh",
@@ -296,6 +297,30 @@
         "title": "Thêm dịch vụ",
         "desc": "(Firebase, Home Assistant…) sẽ xuất hiện ở đây theo thời gian. Hiện tại chúng vẫn nằm trong tab Services của setup wizard."
       }
+    },
+    "gateways": {
+      "intro": "Kết nối bot chat để bạn nhắn cho agent qua Telegram hoặc Zalo. Thay đổi áp dụng tức thì — không cần khởi động lại.",
+      "cardDesc": "Nhận và trả lời tin nhắn qua {name}.",
+      "enable": "Bật {name}",
+      "tokenLabel": "Bot Token",
+      "tokenPlaceholder": "Dán bot token của bạn",
+      "tokenSavedPlaceholder": "•••••••• đã lưu — dán token mới để thay",
+      "tokenHint": "Tạo bot và lấy token tại",
+      "allowLabel": "ID người dùng được phép",
+      "allowHint": "Danh sách id (số) cách nhau bởi dấu phẩy được phép chat. Để trống = không ai (mặc định an toàn). Dùng * để cho phép tất cả.",
+      "agentLabel": "Agent trả lời",
+      "testConnection": "Kiểm tra kết nối",
+      "testing": "Đang kiểm tra…",
+      "needTokenToTest": "Nhập token trước đã",
+      "testOk": "Token hợp lệ — bot: {name}",
+      "testFail": "Kiểm tra token thất bại",
+      "runtimeError": "Lỗi kết nối",
+      "savedMsg": "Đã lưu. Đang áp dụng…",
+      "connectedAs": "Đã kết nối: {name}",
+      "connected": "Đã kết nối",
+      "connecting": "Đang kết nối…",
+      "statusError": "Lỗi",
+      "disabled": "Tắt"
     },
     "voice": {
       "ready": "Sẵn sàng",

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -17,6 +17,7 @@ import SettingsAuth from './settings/SettingsAuth.vue'
 import SettingsYaml from './settings/SettingsYaml.vue'
 import SettingsRunningTemplates from './settings/SettingsRunningTemplates.vue'
 import SettingsServices from './settings/SettingsServices.vue'
+import SettingsGateways from './settings/SettingsGateways.vue'
 import SettingsLLM from './settings/SettingsLLM.vue'
 import SettingsVoice from './settings/SettingsVoice.vue'
 import SettingsCompaction from './settings/SettingsCompaction.vue'
@@ -33,6 +34,7 @@ const TABS = [
   { id: 'llm',          labelKey: 'settings.shell.tab.llm',          eyebrow: 'MODELS' },
   { id: 'voice',        labelKey: 'settings.shell.tab.voice',        eyebrow: 'MODELS' },
   { id: 'services',     labelKey: 'settings.shell.tab.services',     eyebrow: 'INTEGRATIONS' },
+  { id: 'gateways',     labelKey: 'settings.shell.tab.gateways',     eyebrow: 'INTEGRATIONS' },
   { id: 'yaml',         labelKey: 'settings.shell.tab.yaml',         eyebrow: 'INTEGRATIONS' },
   { id: 'running-tmpl', labelKey: 'settings.shell.tab.runningTmpl',  eyebrow: 'INTEGRATIONS' },
   { id: 'compaction',   labelKey: 'settings.shell.tab.compaction',   eyebrow: 'ADVANCED' },
@@ -106,6 +108,7 @@ function labelFor(id) {
         <SettingsYaml v-else-if="active === 'yaml'" />
         <SettingsRunningTemplates v-else-if="active === 'running-tmpl'" />
         <SettingsServices v-else-if="active === 'services'" />
+        <SettingsGateways v-else-if="active === 'gateways'" />
         <SettingsCompaction v-else-if="active === 'compaction'" />
         <SettingsMemory v-else-if="active === 'memory'" />
         <SettingsExperimental v-else-if="active === 'experimental'" />

--- a/frontend/src/views/TeamMonitor.vue
+++ b/frontend/src/views/TeamMonitor.vue
@@ -737,7 +737,10 @@ onMounted(() => {
 }
 
 .bulk-delete-btn:disabled {
-  opacity: 0.4;
+  /* Muted via a theme token, not a heavy opacity. opacity:0.4 over the already
+     dimmed --text-dim washed the label out to near-invisible in light theme. */
+  color: var(--text-muted);
+  background: var(--bg-button);
   cursor: not-allowed;
 }
 
@@ -882,7 +885,7 @@ onMounted(() => {
   background: var(--bg-1);
   border: 1px solid var(--border);
   border-radius: 10px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg);  /* theme-aware; was a hardcoded heavy black shadow */
   z-index: 100;
   overflow: hidden;
 }
@@ -983,7 +986,8 @@ onMounted(() => {
 }
 
 .dropdown-item:hover {
-  background: rgba(30, 34, 51, 0.6);
+  /* token surface, not a hardcoded dark navy (showed as a dark blob in light theme) */
+  background: var(--bg-3);
 }
 
 .dropdown-item.checked {

--- a/frontend/src/views/settings/SettingsGateways.vue
+++ b/frontend/src/views/settings/SettingsGateways.vue
@@ -115,6 +115,12 @@ function parseAllowFrom(text) {
     .filter((s) => s.length > 0)
 }
 
+// "*" = allow everyone — dangerous (the bot exposes the agent's shell/Gmail/IoT
+// tools to anyone who messages it). Drives the inline warning.
+function allowsEveryone(r) {
+  return parseAllowFrom(r.allowFrom).includes('*')
+}
+
 async function testConnection(id) {
   const r = rows[id]
   const token = r.tokenInput.trim()
@@ -266,9 +272,15 @@ onMounted(reload)
           <label class="field-label">{{ t('settings.gateways.allowLabel') }}</label>
           <input
             class="text-input mono"
+            :class="{ danger: allowsEveryone(r) }"
             placeholder="123456789, 987654321"
             v-model="r.allowFrom"
           />
+          <!-- Loud warning when the list is "*": anyone on the platform can then
+               drive the agent (which has shell/Gmail/IoT tools). -->
+          <p v-if="allowsEveryone(r)" class="allow-danger">
+            ⚠️ {{ t('settings.gateways.allowAllWarning') }}
+          </p>
           <p class="hint">{{ t('settings.gateways.allowHint') }}</p>
         </div>
 
@@ -401,6 +413,19 @@ select.text-input { cursor: pointer; }
 
 .hint { margin: 0; font-size: 11.5px; color: var(--text-muted); line-height: 1.5; }
 .hint a { color: var(--accent); }
+
+.text-input.danger { border-color: var(--danger); }
+.text-input.danger:focus { box-shadow: 0 0 0 3px var(--danger-bg); }
+.allow-danger {
+  margin: 0;
+  padding: 7px 10px;
+  background: var(--danger-bg);
+  border: 1px solid var(--danger);
+  border-radius: var(--r-sm);
+  color: var(--danger);
+  font-size: 11.5px;
+  line-height: 1.45;
+}
 
 /* ── Toggle switch ────────────────────────────────────────────────── */
 .switch-row { display: flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }

--- a/frontend/src/views/settings/SettingsGateways.vue
+++ b/frontend/src/views/settings/SettingsGateways.vue
@@ -1,0 +1,472 @@
+<script setup>
+/**
+ * Settings → Messaging Gateways.
+ *
+ * One card per registered platform (Telegram, Zalo, …). The platform LIST is
+ * driven by `GET /api/gateways` — add a gateway in the backend and its card
+ * appears here automatically, no frontend change needed.
+ *
+ * Config (enabled / token / allow-list / agent) is written through the generic
+ * `/api/settings/bulk` endpoint under category `gateways`; the backend
+ * GatewayManager subscribes to those changes and live-reloads (no restart), so
+ * after Save we re-poll status to reflect "Connected as @bot".
+ */
+import { ref, reactive, onMounted } from 'vue'
+import { apiFetch } from '../../api'
+import { useLang } from '../../composables/useLang'
+
+const { t } = useLang()
+
+// Display metadata per platform. Proper nouns + doc links — not translated.
+// Unknown platforms fall back to a generic label so the card still renders.
+const META = {
+  telegram: { label: 'Telegram', tokenHelp: 'https://t.me/BotFather', tokenHint: '@BotFather → /newbot' },
+  zalo: { label: 'Zalo', tokenHelp: 'https://bot.zaloplatforms.com', tokenHint: 'bot.zaloplatforms.com' },
+}
+function metaFor(id) {
+  return META[id] || { label: id, tokenHelp: '', tokenHint: '' }
+}
+
+const loading = ref(true)
+const loadError = ref('')
+const agents = ref([])
+// Per-platform reactive draft + runtime state, keyed by platform id.
+const rows = reactive({})
+
+function blankRow() {
+  return {
+    enabled: false,
+    hasToken: false,
+    tokenInput: '',
+    allowFrom: '', // comma-separated user ids (or *)
+    agent: 'Jarvis',
+    // runtime status
+    running: false,
+    connected: false,
+    botUsername: null,
+    lastError: null,
+    // ui flags
+    saving: false,
+    saved: false,
+    error: '',
+    testing: false,
+    testResult: null, // { ok, name|error }
+  }
+}
+
+async function loadAgents() {
+  try {
+    const list = await apiFetch('/api/agents')
+    agents.value = Array.isArray(list) ? list : (list?.items || [])
+  } catch {
+    agents.value = []
+  }
+}
+
+async function loadConfig() {
+  // Editable values (enabled / allow_from / agent / token-present) live in
+  // the settings category; secret token comes back masked (has_value only).
+  const resp = await apiFetch('/api/settings/gateways').catch(() => ({ items: [] }))
+  const items = resp?.items || []
+  const byKey = Object.fromEntries(items.map((i) => [i.key, i]))
+  for (const id of Object.keys(rows)) {
+    const r = rows[id]
+    r.enabled = byKey[`${id}_enabled`]?.value === 'true'
+    r.hasToken = !!byKey[`${id}_token`]?.has_value
+    r.agent = byKey[`${id}_agent`]?.value || 'Jarvis'
+    let allow = []
+    try { allow = JSON.parse(byKey[`${id}_allow_from`]?.value || '[]') } catch { allow = [] }
+    r.allowFrom = Array.isArray(allow) ? allow.join(', ') : ''
+  }
+}
+
+async function loadStatus() {
+  const resp = await apiFetch('/api/gateways').catch(() => ({ gateways: [] }))
+  for (const s of resp?.gateways || []) {
+    if (!rows[s.platform]) rows[s.platform] = blankRow()
+    const r = rows[s.platform]
+    r.running = s.running
+    r.connected = s.connected
+    r.botUsername = s.bot_username
+    r.lastError = s.last_error
+  }
+}
+
+async function reload() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    // Status first: it enumerates every registered platform → seeds the cards.
+    await loadStatus()
+    // Guarantee at least the known platforms render even if status is empty.
+    for (const id of Object.keys(META)) if (!rows[id]) rows[id] = blankRow()
+    await Promise.all([loadConfig(), loadAgents()])
+  } catch (err) {
+    loadError.value = err?.body?.detail || err?.message || String(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+function parseAllowFrom(text) {
+  return text
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+async function testConnection(id) {
+  const r = rows[id]
+  const token = r.tokenInput.trim()
+  // Need either a freshly-typed token or one already saved to test against.
+  if (!token && !r.hasToken) {
+    r.testResult = { ok: false, error: t('settings.gateways.needTokenToTest') }
+    return
+  }
+  r.testing = true
+  r.testResult = null
+  try {
+    // Omit the token to test the already-saved one (backend reads it from DB).
+    const res = await apiFetch(`/api/gateways/${id}/test`, {
+      method: 'POST',
+      body: JSON.stringify(token ? { token } : {}),
+    })
+    r.testResult = res
+  } catch (err) {
+    r.testResult = { ok: false, error: err?.body?.detail || err?.message || String(err) }
+  } finally {
+    r.testing = false
+  }
+}
+
+// After a save the backend live-reloads (a token change briefly reconnects).
+// Re-poll status a few times so the chip transitions to "Connected" on its own
+// instead of showing a stale mid-reload state.
+function pollStatusAfterSave() {
+  let n = 0
+  const tick = () => {
+    loadStatus()
+    loadConfig()
+    if (++n < 6) setTimeout(tick, 2000)
+  }
+  setTimeout(tick, 800)
+}
+
+async function save(id) {
+  const r = rows[id]
+  r.saving = true
+  r.saved = false
+  r.error = ''
+  r.testResult = null  // a fresh save supersedes any stale test result
+  // Only send the token when the user typed a new one — leaving it blank keeps
+  // the previously-saved secret intact.
+  const items = [
+    { category: 'gateways', key: `${id}_enabled`, value: r.enabled ? 'true' : 'false', is_secret: false },
+    { category: 'gateways', key: `${id}_allow_from`, value: JSON.stringify(parseAllowFrom(r.allowFrom)), is_secret: false },
+    { category: 'gateways', key: `${id}_agent`, value: r.agent || 'Jarvis', is_secret: false },
+  ]
+  const token = r.tokenInput.trim()
+  if (token) items.push({ category: 'gateways', key: `${id}_token`, value: token, is_secret: true })
+
+  try {
+    await apiFetch('/api/settings/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ items }),
+    })
+    r.saved = true
+    r.tokenInput = ''
+    pollStatusAfterSave()
+  } catch (err) {
+    r.error = err?.body?.detail || err?.message || String(err)
+  } finally {
+    r.saving = false
+  }
+}
+
+// Status chip text/role: connected (green), enabled-but-not-connected (amber),
+// off (muted). Mirrors the running/error semantics from manager.status().
+function statusRole(r) {
+  if (r.enabled && r.connected) return 'on'
+  if (r.enabled && r.lastError) return 'err'
+  if (r.enabled) return 'warn'
+  return 'off'
+}
+function statusText(r) {
+  if (r.enabled && r.connected) {
+    return r.botUsername
+      ? t('settings.gateways.connectedAs', { name: r.botUsername })
+      : t('settings.gateways.connected')
+  }
+  if (r.enabled && r.lastError) return t('settings.gateways.statusError')
+  if (r.enabled) return t('settings.gateways.connecting')
+  return t('settings.gateways.disabled')
+}
+
+onMounted(reload)
+</script>
+
+<template>
+  <div class="gw-sections">
+    <p class="intro muted">{{ t('settings.gateways.intro') }}</p>
+
+    <div v-if="loading" class="muted">{{ t('common.loading') }}</div>
+    <div v-else-if="loadError" class="error-msg">{{ loadError }}</div>
+
+    <section
+      v-for="(r, id) in rows"
+      v-else
+      :key="id"
+      class="service-card"
+    >
+      <div class="hud-corner" />
+      <header class="card-header">
+        <div class="icon-circle">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+          </svg>
+        </div>
+        <div class="card-title-block">
+          <h2>{{ metaFor(id).label }}</h2>
+          <p>{{ t('settings.gateways.cardDesc', { name: metaFor(id).label }) }}</p>
+        </div>
+        <span class="status-chip" :class="statusRole(r)">
+          <span class="dot" />
+          {{ statusText(r) }}
+        </span>
+      </header>
+
+      <div class="card-body">
+        <!-- Enable -->
+        <label class="switch-row">
+          <input type="checkbox" v-model="r.enabled" />
+          <span class="switch-track"><span class="switch-thumb" /></span>
+          <span class="switch-label">{{ t('settings.gateways.enable', { name: metaFor(id).label }) }}</span>
+        </label>
+
+        <!-- Token -->
+        <div class="field">
+          <label class="field-label">{{ t('settings.gateways.tokenLabel') }}</label>
+          <input
+            class="text-input mono"
+            type="password"
+            autocomplete="new-password"
+            :placeholder="r.hasToken ? t('settings.gateways.tokenSavedPlaceholder') : t('settings.gateways.tokenPlaceholder')"
+            v-model="r.tokenInput"
+          />
+          <p class="hint">
+            {{ t('settings.gateways.tokenHint') }}
+            <a v-if="metaFor(id).tokenHelp" :href="metaFor(id).tokenHelp" target="_blank" rel="noopener">{{ metaFor(id).tokenHint }}</a>
+            <span v-else>{{ metaFor(id).tokenHint }}</span>
+          </p>
+        </div>
+
+        <!-- Allow-list -->
+        <div class="field">
+          <label class="field-label">{{ t('settings.gateways.allowLabel') }}</label>
+          <input
+            class="text-input mono"
+            placeholder="123456789, 987654321"
+            v-model="r.allowFrom"
+          />
+          <p class="hint">{{ t('settings.gateways.allowHint') }}</p>
+        </div>
+
+        <!-- Agent -->
+        <div class="field">
+          <label class="field-label">{{ t('settings.gateways.agentLabel') }}</label>
+          <select class="text-input" v-model="r.agent">
+            <option v-for="a in agents" :key="a.name" :value="a.name">{{ a.name }}</option>
+            <option v-if="!agents.length" value="Jarvis">Jarvis</option>
+          </select>
+        </div>
+
+        <!-- Test result -->
+        <div v-if="r.testResult" :class="r.testResult.ok ? 'success-msg' : 'error-msg'">
+          <template v-if="r.testResult.ok">
+            {{ t('settings.gateways.testOk', { name: r.testResult.name }) }}
+          </template>
+          <template v-else>
+            {{ t('settings.gateways.testFail') }}: {{ r.testResult.error }}
+          </template>
+        </div>
+
+        <!-- Last runtime error (when enabled & failing) -->
+        <div v-if="r.enabled && r.lastError && !r.connected" class="error-msg">
+          {{ t('settings.gateways.runtimeError') }}: {{ r.lastError }}
+        </div>
+
+        <div class="action-row">
+          <button
+            type="button"
+            class="btn"
+            :disabled="r.testing"
+            @click="testConnection(id)"
+          >{{ r.testing ? t('settings.gateways.testing') : t('settings.gateways.testConnection') }}</button>
+          <button
+            type="button"
+            class="btn primary"
+            :disabled="r.saving"
+            @click="save(id)"
+          >{{ r.saving ? t('settings.common.saving') : t('common.save') }}</button>
+        </div>
+        <div v-if="r.error" class="error-msg">{{ r.error }}</div>
+        <div v-if="r.saved" class="success-msg">{{ t('settings.gateways.savedMsg') }}</div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.gw-sections { display: flex; flex-direction: column; gap: 14px; }
+.intro { margin: 0 0 2px; }
+
+.service-card {
+  position: relative;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 18px 22px;
+}
+.hud-corner {
+  position: absolute; right: 0; bottom: 0;
+  width: 16px; height: 16px;
+  border-right: 1.5px solid var(--accent);
+  border-bottom: 1.5px solid var(--accent);
+  opacity: 0.4;
+  border-bottom-right-radius: var(--r-md);
+  pointer-events: none;
+}
+.card-header { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 14px; }
+.card-title-block { flex: 1; min-width: 0; }
+.card-title-block h2 { font-size: 15px; font-weight: 600; color: var(--text); margin: 0 0 2px; }
+.card-title-block p { margin: 0; font-size: 12.5px; color: var(--text-dim); line-height: 1.5; }
+.icon-circle {
+  flex-shrink: 0;
+  width: 36px; height: 36px;
+  border-radius: var(--r-sm);
+  background: var(--bg-3);
+  border: 1px solid var(--border-strong);
+  color: var(--accent);
+  display: grid; place-items: center;
+}
+
+.status-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-left: 8px;
+  white-space: nowrap;
+  align-self: flex-start;
+}
+.status-chip .dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+.status-chip.on { color: var(--success); }
+.status-chip.warn { color: var(--warning); }
+.status-chip.err { color: var(--danger); }
+.status-chip.off { color: var(--text-muted); }
+
+.card-body {
+  display: flex; flex-direction: column; gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.field { display: flex; flex-direction: column; gap: 4px; }
+.field-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.text-input {
+  width: 100%;
+  background: var(--bg-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  padding: 9px 12px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+}
+.text-input.mono { font-family: var(--font-mono); font-size: 12px; }
+.text-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-bg-strong);
+}
+select.text-input { cursor: pointer; }
+
+.hint { margin: 0; font-size: 11.5px; color: var(--text-muted); line-height: 1.5; }
+.hint a { color: var(--accent); }
+
+/* ── Toggle switch ────────────────────────────────────────────────── */
+.switch-row { display: flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+.switch-row input { position: absolute; opacity: 0; width: 0; height: 0; }
+.switch-track {
+  width: 38px; height: 22px; flex-shrink: 0;
+  background: var(--bg-4);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  position: relative;
+  transition: background 0.15s, border-color 0.15s;
+}
+.switch-thumb {
+  position: absolute; top: 2px; left: 2px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 0.15s, background 0.15s;
+}
+.switch-row input:checked + .switch-track { background: var(--primary); border-color: var(--primary); }
+.switch-row input:checked + .switch-track .switch-thumb { transform: translateX(16px); background: #fff; }
+.switch-row input:focus-visible + .switch-track { box-shadow: 0 0 0 3px var(--primary-bg-strong); }
+.switch-label { font-size: 13px; color: var(--text); font-weight: 500; }
+
+.action-row { display: flex; gap: 8px; justify-content: flex-end; flex-wrap: wrap; margin-top: 4px; }
+.btn {
+  padding: 8px 14px;
+  font-family: inherit; font-size: 13px; font-weight: 500;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-strong);
+  background: transparent; color: var(--text-dim);
+  cursor: pointer; transition: all 0.15s;
+}
+.btn:hover:not([disabled]) { color: var(--text); background: rgba(255, 255, 255, 0.04); }
+.btn.primary { background: var(--primary); color: #fff; border-color: var(--primary); }
+.btn.primary:hover:not([disabled]) { background: var(--primary-active); border-color: var(--primary-active); }
+.btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+.muted { color: var(--text-dim); font-size: 13px; line-height: 1.5; }
+.error-msg {
+  padding: 8px 12px;
+  background: var(--danger-bg);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--r-md);
+  color: var(--danger);
+  font-size: 13px;
+}
+.success-msg {
+  padding: 8px 12px;
+  background: var(--success-bg);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: var(--r-md);
+  color: var(--success);
+  font-size: 13px;
+}
+
+@media (max-width: 768px) {
+  .service-card { padding: 16px; }
+  /* Header: icon + title on row 1, status chip drops to its own left-aligned
+     row instead of being squeezed against the title. */
+  .card-header { flex-wrap: wrap; gap: 10px; }
+  .card-title-block { flex: 1 1 60%; min-width: 0; }
+  .status-chip { margin-left: 0; width: 100%; }
+  /* Full-width tap targets for the action buttons. */
+  .action-row { gap: 8px; }
+  .action-row > .btn { flex: 1; min-width: 0; }
+  /* Token field is monospace + long — keep it readable, never overflow. */
+  .text-input.mono { font-size: 11.5px; }
+}
+</style>

--- a/frontend/tests/e2e/fixtures/settings_gateways.yaml
+++ b/frontend/tests/e2e/fixtures/settings_gateways.yaml
@@ -1,0 +1,75 @@
+# Settings → Messaging Gateways panel.
+#
+# On mount the panel calls:
+#   GET /api/gateways            → enumerates registered platforms + live status
+#   GET /api/settings/gateways   → editable config values (token masked)
+#   GET /api/agents              → "Answering Agent" dropdown
+# Actions:
+#   POST /api/gateways/telegram/test  → validate token via getMe
+#   POST /api/settings/bulk           → save config (token is_secret)
+
+backend_source:
+  - "backend/routes/gateways.py::gateway_status, test_connection"
+  - "backend/routes/settings.py::list_category, bulk_update"
+  - "backend/routes/agents.py::list_agents"
+  - "frontend/src/views/settings/SettingsGateways.vue::reload, testConnection, save"
+
+notes: |
+  Both platforms start disabled with no token. The spec tests the happy path:
+  test a token (getMe ok) then enable + save Telegram, asserting the bulk POST
+  carries telegram_enabled=true and the secret token item.
+
+responses:
+  # SettingsGeneral mounts first (default tab) and calls store.fetchAll().
+  "GET /api/settings":
+    status: 200
+    json:
+      categories: {}
+
+  "GET /api/gateways":
+    status: 200
+    json:
+      gateways:
+        - platform: "telegram"
+          enabled: false
+          running: false
+          connected: false
+          bot_username: null
+          last_error: null
+          agent: "Jarvis"
+          allow_count: 0
+          has_token: false
+        - platform: "zalo"
+          enabled: false
+          running: false
+          connected: false
+          bot_username: null
+          last_error: null
+          agent: "Jarvis"
+          allow_count: 0
+          has_token: false
+
+  "GET /api/settings/gateways":
+    status: 200
+    json:
+      category: "gateways"
+      items: []
+
+  "GET /api/agents":
+    status: 200
+    json:
+      - { name: "Jarvis", status: "idle", is_default: true, type: "builtin" }
+      - { name: "Personal", status: "idle", is_default: false, type: "builtin" }
+
+  "POST /api/gateways/telegram/test":
+    status: 200
+    json:
+      ok: true
+      name: "jarvis_bot"
+
+  "POST /api/settings/bulk":
+    status: 200
+    json:
+      events:
+        - { action: "updated", category: "gateways", key: "telegram_enabled", is_secret: false }
+        - { action: "updated", category: "gateways", key: "telegram_token", is_secret: true }

--- a/frontend/tests/e2e/flows/settings-gateways.spec.ts
+++ b/frontend/tests/e2e/flows/settings-gateways.spec.ts
@@ -56,7 +56,13 @@ test('test a token then enable + save Telegram, asserting the bulk POST contract
   // custom switch — click the track the user actually sees.
   await card.locator('.switch-track').click()
   await expect(card.locator('input[type="checkbox"]')).toBeChecked()
-  await card.getByPlaceholder('123456789, 987654321').fill('111, 222')
+
+  // Security: "*" (allow everyone) must surface a loud warning; specific ids must not.
+  const allow = card.getByPlaceholder('123456789, 987654321')
+  await allow.fill('*')
+  await expect(card.locator('.allow-danger')).toBeVisible()
+  await allow.fill('111, 222')
+  await expect(card.locator('.allow-danger')).toHaveCount(0)
 
   const [bulkResp] = await Promise.all([
     page.waitForResponse(

--- a/frontend/tests/e2e/flows/settings-gateways.spec.ts
+++ b/frontend/tests/e2e/flows/settings-gateways.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * E2E flow: Settings → Messaging Gateways.
+ *
+ * Happy path through production code (only the backend is mocked):
+ *   1. Open the panel → Telegram + Zalo cards render from GET /api/gateways.
+ *   2. Paste a token + Test Connection → POST /api/gateways/telegram/test,
+ *      the valid-token success message appears (no silent pass/fail).
+ *   3. Enable + set allow-list + Save → POST /api/settings/bulk carries
+ *      telegram_enabled=true and the secret token item; the UI confirms.
+ *
+ * A second test asserts the panel renders usably at a phone viewport
+ * (responsive — cards stack, controls reachable).
+ */
+import { expect, test } from '@playwright/test'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { mockBackend, NetworkRecorder, seedApiKey } from '../harness'
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
+const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
+
+function telegramCard(page: import('@playwright/test').Page) {
+  return page.locator('section.service-card').filter({
+    has: page.getByRole('heading', { name: 'Telegram', exact: true }),
+  })
+}
+
+test('test a token then enable + save Telegram, asserting the bulk POST contract', async ({ page }) => {
+  await seedApiKey(page)
+  const backend = await mockBackend(page, [NOISE, join(FIXTURES, 'settings_gateways.yaml')])
+  const recorder = new NetworkRecorder()
+  await recorder.attach(page)
+
+  await page.goto('/settings')
+  await page.getByRole('button', { name: 'Messaging Gateways', exact: true }).click()
+
+  const card = telegramCard(page)
+  await expect(card).toBeVisible()
+  // Both registered platforms render (driven by the status endpoint).
+  await expect(page.getByRole('heading', { name: 'Zalo', exact: true })).toBeVisible()
+
+  // 1) Test connection — valid token path.
+  await card.getByPlaceholder('Paste your bot token').fill('123456:ABCDEF_test-token')
+  const [testResp] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/gateways/telegram/test',
+    ),
+    card.getByRole('button', { name: 'Test Connection', exact: true }).click(),
+  ])
+  expect(testResp.status()).toBe(200)
+  await expect(card.getByText(/jarvis_bot/)).toBeVisible()
+
+  // 2) Enable + allow-list + Save. The checkbox is visually hidden behind a
+  // custom switch — click the track the user actually sees.
+  await card.locator('.switch-track').click()
+  await expect(card.locator('input[type="checkbox"]')).toBeChecked()
+  await card.getByPlaceholder('123456789, 987654321').fill('111, 222')
+
+  const [bulkResp] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/settings/bulk',
+    ),
+    card.getByRole('button', { name: 'Save changes', exact: true }).click(),
+  ])
+  expect(bulkResp.status()).toBe(200)
+
+  // Assert the bulk body carries the right items (no silent drop of fields).
+  const call = recorder.assertContains('POST', '/api/settings/bulk')
+  const items = (call.body as { items?: any[] })?.items || []
+  expect(items).toContainEqual(expect.objectContaining({
+    category: 'gateways', key: 'telegram_enabled', value: 'true',
+  }))
+  expect(items).toContainEqual(expect.objectContaining({
+    category: 'gateways', key: 'telegram_token', value: '123456:ABCDEF_test-token', is_secret: true,
+  }))
+  expect(items).toContainEqual(expect.objectContaining({
+    category: 'gateways', key: 'telegram_allow_from', value: '["111","222"]',
+  }))
+
+  // Visible confirmation — not a silent save.
+  await expect(card.getByText(/Saved\. Applying/)).toBeVisible()
+})
+
+test('responsive: the panel renders and is usable at a phone viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 371, height: 659 })
+  await seedApiKey(page)
+  await mockBackend(page, [NOISE, join(FIXTURES, 'settings_gateways.yaml')])
+
+  await page.goto('/settings')
+  await page.getByRole('button', { name: 'Messaging Gateways', exact: true }).click()
+
+  const card = telegramCard(page)
+  await expect(card).toBeVisible()
+  // Controls remain reachable (not clipped/overflowed off-screen).
+  await expect(card.getByPlaceholder('Paste your bot token')).toBeVisible()
+  await expect(card.getByRole('button', { name: 'Test Connection', exact: true })).toBeVisible()
+  // Card must not overflow the viewport width.
+  const box = await card.boundingBox()
+  expect(box).not.toBeNull()
+  expect((box?.width || 0)).toBeLessThanOrEqual(371)
+})


### PR DESCRIPTION
## Messaging Gateways — Telegram & Zalo

Lets users chat with a Jarvis agent from **Telegram** and **Zalo**. Long-polling Bot APIs (no public domain/webhook needed); inbound text + images; in-chat slash commands.

### What's included
- **Gateway abstraction** — `BaseGateway` (allow-list → typing → dispatch → reply → error) + `BotApiGateway` (shared Telegram-style HTTP transport) + thin `Telegram`/`Zalo` subclasses. Add a platform = ~20 lines + 1 registry line.
- **UI** — Settings → *Messaging Gateways*: enable toggle, bot token, allow-list, answering-agent picker, Test Connection, live status. Config stored in `config_service` (DB, encrypted token); `GatewayManager` subscribes and **live-reloads** (no restart). `GET /api/gateways` (status) + `POST /api/gateways/{platform}/test`.
- **Per-chat session binding** — `gateway_chats` table (SSoT, self-healing): each chat continues the same conversation across restarts.
- **Inbound images** — Telegram `getFile`, Zalo `photo_url` (CDN URL; `image/jpg`→`image/jpeg`), passed as multimodal input. *Requires a vision-capable answering model* — declare unknown/proxy models via a gitignored `.fast-agent/model-overlays/` overlay (see `backend/services/gateways/README.md`).
- **Slash commands** (typed in the chat) — `/new` (`/reset`,`/clear`), `/agent <name>` (per-chat agent), `/help`. `/stop` intentionally omitted (sequential poll loop can't interrupt mid-run).
- **Robustness** — benign 409 handling (Telegram self-overlap), bot-token redaction in errors, diff-reload + orphan-poller guard.
- Plus a small **TeamMonitor** design-system fix (disabled button + dropdown contrast in light theme).

### Testing
- Backend: **40 passed** (unit + integration against real SQLite + e2e poll-loop over mocked httpx), ruff clean.
- Frontend: build ✓, Playwright panel e2e **2 passed** (happy path + responsive).
- Live-verified: Telegram + Zalo read images (combo → gpt-5.5); slash commands work.

### Notes for review
- Branched after the i18n work (#97) + a merge of `main`, so the file diff includes those until #97 lands. **The gateway-specific commits are `cba242c` (feature) and `c62c54f` (UI fix)** — review those.
- ⚠️ **Security:** an empty `allow_from` denies everyone (safe default); `["*"]` allows anyone to drive the agent (which has shell/Gmail/IoT tools) — set it to specific user ids in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
