### PR TITLE
feat(memory): runtime model prefetch + startup verify (drop Docker bake)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,9 +2,10 @@
 # System deps (apt + npm + uv + gitnexus) live in the public base image so CI
 # doesn't re-run apt-get / npm install on every build. Rebuild + bump the tag
 # only when Dockerfile.base changes — see Dockerfile.base header for steps.
-# 1.4.0 pre-bakes the Qwen3 embedder + reranker (see Dockerfile.base 1.4.0), so
-# the memory models load from the image — no runtime download on first chat/deploy.
-ARG BASE_IMAGE=omnigentx/jarvis-backend-base:1.4.0
+# 1.5.0 stops baking memory models — they download at runtime into the
+# persistent jarvis-models volume and are warmed at startup from settings
+# (see Dockerfile.base 1.5.0 + services/memory/model_prefetch).
+ARG BASE_IMAGE=omnigentx/jarvis-backend-base:1.5.0
 FROM ${BASE_IMAGE} AS base
 
 # ─── Stage 2: Python dependencies (cached unless pyproject/lock/fast-agent change) ───

--- a/backend/Dockerfile.base
+++ b/backend/Dockerfile.base
@@ -30,6 +30,16 @@
 #   docker push omnigentx/jarvis-backend-base:${VERSION}
 #
 # Version log:
+#   1.5.0 — STOP baking memory models. Models (embedding + reranker) now download
+#           at runtime into a persistent HF-cache VOLUME (jarvis-models →
+#           /root/.cache/huggingface in docker-compose.yaml) and are verified +
+#           warmed at server startup from the live settings
+#           (services/memory/model_prefetch). WHY: the baked list was a second
+#           source of truth that silently drifted from the config default (a new
+#           default reranker shipped without being on the server); and it bloated
+#           the base by ~5GB. With a persistent volume the download happens once
+#           (first deploy) and survives recreation, so this base is system-only
+#           again — smaller, and model changes need no base rebuild.
 #   1.4.0 — ADD the new default memory models alongside bge-m3:
 #           Qwen3-Embedding-0.6B + Qwen3-Reranker-0.6B (~2.4GB more).
 #           WHY: the reranker is a 0.6B causal LM that loaded lazily on the FIRST
@@ -106,22 +116,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uvx /bin/uvx
 RUN uvx --from "scrapling[ai]" scrapling install \
     && rm -rf /root/.cache/uv
 
-# Pre-download the memory models (bge-m3 + the new defaults Qwen3-Embedding-0.6B +
-# Qwen3-Reranker-0.6B) into the HF cache so the dense lane, knowledge graph, AND the
-# precision reranker load INSTANTLY at runtime — no first-request download, and it
-# survives container recreation (baked into this layer, exactly like the Playwright
-# browsers above). Critical for the reranker: it's a 0.6B causal LM whose lazy
-# first-load otherwise stalls the FIRST chat ~65s on CPU (and re-downloads every
-# deploy, since the cache is in the container layer, not a volume). These are
-# large, STABLE runtime assets, so the base is the right home: built once, every
-# app image inherits it, app builds stay fast. transformers + sentence-transformers
-# (the loaders) stay app deps (`--extra memory`); a non-default `embedding_model` /
-# `rerank_model` still works — it just downloads on first use (only defaults are
-# pre-baked). HF_HOME is pinned so the build and the root runtime agree on the
-# cache path. Both models are public (no HF_TOKEN needed; pass one as a build
-# secret if rate-limited).
+# Memory models are NOT baked here anymore (see the 1.5.0 version-log entry).
+# They download at runtime into the persistent jarvis-models volume mounted at
+# this path, and the backend verifies + warms the CONFIGURED embedding/reranker
+# at startup (services/memory/model_prefetch), streaming progress to the UI.
+# Pin HF_HOME so the build, the root runtime, and the volume mount all agree on
+# the cache path.
 ENV HF_HOME=/root/.cache/huggingface
-RUN uvx --from huggingface_hub hf download BAAI/bge-m3 \
-    && uvx --from huggingface_hub hf download Qwen/Qwen3-Embedding-0.6B \
-    && uvx --from huggingface_hub hf download Qwen/Qwen3-Reranker-0.6B \
-    && rm -rf /root/.cache/uv

--- a/backend/routes/memory_settings.py
+++ b/backend/routes/memory_settings.py
@@ -16,40 +16,41 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from core.auth import verify_api_key
-from services.activity_stream import activity_stream_manager
 from services.memory.settings import get_memory_settings, update_memory_settings
 
 logger = logging.getLogger("memory_settings_api")
 router = APIRouter(prefix="/api/memory", tags=["memory"])
 
 
+def _running_loop():
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None
+
+
 def _kick_reranker_warm(model_name: str) -> None:
     """After a rerank-model switch, download + warm the new model in a daemon
     thread and stream progress to the activity SSE — so the UI shows a progress
     bar instead of the FIRST recall silently hanging on the download/load.
-
-    The warm runs off the event loop (it blocks); progress is marshalled back
-    onto the loop with ``call_soon_threadsafe`` because ``broadcast`` touches
-    asyncio.Queues that are not thread-safe to write from another thread.
+    Shares the SSE-progress builder + prefetch with the startup path
+    (services.memory.model_prefetch) so both stay in sync.
     """
+    from services.memory.model_prefetch import make_sse_progress
     from services.retrieval.reranker import prefetch_and_warm
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-
-    def on_progress(state: str, pct: int) -> None:
-        # ``memory_`` prefix so the frontend's activity-stream router forwards it
-        # to the memory store (agents.js gates forwarding on event_type.startsWith).
-        ev = {"event_type": "memory_reranker_loading", "state": state,
-              "progress": pct, "model": model_name}
-        if loop is not None:
-            loop.call_soon_threadsafe(activity_stream_manager.broadcast, ev)
-        else:
-            activity_stream_manager.broadcast(ev)
-
+    on_progress = make_sse_progress("memory_reranker_loading", model_name, _running_loop())
     threading.Thread(target=prefetch_and_warm, args=(model_name, on_progress),
                      name="reranker-prefetch", daemon=True).start()
+
+
+def _kick_embedding_warm(model_name: str, revision: str) -> None:
+    """Same as :func:`_kick_reranker_warm`, for a newly-selected embedding model
+    — so switching the embedder also downloads/warms with progress instead of
+    hanging the first index write/recall."""
+    from services.memory.model_prefetch import make_sse_progress, prefetch_embedding
+    on_progress = make_sse_progress("memory_embedding_loading", model_name, _running_loop())
+    threading.Thread(target=prefetch_embedding, args=(model_name, revision, on_progress),
+                     name="embedding-prefetch", daemon=True).start()
 
 
 class MemorySettingsPatch(BaseModel):
@@ -97,9 +98,12 @@ async def patch_settings(patch: MemorySettingsPatch) -> dict[str, Any]:
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     logger.info("[MEMORY] Settings updated: %s", sorted(updates))
-    # A rerank-model switch would otherwise download + load on the first recall
-    # (a multi-second silent hang). Pre-warm in the background and stream
-    # progress to the UI. Only when the reranker is actually enabled.
+    # A model switch would otherwise download + load on the first recall (a
+    # multi-second silent hang). Pre-warm in the background and stream progress
+    # to the UI — for the reranker (when enabled) AND the embedder.
     if "rerank_model" in updates and settings.reranker_enabled:
         _kick_reranker_warm(settings.rerank_model)
+    if "embedding_model" in updates and settings.embedding_model:
+        _kick_embedding_warm(settings.embedding_model,
+                             getattr(settings, "embedding_revision", "") or "")
     return asdict(settings)

--- a/backend/routes/memory_settings.py
+++ b/backend/routes/memory_settings.py
@@ -98,12 +98,21 @@ async def patch_settings(patch: MemorySettingsPatch) -> dict[str, Any]:
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     logger.info("[MEMORY] Settings updated: %s", sorted(updates))
-    # A model switch would otherwise download + load on the first recall (a
-    # multi-second silent hang). Pre-warm in the background and stream progress
-    # to the UI — for the reranker (when enabled) AND the embedder.
-    if "rerank_model" in updates and settings.reranker_enabled:
+    # A change to WHICH model loads would otherwise download + load on the first
+    # recall (a multi-second silent hang). Pre-warm in the background and stream
+    # progress to the UI. Kick on ANY change that alters the loaded model:
+    #   reranker — model changed OR the reranker was just enabled (now on). The
+    #     enable case sends only {reranker_enabled}, so guarding on "rerank_model"
+    #     alone would miss it and leave the exact cold-load this feature targets.
+    #   embedder — model OR revision changed; the shared provider key is
+    #     (model, revision), so a revision-only pin also loads a new provider.
+    if settings.reranker_enabled and (
+        "rerank_model" in updates or "reranker_enabled" in updates
+    ):
         _kick_reranker_warm(settings.rerank_model)
-    if "embedding_model" in updates and settings.embedding_model:
+    if settings.embedding_model and (
+        "embedding_model" in updates or "embedding_revision" in updates
+    ):
         _kick_embedding_warm(settings.embedding_model,
                              getattr(settings, "embedding_revision", "") or "")
     return asdict(settings)

--- a/backend/server.py
+++ b/backend/server.py
@@ -485,16 +485,16 @@ async def lifespan(app: FastAPI):
             if _gw:
                 logger.warning("[MEMORY] recall gate may be mistuned for the embedding "
                                "model: %s", _gw)
-            # Eager-warm the reranker OFF the request path. It's a 0.6B causal LM
-            # whose first cold-load is slow (~tens of s on CPU). Warming it in a
-            # daemon thread at boot means the FIRST chat never blocks on it — the
-            # recall path keeps fusion order until it's ready (see _apply_rerank).
-            if getattr(_mem_cfg, "reranker_enabled", False):
-                from services.retrieval.reranker import get_shared_reranker
-                get_shared_reranker(
-                    getattr(_mem_cfg, "rerank_model", None) or "BAAI/bge-reranker-v2-m3"
-                ).warm_async()
-                logger.info("[MEMORY] reranker eager-warm kicked off (background)")
+            # Ensure the CONFIGURED memory models (embedding + reranker) are
+            # present + warm, OFF the request path. Each downloads (into the
+            # persistent HF-cache volume) + warms in a daemon thread, streaming
+            # progress to the Settings UI; the server is ready immediately and
+            # recall degrades gracefully until they load. This replaces baking a
+            # fixed model list into the Docker image — the set now derives ONLY
+            # from settings, so changing a default can never ship without the
+            # model. See services/memory/model_prefetch.
+            from services.memory.model_prefetch import ensure_models_warm
+            ensure_models_warm(_mem_cfg)
     except Exception:
         logger.exception("Failed to start memory index worker")
 

--- a/backend/services/memory/model_prefetch.py
+++ b/backend/services/memory/model_prefetch.py
@@ -1,0 +1,154 @@
+"""Ensure the CONFIGURED memory models are present + warm — at startup and on a
+config change — instead of baking a fixed model list into the Docker image.
+
+Why this exists
+---------------
+The reranker/embedding defaults change over time (a Docker-baked list is a second
+source of truth that silently drifts from the config default — exactly how a new
+default reranker once shipped without being on the server). Here the model set is
+derived from ONE source: the live memory settings. The HF cache is a persistent
+volume (see docker-compose.yaml), so a model downloaded once survives deploys and
+the next startup is a fast no-op.
+
+Non-blocking by design: each model is downloaded + warmed in a daemon thread and
+streams byte-level progress to the activity SSE (the Settings UI shows a progress
+bar). The server becomes ready immediately; recall degrades gracefully (keeps
+fusion order / skips rerank) until a model is ready.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Callable, Optional
+
+from services.activity_stream import activity_stream_manager
+
+logger = logging.getLogger("memory")
+
+# SSE event types the frontend already routes to the memory store (it gates
+# forwarding on event_type.startswith("memory_")).
+_RERANKER_EVENT = "memory_reranker_loading"
+_EMBEDDING_EVENT = "memory_embedding_loading"
+
+
+def make_sse_progress(
+    event_type: str, model_name: str, loop: Optional[asyncio.AbstractEventLoop]
+) -> Callable[[str, int], None]:
+    """Build an ``on_progress(state, pct)`` that broadcasts model-load progress
+    to the activity SSE. ``broadcast`` touches asyncio.Queues that are not
+    thread-safe to write from a worker thread, so when a loop is supplied the
+    event is marshalled back onto it with ``call_soon_threadsafe``."""
+    def on_progress(state: str, pct: int) -> None:
+        ev = {"event_type": event_type, "state": state,
+              "progress": pct, "model": model_name}
+        if loop is not None:
+            loop.call_soon_threadsafe(activity_stream_manager.broadcast, ev)
+        else:
+            activity_stream_manager.broadcast(ev)
+    return on_progress
+
+
+def prefetch_embedding(model_name: str, revision: str, on_progress) -> None:
+    """Download (with byte-level progress) then warm the embedding model, so the
+    first index write / recall never pays the download+load on the request path.
+    Mirrors :func:`services.retrieval.reranker.prefetch_and_warm`. Best-effort:
+    any failure ends in a single ``error`` event and is logged, never raised
+    (the embedding still loads lazily on first use as a fallback).
+
+    MUST run OFF the event loop (blocks on network + a model load).
+    """
+    state = {"done": 0, "total": 0, "last_pct": -1}
+
+    def _emit(st: str, pct: int) -> None:
+        if st == "downloading" and pct == state["last_pct"]:
+            return  # throttle: only fire when the integer pct advances
+        state["last_pct"] = pct
+        try:
+            on_progress(st, pct)
+        except Exception:  # noqa: BLE001 — progress is best-effort, never break warm
+            logger.debug("[MEMORY] embedding progress callback failed", exc_info=True)
+
+    try:
+        _emit("downloading", 0)
+        try:
+            from huggingface_hub import snapshot_download
+            from tqdm.auto import tqdm as _tqdm
+
+            # Aggregate byte progress across HF's per-file bars; ignore the outer
+            # "Fetching N files" bar (unit 'it') so it doesn't skew the total.
+            class _ProgressTqdm(_tqdm):
+                def __init__(self, *a, **k):
+                    super().__init__(*a, **k)
+                    if self.unit == "B":
+                        state["total"] += (self.total or 0)
+
+                def update(self, n=1):
+                    r = super().update(n)
+                    if self.unit == "B" and state["total"]:
+                        state["done"] += n
+                        _emit("downloading",
+                              min(99, int(state["done"] * 100 / state["total"])))
+                    return r
+
+            kwargs = {"repo_id": model_name, "tqdm_class": _ProgressTqdm}
+            if revision:
+                kwargs["revision"] = revision
+            snapshot_download(**kwargs)
+        except Exception as exc:  # noqa: BLE001 — already cached / offline / hub error
+            logger.info("[MEMORY] embedding prefetch skipped/failed (%s) — trying load", exc)
+
+        _emit("loading", max(state["last_pct"], 99))
+        from services.indexing.embedding_provider import get_shared_embedding_provider
+        prov = get_shared_embedding_provider(model_name, revision)
+        if not prov.is_available():
+            raise RuntimeError("embedding provider unavailable after load (missing dep?)")
+        prov.embed_query("warm")  # forces the weights into RAM
+        _emit("ready", 100)
+        logger.info("[MEMORY] embedding '%s' downloaded + warmed", model_name)
+    except Exception as exc:  # noqa: BLE001 — surface one error event, never crash startup
+        logger.warning("[MEMORY] embedding prefetch_and_warm failed: %s", exc)
+        try:
+            on_progress("error", 0)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def ensure_models_warm(settings, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+    """Download + warm every memory model the CURRENT settings require, each in
+    its own daemon thread with SSE progress. Safe to call repeatedly (a cached
+    model is a fast no-op) — used at server startup and after a settings change.
+
+    Resolve the running loop on the caller's thread (the event loop), because the
+    worker threads can only marshal progress back via a loop captured here.
+    """
+    if not getattr(settings, "enabled", False):
+        return
+    if loop is None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+    # Embedding powers dense recall + the knowledge graph — always needed.
+    emb_model = getattr(settings, "embedding_model", None)
+    if emb_model:
+        emb_rev = getattr(settings, "embedding_revision", "") or ""
+        on_prog = make_sse_progress(_EMBEDDING_EVENT, emb_model, loop)
+        threading.Thread(
+            target=prefetch_embedding, args=(emb_model, emb_rev, on_prog),
+            name="embedding-prefetch", daemon=True,
+        ).start()
+        logger.info("[MEMORY] embedding prefetch/warm kicked off: %s", emb_model)
+
+    # Reranker only when enabled. Reuse the reranker's own download+warm.
+    if getattr(settings, "reranker_enabled", False):
+        rr_model = getattr(settings, "rerank_model", None)
+        if rr_model:
+            from services.retrieval.reranker import prefetch_and_warm
+            on_prog = make_sse_progress(_RERANKER_EVENT, rr_model, loop)
+            threading.Thread(
+                target=prefetch_and_warm, args=(rr_model, on_prog),
+                name="reranker-prefetch", daemon=True,
+            ).start()
+            logger.info("[MEMORY] reranker prefetch/warm kicked off: %s", rr_model)

--- a/backend/tests/test_routes/test_memory_settings_route.py
+++ b/backend/tests/test_routes/test_memory_settings_route.py
@@ -167,3 +167,27 @@ def test_candidate_approve_route(client):
     r = client.post(f"/api/agents/Jarvis/memory-candidates/{cid}/approve")
     assert r.status_code == 200, r.text
     assert client.get("/api/agents/Jarvis/memories").json()["total"] >= 1
+
+
+def test_patch_warms_on_reranker_enable_and_revision_change(client, monkeypatch):
+    """Pre-warm must fire on enabling the reranker (payload carries only
+    reranker_enabled) and on an embedding_revision-only change — both alter which
+    model loads, the cold-load this feature targets (PR #114 review)."""
+    import routes.memory_settings as rms
+    rr, emb = [], []
+    monkeypatch.setattr(rms, "_kick_reranker_warm", lambda m: rr.append(m))
+    monkeypatch.setattr(rms, "_kick_embedding_warm", lambda m, rev: emb.append((m, rev)))
+
+    # Enabling the reranker → warm it (even though only reranker_enabled is sent).
+    assert client.patch("/api/memory/settings", json={"reranker_enabled": True}).status_code == 200
+    assert len(rr) == 1 and emb == []
+
+    # A revision-only pin → warm the embedder (provider key is (model, revision)).
+    rr.clear(); emb.clear()
+    assert client.patch("/api/memory/settings", json={"embedding_revision": "rev-xyz"}).status_code == 200
+    assert len(emb) == 1 and emb[0][1] == "rev-xyz" and rr == []
+
+    # A non-model change → warm nothing.
+    rr.clear(); emb.clear()
+    assert client.patch("/api/memory/settings", json={"mode": "deep"}).status_code == 200
+    assert rr == [] and emb == []

--- a/backend/tests/test_services/test_model_prefetch.py
+++ b/backend/tests/test_services/test_model_prefetch.py
@@ -1,0 +1,95 @@
+"""Tests for services.memory.model_prefetch — runtime model verify/warm that
+replaces baking models into the Docker image."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import services.memory.model_prefetch as mp
+
+
+class _InlineThread:
+    """Run the thread target synchronously so we can assert what was kicked."""
+    def __init__(self, target=None, args=(), **_kw):
+        self._target, self._args = target, args
+
+    def start(self):
+        self._target(*self._args)
+
+
+def _settings(**kw):
+    base = dict(enabled=True, embedding_model="emb/model", embedding_revision="",
+                reranker_enabled=True, rerank_model="rr/model")
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_ensure_models_warm_kicks_both_from_config(monkeypatch):
+    calls = []
+    monkeypatch.setattr(mp, "prefetch_embedding",
+                        lambda m, r, cb: calls.append(("emb", m, r)))
+    import services.retrieval.reranker as rr
+    monkeypatch.setattr(rr, "prefetch_and_warm", lambda m, cb: calls.append(("rr", m)))
+    monkeypatch.setattr(mp.threading, "Thread", _InlineThread)
+
+    mp.ensure_models_warm(_settings(embedding_revision="r1"), loop=None)
+
+    assert ("emb", "emb/model", "r1") in calls
+    assert ("rr", "rr/model") in calls
+
+
+def test_ensure_models_warm_skips_when_memory_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(mp, "prefetch_embedding", lambda *a: calls.append("emb"))
+    monkeypatch.setattr(mp.threading, "Thread", _InlineThread)
+    mp.ensure_models_warm(_settings(enabled=False), loop=None)
+    assert calls == []
+
+
+def test_ensure_models_warm_skips_reranker_when_disabled(monkeypatch):
+    calls = []
+    monkeypatch.setattr(mp, "prefetch_embedding", lambda m, r, cb: calls.append(("emb", m)))
+    import services.retrieval.reranker as rr
+    monkeypatch.setattr(rr, "prefetch_and_warm", lambda m, cb: calls.append(("rr", m)))
+    monkeypatch.setattr(mp.threading, "Thread", _InlineThread)
+
+    mp.ensure_models_warm(_settings(reranker_enabled=False), loop=None)
+
+    assert ("emb", "emb/model") in calls
+    assert not any(c[0] == "rr" for c in calls)
+
+
+def test_prefetch_embedding_emits_phases_in_order(monkeypatch):
+    import huggingface_hub
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **k: None)
+    import services.indexing.embedding_provider as ep
+    prov = SimpleNamespace(is_available=lambda: True, embed_query=lambda t: [0.0])
+    monkeypatch.setattr(ep, "get_shared_embedding_provider", lambda m, r: prov)
+
+    states = []
+    mp.prefetch_embedding("emb/model", "", lambda st, pct: states.append(st))
+
+    assert states[0] == "downloading"
+    assert "loading" in states
+    assert states[-1] == "ready"
+
+
+def test_prefetch_embedding_emits_error_on_unavailable(monkeypatch):
+    import huggingface_hub
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **k: None)
+    import services.indexing.embedding_provider as ep
+    prov = SimpleNamespace(is_available=lambda: False)  # triggers the RuntimeError path
+    monkeypatch.setattr(ep, "get_shared_embedding_provider", lambda m, r: prov)
+
+    states = []
+    mp.prefetch_embedding("emb/model", "", lambda st, pct: states.append(st))
+
+    assert states[-1] == "error"
+
+
+def test_make_sse_progress_broadcasts_event(monkeypatch):
+    sent = []
+    monkeypatch.setattr(mp.activity_stream_manager, "broadcast", lambda ev: sent.append(ev))
+    on_prog = mp.make_sse_progress("memory_embedding_loading", "emb/model", None)
+    on_prog("downloading", 42)
+    assert sent == [{"event_type": "memory_embedding_loading", "state": "downloading",
+                     "progress": 42, "model": "emb/model"}]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,12 @@ services:
       - jarvis-sessions:/app/.fast-agent/sessions
       - jarvis-runtime:/app/.runtime
       - jarvis-logs:/app/logs
+      # --- HF model cache (embedding + reranker) ---
+      # Persist the multi-GB model cache across deploys. Models are downloaded at
+      # runtime (services/memory/model_prefetch) instead of baked into the image,
+      # so without this volume --force-recreate would re-download them EVERY
+      # deploy. HF_HOME=/root/.cache/huggingface (set in Dockerfile.base).
+      - jarvis-models:/root/.cache/huggingface
     environment:
       - PYTHONUNBUFFERED=1
       - LOG_CONSOLE_LEVEL=${LOG_CONSOLE_LEVEL:-INFO}
@@ -59,3 +65,4 @@ volumes:
   jarvis-sessions:
   jarvis-runtime:
   jarvis-logs:
+  jarvis-models:


### PR DESCRIPTION
## Runtime model prefetch — stop baking models into the Docker image

### Problem
The reranker/embedding models were **baked into `Dockerfile.base`** (a fixed `hf download` list). That list is a *second source of truth* that silently drifts from the config default: v2.10.0 changed the default reranker to `bge-reranker-v2-m3`, but the base still baked the old `Qwen3-Reranker-0.6B` — so the new default **was never on the server**. Confirmed live: the prod container's HF cache had only `bge-m3`, `Qwen3-Embedding-0.6B`, `Qwen3-Reranker-0.6B`. On first recall it would download ~GB on the request path, and re-download **every deploy** (the cache lived in the ephemeral container layer, not a volume).

### Fix — derive the model set from ONE source (live settings), download at runtime, persist on a volume
- **`services/memory/model_prefetch.ensure_models_warm(settings)`** — at startup, download + warm the **configured** embedding + reranker, each in a daemon thread with byte-level progress streamed to the activity SSE (the Settings UI already renders this). Non-blocking: the server is ready immediately; recall degrades gracefully (keeps fusion order / skips rerank) until a model is ready.
- **`server.py` lifespan** now calls it (was reranker-only `warm_async`, no progress).
- **`routes/memory_settings.py`** shares the SSE-progress builder and now also pre-warms the **embedder** on an `embedding_model` change (was reranker-only) — closes the gap where switching the embedder silently hung the first recall.
- **`docker-compose.yaml`** — new **`jarvis-models`** named volume mounted at `/root/.cache/huggingface`, so a runtime download survives `--force-recreate` instead of re-downloading every deploy. (Named volume → `up -V` does **not** wipe it.)
- **`Dockerfile.base` 1.4.0 → 1.5.0** — remove the model bake; the base is system-only again (~5GB smaller). **`Dockerfile`** pins `FROM …base:1.5.0`.

### Tests
- `34 passed` (new `test_model_prefetch.py` + existing reranker/memory-settings suites), ruff clean.
- `ensure_models_warm` kicks both models from config and honors the `enabled` / `reranker_enabled` flags; `prefetch_embedding` emits `downloading → loading → ready` and `error`.

### Deploy steps (manual prerequisite — base image)
1. **Build `omnigentx/jarvis-backend-base:1.5.0`** (system-only). Already built locally on the deploy server (no Docker Hub push needed — `docker compose build` uses the local base, no `--pull`).
2. Merge → CD runs `docker compose build` (app `FROM base:1.5.0`) + `up -d --force-recreate -V`.
3. First startup downloads `bge-reranker-v2-m3` + the embedder into `jarvis-models` (progress in Settings); it persists for subsequent deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
