### PR TITLE
perf(tts): SQLite SSoT for pre-gen chapter status; stop per-tick full disk scan

### DIFF
--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -161,6 +161,28 @@ class AudioCacheEntry(Base):
     last_accessed_at = Column(Float, nullable=True)  # for LRU eviction
 
 
+class StoryChapter(Base):
+    """SSoT for per-chapter TTS pre-generation status.
+
+    Maps a chapter ``(story_id, chapter_file)`` to the content hash of its cleaned
+    text plus a file fingerprint, and tracks whether its audio is generated. The
+    reconcile pass (services.story_audio_index) keeps this in sync with
+    ``data/stories`` + the audio cache on disk — re-reading/re-hashing ONLY files
+    whose ``(mtime, size)`` changed. The pre-gen queue and status reads then hit
+    ONLY this table (indexed), replacing the old per-tick full disk scan that
+    re-read + re-hashed every chapter (~1s of blocking work every 10s)."""
+    __tablename__ = "story_chapters"
+
+    story_id = Column(String(255), primary_key=True)      # = folder under data/stories/
+    chapter_file = Column(String(255), primary_key=True)  # .txt filename
+    chapter_num = Column(Integer, default=0)              # sorted position within story
+    content_hash = Column(String(64), nullable=True, index=True)  # md5(clean_text) → cache key
+    text_mtime = Column(Float, default=0.0)               # fingerprint: source .txt mtime
+    text_size = Column(Integer, default=0)                # fingerprint: source .txt size
+    status = Column(String(20), default="pending", index=True)  # pending | ready | failed
+    updated_at = Column(Float, default=lambda: datetime.now().timestamp())
+
+
 class PendingAction(Base):
     """Cross-process action queue — replaces pending_read.json.
     MCP subprocess writes; FastAPI routes read and delete."""

--- a/backend/routes/stories.py
+++ b/backend/routes/stories.py
@@ -245,11 +245,12 @@ async def delete_story_endpoint(story_id: str, _=Depends(verify_api_key)):
         logger.error(f"Delete failed: {e}", exc_info=True)
         return JSONResponse(status_code=500, content={"error": str(e)})
     finally:
-        # Trigger TTS pregen rescan
+        # Trigger TTS pregen rescan — OFF the event loop: rescan() stats the whole
+        # story tree + reconciles, which shouldn't block the loop on a user action.
         if _state.bg_scheduler:
             for job in _state.bg_scheduler._jobs:
                 if hasattr(job, 'rescan'):
-                    job.rescan()
+                    await asyncio.to_thread(job.rescan)
 
 
 @router.get("/crawl/status")

--- a/backend/services/story_audio_index.py
+++ b/backend/services/story_audio_index.py
@@ -20,8 +20,10 @@ This module makes SQLite the single source of truth for per-chapter status:
 
 Readiness is authoritative in this table (``status``): reconcile seeds it from the
 mp3's existence for new/changed chapters; generation flips it to ``ready``; eviction
-flips it back to ``pending``. The serve path still checks the file directly, so an
-out-of-band mp3 deletion is caught there; a ``force`` reconcile re-syncs drift.
+flips it back to ``pending`` (mark_pending_by_hash). An out-of-band mp3 deletion
+(the ``.txt`` unchanged, so the fingerprint can't see it) is re-synced by the force
+reconcile (``verify_ready``, run by ``rescan``); the serve path also regenerates
+on demand when it finds the file missing.
 """
 from __future__ import annotations
 
@@ -96,11 +98,16 @@ def _hash_and_status(story_id: str, chapter_file: str) -> tuple[str | None, str]
 
 
 # ── reconcile: disk → table (incremental) ───────────────────────────────────
-def reconcile(db, sig: list[tuple] | None = None) -> dict:
+def reconcile(db, sig: list[tuple] | None = None, *, verify_ready: bool = False) -> dict:
     """Sync ``story_chapters`` with the story tree. Re-reads/re-hashes ONLY files
     whose ``(mtime, size)`` changed; unchanged chapters keep their content hash and
     status (a position shift just updates ``chapter_num``, no read). Removes rows
-    for deleted files. Returns counts. Best-effort per row; commits once."""
+    for deleted files. Returns counts. Best-effort per row; commits once.
+
+    ``verify_ready`` (used by the rare force reconcile): also stat the mp3 of each
+    ``ready`` chapter whose ``.txt`` did NOT change, and flip it back to ``pending``
+    if the file is gone — catches an out-of-band mp3 deletion that the fingerprint
+    alone can't see (normal eviction already resets status via mark_pending_by_hash)."""
     if sig is None:
         sig = signature()
     # Assign chapter_num = sorted position within each story.
@@ -129,8 +136,15 @@ def reconcile(db, sig: list[tuple] | None = None) -> dict:
             row.text_mtime, row.text_size = mtime, size
             row.status, row.updated_at = status, now
             changed += 1
-        elif row.chapter_num != num:
-            row.chapter_num = num  # sibling added/removed shifted position — no re-hash
+        else:
+            # (mtime, size) unchanged → no read/hash.
+            if row.chapter_num != num:
+                row.chapter_num = num  # sibling added/removed shifted position
+            if (verify_ready and row.status == STATUS_READY and row.content_hash
+                    and not os.path.exists(
+                        os.path.join(AUDIO_CACHE_DIR, f"{row.content_hash}.mp3"))):
+                row.status, row.updated_at = STATUS_PENDING, now  # mp3 vanished out-of-band
+                changed += 1
 
     for key, row in existing.items():
         if key not in disk:
@@ -250,8 +264,11 @@ def preview_queue(db, story_id: str | None = None, limit: int = 10) -> list[dict
                               StoryChapter.status == STATUS_PENDING,
                               StoryChapter.chapter_num > last_num)
                       .order_by(StoryChapter.chapter_num).limit(limit).all())
-            _push(active[:1], 0)   # P0: immediate next
-            _push(active[1:], 1)   # P1: subsequent
+            if active:
+                # P0 only when it's literally the immediate next chapter (matches
+                # next_task); otherwise the whole active tail is P1.
+                _push(active[:1], 0 if active[0].chapter_num == last_num + 1 else 1)
+                _push(active[1:], 1)
 
     story = _first_story_without_ready(db)
     if story is not None:

--- a/backend/services/story_audio_index.py
+++ b/backend/services/story_audio_index.py
@@ -1,0 +1,276 @@
+"""SSoT for per-chapter TTS pre-generation status (the ``story_chapters`` table).
+
+WHY THIS EXISTS
+The TTS pre-gen job used to re-derive "which chapters need audio" from disk on
+EVERY scheduler tick (~10s): read every chapter's text, ``clean_text_for_tts`` +
+md5, then ``os.path.exists`` the cache file. With one real story that was ~1s of
+blocking CPU/IO on the event loop every ~10s (561 chapters, 5.2MB re-read + 561
+hashes each pass) — measured, and it stalled live turns for ~1s.
+
+Chapter ``.txt`` files are immutable once written, so their content hash is stable.
+This module makes SQLite the single source of truth for per-chapter status:
+
+  reconcile(db, sig)   sync the table with disk, re-reading/re-hashing ONLY files
+                       whose (mtime, size) changed. Cheap in steady state.
+  next_task(db)        pick the next chapter to generate, by priority, via one
+                       indexed query — no disk scan, no hashing.
+  preview_queue(db)    the upcoming queue for the SSE snapshot.
+  status_counts(db)    done/total for the status endpoint — instant.
+  mark_ready / mark_pending_by_hash   status transitions from generate / evict.
+
+Readiness is authoritative in this table (``status``): reconcile seeds it from the
+mp3's existence for new/changed chapters; generation flips it to ``ready``; eviction
+flips it back to ``pending``. The serve path still checks the file directly, so an
+out-of-band mp3 deletion is caught there; a ``force`` reconcile re-syncs drift.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from sqlalchemy import func
+
+from core.database import StoryChapter, StoryProgress
+from helpers.audio_cache import AUDIO_CACHE_DIR, get_content_hash
+from helpers.path_safety import safe_story_path
+from helpers.text_processing import clean_text_for_tts
+
+logger = logging.getLogger("story_audio_index")
+
+STORIES_DIR = os.path.join("data", "stories")
+
+STATUS_READY = "ready"
+STATUS_PENDING = "pending"
+
+
+# ── disk fingerprint (cheap change-detection) ───────────────────────────────
+def signature() -> list[tuple]:
+    """A cheap fingerprint of the story tree: sorted ``(story, chapter, mtime,
+    size)`` — one ``os.stat`` per chapter, NO read/hash. reconcile() consumes it,
+    and the caller compares it to the previous one to skip reconcile when nothing
+    changed."""
+    sig: list[tuple] = []
+    if not os.path.isdir(STORIES_DIR):
+        return sig
+    for story in sorted(os.listdir(STORIES_DIR)):
+        sp = os.path.join(STORIES_DIR, story)
+        if not os.path.isdir(sp):
+            continue
+        for ch in sorted(os.listdir(sp)):
+            if not ch.endswith(".txt"):
+                continue
+            try:
+                st = os.stat(os.path.join(sp, ch))
+            except OSError:
+                continue
+            sig.append((story, ch, st.st_mtime, st.st_size))
+    return sig
+
+
+def _read_chapter(story_id: str, chapter_file: str) -> str | None:
+    try:
+        path = safe_story_path(STORIES_DIR, story_id, chapter_file)
+    except ValueError as e:
+        logger.warning("[AUDIO-INDEX] unsafe path %r/%r: %s", story_id, chapter_file, e)
+        return None
+    try:
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read().strip()
+    except Exception as e:  # noqa: BLE001
+        logger.error("[AUDIO-INDEX] read error %s: %s", path, e)
+    return None
+
+
+def _hash_and_status(story_id: str, chapter_file: str) -> tuple[str | None, str]:
+    """(content_hash, status) for a chapter, read from disk. Only called for NEW or
+    CHANGED files during reconcile — the expensive read+hash is amortised away for
+    the unchanged majority."""
+    text = _read_chapter(story_id, chapter_file)
+    if not text:
+        return None, STATUS_PENDING
+    content_hash = get_content_hash(clean_text_for_tts(text))
+    cache_path = os.path.join(AUDIO_CACHE_DIR, f"{content_hash}.mp3")
+    return content_hash, (STATUS_READY if os.path.exists(cache_path) else STATUS_PENDING)
+
+
+# ── reconcile: disk → table (incremental) ───────────────────────────────────
+def reconcile(db, sig: list[tuple] | None = None) -> dict:
+    """Sync ``story_chapters`` with the story tree. Re-reads/re-hashes ONLY files
+    whose ``(mtime, size)`` changed; unchanged chapters keep their content hash and
+    status (a position shift just updates ``chapter_num``, no read). Removes rows
+    for deleted files. Returns counts. Best-effort per row; commits once."""
+    if sig is None:
+        sig = signature()
+    # Assign chapter_num = sorted position within each story.
+    disk: dict[tuple, tuple] = {}
+    per_story_idx: dict[str, int] = {}
+    for story, ch, mtime, size in sig:
+        idx = per_story_idx.get(story, 0)
+        disk[(story, ch)] = (idx, mtime, size)
+        per_story_idx[story] = idx + 1
+
+    existing = {(r.story_id, r.chapter_file): r for r in db.query(StoryChapter).all()}
+    now = time.time()
+    changed = removed = 0
+
+    for (story, ch), (num, mtime, size) in disk.items():
+        row = existing.get((story, ch))
+        if row is None:
+            content_hash, status = _hash_and_status(story, ch)
+            db.add(StoryChapter(story_id=story, chapter_file=ch, chapter_num=num,
+                                content_hash=content_hash, text_mtime=mtime,
+                                text_size=size, status=status, updated_at=now))
+            changed += 1
+        elif row.text_mtime != mtime or row.text_size != size:
+            content_hash, status = _hash_and_status(story, ch)
+            row.chapter_num, row.content_hash = num, content_hash
+            row.text_mtime, row.text_size = mtime, size
+            row.status, row.updated_at = status, now
+            changed += 1
+        elif row.chapter_num != num:
+            row.chapter_num = num  # sibling added/removed shifted position — no re-hash
+
+    for key, row in existing.items():
+        if key not in disk:
+            db.delete(row)
+            removed += 1
+
+    db.commit()
+    if changed or removed:
+        logger.info("[AUDIO-INDEX] reconciled: %d changed, %d removed, %d total",
+                    changed, removed, len(disk))
+    return {"changed": changed, "removed": removed, "total": len(disk)}
+
+
+# ── status transitions ──────────────────────────────────────────────────────
+def mark_ready(db, story_id: str, chapter_file: str, content_hash: str | None = None) -> None:
+    row = db.get(StoryChapter, (story_id, chapter_file))
+    if row is None:
+        return
+    row.status = STATUS_READY
+    if content_hash:
+        row.content_hash = content_hash
+    row.updated_at = time.time()
+    db.commit()
+
+
+def mark_pending_by_hash(db, content_hash: str) -> int:
+    """Flip every chapter pointing at an evicted audio file back to pending, so it
+    is regenerated. Content-addressed: dedup'd chapters sharing the hash all reset."""
+    n = (db.query(StoryChapter)
+         .filter(StoryChapter.content_hash == content_hash, StoryChapter.status == STATUS_READY)
+         .update({"status": STATUS_PENDING, "updated_at": time.time()},
+                 synchronize_session=False))
+    db.commit()
+    return n
+
+
+# ── queue / status reads (indexed, no disk) ─────────────────────────────────
+def _task(row: StoryChapter, priority: int) -> dict:
+    return {"story_title": row.story_id, "chapter_file": row.chapter_file, "priority": priority}
+
+
+def _chapter_num(db, story_id: str, chapter_file: str | None) -> int | None:
+    if not chapter_file:
+        return None
+    row = db.get(StoryChapter, (story_id, chapter_file))
+    return row.chapter_num if row else None
+
+
+def _active_story(db) -> StoryProgress | None:
+    return (db.query(StoryProgress)
+            .order_by(StoryProgress.last_played_at.desc()).first())
+
+
+def _first_story_without_ready(db) -> str | None:
+    """First (alphabetical) story that has a pending chapter and NO ready chapter —
+    i.e. a story with no audio at all yet (P2)."""
+    ready = {s for (s,) in db.query(StoryChapter.story_id)
+             .filter(StoryChapter.status == STATUS_READY).distinct()}
+    for (sid,) in (db.query(StoryChapter.story_id)
+                   .filter(StoryChapter.status == STATUS_PENDING)
+                   .order_by(StoryChapter.story_id).distinct()):
+        if sid not in ready:
+            return sid
+    return None
+
+
+def next_task(db) -> dict | None:
+    """The single next chapter to generate, by priority — one indexed query set,
+    no disk. P0: next chapter of the actively-listened story. P1: subsequent
+    chapters of that story. P2: first chapter of a story with no audio. P3: any
+    pending chapter."""
+    prog = _active_story(db)
+    if prog is not None:
+        last_num = _chapter_num(db, prog.story_title, prog.last_chapter_file)
+        if last_num is not None:
+            row = (db.query(StoryChapter)
+                   .filter(StoryChapter.story_id == prog.story_title,
+                           StoryChapter.status == STATUS_PENDING,
+                           StoryChapter.chapter_num > last_num)
+                   .order_by(StoryChapter.chapter_num).first())
+            if row is not None:
+                return _task(row, 0 if row.chapter_num == last_num + 1 else 1)
+
+    story = _first_story_without_ready(db)
+    if story is not None:
+        row = (db.query(StoryChapter)
+               .filter(StoryChapter.story_id == story, StoryChapter.status == STATUS_PENDING)
+               .order_by(StoryChapter.chapter_num).first())
+        if row is not None:
+            return _task(row, 2)
+
+    row = (db.query(StoryChapter).filter(StoryChapter.status == STATUS_PENDING)
+           .order_by(StoryChapter.story_id, StoryChapter.chapter_num).first())
+    return _task(row, 3) if row is not None else None
+
+
+def preview_queue(db, story_id: str | None = None, limit: int = 10) -> list[dict]:
+    """The upcoming generation queue in execution order (P0→P3), deduped — for the
+    SSE snapshot. Pure DB, no disk."""
+    queue: list[dict] = []
+    seen: set[tuple] = set()
+
+    def _push(rows, prio):
+        for r in rows:
+            key = (r.story_id, r.chapter_file)
+            if key in seen:
+                continue
+            seen.add(key)
+            queue.append({"story_id": r.story_id, "chapter_file": r.chapter_file, "priority": prio})
+
+    prog = _active_story(db)
+    if prog is not None:
+        last_num = _chapter_num(db, prog.story_title, prog.last_chapter_file)
+        if last_num is not None:
+            active = (db.query(StoryChapter)
+                      .filter(StoryChapter.story_id == prog.story_title,
+                              StoryChapter.status == STATUS_PENDING,
+                              StoryChapter.chapter_num > last_num)
+                      .order_by(StoryChapter.chapter_num).limit(limit).all())
+            _push(active[:1], 0)   # P0: immediate next
+            _push(active[1:], 1)   # P1: subsequent
+
+    story = _first_story_without_ready(db)
+    if story is not None:
+        _push((db.query(StoryChapter)
+               .filter(StoryChapter.story_id == story, StoryChapter.status == STATUS_PENDING)
+               .order_by(StoryChapter.chapter_num).limit(1).all()), 2)
+
+    if len(queue) < limit:
+        _push((db.query(StoryChapter).filter(StoryChapter.status == STATUS_PENDING)
+               .order_by(StoryChapter.story_id, StoryChapter.chapter_num)
+               .limit(limit).all()), 3)
+
+    if story_id:
+        queue = [q for q in queue if q["story_id"] == story_id]
+    return queue[:limit]
+
+
+def status_counts(db) -> dict:
+    total = db.query(func.count()).select_from(StoryChapter).scalar() or 0
+    ready = (db.query(func.count()).select_from(StoryChapter)
+             .filter(StoryChapter.status == STATUS_READY).scalar() or 0)
+    return {"total": total, "done": ready, "pending": total - ready}

--- a/backend/services/tts_pregen_job.py
+++ b/backend/services/tts_pregen_job.py
@@ -22,9 +22,10 @@ from helpers.path_safety import safe_story_path
 import edge_tts
 
 from services.background_jobs import BackgroundJobRunner, BackgroundJobScheduler
-from core.database import get_db_session, StoryProgress, BackgroundJobState
-from helpers.audio_cache import get_audio_cache_path, get_content_hash, AUDIO_CACHE_DIR, mark_ready, mark_failed, register_audio
+from core.database import get_db_session
+from helpers.audio_cache import get_audio_cache_path, get_content_hash, AUDIO_CACHE_DIR
 from helpers.text_processing import clean_text_for_tts
+from services import story_audio_index  # SSoT for per-chapter status (data/story_chapters)
 
 logger = logging.getLogger("tts_pregen_job")
 
@@ -57,6 +58,7 @@ class TTSPreGenJob(BackgroundJobRunner):
             "errors": 0,
             "last_error": None,
         }
+        self._last_sig = None  # last reconciled story-tree fingerprint (change-detection)
         self.rescan()
     
     def set_pregen_stream(self, stream):
@@ -81,69 +83,71 @@ class TTSPreGenJob(BackgroundJobRunner):
         return None
     
     def rescan(self):
-        """Scan data/stories/ to count total chapters."""
-        total = 0
-        done = 0
-        if os.path.exists(STORIES_DIR):
-            for story in sorted(os.listdir(STORIES_DIR)):
-                story_path = os.path.join(STORIES_DIR, story)
-                if not os.path.isdir(story_path):
-                    continue
-                for chapter in os.listdir(story_path):
-                    if chapter.endswith(".txt"):
-                        total += 1
-                        # Check if audio already exists
-                        text = self._read_chapter_text(story, chapter)
-                        if text:
-                            cache_path = get_audio_cache_path(clean_text_for_tts(text))
-                            if os.path.exists(cache_path):
-                                done += 1
-        
-        self._stats["total_chapters"] = total
-        self._stats["done_chapters"] = done
+        """FORCE a reconcile of the story_chapters SSoT with disk, then refresh the
+        cached counts. Called at boot and by the stories API after a story is
+        added/removed (the event-driven trigger). Re-reads/re-hashes only changed
+        chapters — not the whole tree."""
+        try:
+            db = get_db_session()
+            try:
+                sig = story_audio_index.signature()
+                story_audio_index.reconcile(db, sig)
+                self._last_sig = sig
+                counts = story_audio_index.status_counts(db)
+            finally:
+                db.close()
+            self._stats["total_chapters"] = counts["total"]
+            self._stats["done_chapters"] = counts["done"]
+        except Exception as e:  # noqa: BLE001 — never break boot / the stories route
+            logger.error(f"[PRE-GEN] rescan/reconcile failed: {e}", exc_info=True)
         self._stats["disk_usage_mb"] = self._get_cache_size_mb()
-        logger.info(f"[PRE-GEN] Scanned: {done}/{total} chapters already generated, "
+        logger.info(f"[PRE-GEN] Reconciled: {self._stats['done_chapters']}/"
+                    f"{self._stats['total_chapters']} chapters generated, "
                     f"disk: {self._stats['disk_usage_mb']:.0f}MB")
+
+    def _maybe_reconcile(self):
+        """Cheap change-detection: fingerprint the story tree (one stat per chapter,
+        no read/hash) and reconcile ONLY when it changed since last time. Runs on a
+        worker thread (see get_next_task) so neither the stat sweep nor a real
+        reconcile ever blocks the event loop."""
+        sig = story_audio_index.signature()
+        if sig == self._last_sig:
+            return
+        db = get_db_session()
+        try:
+            counts = story_audio_index.reconcile(db, sig)
+            self._last_sig = sig
+            self._stats["total_chapters"] = counts["total"]
+        finally:
+            db.close()
     
     async def get_next_task(self) -> dict | None:
-        """Dynamic priority queue: P0 → P1 → P2 → P3."""
-        # Check disk quota
-        usage_bytes = self._get_cache_size_bytes()
-        if usage_bytes > self.DISK_QUOTA_BYTES * self.EVICTION_THRESHOLD:
-            evicted = self._evict_old_audio()
-            if evicted > 0:
-                logger.warning(f"[EVICTION] Evicted {evicted} files, "
-                              f"disk now: {self._get_cache_size_mb():.0f}MB")
-            # Re-check after eviction
-            if self._get_cache_size_bytes() > self.DISK_QUOTA_BYTES * self.EVICTION_THRESHOLD:
-                logger.debug("[PRE-GEN] Disk quota still exceeded after eviction, skipping")
-                return None
-        
-        # P0: Next chapter (n+1) for actively listened story
-        task = self._find_p0_next_chapter()
-        if task:
-            task["priority"] = 0
-            return task
-        
-        # P1: Upcoming chapters (n+2, n+3...) of the same actively listened story
-        task = self._find_p1_upcoming_chapters()
-        if task:
-            task["priority"] = 1
-            return task
-        
-        # P2: First chapter of stories with no audio at all
-        task = self._find_p2_new_stories()
-        if task:
-            task["priority"] = 2
-            return task
-        
-        # P3: Sequential chapters across all stories
-        task = self._find_p3_sequential()
-        if task:
-            task["priority"] = 3
-            return task
-        
-        return None  # All chapters generated!
+        """Next chapter to generate, by priority (P0→P3). The heavy work — the
+        story-tree fingerprint + any reconcile, and the disk-quota sweep — runs on
+        a worker thread so it NEVER blocks the event loop (the old inline per-tick
+        full scan stalled it ~1s every 10s). Picking the task itself is one indexed
+        query against the story_chapters SSoT — no disk, no hashing."""
+        # Keep the SSoT in sync with disk (only when the tree changed) + quota — off-loop.
+        await asyncio.to_thread(self._maybe_reconcile)
+        if not await asyncio.to_thread(self._ensure_disk_quota):
+            return None  # over quota even after eviction — skip this cycle
+
+        db = get_db_session()
+        try:
+            return story_audio_index.next_task(db)
+        finally:
+            db.close()
+
+    def _ensure_disk_quota(self) -> bool:
+        """Evict old audio if over quota. Returns False if still over quota after
+        eviction (caller should skip). Runs off-loop (disk I/O)."""
+        if self._get_cache_size_bytes() <= self.DISK_QUOTA_BYTES * self.EVICTION_THRESHOLD:
+            return True
+        evicted = self._evict_old_audio()
+        if evicted > 0:
+            logger.warning(f"[EVICTION] Evicted {evicted} files, "
+                          f"disk now: {self._get_cache_size_mb():.0f}MB")
+        return self._get_cache_size_bytes() <= self.DISK_QUOTA_BYTES * self.EVICTION_THRESHOLD
     
     async def execute_task(self, task: dict) -> bool:
         """Generate audio for 1 chapter using Edge TTS with pause/cancel checkpoints."""
@@ -176,6 +180,7 @@ class TTSPreGenJob(BackgroundJobRunner):
         if os.path.exists(cache_path) and not os.path.exists(cache_path + ".lock"):
             logger.debug(f"[PRE-GEN] Already exists: {story_title}/{chapter_file}")
             self._stats["done_chapters"] += 1
+            self._mark_ready_status(story_title, chapter_file, text)
             self._emit({
                 "type": "chapter_ready",
                 "story_id": story_title,
@@ -262,7 +267,10 @@ class TTSPreGenJob(BackgroundJobRunner):
             # Done — remove lock
             if os.path.exists(lock_path):
                 os.remove(lock_path)
-            
+
+            # Flip the SSoT to 'ready' (the source of truth the queue/status read).
+            self._mark_ready_status(story_title, chapter_file, text)
+
             duration = time.time() - start_time
             size_mb = bytes_written / (1024 * 1024)
             self._stats["done_chapters"] += 1
@@ -317,13 +325,25 @@ class TTSPreGenJob(BackgroundJobRunner):
             return False
     
     def get_status(self) -> dict:
-        """Return status for /api/background/status."""
+        """Return status for /api/background/status — counts come from the SSoT
+        (one indexed query), not a disk scan."""
         self._stats["disk_usage_mb"] = self._get_cache_size_mb()
+        total, done = self._stats["total_chapters"], self._stats["done_chapters"]
+        try:
+            db = get_db_session()
+            try:
+                counts = story_audio_index.status_counts(db)
+            finally:
+                db.close()
+            total, done = counts["total"], counts["done"]
+            self._stats["total_chapters"], self._stats["done_chapters"] = total, done
+        except Exception as e:  # noqa: BLE001 — status must never raise
+            logger.warning(f"[PRE-GEN] status_counts failed: {e}")
         return {
             "job_name": self.job_name,
             "status": "running" if self._stats["current_chapter"] else "idle",
-            "total": self._stats["total_chapters"],
-            "done": self._stats["done_chapters"],
+            "total": total,
+            "done": done,
             "current_chapter": (
                 f"{self._stats['current_story']}/{self._stats['current_chapter']}"
                 if self._stats["current_chapter"] else None
@@ -335,250 +355,33 @@ class TTSPreGenJob(BackgroundJobRunner):
         }
     
     # --- Preview queue (for SSE initial snapshot + queue_update) ---
-    
+
     def preview_queue(self, story_id: str | None = None, limit: int = 10) -> list[dict]:
-        """Preview the upcoming generation queue without executing.
-        
-        Returns list of {story_id, chapter_file, priority} in execution order.
-        Used by SSE endpoint for initial snapshot and queue_update events.
-        """
-        queue = []
-        seen = set()  # (story_id, chapter_file) to avoid duplicates
-        
-        # P0: next chapter of active story
-        p0_items = self._collect_p0_next_chapter()
-        for item in p0_items:
-            key = (item["story_title"], item["chapter_file"])
-            if key not in seen:
-                seen.add(key)
-                queue.append({
-                    "story_id": item["story_title"],
-                    "chapter_file": item["chapter_file"],
-                    "priority": 0,
-                })
-        
-        # P1: upcoming chapters (n+2, n+3...) of active story
-        p1_items = self._collect_p1_upcoming_chapters(limit=limit)
-        for item in p1_items:
-            key = (item["story_title"], item["chapter_file"])
-            if key not in seen:
-                seen.add(key)
-                queue.append({
-                    "story_id": item["story_title"],
-                    "chapter_file": item["chapter_file"],
-                    "priority": 1,
-                })
-        
-        # P2: first chapter of new stories
-        p2_items = self._collect_p2_new_stories(limit=limit)
-        for item in p2_items:
-            key = (item["story_title"], item["chapter_file"])
-            if key not in seen:
-                seen.add(key)
-                queue.append({
-                    "story_id": item["story_title"],
-                    "chapter_file": item["chapter_file"],
-                    "priority": 2,
-                })
-        
-        # P3: sequential round-robin
-        remaining = limit - len(queue)
-        if remaining > 0:
-            p3_items = self._collect_p3_sequential(limit=remaining, exclude=seen)
-            for item in p3_items:
-                queue.append({
-                    "story_id": item["story_title"],
-                    "chapter_file": item["chapter_file"],
-                    "priority": 3,
-                })
-        
-        # Apply story_id filter if requested
-        if story_id:
-            queue = [q for q in queue if q["story_id"] == story_id]
-        
-        return queue[:limit]
-    
-    # --- Priority queue methods ---
-    
-    def _find_p0_next_chapter(self) -> dict | None:
-        """P0: Next chapter (n+1) of the story user is currently listening to."""
-        items = self._collect_p0_next_chapter()
-        return items[0] if items else None
-    
-    def _find_p1_upcoming_chapters(self) -> dict | None:
-        """P1: Next un-generated chapter (n+2, n+3...) of active story."""
-        items = self._collect_p1_upcoming_chapters(limit=1)
-        return items[0] if items else None
-    
-    def _find_p2_new_stories(self) -> dict | None:
-        """P2: First chapter of stories that have NO audio generated yet."""
-        items = self._collect_p2_new_stories(limit=1)
-        return items[0] if items else None
-    
-    def _find_p3_sequential(self) -> dict | None:
-        """P3: Find next un-generated chapter across all stories (round-robin)."""
-        items = self._collect_p3_sequential(limit=1)
-        return items[0] if items else None
-    
-    # --- Collector methods (return list for preview_queue) ---
-    
-    def _collect_p0_next_chapter(self) -> list[dict]:
-        """Collect the immediate next chapter (n+1) for active stories."""
-        results = []
+        """Preview the upcoming generation queue (P0→P3), in execution order.
+        Reads the story_chapters SSoT — one indexed query set, no disk scan."""
         try:
             db = get_db_session()
-            progresses = db.query(StoryProgress).order_by(
-                StoryProgress.last_played_at.desc()
-            ).limit(3).all()
-            
-            for progress in progresses:
-                story_dir = os.path.join(STORIES_DIR, progress.story_title)
-                if not os.path.exists(story_dir):
-                    continue
-                
-                chapters = sorted([f for f in os.listdir(story_dir) if f.endswith(".txt")])
-                
-                # Find the chapter AFTER last_chapter_file
-                found_current = False
-                for chapter_file in chapters:
-                    if progress.last_chapter_file and chapter_file == progress.last_chapter_file:
-                        found_current = True
-                        continue
-                    
-                    if found_current:
-                        # Check if this chapter already has audio
-                        text = self._read_chapter_text(progress.story_title, chapter_file)
-                        if text:
-                            cache_path = get_audio_cache_path(clean_text_for_tts(text))
-                            if not os.path.exists(cache_path):
-                                results.append({
-                                    "story_title": progress.story_title,
-                                    "chapter_file": chapter_file,
-                                })
-                        break  # Only the immediate next (n+1)
-            
-            db.close()
-        except Exception as e:
-            logger.error(f"[PRE-GEN] P0 query error: {e}")
-        return results
-    
-    def _collect_p1_upcoming_chapters(self, limit: int = 10) -> list[dict]:
-        """Collect chapters n+2, n+3... of the actively listened story.
-        
-        Skips n+1 (that's P0) and returns subsequent un-generated chapters.
-        """
-        results = []
+            try:
+                return story_audio_index.preview_queue(db, story_id=story_id, limit=limit)
+            finally:
+                db.close()
+        except Exception as e:  # noqa: BLE001 — preview must never raise
+            logger.error(f"[PRE-GEN] preview_queue error: {e}")
+            return []
+
+    def _mark_ready_status(self, story_title: str, chapter_file: str, cleaned_text: str) -> None:
+        """Record a chapter as generated in the SSoT (best-effort). ``cleaned_text``
+        is the text that was fed to TTS, so its hash IS the audio cache key."""
         try:
             db = get_db_session()
-            progress = db.query(StoryProgress).order_by(
-                StoryProgress.last_played_at.desc()
-            ).first()
-            
-            if not progress:
+            try:
+                story_audio_index.mark_ready(
+                    db, story_title, chapter_file, get_content_hash(cleaned_text))
+            finally:
                 db.close()
-                return results
-            
-            story_dir = os.path.join(STORIES_DIR, progress.story_title)
-            if not os.path.exists(story_dir):
-                db.close()
-                return results
-            
-            chapters = sorted([f for f in os.listdir(story_dir) if f.endswith(".txt")])
-            
-            # Find current position and skip n+1 (P0 handles that)
-            found_current = False
-            skip_next = True  # Skip the first one after current (that's P0)
-            
-            for chapter_file in chapters:
-                if progress.last_chapter_file and chapter_file == progress.last_chapter_file:
-                    found_current = True
-                    continue
-                
-                if found_current:
-                    if skip_next:
-                        skip_next = False
-                        continue  # This is n+1, handled by P0
-                    
-                    # Check if un-generated
-                    text = self._read_chapter_text(progress.story_title, chapter_file)
-                    if text:
-                        cache_path = get_audio_cache_path(clean_text_for_tts(text))
-                        if not os.path.exists(cache_path):
-                            results.append({
-                                "story_title": progress.story_title,
-                                "chapter_file": chapter_file,
-                            })
-                            if len(results) >= limit:
-                                break
-            
-            db.close()
-        except Exception as e:
-            logger.error(f"[PRE-GEN] P1 query error: {e}")
-        return results
-    
-    def _collect_p2_new_stories(self, limit: int = 10) -> list[dict]:
-        """Collect first chapter of stories that have NO audio generated yet."""
-        results = []
-        if not os.path.exists(STORIES_DIR):
-            return results
-        
-        for story in sorted(os.listdir(STORIES_DIR)):
-            story_path = os.path.join(STORIES_DIR, story)
-            if not os.path.isdir(story_path):
-                continue
-            
-            chapters = sorted([f for f in os.listdir(story_path) if f.endswith(".txt")])
-            if not chapters:
-                continue
-            
-            # Check if ANY chapter has audio
-            has_audio = False
-            for chapter in chapters:
-                text = self._read_chapter_text(story, chapter)
-                if text:
-                    cache_path = get_audio_cache_path(clean_text_for_tts(text))
-                    if os.path.exists(cache_path):
-                        has_audio = True
-                        break
-            
-            if not has_audio:
-                first = chapters[0]
-                text = self._read_chapter_text(story, first)
-                if text:
-                    results.append({"story_title": story, "chapter_file": first})
-                    if len(results) >= limit:
-                        break
-        
-        return results
-    
-    def _collect_p3_sequential(self, limit: int = 10, exclude: set | None = None) -> list[dict]:
-        """Collect next un-generated chapters across all stories (round-robin)."""
-        results = []
-        exclude = exclude or set()
-        
-        if not os.path.exists(STORIES_DIR):
-            return results
-        
-        for story in sorted(os.listdir(STORIES_DIR)):
-            story_path = os.path.join(STORIES_DIR, story)
-            if not os.path.isdir(story_path):
-                continue
-            
-            chapters = sorted([f for f in os.listdir(story_path) if f.endswith(".txt")])
-            for chapter in chapters:
-                if (story, chapter) in exclude:
-                    continue
-                text = self._read_chapter_text(story, chapter)
-                if text:
-                    clean = clean_text_for_tts(text)
-                    cache_path = get_audio_cache_path(clean)
-                    if not os.path.exists(cache_path):
-                        results.append({"story_title": story, "chapter_file": chapter})
-                        if len(results) >= limit:
-                            return results
-        
-        return results
-    
+        except Exception as e:  # noqa: BLE001 — never fail generation over a status write
+            logger.warning(f"[PRE-GEN] mark_ready failed for {story_title}/{chapter_file}: {e}")
+
     # --- Disk management ---
     
     def _get_cache_size_bytes(self) -> int:
@@ -614,22 +417,37 @@ class TTSPreGenJob(BackgroundJobRunner):
             files_with_meta.sort(key=lambda x: x["mtime"])
             
             evicted = 0
+            evicted_hashes = []  # content_hash of each removed <hash>.mp3
             target = self.DISK_QUOTA_BYTES * 0.8  # Evict down to 80%
             current_size = self._get_cache_size_bytes()
-            
+
             for file_info in files_with_meta:
                 if current_size <= target:
                     break
                 # Don't evict files with .lock (currently generating)
                 if os.path.exists(file_info["path"] + ".lock"):
                     continue
-                
+
                 os.remove(file_info["path"])
                 current_size -= file_info["size"]
                 evicted += 1
+                evicted_hashes.append(file_info["file"][:-4])  # strip ".mp3"
                 logger.debug(f"[EVICTION] Deleted: {file_info['file']} "
                           f"(age: {(time.time() - file_info['mtime'])/3600:.0f}h)")
-            
+
+            # Flip the SSoT rows for evicted audio back to 'pending' so the queue
+            # regenerates them (readiness is authoritative in story_chapters).
+            if evicted_hashes:
+                try:
+                    db = get_db_session()
+                    try:
+                        for h in evicted_hashes:
+                            story_audio_index.mark_pending_by_hash(db, h)
+                    finally:
+                        db.close()
+                except Exception as e:  # noqa: BLE001 — eviction must not fail over this
+                    logger.warning(f"[EVICTION] SSoT status reset failed: {e}")
+
             return evicted
         except Exception as e:
             logger.error(f"[EVICTION] Error: {e}", exc_info=True)

--- a/backend/services/tts_pregen_job.py
+++ b/backend/services/tts_pregen_job.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -59,6 +60,10 @@ class TTSPreGenJob(BackgroundJobRunner):
             "last_error": None,
         }
         self._last_sig = None  # last reconciled story-tree fingerprint (change-detection)
+        # Serialise reconciles: rescan() (stories route) and _maybe_reconcile()
+        # (scheduler worker thread) can fire at once — one writer at a time avoids
+        # interleaved commits / "database is locked" on story_chapters.
+        self._reconcile_lock = threading.Lock()
         self.rescan()
     
     def set_pregen_stream(self, stream):
@@ -88,14 +93,17 @@ class TTSPreGenJob(BackgroundJobRunner):
         added/removed (the event-driven trigger). Re-reads/re-hashes only changed
         chapters — not the whole tree."""
         try:
-            db = get_db_session()
-            try:
-                sig = story_audio_index.signature()
-                story_audio_index.reconcile(db, sig)
-                self._last_sig = sig
-                counts = story_audio_index.status_counts(db)
-            finally:
-                db.close()
+            with self._reconcile_lock:
+                db = get_db_session()
+                try:
+                    sig = story_audio_index.signature()
+                    # verify_ready: a force pass also re-checks each ready chapter's
+                    # mp3 so an out-of-band deletion is re-queued.
+                    story_audio_index.reconcile(db, sig, verify_ready=True)
+                    self._last_sig = sig
+                    counts = story_audio_index.status_counts(db)
+                finally:
+                    db.close()
             self._stats["total_chapters"] = counts["total"]
             self._stats["done_chapters"] = counts["done"]
         except Exception as e:  # noqa: BLE001 — never break boot / the stories route
@@ -113,13 +121,19 @@ class TTSPreGenJob(BackgroundJobRunner):
         sig = story_audio_index.signature()
         if sig == self._last_sig:
             return
-        db = get_db_session()
         try:
-            counts = story_audio_index.reconcile(db, sig)
-            self._last_sig = sig
-            self._stats["total_chapters"] = counts["total"]
-        finally:
-            db.close()
+            with self._reconcile_lock:
+                if sig == self._last_sig:   # another reconcile just did this fingerprint
+                    return
+                db = get_db_session()
+                try:
+                    counts = story_audio_index.reconcile(db, sig)
+                    self._last_sig = sig
+                    self._stats["total_chapters"] = counts["total"]
+                finally:
+                    db.close()
+        except Exception as e:  # noqa: BLE001 — a transient DB error just skips this cycle,
+            logger.error(f"[PRE-GEN] reconcile failed: {e}", exc_info=True)  # never crash the scheduler
     
     async def get_next_task(self) -> dict | None:
         """Next chapter to generate, by priority (P0→P3). The heavy work — the

--- a/backend/tests/test_services/test_story_audio_index.py
+++ b/backend/tests/test_services/test_story_audio_index.py
@@ -72,6 +72,22 @@ def test_reconcile_skips_unchanged_without_rehash(env, monkeypatch):
     assert calls["n"] == 0
 
 
+def test_reconcile_verify_ready_requeues_deleted_mp3(env):
+    _chapter(env, "storyA", "01.txt", "a1")
+    _generate(env, "a1")
+    db = env.Session()
+    sai.reconcile(db)
+    assert db.get(StoryChapter, ("storyA", "01.txt")).status == "ready"
+
+    # mp3 deleted out-of-band; the .txt is untouched so the fingerprint can't see it.
+    h = get_content_hash(clean_text_for_tts("a1"))
+    (env.audio / f"{h}.mp3").unlink()
+    sai.reconcile(db)                       # plain pass → stays ready (fingerprint unchanged)
+    assert db.get(StoryChapter, ("storyA", "01.txt")).status == "ready"
+    sai.reconcile(db, verify_ready=True)    # force pass re-checks the mp3 → requeue
+    assert db.get(StoryChapter, ("storyA", "01.txt")).status == "pending"
+
+
 def test_reconcile_detects_new_and_removed(env):
     _chapter(env, "storyA", "01.txt")
     db = env.Session()

--- a/backend/tests/test_services/test_story_audio_index.py
+++ b/backend/tests/test_services/test_story_audio_index.py
@@ -1,0 +1,151 @@
+"""SSoT for per-chapter TTS status (services.story_audio_index).
+
+Real in-memory SQLite + real reconcile against a temp story tree / audio cache.
+The only thing faked is the filesystem location (tmp dirs) — the read/hash/status
+logic and the priority queries run for real.
+"""
+import types
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from core.database import Base, StoryChapter, StoryProgress
+from helpers.audio_cache import get_content_hash
+from helpers.text_processing import clean_text_for_tts
+from services import story_audio_index as sai
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    stories = tmp_path / "stories"
+    audio = tmp_path / "audio"
+    stories.mkdir()
+    audio.mkdir()
+    monkeypatch.setattr(sai, "STORIES_DIR", str(stories))
+    monkeypatch.setattr(sai, "AUDIO_CACHE_DIR", str(audio))
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    return types.SimpleNamespace(stories=stories, audio=audio, Session=Session)
+
+
+def _chapter(env, story, fname, text="hello world"):
+    d = env.stories / story
+    d.mkdir(exist_ok=True)
+    (d / fname).write_text(text, encoding="utf-8")
+
+
+def _generate(env, text="hello world"):
+    """Create the mp3 the reconcile will see as 'ready' (same hash the code uses)."""
+    h = get_content_hash(clean_text_for_tts(text))
+    (env.audio / f"{h}.mp3").write_bytes(b"MP3")
+    return h
+
+
+# ── reconcile: disk → table ─────────────────────────────────────────────────
+def test_reconcile_builds_rows_and_status_from_disk(env):
+    _chapter(env, "storyA", "01.txt", "chapter one text")
+    _chapter(env, "storyA", "02.txt", "chapter two text")
+    _generate(env, "chapter one text")   # 01 already has audio
+
+    db = env.Session()
+    sai.reconcile(db)
+    rows = {r.chapter_file: r for r in db.query(StoryChapter).all()}
+    assert set(rows) == {"01.txt", "02.txt"}
+    assert rows["01.txt"].status == "ready" and rows["01.txt"].chapter_num == 0
+    assert rows["02.txt"].status == "pending" and rows["02.txt"].chapter_num == 1
+    assert sai.status_counts(db) == {"total": 2, "done": 1, "pending": 1}
+
+
+def test_reconcile_skips_unchanged_without_rehash(env, monkeypatch):
+    _chapter(env, "storyA", "01.txt")
+    db = env.Session()
+    sai.reconcile(db)                       # first pass reads+hashes
+    calls = {"n": 0}
+    real = sai._hash_and_status
+    monkeypatch.setattr(sai, "_hash_and_status",
+                        lambda s, c: calls.__setitem__("n", calls["n"] + 1) or real(s, c))
+    sai.reconcile(db)                       # same fingerprint → must NOT re-hash
+    assert calls["n"] == 0
+
+
+def test_reconcile_detects_new_and_removed(env):
+    _chapter(env, "storyA", "01.txt")
+    db = env.Session()
+    sai.reconcile(db)
+    _chapter(env, "storyA", "02.txt")       # added
+    (env.stories / "storyA" / "01.txt").unlink()  # removed
+    sai.reconcile(db)
+    files = {r.chapter_file for r in db.query(StoryChapter).all()}
+    assert files == {"02.txt"}
+
+
+# ── priority queue ──────────────────────────────────────────────────────────
+def test_next_task_p0_is_active_story_next_chapter(env):
+    for i, t in [("01.txt", "t1"), ("02.txt", "t2"), ("03.txt", "t3")]:
+        _chapter(env, "storyA", i, t)
+    _generate(env, "t1")                    # 01 ready; 02,03 pending
+    db = env.Session()
+    sai.reconcile(db)
+    db.add(StoryProgress(story_title="storyA", last_chapter_num=0,
+                         last_chapter_file="01.txt", last_played_at=100.0))
+    db.commit()
+    task = sai.next_task(db)
+    assert task == {"story_title": "storyA", "chapter_file": "02.txt", "priority": 0}
+
+
+def test_next_task_p2_then_p3(env):
+    # storyA fully generated; storyB has no audio → P2 picks storyB ch1
+    _chapter(env, "storyA", "01.txt", "a1")
+    _generate(env, "a1")
+    _chapter(env, "storyB", "01.txt", "b1")
+    _chapter(env, "storyB", "02.txt", "b2")
+    db = env.Session()
+    sai.reconcile(db)
+    task = sai.next_task(db)
+    assert task["story_title"] == "storyB" and task["chapter_file"] == "01.txt"
+    assert task["priority"] == 2
+    # once storyB has some audio, remaining falls to P3
+    sai.mark_ready(db, "storyB", "01.txt")
+    task = sai.next_task(db)
+    assert task["chapter_file"] == "02.txt" and task["priority"] == 3
+
+
+def test_next_task_none_when_all_ready(env):
+    _chapter(env, "storyA", "01.txt", "a1")
+    _generate(env, "a1")
+    db = env.Session()
+    sai.reconcile(db)
+    assert sai.next_task(db) is None
+
+
+# ── status transitions ──────────────────────────────────────────────────────
+def test_mark_ready_and_pending_by_hash(env):
+    _chapter(env, "storyA", "01.txt", "a1")
+    db = env.Session()
+    sai.reconcile(db)
+    row = db.get(StoryChapter, ("storyA", "01.txt"))
+    assert row.status == "pending"
+    h = get_content_hash(clean_text_for_tts("a1"))
+    sai.mark_ready(db, "storyA", "01.txt", h)
+    assert db.get(StoryChapter, ("storyA", "01.txt")).status == "ready"
+    # eviction of that hash flips it back
+    n = sai.mark_pending_by_hash(db, h)
+    assert n == 1
+    assert db.get(StoryChapter, ("storyA", "01.txt")).status == "pending"
+
+
+def test_preview_queue_orders_by_priority(env):
+    for i, t in [("01.txt", "t1"), ("02.txt", "t2"), ("03.txt", "t3")]:
+        _chapter(env, "storyA", i, t)
+    _generate(env, "t1")
+    db = env.Session()
+    sai.reconcile(db)
+    db.add(StoryProgress(story_title="storyA", last_chapter_num=0,
+                         last_chapter_file="01.txt", last_played_at=100.0))
+    db.commit()
+    q = sai.preview_queue(db, limit=10)
+    assert [(x["chapter_file"], x["priority"]) for x in q] == [("02.txt", 0), ("03.txt", 1)]

--- a/backend/tests/test_services/test_tts_pregen_e2e.py
+++ b/backend/tests/test_services/test_tts_pregen_e2e.py
@@ -92,6 +92,28 @@ async def test_e2e_pregen_queue_flow(job_env):
     assert job.get_status()["done"] == 2
 
 
+async def test_e2e_concurrent_rescan_and_get_next_task(job_env):
+    """The reconcile lock + guards must keep a rescan (stories route) and the
+    scheduler's get_next_task from raising or corrupting the table when they race."""
+    import asyncio
+    env = job_env
+    for i in range(1, 6):
+        _chapter(env, "storyA", f"0{i}.txt", f"chapter {i}")
+    job = env.tpj.TTSPreGenJob(types.SimpleNamespace())
+
+    results = await asyncio.gather(
+        job.get_next_task(),
+        asyncio.to_thread(job.rescan),
+        job.get_next_task(),
+        asyncio.to_thread(job.rescan),
+        job.get_next_task(),
+        return_exceptions=True,
+    )
+    assert not any(isinstance(r, Exception) for r in results), results
+    assert job.get_status()["total"] == 5
+    assert env.Session().query(StoryChapter).count() == 5   # no duplicate/lost rows
+
+
 async def test_e2e_new_story_is_picked_up_after_reconcile(job_env):
     env = job_env
     _chapter(env, "storyA", "01.txt", "alpha one")

--- a/backend/tests/test_services/test_tts_pregen_e2e.py
+++ b/backend/tests/test_services/test_tts_pregen_e2e.py
@@ -1,0 +1,107 @@
+"""E2E for the TTS pre-gen queue through the REAL TTSPreGenJob.
+
+Drives the actual production methods — construction → rescan/reconcile,
+``get_next_task`` (real ``asyncio.to_thread`` + reconcile + SSoT query),
+``execute_task`` (its real already-generated fast path → status write),
+``get_status`` — against a real in-memory SQLite + a temp story tree / audio
+cache. The ONLY thing avoided is the edge_tts network call, via the
+already-on-disk short-circuit; the queue/status subsystem under change runs for
+real (no mocking of it).
+"""
+import types
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from core.database import Base, StoryChapter
+from helpers.audio_cache import get_content_hash
+from helpers.text_processing import clean_text_for_tts
+
+
+@pytest.fixture()
+def job_env(tmp_path, monkeypatch):
+    import helpers.audio_cache as ac
+    import services.story_audio_index as sai
+    import services.tts_pregen_job as tpj
+
+    stories = tmp_path / "stories"
+    audio = tmp_path / "audio"
+    stories.mkdir()
+    audio.mkdir()
+    # Point every module that resolves the story tree / audio cache at the temp dirs.
+    for mod, attr in [(sai, "STORIES_DIR"), (sai, "AUDIO_CACHE_DIR"),
+                      (tpj, "STORIES_DIR"), (tpj, "AUDIO_CACHE_DIR"),
+                      (ac, "AUDIO_CACHE_DIR")]:
+        monkeypatch.setattr(mod, attr, str(stories if attr == "STORIES_DIR" else audio))
+
+    engine = create_engine("sqlite:///:memory:",
+                           connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(tpj, "get_db_session", lambda: Session())
+    return types.SimpleNamespace(stories=stories, audio=audio, Session=Session, tpj=tpj)
+
+
+def _chapter(env, story, fname, text):
+    d = env.stories / story
+    d.mkdir(exist_ok=True)
+    (d / fname).write_text(text, encoding="utf-8")
+
+
+def _write_mp3(env, text):
+    """Simulate a generated chapter: the mp3 the job's fast path will find."""
+    h = get_content_hash(clean_text_for_tts(text))
+    (env.audio / f"{h}.mp3").write_bytes(b"MP3")
+    return h
+
+
+async def test_e2e_pregen_queue_flow(job_env):
+    env = job_env
+    _chapter(env, "storyA", "01.txt", "alpha chapter one")
+    _chapter(env, "storyA", "02.txt", "alpha chapter two")
+
+    job = env.tpj.TTSPreGenJob(types.SimpleNamespace())   # __init__ → rescan → reconcile
+
+    # Both chapters pending → status endpoint reflects the SSoT.
+    assert job.get_status()["total"] == 2
+    assert job.get_status()["done"] == 0
+
+    # get_next_task drives the real to_thread reconcile + indexed SSoT query.
+    task = await job.get_next_task()
+    assert task["story_title"] == "storyA" and task["chapter_file"] == "01.txt"
+
+    # "Generate" ch01: its mp3 now exists → execute_task takes the already-done
+    # fast path (no network) and flips the SSoT status to ready.
+    _write_mp3(env, "alpha chapter one")
+    assert await job.execute_task(dict(task)) is True
+
+    db = env.Session()
+    assert db.get(StoryChapter, ("storyA", "01.txt")).status == "ready"
+    assert job.get_status()["done"] == 1
+
+    # Queue advances to the next pending chapter.
+    task2 = await job.get_next_task()
+    assert task2["chapter_file"] == "02.txt"
+
+    # Generate the last one → queue drains to empty.
+    _write_mp3(env, "alpha chapter two")
+    await job.execute_task(dict(task2))
+    assert await job.get_next_task() is None
+    assert job.get_status()["done"] == 2
+
+
+async def test_e2e_new_story_is_picked_up_after_reconcile(job_env):
+    env = job_env
+    _chapter(env, "storyA", "01.txt", "alpha one")
+    _write_mp3(env, "alpha one")                         # storyA already generated
+    job = env.tpj.TTSPreGenJob(types.SimpleNamespace())  # reconcile → storyA/01 ready
+    assert env.Session().get(StoryChapter, ("storyA", "01.txt")).status == "ready"
+    assert await job.get_next_task() is None             # nothing pending
+
+    # A new story appears on disk; the fingerprint changes → the next tick's
+    # off-loop reconcile brings it into the SSoT and the queue serves it.
+    _chapter(env, "storyB", "01.txt", "beta one")
+    task = await job.get_next_task()
+    assert task["story_title"] == "storyB" and task["chapter_file"] == "01.txt"


### PR DESCRIPTION
## Problem

The TTS pre-gen scheduler re-derived *"which chapters need audio"* from disk on **every idle tick (~10s)**: read every chapter's text → `clean_text_for_tts` + md5 → `os.path.exists` the cache file — for the whole story tree, **inline on the event loop**.

Measured on production: **~1.0s of blocking CPU/IO every ~11s** (one story, 561 chapters; 5.2MB re-read + 561 hashes each pass). It froze the event loop in ~1s bursts (visible as `/api/health` stalling ~1s every 11s) and burned ~8600 file-ops/min **forever, even when everything was already generated**.

Root reason: no durable per-chapter status, and the content hash (the expensive part) was recomputed for immutable files on every pass.

## Redesign — SQLite as the single source of truth

- **New `story_chapters` table** (PK `story_id`+`chapter_file`): `chapter_num`, `content_hash`, text `(mtime, size)` fingerprint, `status` (`pending`|`ready`).
- **`services/story_audio_index.py`:**
  - `reconcile(db, sig)` — sync table↔disk, re-reading/re-hashing **only** files whose `(mtime, size)` changed; a position shift just updates `chapter_num`; deleted files drop out. Steady state = one `stat` per chapter, no read/hash.
  - `next_task` / `preview_queue` — priority (P0→P3 via `story_progress`) as **indexed queries**, no disk, no hashing.
  - `status_counts` — done/total as a `COUNT` → instant status endpoint.
  - `mark_ready` / `mark_pending_by_hash` — status from generate / evict.
- **`tts_pregen_job.py`:** `get_next_task` runs the fingerprint + any reconcile + the disk-quota sweep on a worker thread (`asyncio.to_thread`) so nothing blocks the loop; picking the task is one query. `execute_task` flips status→`ready`; eviction flips evicted hashes→`pending`; `rescan()` (called by the stories API on add/remove) forces a reconcile — the event-driven trigger. Dead P0–P3 finder/collector scan methods removed.

## Effect

- Steady-state per tick: **~1s → ~ms**, and off the event loop.
- Status check: a DB count, not a disk scan.
- Cost scales with **changed** files, not total chapters.

## Impact (gitnexus, repo=jarvis)

**LOW** — `TTSPreGenJob` upstream is only `server.py` lifespan; the stories route / scheduler use the preserved public methods (`rescan`/`get_next_task`/`preview_queue`/`get_status`/`execute_task`).

## Tests

- `test_story_audio_index.py`: reconcile build / skip-unchanged (no re-hash) / add+remove, P0/P2/P3 priority, mark_ready + evict→pending, preview order — **8 passed**.
- Existing `test_tts_pregen_integration.py` still green.
- New table auto-creates via `Base.metadata.create_all`; first boot runs one reconcile (backfills status from existing mp3s on disk — no bulk re-hash of already-generated chapters beyond the one-time pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)