### PR TITLE
fix(memory): invalidate retrieval cache on a recall-settings change

### DIFF
--- a/backend/services/retrieval/cache.py
+++ b/backend/services/retrieval/cache.py
@@ -43,10 +43,14 @@ def settings_fingerprint(settings) -> str:
 
 
 def cache_key(*, owner_agent_name: str, normalized_query: str, filters: str,
-              index_revision: int, settings_fp: str = "",
+              index_revision: int, mode: str = "", settings_fp: str = "",
               policy_version: str = POLICY_VERSION) -> str:
+    # ``mode`` is part of the key because it changes the result for the same
+    # query: a "deep" run escalates (corrective round) and gets a larger evidence
+    # budget than "balanced". Without it, a query cached under one mode would be
+    # served to another — the same staleness class as settings_fp / index_revision.
     raw = (f"{owner_agent_name}\x1f{normalized_query}\x1f{filters}\x1f"
-           f"{index_revision}\x1f{settings_fp}\x1f{policy_version}")
+           f"{index_revision}\x1f{mode}\x1f{settings_fp}\x1f{policy_version}")
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 

--- a/backend/services/retrieval/cache.py
+++ b/backend/services/retrieval/cache.py
@@ -1,10 +1,12 @@
 """Per-agent retrieval cache (spec §10). Keyed by owner + normalized query +
-filters + memory index revision + policy version. Invalidated by revision
-change, NOT TTL alone; never shared across agents.
+filters + memory index revision + recall-settings fingerprint + policy version.
+Invalidated by an index-revision OR a recall-settings change, NOT TTL alone;
+never shared across agents.
 """
 from __future__ import annotations
 
 import hashlib
+import json
 import threading
 from collections import OrderedDict
 
@@ -13,10 +15,38 @@ from services.retrieval.contracts import Evidence
 POLICY_VERSION = "1"
 _MAX_ENTRIES = 512
 
+# Memory settings whose value changes WHAT recall returns for the same query +
+# index revision: the reranker on/off + its knobs, the relevance gate, the dense
+# embedding model, and the graph/budget/gate parameters. A change to any of these
+# must invalidate cached results — the cache key embeds settings_fingerprint(),
+# so a stale entry is simply never hit again (the SAME mechanism as
+# index_revision: no explicit clear, works regardless of process boundaries).
+# Capture/curator/retention/approval settings are deliberately NOT here — they
+# don't touch the recall read path, so folding them in would bust the cache for
+# no reason. Add a new recall-affecting setting → add its name here (one line).
+_RECALL_AFFECTING_KEYS = (
+    "reranker_enabled", "rerank_model", "rerank_top_k", "rerank_min_score",
+    "recall_min_similarity", "graph_max_hops", "hub_max_df",
+    "embedding_model", "embedding_revision",
+    "evidence_token_budget", "quality_gate_thresholds", "trigger_lexicon_overrides",
+)
+
+
+def settings_fingerprint(settings) -> str:
+    """Short, stable hash of the recall-affecting settings (``_RECALL_AFFECTING_KEYS``).
+    Folded into :func:`cache_key` so a settings edit (e.g. enabling the reranker)
+    invalidates cached recalls for the same query — the next call is a guaranteed
+    miss and reflects the new config immediately, no explicit cache clear."""
+    payload = {k: getattr(settings, k, None) for k in _RECALL_AFFECTING_KEYS}
+    raw = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
 
 def cache_key(*, owner_agent_name: str, normalized_query: str, filters: str,
-              index_revision: int, policy_version: str = POLICY_VERSION) -> str:
-    raw = f"{owner_agent_name}\x1f{normalized_query}\x1f{filters}\x1f{index_revision}\x1f{policy_version}"
+              index_revision: int, settings_fp: str = "",
+              policy_version: str = POLICY_VERSION) -> str:
+    raw = (f"{owner_agent_name}\x1f{normalized_query}\x1f{filters}\x1f"
+           f"{index_revision}\x1f{settings_fp}\x1f{policy_version}")
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
@@ -25,9 +55,9 @@ def normalize_query(query: str) -> str:
 
 
 class RetrievalCache:
-    """Small in-process LRU. The key embeds the index revision, so a stale
-    entry is simply never hit again after an index update (no explicit
-    invalidation needed)."""
+    """Small in-process LRU. The key embeds the index revision AND a
+    recall-settings fingerprint, so a stale entry is simply never hit again after
+    an index update or a settings change (no explicit invalidation needed)."""
 
     def __init__(self, max_entries: int = _MAX_ENTRIES):
         self._data: "OrderedDict[str, list[Evidence]]" = OrderedDict()

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -22,7 +22,8 @@ from core.database import RetrievalRun
 from services.indexing.embedding_provider import get_shared_embedding_provider
 from services.retrieval import fusion
 from services.retrieval.budget import build_budget
-from services.retrieval.cache import RetrievalCache, cache_key, normalize_query
+from services.retrieval.cache import (
+    RetrievalCache, cache_key, normalize_query, settings_fingerprint)
 from services.retrieval.contracts import Evidence, RetrievalRequest, RetrievalResult
 from services.retrieval.evidence_builder import build_evidence
 from services.retrieval.intent_router import (
@@ -103,7 +104,8 @@ class RetrievalOrchestrator:
         index_rev = self._index_revision()
         key = cache_key(owner_agent_name=request.owner_agent_name,
                         normalized_query=normalize_query(request.query),
-                        filters=json.dumps(sorted(request.types)), index_revision=index_rev)
+                        filters=json.dumps(sorted(request.types)), index_revision=index_rev,
+                        settings_fp=settings_fingerprint(self.settings))
         cached = _CACHE.get(key)
         if cached is not None:
             # Copy the cached list: _finalize re-applies the recency/authority

--- a/backend/services/retrieval/orchestrator.py
+++ b/backend/services/retrieval/orchestrator.py
@@ -105,7 +105,7 @@ class RetrievalOrchestrator:
         key = cache_key(owner_agent_name=request.owner_agent_name,
                         normalized_query=normalize_query(request.query),
                         filters=json.dumps(sorted(request.types)), index_revision=index_rev,
-                        settings_fp=settings_fingerprint(self.settings))
+                        mode=request.mode, settings_fp=settings_fingerprint(self.settings))
         cached = _CACHE.get(key)
         if cached is not None:
             # Copy the cached list: _finalize re-applies the recency/authority

--- a/backend/tests/test_services/test_memory_retrieval_core.py
+++ b/backend/tests/test_services/test_memory_retrieval_core.py
@@ -164,6 +164,45 @@ def test_cache_key_changes_with_revision():
     assert c.get(k2) is None          # different revision → miss
 
 
+def test_cache_key_changes_with_settings_fingerprint():
+    # A recall-settings change (e.g. enabling the reranker) must invalidate the
+    # cached result for the same query — else the UI shows stale, pre-rerank hits.
+    base = dict(owner_agent_name="J", normalized_query="q", filters="f", index_revision=1)
+    k1 = cache_mod.cache_key(**base, settings_fp="aaa")
+    k2 = cache_mod.cache_key(**base, settings_fp="bbb")
+    assert k1 != k2
+    c = cache_mod.RetrievalCache()
+    c.set(k1, [_ev("A")])
+    assert c.get(k1) is not None
+    assert c.get(k2) is None          # different settings → miss (no stale rerank)
+
+
+def test_settings_fingerprint_reacts_to_recall_fields_only():
+    import types
+
+    def s(**kw):
+        base = dict(
+            reranker_enabled=False, rerank_model="m", rerank_top_k=5,
+            rerank_min_score=0.001, recall_min_similarity=0.3, graph_max_hops=1,
+            hub_max_df=0.5, embedding_model="e", embedding_revision="",
+            evidence_token_budget=2500, quality_gate_thresholds={},
+            trigger_lexicon_overrides={},
+            # Non-recall settings that must NOT bust the cache:
+            approval_policy="auto", extract_every_n=4, retention_episodic_days=30)
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    base_fp = cache_mod.settings_fingerprint(s())
+    # Recall-affecting edits flip the fingerprint → cache invalidates.
+    assert cache_mod.settings_fingerprint(s(reranker_enabled=True)) != base_fp
+    assert cache_mod.settings_fingerprint(s(recall_min_similarity=0.5)) != base_fp
+    assert cache_mod.settings_fingerprint(s(rerank_min_score=0.5)) != base_fp
+    # Capture/approval/retention edits do NOT (they don't touch the recall path).
+    assert cache_mod.settings_fingerprint(s(approval_policy="manual")) == base_fp
+    assert cache_mod.settings_fingerprint(s(extract_every_n=8)) == base_fp
+    assert cache_mod.settings_fingerprint(s(retention_episodic_days=90)) == base_fp
+
+
 def _orch_settings():
     import types
     return types.SimpleNamespace(

--- a/backend/tests/test_services/test_memory_retrieval_core.py
+++ b/backend/tests/test_services/test_memory_retrieval_core.py
@@ -177,6 +177,13 @@ def test_cache_key_changes_with_settings_fingerprint():
     assert c.get(k2) is None          # different settings → miss (no stale rerank)
 
 
+def test_cache_key_changes_with_mode():
+    # A "deep" run escalates + gets a bigger budget than "balanced"; the same
+    # query under a different mode must not be served the other mode's entry.
+    base = dict(owner_agent_name="J", normalized_query="q", filters="f", index_revision=1)
+    assert cache_mod.cache_key(**base, mode="balanced") != cache_mod.cache_key(**base, mode="deep")
+
+
 def test_settings_fingerprint_reacts_to_recall_fields_only():
     import types
 


### PR DESCRIPTION
## Vấn đề
Đổi một memory-setting ảnh hưởng recall (bật reranker, đổi relevance gate / rerank knobs…) **không** invalidate retrieval cache → query đã cache trả kết quả theo config cũ.

Chẩn đoán live trên prod: sau khi bật reranker và model `bge-reranker-v2-m3` đã download + warm xong, query "hello" **vẫn** ra đúng kết quả fusion cũ (chỉ `rrf`, không rerank). Nguyên nhân: cache key nhúng `index_revision` + `policy_version` nhưng **không** nhúng recall-settings, và route đổi settings không gọi `_CACHE.clear()`. `RetrievalOrchestrator.retrieve()` check cache **trước** `_apply_rerank`, nên cache hit trả thẳng list cũ (chưa rerank).

## Cách fix
Fold một **fingerprint của các settings ảnh hưởng recall** vào cache key — cùng cơ chế với `index_revision`: input đổi thì entry cũ đơn giản không bao giờ hit lại, **không cần clear thủ công**, đúng ở mọi process boundary. Settings capture / curator / retention / approval bị loại khỏi fingerprint để không bust cache thừa.

Vì sao chọn cách này (thay vì `_CACHE.clear()` trong route): khớp mẫu invalidation sẵn có, dễ maintain (thêm setting recall mới → thêm 1 dòng vào `_RECALL_AFFECTING_KEYS`), self-healing, không phụ thuộc cùng-process.

## Thay đổi
- `services/retrieval/cache.py`: thêm `settings_fingerprint()` + `_RECALL_AFFECTING_KEYS`; `cache_key()` thêm kwarg `settings_fp` (default `""` → **tương thích ngược**); cập nhật docstring.
- `services/retrieval/orchestrator.py`: `retrieve()` truyền `settings_fp=settings_fingerprint(self.settings)`.
- `tests/test_services/test_memory_retrieval_core.py`: 2 test mới — khóa đổi theo fingerprint; fingerprint chỉ phản ứng với field recall (approval/capture/retention thì không).

## UI/UX
Sau khi save setting (vd bật reranker) → fingerprint đổi → recall kế tiếp **chắc chắn miss** → rerank chạy thật → chip "memories used" hiện điểm rerank + thứ tự mới ngay, không thao tác thừa. Đây là root cause của UX "bật reranker mà không thấy gì đổi".

## Ảnh hưởng
- `gitnexus_impact`/`detect_changes`: risk **LOW**. Chữ ký `cache_key` additive (kwarg default) → không caller nào vỡ; không process nào break. Khóa chỉ cụ thể hơn (nhiều miss hơn sau khi đổi setting — đúng ý đồ), **không bao giờ hit sai**. Cold cache → output recall không đổi (eval quality giữ nguyên).

## Test
- **34 passed**: `test_memory_retrieval_core` + `test_memory_orchestrator` + `test_memory_recall_e2e` + `test_memory_reranker`. Ruff sạch.
- Gap: chưa có e2e tự động cho "PATCH setting → recall đổi" (cần model thật); đã verify tay trên prod + unit chứng minh khóa đổi theo từng field recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)