### PR TITLE
feat(memory): per-agent memory — every agent gets its OWN isolated silo

### DIFF
--- a/backend/agent.py
+++ b/backend/agent.py
@@ -86,11 +86,24 @@ CORE_SKILLS = get_skills("user-context")
 
 # --- Static Agents (require TagRelayAgent or specific hooks) ---
 
+# Every agent gets its OWN durable memory (per-agent silo, isolated by the
+# caller-identity fast-agent stamps on each tool call — see tools/memory_server.py).
+# Spread into each agent's `servers` so a new agent opts in with one token.
+_MEMORY_SERVERS = ["memory_server"]
+# One shared memory instruction for every memory-capable agent (single source).
+_MEMORY_PROMPT = (
+    "\n\nYou have your OWN private long-term memory (separate from other agents). "
+    "Call memory_search BEFORE asking the user something they may have already told you; "
+    "call memory_remember to store durable facts/preferences when the user says to remember "
+    "or states a lasting fact. Never write memory to files."
+)
+
+
 @fast.agent(
     name="PersonalAgent",
-    instruction="You are a personal assistant.\n\n{{agentSkills}}",
+    instruction="You are a personal assistant." + _MEMORY_PROMPT + "\n\n{{agentSkills}}",
     skills=CORE_SKILLS + get_skills("personal-assistant", "cron-management", "scrape-web"),
-    servers=["serpapi", "time-service", "gmail", "calendar", "cron-server", "scrapling-server"],
+    servers=["serpapi", "time-service", "gmail", "calendar", "cron-server", "scrapling-server", *_MEMORY_SERVERS],
     request_params=RequestParams(parallel_tool_calls=True),
 )
 async def personal_agent(prompt: str):
@@ -98,9 +111,9 @@ async def personal_agent(prompt: str):
 
 @fast.agent(
     name="IoTAgent",
-    instruction="You are an IoT specialist.\n\n{{agentSkills}}",
+    instruction="You are an IoT specialist." + _MEMORY_PROMPT + "\n\n{{agentSkills}}",
     skills=CORE_SKILLS + get_skills("iot-control"),
-    servers=["iot-control", "time-service", "gmail"],
+    servers=["iot-control", "time-service", "gmail", *_MEMORY_SERVERS],
     tools={"time-service": ["get_current_time", "wait_for_seconds"]},
     request_params=RequestParams(parallel_tool_calls=True),
 )
@@ -110,9 +123,9 @@ async def iot_agent(prompt: str):
 @fast.custom(
     TagRelayAgent,
     name="MusicAgent",
-    instruction="You are a music specialist.\n\n{{agentSkills}}",
+    instruction="You are a music specialist." + _MEMORY_PROMPT + "\n\n{{agentSkills}}",
     skills=CORE_SKILLS + get_skills("music-playback"),
-    servers=["media-server"],
+    servers=["media-server", *_MEMORY_SERVERS],
     tools={"media-server": ["search_youtube"]}
 )
 async def music_agent(prompt: str):
@@ -121,9 +134,9 @@ async def music_agent(prompt: str):
 @fast.custom(
     TagRelayAgent,
     name="AudioReaderAgent",
-    instruction="You are a specialist in finding stories and playing audio.\n\n{{agentSkills}}",
+    instruction="You are a specialist in finding stories and playing audio." + _MEMORY_PROMPT + "\n\n{{agentSkills}}",
     skills=CORE_SKILLS + get_skills("audio-reading"),
-    servers=["story-server", "library-server"],
+    servers=["story-server", "library-server", *_MEMORY_SERVERS],
     tools={
         "story-server": ["find_story_chapter"],
         "library-server": ["local_list_stories", "local_list_chapters", "local_search"]
@@ -151,7 +164,7 @@ Rule: Always try serpapi first → if serpapi does not return the desired result
 
 {{agentSkills}}""",
     skills=CORE_SKILLS + get_skills("proactive-mode", "research", "scrape-web"),
-    servers=["serpapi", "scrapling-server", "chrome-devtools", "time-service"],
+    servers=["serpapi", "scrapling-server", "chrome-devtools", "time-service", *_MEMORY_SERVERS],
 )
 async def research_agent(prompt: str):
     pass
@@ -169,7 +182,7 @@ FINANCE DUTIES:
 
 {{agentSkills}}""",
     skills=CORE_SKILLS + get_skills("proactive-mode", "finance", "research", "scrape-web"),
-    servers=["serpapi", "scrapling-server", "time-service"],
+    servers=["serpapi", "scrapling-server", "time-service", *_MEMORY_SERVERS],
 )
 async def finance_agent(prompt: str):
     pass
@@ -231,7 +244,7 @@ CRAWL WORKFLOW:
 
 {{agentSkills}}""",
     skills=CORE_SKILLS + get_skills("proactive-mode", "crawling", "scrape-web"),
-    servers=["story-server", "scrapling-server", "serpapi"],
+    servers=["story-server", "scrapling-server", "serpapi", *_MEMORY_SERVERS],
 )
 async def crawl_stories_agent(prompt: str):
     pass

--- a/backend/fastagent.config.yaml
+++ b/backend/fastagent.config.yaml
@@ -243,18 +243,17 @@ mcp:
         JARVIS_RUNTIME_RPC_SOCKET: "${JARVIS_RUNTIME_RPC_SOCKET}"
     # Per-agent durable memory (search/remember/forget). Same RPC bridge as
     # skill_server: tools delegate to services.memory.rpc_handlers in the main
-    # backend (DB + retrieval + model live there; this subprocess loads no
-    # model). Tools self-gate on the `memory` settings flag (hot-reload, no
-    # restart). MEMORY_AGENT_NAME binds the in-process master's identity;
-    # spawned agents override it with their own TEAM_MY_NAME (set by
-    # config_reader.get_server_env) — see tools/memory_server.py:_owner().
+    # backend (DB + retrieval + model live there; this subprocess loads no model).
+    # Pooled across in-process agents — the OWNER of each call is resolved per-call
+    # from the trusted _meta.caller_agent fast-agent stamps (TEAM_MY_NAME for
+    # spawned). NO static MEMORY_AGENT_NAME: a missing identity FAILS rather than
+    # mis-scoping into the master's silo. See tools/memory_server.py:_owner().
     memory_server:
       command: "python"
       args: ["tools/memory_server.py"]
       env:
         PYTHONUNBUFFERED: "1"
         JARVIS_RUNTIME_RPC_SOCKET: "${JARVIS_RUNTIME_RPC_SOCKET}"
-        MEMORY_AGENT_NAME: "Jarvis"
     mcp-atlassian:
       command: "uv"
       args: ["run", "--directory", "mcp-atlassian", "mcp-atlassian"]

--- a/backend/routes/agents.py
+++ b/backend/routes/agents.py
@@ -1251,13 +1251,17 @@ async def delete_agent(name: str):
         logger.warning("[AGENTS API] Failed to remove from registry: %s", e)
     
     if deleted_count > 0:
-        # Also delete related activities
+        # Also delete related activities + the agent's OWN memory silo (records,
+        # candidates, episodic, retrieval runs, FTS, graph) so a deleted agent
+        # leaves no orphaned rows.
         try:
             from core.database import AgentActivity, get_db_session
+            from services.memory.memory_service import purge_agent_memory
             db = get_db_session()
             try:
                 db.query(AgentActivity).filter(AgentActivity.agent_name == name).delete()
                 db.commit()
+                purge_agent_memory(db, name)
             except Exception:
                 db.rollback()
             finally:
@@ -1485,16 +1489,20 @@ async def delete_team(team_name: str):
     except Exception as e:
         logger.warning("[AGENTS API] team_sessions cleanup error: %s", e)
     
-    # ── 7. Clean up DB activities ──
+    # ── 7. Clean up DB activities + each member's OWN memory silo ──
     try:
         from core.database import AgentActivity, get_db_session
+        from services.memory.memory_service import purge_agent_memory
         db = get_db_session()
         try:
             for agent_name in team_agent_names:
                 if agent_name:
                     db.query(AgentActivity).filter(AgentActivity.agent_name == agent_name).delete()
             db.commit()
-            cleanup_log.append("activities")
+            for agent_name in team_agent_names:
+                if agent_name:
+                    purge_agent_memory(db, agent_name)
+            cleanup_log.append("activities+memory")
         except Exception:
             db.rollback()
         finally:

--- a/backend/services/indexing/ladybug_store.py
+++ b/backend/services/indexing/ladybug_store.py
@@ -252,6 +252,16 @@ class LadybugStore:
             if self.count() == 0:
                 self._rebuild_vector_index()
 
+    def purge_owner(self, owner: str) -> None:
+        """Delete ALL graph state for one agent's silo — Memory nodes + RELATES
+        triples scoped to ``owner``. Used when an agent is deleted so the
+        rebuildable graph doesn't accumulate orphaned per-agent data."""
+        with self._lock:
+            self._exec("MATCH (m:Memory {owner: $owner}) DETACH DELETE m", {"owner": owner})
+            self._exec("MATCH ()-[r:RELATES {owner: $owner}]->() DELETE r", {"owner": owner})
+            if self.count() == 0:                 # see delete_memory: empty table kills HNSW
+                self._rebuild_vector_index()
+
     def link_entity(self, *, record_id: str, entity_id: str, name: str,
                     etype: str, normalized: str) -> None:
         """MENTIONS edge from a memory to an entity (entity linking). Creates the

--- a/backend/services/memory/memory_service.py
+++ b/backend/services/memory/memory_service.py
@@ -269,3 +269,42 @@ class MemoryService:
             raise MemoryWriteError(
                 f"pinned token budget exceeded ({used + incoming_tokens} > "
                 f"{self.pinned_token_budget}); unpin something first")
+
+
+def purge_agent_memory(db: Session, owner_agent_name: str) -> dict[str, int]:
+    """Delete EVERY durable memory artifact for one agent's silo — called when the
+    agent is deleted so the DB doesn't accumulate orphaned rows. Covers the SQLite
+    tables, the FTS mirror, and the rebuildable LadybugDB graph. The SQLite delete
+    is authoritative; the graph purge is best-effort (it's rebuildable)."""
+    from sqlalchemy import text as _sql_text
+
+    from core.database import (EpisodicDocument, MemoryCandidate, MemoryRecord,
+                               MemoryVersion, RetrievalRun)
+
+    counts: dict[str, int] = {}
+    # MemoryVersion keys on memory_id (not owner) → resolve the owner's ids first.
+    rec_ids = [r[0] for r in db.query(MemoryRecord.id)
+               .filter(MemoryRecord.owner_agent_name == owner_agent_name).all()]
+    if rec_ids:
+        counts["versions"] = (db.query(MemoryVersion)
+                              .filter(MemoryVersion.memory_id.in_(rec_ids))
+                              .delete(synchronize_session=False))
+    for model, key in ((MemoryRecord, "records"), (MemoryCandidate, "candidates"),
+                       (EpisodicDocument, "episodic"), (RetrievalRun, "retrieval_runs")):
+        counts[key] = (db.query(model)
+                       .filter(model.owner_agent_name == owner_agent_name)
+                       .delete(synchronize_session=False))
+    try:                                  # FTS mirror (virtual table)
+        db.execute(_sql_text("DELETE FROM memory_fts WHERE owner_agent_name = :o"),
+                   {"o": owner_agent_name})
+    except Exception:  # noqa: BLE001 — rebuildable mirror, never block the delete
+        logger.debug("[MEMORY] fts purge skipped for %s", owner_agent_name, exc_info=True)
+    db.commit()
+    try:                                  # rebuildable graph — best-effort
+        from services.indexing.ladybug_store import get_ladybug_store
+        from services.memory.settings import get_memory_settings
+        get_ladybug_store(get_memory_settings().ladybug_path).purge_owner(owner_agent_name)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[MEMORY] ladybug purge skipped for %s: %s", owner_agent_name, exc)
+    logger.info("[MEMORY] purged memory of deleted agent %s: %s", owner_agent_name, counts)
+    return counts

--- a/backend/services/spawn_progress_bridge.py
+++ b/backend/services/spawn_progress_bridge.py
@@ -247,9 +247,12 @@ class SpawnProgressBridge:
             self._handle_removal(data)
             return  # Don't push removal events to chat SSE
 
-        # 4d. Handle lifecycle cleanup — broadcast agent_removed for UI sync
+        # 4d. Handle lifecycle cleanup — broadcast agent_removed for UI sync +
+        # purge the agent's memory (the spawner emits this ONLY for a oneshot that
+        # has been removed from the registry → it's gone for good).
         if event_type_str == "lifecycle_after_cleanup":
             self._broadcast_agent_removed(agent_name, data, event_data)
+            self._maybe_purge_oneshot_memory(agent_name, data)
             return  # Don't push to chat SSE
 
         # 5. Handle token_usage events — persist + broadcast (monitoring only, not chat SSE)
@@ -555,6 +558,48 @@ class SpawnProgressBridge:
             )
         except Exception as e:
             logger.warning("Failed to handle removal: %s", e)
+
+    def _maybe_purge_oneshot_memory(self, agent_name: str, data: dict) -> None:
+        """Purge a cleaned-up ONESHOT agent's memory silo (it's gone for good — its
+        unique name will never run again). Driven by ``lifecycle_after_cleanup``,
+        which the spawner (agent_spawner_server on_after_cleanup) emits ONLY for a
+        oneshot, after registry removal. Reuses ``purge_agent_memory`` (the same
+        cleanup the DELETE endpoint runs). Best-effort: never block event flow.
+        """
+        if data.get("lifecycle") != "oneshot":        # defensive: oneshot-only
+            return
+        if not agent_name or agent_name == "agent":   # defensive: no real identity
+            return
+        # Fail-safe for an IRREVERSIBLE delete: never wipe a PERSISTENT agent's silo.
+        # Spawn-time uniqueness (fast-agent ensure_unique_agent_name) should stop a
+        # oneshot from ever sharing a persistent name, but a destructive op must not
+        # trust an invariant enforced in another module — probe the authoritative
+        # sources here. If a future creation path bypasses the uniqueness gate, or we
+        # simply can't verify, we skip rather than risk deleting Jarvis's memory.
+        try:
+            import services.shared_state as _state
+            from services.agent_definitions import get_definition
+            live = getattr(_state.agent_app, "_agents", None) or {}
+            is_persistent = agent_name in live or get_definition(agent_name) is not None
+        except Exception:
+            is_persistent = True   # cannot verify → fail SAFE (do not delete)
+        if is_persistent:
+            logger.warning("[SPAWN] skipping oneshot memory purge for %r — it matches a "
+                           "persistent agent (static/dynamic), not a throwaway oneshot", agent_name)
+            return
+        try:
+            from core.database import get_db_session
+            from services.memory.memory_service import purge_agent_memory
+            db = get_db_session()
+            try:
+                counts = purge_agent_memory(db, agent_name)
+                if any(counts.values()):
+                    logger.info("[SPAWN] purged completed oneshot %s memory: %s",
+                                agent_name, counts)
+            finally:
+                db.close()
+        except Exception as exc:  # noqa: BLE001 — cleanup must not break the bridge
+            logger.warning("[SPAWN] oneshot memory purge failed for %s: %s", agent_name, exc)
 
     def _upsert_spawn_record(self, role: str, event_type_str: str, data: dict, raw: dict) -> None:
         """Upsert spawn_records on lifecycle events (started, result, error)."""

--- a/backend/team_templates/agile_team.yaml
+++ b/backend/team_templates/agile_team.yaml
@@ -117,6 +117,7 @@ roles:
       ]
     servers:
       [
+        memory_server,
         filesystem,
         meeting_room,
         email,
@@ -167,6 +168,7 @@ roles:
     skills: [ba-workflow, team-roster, team-communication, jarvis-knowledge, self-audit-tools]
     servers:
       [
+        memory_server,
         filesystem,
         meeting_room,
         email,
@@ -218,6 +220,7 @@ roles:
       [software-architecture, team-roster, team-communication, jarvis-knowledge, self-audit-tools]
     servers:
       [
+        memory_server,
         filesystem,
         meeting_room,
         email,
@@ -292,6 +295,7 @@ roles:
       ]
     servers:
       [
+        memory_server,
         filesystem,
         meeting_room,
         email,
@@ -339,7 +343,7 @@ roles:
 
     skills: [figma-designer, team-roster, team-communication, self-audit-tools]
     servers:
-      [filesystem, meeting_room, email, github, mcp-atlassian, figma-ui-mcp]
+      [memory_server, filesystem, meeting_room, email, github, mcp-atlassian, figma-ui-mcp]
     server_overrides:
       filesystem:
         args:
@@ -399,6 +403,7 @@ roles:
       ]
     servers:
       [
+        memory_server,
         filesystem,
         meeting_room,
         email,
@@ -451,6 +456,7 @@ roles:
       ]
     servers:
       [
+        memory_server,
         filesystem,
         meeting_room,
         email,

--- a/backend/team_templates/research_team.yaml
+++ b/backend/team_templates/research_team.yaml
@@ -10,7 +10,7 @@ roles:
       3. Save raw research findings to specs/research_notes.md
       
       Be thorough and cite your sources.
-    servers: [fetch, filesystem]
+    servers: [memory_server, fetch, filesystem]
     model: ""
 
   analyst:
@@ -20,7 +20,7 @@ roles:
       2. Analyze patterns, trends, and insights
       3. Create a structured analysis with key findings
       4. Save analysis to specs/analysis.md
-    servers: [filesystem]
+    servers: [memory_server, filesystem]
     model: ""
 
   writer:
@@ -30,7 +30,7 @@ roles:
       2. Write a polished, well-structured report
       3. Include executive summary, key findings, and recommendations
       4. Save final report to docs/report.md
-    servers: [filesystem]
+    servers: [memory_server, filesystem]
     model: ""
 
 workflow:

--- a/backend/tests/test_services/test_memory_owner_identity.py
+++ b/backend/tests/test_services/test_memory_owner_identity.py
@@ -1,0 +1,147 @@
+"""Per-agent memory ownership — ONE mechanism. The owner of every memory op is
+the per-call ``caller_agent`` fast-agent stamps from the calling agent's own name
+(mcp_aggregator._execute_on_server). It works identically for in-process agents
+(sharing the pooled memory_server subprocess) and spawned agents (dedicated
+subprocess) because every agent — including spawned ones — is named with its real
+identity. No env/static fallback: a missing identity FAILS rather than mis-scoping.
+"""
+from types import SimpleNamespace
+
+from tools import memory_server as ms
+
+
+def _ctx(meta):
+    return SimpleNamespace(request_context=SimpleNamespace(meta=meta))
+
+
+# ── owner resolution: caller_agent is the single source ──────────────────────
+
+def test_caller_agent_resolves_owner():
+    # Same path for in-process and spawned: the agent's own name arrives as the
+    # trusted per-call caller_agent and scopes the op to that agent's silo.
+    assert ms._owner(_ctx({"caller_agent": "IoTAgent"})) == "IoTAgent"
+    assert ms._owner(_ctx({"caller_agent": "MemTestCarol"})) == "MemTestCarol"
+
+
+def test_caller_from_pydantic_style_meta():
+    # transport may hand meta as a pydantic model carrying extras (not a dict)
+    assert ms._caller_from_ctx(_ctx(SimpleNamespace(caller_agent="MusicAgent"))) == "MusicAgent"
+    assert ms._caller_from_ctx(_ctx(SimpleNamespace(model_extra={"caller_agent": "FinanceAgent"}))) == "FinanceAgent"
+
+
+def test_no_identity_returns_empty_no_fallback():
+    # No ctx / no caller / blank → "" so the tool FAILS the op. There is NO
+    # fallback to any env or static name (which would mis-scope the write).
+    assert ms._owner(None) == ""
+    assert ms._owner(_ctx(None)) == ""
+    assert ms._owner(_ctx({})) == ""
+    assert ms._owner(_ctx({"caller_agent": "  "})) == ""
+
+
+# ── E2E: caller_agent _meta actually flows through FastMCP to the RPC owner ───
+
+async def test_caller_agent_meta_flows_through_fastmcp(monkeypatch):
+    """The real path: a tool call carrying _meta.caller_agent → FastMCP
+    request_context.meta → _owner() → the agent_name sent to the backend RPC."""
+    from mcp.shared.memory import create_connected_server_and_client_session as connect
+
+    captured = {}
+
+    def fake_rpc(method, params):
+        captured["method"] = method
+        captured["agent_name"] = params.get("agent_name")
+        return {"status": "auto_approved", "candidate_id": "x"}
+
+    monkeypatch.setattr(ms, "rpc_call", fake_rpc)
+    async with connect(ms.mcp._mcp_server) as client:
+        await client.call_tool("memory_remember", {"content": "the vacuum is a Roborock"},
+                               meta={"caller_agent": "IoTAgent"})
+    assert captured["method"] == "memory.remember"
+    assert captured["agent_name"] == "IoTAgent"
+
+
+# ── fast-agent stamps caller_agent (the producer side) ───────────────────────
+
+def _mock_aggregator(name, captured):
+    from fast_agent.mcp.mcp_aggregator import MCPAggregator
+
+    agg = MCPAggregator.__new__(MCPAggregator)   # bypass heavy __init__
+    agg.agent_name = name
+    agg.connection_persistence = True
+
+    class _Sess:
+        async def call_tool(self, **kw):
+            captured.update(kw)
+            return "ok"
+
+    class _Conn:
+        session = _Sess()
+
+    class _Mgr:
+        async def get_server(self, n, client_session_factory=None):
+            return _Conn()
+
+    async def _noop_record(*a, **k):
+        return None
+
+    agg._require_connection_manager = lambda: _Mgr()
+    agg._create_session_factory = lambda n: None
+    agg._maybe_mark_rejected_session_cookie_from_tool_result = lambda **kw: None
+    agg._record_server_call = _noop_record
+    return agg
+
+
+async def test_aggregator_stamps_caller_agent_on_tool_calls():
+    """fast-agent stamps caller_agent=<its agent name> onto every tool call's
+    _meta. Same code path for an in-process agent and a spawned-process agent —
+    a spawned agent is now named with its real identity, so this stamps it too."""
+    captured = {}
+    agg = _mock_aggregator("IoTAgent", captured)
+    await agg._execute_on_server("memory_server", "tool", "memory_remember", "call_tool",
+                                 {"name": "memory_remember", "arguments": {"content": "x"}})
+    assert captured["meta"]["caller_agent"] == "IoTAgent"
+
+
+async def test_stamp_then_read_full_loop():
+    """End-to-end: aggregator stamp (producer) feeds memory_server _owner
+    (consumer) — the exact stamped meta resolves back to the same owner."""
+    captured = {}
+    agg = _mock_aggregator("MemTestCarol", captured)   # a spawned-style real name
+    await agg._execute_on_server("memory_server", "tool", "memory_search", "call_tool",
+                                 {"name": "memory_search", "arguments": {"query": "q"}})
+    ctx = SimpleNamespace(request_context=SimpleNamespace(meta=captured["meta"]))
+    assert ms._owner(ctx) == "MemTestCarol"
+
+
+# ── Cascade: deleting an agent purges ONLY its own memory (no DB garbage) ─────
+
+def test_purge_agent_memory_deletes_only_that_agent():
+    """When an agent is deleted its silo is purged; other agents are untouched."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from core.database import Base, MemoryCandidate, MemoryRecord
+    from services.memory.memory_service import purge_agent_memory
+
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    for owner in ("IoTAgent", "Jarvis"):
+        db.add(MemoryRecord(id=f"m-{owner}", owner_agent_name=owner, memory_type="semantic",
+                            subject_scope="user", content="x", normalized_content="x",
+                            status="active", authority="user_confirmed", confidence=0.9,
+                            current_version=1, created_at=1.0, updated_at=1.0))
+        db.add(MemoryCandidate(id=f"c-{owner}", owner_agent_name=owner, candidate_type="extracted",
+                               payload_json="{}", source_refs_json="[]", status="pending",
+                               confidence=0.5, created_at=1.0))
+    db.commit()
+
+    counts = purge_agent_memory(db, "IoTAgent")
+
+    assert counts["records"] == 1 and counts["candidates"] == 1
+    for model in (MemoryRecord, MemoryCandidate):
+        assert db.query(model).filter(model.owner_agent_name == "IoTAgent").count() == 0
+        assert db.query(model).filter(model.owner_agent_name == "Jarvis").count() == 1  # untouched
+    db.close()

--- a/backend/tests/test_services/test_spawn_progress_bridge.py
+++ b/backend/tests/test_services/test_spawn_progress_bridge.py
@@ -508,3 +508,57 @@ class TestLateJoinerHook:
         finally:
             import services.shared_state as st
             st.registry_db = original_st
+
+
+    def _patch_purge(self, monkeypatch, calls, *, persistent=()):
+        """Common harness: capture purge calls; treat ``persistent`` names as live
+        persistent agents (so the fail-safe should refuse to purge them)."""
+        import core.database as cdb
+        import services.agent_definitions as adefs
+        import services.memory.memory_service as msvc
+        import services.shared_state as ss
+        monkeypatch.setattr(msvc, "purge_agent_memory",
+                            lambda db, name: calls.append(name) or {"records": 1})
+        monkeypatch.setattr(cdb, "get_db_session", lambda: MagicMock())
+        monkeypatch.setattr(adefs, "get_definition", lambda name: None)   # no dynamic defs
+        monkeypatch.setattr(ss, "agent_app",
+                            MagicMock(_agents={n: object() for n in persistent}))
+
+    def test_oneshot_cleanup_purges_memory_only_for_oneshot(self, monkeypatch):
+        """lifecycle_after_cleanup purges a oneshot's memory silo; a resumable
+        agent (or a blank identity) is left untouched."""
+        calls: list[str] = []
+        self._patch_purge(monkeypatch, calls)
+
+        bridge = SpawnProgressBridge(MagicMock())
+        bridge._maybe_purge_oneshot_memory("MemTestCarol", {"lifecycle": "oneshot"})
+        bridge._maybe_purge_oneshot_memory("DevAgent", {"lifecycle": "resumable"})  # kept
+        bridge._maybe_purge_oneshot_memory("", {"lifecycle": "oneshot"})            # no identity
+
+        assert calls == ["MemTestCarol"]
+
+    def test_oneshot_purge_fail_safe_refuses_persistent_agent(self, monkeypatch):
+        """IRREVERSIBLE-delete fail-safe: even if a oneshot cleanup event arrives for
+        a name that matches a PERSISTENT agent (e.g. Jarvis — uniqueness bypassed),
+        the silo is NOT purged."""
+        calls: list[str] = []
+        self._patch_purge(monkeypatch, calls, persistent=("Jarvis",))
+
+        bridge = SpawnProgressBridge(MagicMock())
+        bridge._maybe_purge_oneshot_memory("Jarvis", {"lifecycle": "oneshot"})        # persistent → skip
+        bridge._maybe_purge_oneshot_memory("ThrowawayBot", {"lifecycle": "oneshot"})  # real oneshot → purge
+
+        assert calls == ["ThrowawayBot"]   # Jarvis never purged
+
+    def test_oneshot_purge_fail_safe_skips_when_unverifiable(self, monkeypatch):
+        """If persistence can't be verified (lookup raises), fail SAFE: do not delete."""
+        calls: list[str] = []
+        import services.agent_definitions as adefs
+        import services.shared_state as ss
+        monkeypatch.setattr(adefs, "get_definition",
+                            lambda name: (_ for _ in ()).throw(RuntimeError("db down")))
+        monkeypatch.setattr(ss, "agent_app", None)
+
+        bridge = SpawnProgressBridge(MagicMock())
+        bridge._maybe_purge_oneshot_memory("AnyBot", {"lifecycle": "oneshot"})
+        assert calls == []   # unverifiable → skipped

--- a/backend/tools/memory_server.py
+++ b/backend/tools/memory_server.py
@@ -1,10 +1,12 @@
 """MCP tool server — exposes durable memory search/fetch to an agent.
 
-Trust model (spec §15, §21): the agent's identity is BOUND at spawn time via
-the ``MEMORY_AGENT_NAME`` environment variable (falls back to ``TEAM_MY_NAME``).
-The LLM never passes an identity — these tools inject the bound name into the
-RPC call, so an agent can only ever reach its OWN memory. Tool arguments that
-look like an identity are ignored.
+Trust model (spec §15, §21): the agent's identity is resolved by ONE mechanism —
+the trusted transport ``_meta.caller_agent`` that fast-agent stamps on every tool
+call (mcp_aggregator._execute_on_server) from the agent's own name. It works the
+same whether this subprocess is POOLED across in-process agents or dedicated to a
+spawned one (spawned agents are now named with their real identity, not a generic
+"child"). Never from a tool argument; NO fallback chain — a missing identity FAILS
+the op rather than silently mis-scoping the write into another agent's silo.
 
 Delegates to the live backend via the RuntimeRpcServer Unix socket (same
 pattern as tools/mcp_admin_server.py) — no HTTP, no API key, no model loading
@@ -13,11 +15,10 @@ in this subprocess.
 from __future__ import annotations
 
 import logging
-import os
 import sys
 from pathlib import Path
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -27,16 +28,44 @@ logger = logging.getLogger("memory_server")
 mcp = FastMCP("Memory")
 
 
-def _owner() -> str:
-    """The bound agent identity. NEVER taken from a tool argument.
+def _caller_from_ctx(ctx: Context | None) -> str:
+    """The calling agent's identity from the trusted ``_meta.caller_agent`` that
+    fast-agent stamps on each tool call. Empty when absent (older callers).
+    Tolerant of meta being a dict OR a pydantic model (transport-dependent)."""
+    if ctx is None:
+        return ""
+    try:
+        meta = ctx.request_context.meta
+    except Exception:  # noqa: BLE001 — no request context (e.g. direct call)
+        logger.debug("memory tool: no request_context.meta on ctx (%r) — "
+                     "transport may not expose it; owner will fall through to env",
+                     type(ctx).__name__, exc_info=True)
+        return ""
+    if meta is None:
+        return ""
+    val = None
+    if isinstance(meta, dict):
+        val = meta.get("caller_agent")
+    else:
+        val = getattr(meta, "caller_agent", None)
+        if val is None:
+            extra = getattr(meta, "model_extra", None) or getattr(meta, "__pydantic_extra__", None)
+            if isinstance(extra, dict):
+                val = extra.get("caller_agent")
+    return val.strip() if isinstance(val, str) else ""
 
-    TEAM_MY_NAME (set per-agent by the spawn env, config_reader.get_server_env)
-    takes precedence over MEMORY_AGENT_NAME (the in-process master's static
-    config value). This ordering is a SECURITY invariant: a spawned agent
-    inherits the static MEMORY_AGENT_NAME=<master> from the config block, so
-    its own TEAM_MY_NAME must win or it would read the master's memory.
+
+def _owner(ctx: Context | None = None) -> str:
+    """The bound agent identity — ONE source: the per-call ``caller_agent`` that
+    fast-agent stamps from the calling agent's own name. Same for in-process
+    (pooled subprocess) and spawned (dedicated subprocess) agents, since every
+    agent — including spawned ones — is now named with its real identity.
+
+    NEVER from a tool argument. NO fallback chain: if it doesn't resolve we return
+    "" and the caller FAILS the op, rather than silently mis-scoping the write
+    into another agent's silo.
     """
-    return os.environ.get("TEAM_MY_NAME") or os.environ.get("MEMORY_AGENT_NAME") or ""
+    return _caller_from_ctx(ctx)
 
 
 def _bridge_error(exc: Exception) -> dict:
@@ -45,7 +74,7 @@ def _bridge_error(exc: Exception) -> dict:
 
 @mcp.tool()
 def memory_search(query: str, types: list[str] | None = None,
-                  mode: str = "balanced", limit: int = 5) -> dict:
+                  mode: str = "balanced", limit: int = 5, ctx: Context = None) -> dict:
     """Search YOUR durable memory (episodic history, decisions, preferences,
     procedures). Returns {"memories": [{"id", "type", "text"}, ...]} ordered by
     relevance — ``text`` is the content to use; pass ``id`` to memory_fetch for
@@ -58,7 +87,7 @@ def memory_search(query: str, types: list[str] | None = None,
     embeds far from the concrete stored facts and returns nothing. For a BROAD
     need, issue SEVERAL focused searches (one concept each: job, skills,
     certifications) and merge — not one long catch-all query."""
-    owner = _owner()
+    owner = _owner(ctx)
     if not owner:
         return {"error": "no bound agent identity; memory unavailable"}
     try:
@@ -71,10 +100,10 @@ def memory_search(query: str, types: list[str] | None = None,
 
 
 @mcp.tool()
-def memory_fetch(evidence_ids: list[str]) -> dict:
+def memory_fetch(evidence_ids: list[str], ctx: Context = None) -> dict:
     """Fetch the full source content for evidence ids returned by
     memory_search (progressive disclosure)."""
-    owner = _owner()
+    owner = _owner(ctx)
     if not owner:
         return {"error": "no bound agent identity; memory unavailable"}
     try:
@@ -84,7 +113,7 @@ def memory_fetch(evidence_ids: list[str]) -> dict:
 
 
 @mcp.tool()
-def memory_remember(content: str, memory_type: str = "semantic", pinned: bool = False) -> dict:
+def memory_remember(content: str, memory_type: str = "semantic", pinned: bool = False, ctx: Context = None) -> dict:
     """STORE a durable fact or preference into memory (this SAVES — use
     memory_search to RECALL what is already stored). Call this when the user
     states something worth keeping ("remember that I…", "from now on…", a
@@ -92,7 +121,7 @@ def memory_remember(content: str, memory_type: str = "semantic", pinned: bool = 
     ``memory_type``: "semantic" (facts about the user/world), "pinned"
     (standing instructions), "procedural" (reusable workflows). It creates a
     candidate that auto-saves or awaits approval per policy."""
-    owner = _owner()
+    owner = _owner(ctx)
     if not owner:
         return {"error": "no bound agent identity; memory unavailable"}
     try:
@@ -105,9 +134,9 @@ def memory_remember(content: str, memory_type: str = "semantic", pinned: bool = 
 
 
 @mcp.tool()
-def memory_forget(memory_id: str, reason: str = "") -> dict:
+def memory_forget(memory_id: str, reason: str = "", ctx: Context = None) -> dict:
     """Archive one of YOUR memories (reversible, audited)."""
-    owner = _owner()
+    owner = _owner(ctx)
     if not owner:
         return {"error": "no bound agent identity; memory unavailable"}
     try:
@@ -118,10 +147,10 @@ def memory_forget(memory_id: str, reason: str = "") -> dict:
 
 
 @mcp.tool()
-def procedure_propose(title: str, steps: str) -> dict:
+def procedure_propose(title: str, steps: str, ctx: Context = None) -> dict:
     """Propose a reusable procedure/Skill (always requires approval; never
     auto-published)."""
-    owner = _owner()
+    owner = _owner(ctx)
     if not owner:
         return {"error": "no bound agent identity; memory unavailable"}
     try:


### PR DESCRIPTION
## What

Every agent now has its **own** durable memory silo, instead of only Jarvis having memory tools while the pooled `memory_server` resolved its owner from a static `MEMORY_AGENT_NAME="Jarvis"` (so other agents had no tool, or wrote into Jarvis's silo).

**One mechanism — caller-identity** (needs submodule fast-agent#11):
- fast-agent stamps a trusted `_meta.caller_agent` (the calling agent's own name) on every tool call; spawned agents are named with their real identity (not `"child"`). Same signal identifies in-process and spawned callers.
- `memory_server._owner()` = `caller_agent`, full stop — no env/static fallback chain; a missing identity FAILS the op rather than mis-scoping. (`MEMORY_AGENT_NAME` removed from config.)
- `memory_server` attached to ALL agents via a shared `_MEMORY_SERVERS` (standalone) + the team templates (agile/research) for spawned; shared `_MEMORY_PROMPT`.

**Lifecycle cleanup — one reused `purge_agent_memory`** (SQLite tables + FTS mirror + `LadybugStore.purge_owner`):
- manual delete: `routes/agents` delete_agent / delete_team.
- oneshot completion: `spawn_progress_bridge` purges on `lifecycle_after_cleanup` (emitted only for a removed oneshot), so throwaway oneshot agents leave no dead silos.

## Verified live (real API)

- IoTAgent (in-process) and a spawned MemTestCarol each wrote to their **own** silo (owner = the agent, never `"child"`/Jarvis); recall returns their own facts.
- Deleting a registered agent purged its memory; a seeded silo for a oneshot was auto-purged on completion.
- Full services+eval suite passes; unit/integration in `tests/test_services/test_memory_owner_identity.py` + `test_spawn_progress_bridge.py`.

## Depends on

- omnigentx/fast-agent#11 (must merge first; this PR bumps the submodule pointer to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)