### PR TITLE
fix(memory): conflict gate reuses stored vectors + runs off the event loop

### DIFF
--- a/backend/services/memory/conflict.py
+++ b/backend/services/memory/conflict.py
@@ -38,8 +38,14 @@ import asyncio
 import json
 import logging
 import re
+from collections import namedtuple
 
 logger = logging.getLogger("memory.conflict")
+
+# Plain, thread-safe carrier for the gate. resolve_conflicts converts the loaded
+# ORM rows to these BEFORE handing them to the to_thread worker so the worker never
+# touches a main-thread-owned Session (PR #121 review #2).
+_GateCand = namedtuple("_GateCand", ("id", "content", "owner_agent_name"))
 
 # Loose gate: only PURPOSE is to make the LLM call rare by skipping saves with no
 # semantically-close sibling. The LLM is the real judge, so erring low here is
@@ -83,6 +89,10 @@ def _shared_embed(texts: list[str]) -> list[list[float]]:
     # Qwen3-Embedding-0.6B — the cosine gate would then be meaningless and silently
     # disable conflict resolution on the default config (PR #120 review). Mirrors
     # orchestrator.py / memory_index_worker.py, and reuses the same warm singleton.
+    # MUST stay identical to the INDEXER's embedder (model + normalization): the
+    # stored-vector gate (_stored_scores) compares a fresh qv against index vectors,
+    # so a silent model/normalization divergence would mis-gate WITHOUT erroring
+    # (vector_search only catches a dimension mismatch) (PR #121 review #3).
     from services.indexing.embedding_provider import get_shared_embedding_provider
     from services.memory.settings import get_memory_settings
     cfg = get_memory_settings()
@@ -178,6 +188,20 @@ def _gate(new_content: str, cands: list, embed_fn) -> list:
     scores = _stored_scores(cands, qv)
     if scores is None:                    # dense index unavailable → re-embed fallback
         return _gate_by_embed(new_content, cands, _shared_embed)
+    # vector_search ranks across the owner's WHOLE store (owner+status only, not the
+    # slot), so once an owner grows past the fetch window a genuinely-similar same-slot
+    # candidate can fall outside `hits` — scoring it 0.0 would silently drop it and miss
+    # the conflict (PR #121 review #1). Embed ONLY those few directly. The common case
+    # (all cands are near neighbours, or a small store) embeds nothing here.
+    missing = [c for c in cands if c.id not in scores]
+    if missing:
+        logger.info("[MEMORY] conflict gate: %d/%d candidate(s) outside the dense "
+                    "window — scoring by embedding", len(missing), len(cands))
+        try:
+            for c, v in zip(missing, _shared_embed([c.content for c in missing])):
+                scores[c.id] = _cosine(qv, v)
+        except Exception as exc:  # noqa: BLE001 — best-effort; keep the dense scores
+            logger.warning("[MEMORY] conflict gate tail-embed failed: %s", exc)
     return _top([(c, scores.get(c.id, 0.0)) for c in cands])
 
 
@@ -243,8 +267,10 @@ async def resolve_conflicts(record_id: str, *, generate_fn=None, embed_fn=None,
         # schedule_resolve_conflicts runs this as a loop task, so a synchronous
         # embed here would freeze the WHOLE loop (every embed releases the GIL for
         # C++ compute but the coroutine never yields), stalling the live chat turn's
-        # SSE until it finished. to_thread keeps the loop responsive.
-        gated = await asyncio.to_thread(_gate, rec.content, cands, embed_fn)
+        # SSE until it finished. to_thread keeps the loop responsive. Cross the
+        # thread boundary with plain tuples, not the live ORM rows (review #2).
+        gate_cands = [_GateCand(c.id, c.content, c.owner_agent_name) for c in cands]
+        gated = await asyncio.to_thread(_gate, rec.content, gate_cands, embed_fn)
         if not gated:
             return []
         idxs = await _judge(rec.content, gated, generate_fn)

--- a/backend/services/memory/conflict.py
+++ b/backend/services/memory/conflict.py
@@ -101,11 +101,51 @@ def _cosine(a: list[float], b: list[float]) -> float:
     return dot / (na * nb)
 
 
-def _gate(new_content: str, cands: list, embed_fn) -> list:
-    """Embed the new fact + candidates once; keep candidates whose cosine to the
-    new fact clears the gate, top-N by similarity. Any embedding failure → no
-    candidates (skip the LLM), never raise."""
-    embed_fn = embed_fn or _shared_embed
+def _top(scored: list) -> list:
+    """Apply the similarity floor + top-N cap. Shared by both gate paths."""
+    scored = [(c, s) for c, s in scored if s >= _GATE_SIM]
+    scored.sort(key=lambda t: t[1], reverse=True)
+    return [c for c, _ in scored[:_MAX_CANDIDATES_LLM]]
+
+
+def _stored_scores(cands: list, qv: list[float]) -> dict | None:
+    """Similarity of each candidate to ``qv``, read from the ALREADY-STORED dense
+    vectors (LadybugDB HNSW) — NO re-embed. Returns ``{record_id: cosine_sim}`` for
+    the candidates the index knows, or ``None`` if the dense index is unavailable
+    (indexing lag / dense outage) so the caller can fall back to embedding.
+
+    This is the "switch the gate to the dense index" the module header anticipated.
+    The old path re-embedded the WHOLE (owner, scope, type) slot on every save —
+    one batch padded to the longest fact, so cost was O(N x max_len). On a small
+    real store that measured ~150s of pure CPU, and (running on the event loop via
+    ``schedule_resolve_conflicts``) it stalled the whole turn → the chat SSE hung
+    and the UI showed "Unknown error". Here the caller embeds only the NEW fact and
+    we reuse the candidates' stored vectors instead."""
+    if not cands:
+        return {}
+    try:
+        from services.indexing.ladybug_store import get_ladybug_store
+        from services.memory.settings import get_memory_settings
+        store = get_ladybug_store(get_memory_settings().ladybug_path)
+        # Over-fetch: the near neighbours we care about are the same-slot cands, so
+        # ask for at least as many hits as there are candidates.
+        hits = store.vector_search(owner=cands[0].owner_agent_name,
+                                   query_embedding=qv,
+                                   limit=max(len(cands), _MAX_CANDIDATES_SCAN))
+    except Exception as exc:  # noqa: BLE001 — dense outage → embedding fallback
+        logger.warning("[MEMORY] conflict gate dense lookup failed (%s) — "
+                       "embedding fallback", exc)
+        return None
+    if not hits:
+        return None
+    # VectorHit.distance is cosine DISTANCE; similarity = 1 - distance.
+    return {h.record_id: 1.0 - h.distance for h in hits}
+
+
+def _gate_by_embed(new_content: str, cands: list, embed_fn) -> list:
+    """Score candidates by RE-EMBEDDING them. Used for the injected-``embed_fn``
+    tests and as the fallback when the dense index is unavailable. Kept as the
+    original single batch call so scripted-``embed_fn`` tests are unchanged."""
     try:
         vecs = embed_fn([new_content] + [c.content for c in cands])
     except Exception as exc:  # noqa: BLE001 — gate is best-effort
@@ -114,10 +154,31 @@ def _gate(new_content: str, cands: list, embed_fn) -> list:
     if not vecs or len(vecs) != len(cands) + 1:
         return []
     qv = vecs[0]
-    scored = [(c, _cosine(qv, v)) for c, v in zip(cands, vecs[1:])]
-    scored = [(c, s) for c, s in scored if s >= _GATE_SIM]
-    scored.sort(key=lambda t: t[1], reverse=True)
-    return [c for c, _ in scored[:_MAX_CANDIDATES_LLM]]
+    return _top([(c, _cosine(qv, v)) for c, v in zip(cands, vecs[1:])])
+
+
+def _gate(new_content: str, cands: list, embed_fn) -> list:
+    """Keep same-slot candidates whose similarity to the new fact clears the gate,
+    top-N. Any failure → no candidates (skip the LLM), never raise.
+
+    Production (``embed_fn is None``): embed ONLY the new fact, then score the
+    candidates against their stored vectors via the dense index (:func:`_stored_scores`)
+    — see that function for why the old whole-slot re-embed was removed. An injected
+    ``embed_fn`` (tests / explicit) keeps the direct embed path; the dense path also
+    falls back to it when the index is unavailable."""
+    if embed_fn is not None:
+        return _gate_by_embed(new_content, cands, embed_fn)
+    if not cands:
+        return []
+    try:
+        qv = _shared_embed([new_content])[0]
+    except Exception as exc:  # noqa: BLE001 — gate is best-effort
+        logger.warning("[MEMORY] conflict gate embed failed: %s", exc)
+        return []
+    scores = _stored_scores(cands, qv)
+    if scores is None:                    # dense index unavailable → re-embed fallback
+        return _gate_by_embed(new_content, cands, _shared_embed)
+    return _top([(c, scores.get(c.id, 0.0)) for c in cands])
 
 
 def _parse_superseded(raw: str, n: int) -> list[int]:
@@ -178,7 +239,12 @@ async def resolve_conflicts(record_id: str, *, generate_fn=None, embed_fn=None,
                  .limit(_MAX_CANDIDATES_SCAN).all())
         if not cands:
             return []
-        gated = _gate(rec.content, cands, embed_fn)
+        # Off the event loop: the gate does CPU-bound embedding / dense lookups.
+        # schedule_resolve_conflicts runs this as a loop task, so a synchronous
+        # embed here would freeze the WHOLE loop (every embed releases the GIL for
+        # C++ compute but the coroutine never yields), stalling the live chat turn's
+        # SSE until it finished. to_thread keeps the loop responsive.
+        gated = await asyncio.to_thread(_gate, rec.content, cands, embed_fn)
         if not gated:
             return []
         idxs = await _judge(rec.content, gated, generate_fn)

--- a/backend/tests/test_services/test_memory_conflict.py
+++ b/backend/tests/test_services/test_memory_conflict.py
@@ -194,6 +194,51 @@ def test_cosine_basics():
     assert conflict._cosine([1.0], [1.0, 0.0]) == 0.0          # length mismatch guard
 
 
+class _Cand:
+    def __init__(self, id, content, owner="Jarvis"):
+        self.id, self.content, self.owner_agent_name = id, content, owner
+
+
+# ── production gate reuses STORED vectors (no whole-slot re-embed) ──
+def test_gate_production_reuses_stored_vectors(monkeypatch):
+    """embed_fn=None → embed ONLY the new fact, score candidates from the dense
+    index. Guards the fix for the 150s whole-slot re-embed that stalled the loop."""
+    import types
+    from services.indexing.ladybug_store import VectorHit
+    cands = [_Cand("a", "works at AcmeCorp"), _Cand("b", "likes green tea")]
+
+    embed_calls = []
+    monkeypatch.setattr(conflict, "_shared_embed",
+                        lambda texts: embed_calls.append(list(texts)) or [[1.0, 0.0]])
+    monkeypatch.setattr("services.memory.settings.get_memory_settings",
+                        lambda: types.SimpleNamespace(ladybug_path="unused"))
+
+    class FakeStore:
+        def vector_search(self, *, owner, query_embedding, limit):
+            # 'a' near (dist 0.10 → sim 0.90 ≥ gate), 'b' far (dist 0.80 → sim 0.20)
+            return [VectorHit("a", owner, "semantic", "works at AcmeCorp", 0.10),
+                    VectorHit("b", owner, "semantic", "likes green tea", 0.80)]
+    monkeypatch.setattr("services.indexing.ladybug_store.get_ladybug_store",
+                        lambda path: FakeStore())
+
+    gated = conflict._gate("works at NovaCorp", cands, None)
+    assert [c.id for c in gated] == ["a"]              # only the near neighbour passes
+    assert embed_calls == [["works at NovaCorp"]]      # candidates NOT re-embedded
+
+
+# ── production gate falls back to embedding when the dense index is down ──
+def test_gate_production_falls_back_when_index_unavailable(monkeypatch):
+    import types
+    cands = [_Cand("a", "works at AcmeCorp")]
+    monkeypatch.setattr(conflict, "_shared_embed", _embed_by_keyword)
+    monkeypatch.setattr("services.memory.settings.get_memory_settings",
+                        lambda: types.SimpleNamespace(ladybug_path="unused"))
+    monkeypatch.setattr("services.indexing.ladybug_store.get_ladybug_store",
+                        lambda path: (_ for _ in ()).throw(RuntimeError("dense down")))
+    gated = conflict._gate("works at NovaCorp", cands, None)   # 'work' keyword → gate passes
+    assert [c.id for c in gated] == ["a"]
+
+
 # ── the capture chokepoint actually schedules conflict resolution ──
 def test_persist_wires_conflict_resolution(monkeypatch):
     from services.memory import candidate_service as cnd

--- a/backend/tests/test_services/test_memory_conflict.py
+++ b/backend/tests/test_services/test_memory_conflict.py
@@ -239,6 +239,29 @@ def test_gate_production_falls_back_when_index_unavailable(monkeypatch):
     assert [c.id for c in gated] == ["a"]
 
 
+# ── review #1: a same-slot candidate outside the dense window is embedded, not dropped ──
+def test_gate_embeds_candidates_missing_from_dense_window(monkeypatch):
+    import types
+    from services.indexing.ladybug_store import VectorHit
+    cands = [_Cand("a", "works at AcmeCorp"), _Cand("b", "employed at AcmeCorp")]
+    embed_calls = []
+    monkeypatch.setattr(conflict, "_shared_embed",
+                        lambda texts: embed_calls.append(list(texts)) or [[1.0, 0.0] for _ in texts])
+    monkeypatch.setattr("services.memory.settings.get_memory_settings",
+                        lambda: types.SimpleNamespace(ladybug_path="unused"))
+
+    class FakeStore:  # only 'a' is in the fetched window; 'b' ranked out
+        def vector_search(self, *, owner, query_embedding, limit):
+            return [VectorHit("a", owner, "semantic", "works at AcmeCorp", 0.10)]
+    monkeypatch.setattr("services.indexing.ladybug_store.get_ladybug_store",
+                        lambda path: FakeStore())
+
+    gated = conflict._gate("works at NovaCorp", cands, None)
+    assert {c.id for c in gated} == {"a", "b"}          # 'b' NOT silently dropped
+    assert ["works at NovaCorp"] in embed_calls         # the new fact
+    assert ["employed at AcmeCorp"] in embed_calls      # only the missing candidate (tail)
+
+
 # ── the capture chokepoint actually schedules conflict resolution ──
 def test_persist_wires_conflict_resolution(monkeypatch):
     from services.memory import candidate_service as cnd


### PR DESCRIPTION
## Root cause (verified live on prod)

`memory_remember` showed **"Unknown error"** in the UI. Root cause: the conflict-resolution gate (`conflict._gate`) **re-embedded the ENTIRE `(owner, scope, type)` memory slot on every save** — one sentence-transformers batch, padded to the longest fact → cost **O(N × max_len)**. On a 14-memory store this measured **~150s of pure CPU**, and because `schedule_resolve_conflicts` runs it as a task on the **main asyncio loop**, the synchronous embed **froze the whole event loop** → the live chat turn's SSE hung → UI rendered "Unknown error" (the memory was still saved).

### Evidence
- **Live**: a trivial async endpoint (`/api/health`) hung **71s**, unblocking the instant the embed finished (`tool_done duration=133s`), then back to `0.001s`.
- During the stall the **main thread (tid=1) + 3 torch threads were pinned at 100% CPU** — genuine compute, not I/O/lock.
- Diagnostic caller stack: `resolve_conflicts → _gate → _shared_embed → embed_documents(n=15, max_chars=1306, took=153.8s)`.
- Isolated: sync embed on a real loop → loop lag == embed time; `asyncio.to_thread` → **0.00s lag**.

## Fix
The module header already anticipated this: *"if a slot grows past this, switch the gate to the dense index (vector search)."*
- `_gate` production path (`embed_fn=None`) embeds **only the new fact** and scores candidates against their **already-stored** vectors via `LadybugStore.vector_search` (`_stored_scores`). Falls back to embedding if the dense index is unavailable. Injected-`embed_fn` tests keep the direct path.
- `resolve_conflicts` runs the CPU-bound gate via `asyncio.to_thread` → never blocks the loop.

Result: ~150s → ~0.3s, and the turn no longer stalls.

## Impact (gitnexus, repo=jarvis)
**LOW** — `resolve_conflicts` upstream is only `schedule_resolve_conflicts` (fire-and-forget); change is contained to `conflict.py`.

## Tests
- `test_gate_production_reuses_stored_vectors` — only the new fact is embedded; candidates scored from the index.
- `test_gate_production_falls_back_when_index_unavailable`.
- Existing scripted-`embed_fn` tests unchanged. **14 passed.**

Not yet verified end-to-end on prod (needs deploy) — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)