### PR TITLE
fix(memory): LadybugDB self-heal must clear ALL WAL sidecars (.wal.checkpoint)

### DIFF
--- a/backend/services/indexing/ladybug_store.py
+++ b/backend/services/indexing/ladybug_store.py
@@ -14,6 +14,7 @@ only ever sees its own memory (mirrors the SQLite rules).
 """
 from __future__ import annotations
 
+import glob
 import logging
 import os
 import shutil
@@ -29,30 +30,45 @@ def _norm(s: str) -> str:
     return " ".join((s or "").strip().lower().split())
 
 
-_GRAPH_SIDECARS = ("", ".wal", ".lock", ".shadow", ".tmp")
+def _graph_files(path: str) -> list[str]:
+    """The graph file/dir + EVERY LadybugDB sidecar (``.wal``, ``.wal.checkpoint``,
+    ``.shadow``, ``.lock``, ``.tmp``, …), EXCLUDING our own ``.corrupt`` quarantine
+    copies.
+
+    Enumerated by glob rather than a fixed suffix tuple: a fixed list silently
+    left ``.wal.checkpoint`` behind, so after quarantining the graph the "fresh"
+    reopen re-read that corrupt checkpoint and threw "Corrupted wal file" again —
+    the index stayed unavailable across restarts. Globbing covers any sidecar a
+    LadybugDB version adds."""
+    files = glob.glob(path + ".*")           # dot-suffixed sidecars
+    if os.path.exists(path):
+        files.append(path)                   # the graph file/dir itself (no suffix)
+    return [p for p in files if not p.endswith(".corrupt")]
+
+
+def _remove_path(p: str) -> None:
+    try:
+        if os.path.isdir(p):
+            shutil.rmtree(p, ignore_errors=True)
+        else:
+            os.remove(p)
+    except OSError:
+        pass
 
 
 def _wipe_graph_files(path: str) -> None:
-    """Remove a LadybugDB graph and its sidecars. The store is a disposable
+    """Remove a LadybugDB graph and all its sidecars. The store is a disposable
     projection — see ``_open``."""
-    if os.path.isdir(path):
-        shutil.rmtree(path, ignore_errors=True)
-    for s in _GRAPH_SIDECARS:
-        try:
-            os.remove(path + s)
-        except OSError:
-            pass
+    for p in _graph_files(path):
+        _remove_path(p)
 
 
 def _quarantine_graph_files(path: str) -> None:
-    """Move a corrupt graph + sidecars ASIDE to ``<path>*.corrupt`` instead of
-    deleting them, so a mis-triggered self-heal is forensically recoverable (the
+    """Move a corrupt graph + ALL its sidecars ASIDE to ``<path>*.corrupt`` instead
+    of deleting them, so a mis-triggered self-heal is forensically recoverable (the
     projection is rebuildable from SQLite either way). Overwrites a previous
     quarantine — only the latest corruption is kept. Best-effort."""
-    for s in _GRAPH_SIDECARS:
-        src = path + s
-        if not os.path.exists(src):
-            continue
+    for src in _graph_files(path):
         dst = src + ".corrupt"
         try:
             if os.path.isdir(dst):
@@ -61,8 +77,7 @@ def _quarantine_graph_files(path: str) -> None:
                 os.remove(dst)
             os.replace(src, dst)
         except OSError:
-            # last resort: don't let an unmovable file block recovery
-            _wipe_graph_files(src)
+            _remove_path(src)  # unmovable → delete so it can't block the fresh open
 
 EMBED_DIM = 1024  # BAAI/bge-m3
 _VECTOR_INDEX = "memory_emb_idx"

--- a/backend/tests/test_services/test_ladybug_selfheal_sidecars.py
+++ b/backend/tests/test_services/test_ladybug_selfheal_sidecars.py
@@ -1,0 +1,49 @@
+"""Self-heal sidecar coverage for ladybug_store (pure filesystem — no ladybug).
+
+Regression: the quarantine/wipe used a fixed suffix tuple that missed
+``.wal.checkpoint``. After quarantining a corrupt graph, the leftover checkpoint
+was re-read by the "fresh" reopen → "Corrupted wal file" again → the semantic
+index stayed *unavailable* across every restart until a human deleted the file.
+These lock in that ALL sidecars (globbed) are moved/removed.
+"""
+import os
+
+from services.indexing import ladybug_store as ls
+
+SIDECARS = ("", ".wal", ".wal.checkpoint", ".shadow", ".lock", ".tmp")
+
+
+def _make(tmp_path, *suffixes):
+    for s in suffixes:
+        (tmp_path / f"memory_graph{s}").write_text("x")
+    return str(tmp_path / "memory_graph")
+
+
+def test_graph_files_lists_all_sidecars_excluding_corrupt(tmp_path):
+    base = _make(tmp_path, *SIDECARS)
+    (tmp_path / "memory_graph.wal.corrupt").write_text("old")   # a prior quarantine copy
+    names = sorted(os.path.basename(p) for p in ls._graph_files(base))
+    assert names == sorted(f"memory_graph{s}" for s in SIDECARS)  # every live sidecar, no .corrupt
+
+
+def test_quarantine_moves_every_sidecar_including_wal_checkpoint(tmp_path):
+    base = _make(tmp_path, *SIDECARS)
+    ls._quarantine_graph_files(base)
+    leftovers = [p.name for p in tmp_path.iterdir() if not p.name.endswith(".corrupt")]
+    assert leftovers == []                                       # nothing left to re-corrupt the reopen
+    assert (tmp_path / "memory_graph.wal.checkpoint.corrupt").exists()
+
+
+def test_quarantine_preserves_prior_corrupt_copies(tmp_path):
+    (tmp_path / "memory_graph.corrupt").write_text("prev")       # untouchable forensic copy
+    base = _make(tmp_path, ".wal")
+    ls._quarantine_graph_files(base)
+    assert (tmp_path / "memory_graph.corrupt").exists()          # not re-quarantined
+    assert (tmp_path / "memory_graph.wal.corrupt").exists()      # newly quarantined
+    assert not (tmp_path / "memory_graph.corrupt.corrupt").exists()
+
+
+def test_wipe_removes_all_sidecars(tmp_path):
+    _make(tmp_path, *SIDECARS)
+    ls._wipe_graph_files(str(tmp_path / "memory_graph"))
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Problem

Prod semantic index (LadybugDB) showed **"Index unavailable — semantic search is degraded, falling back to keyword search"** and stayed there across restarts.

Root cause: the corrupt-WAL self-heal (`ladybug_store._open`) quarantines the graph + sidecars then reopens a fresh graph, but the sidecar set was a **fixed suffix tuple** `("", ".wal", ".lock", ".shadow", ".tmp")` that **missed `.wal.checkpoint`**. After quarantining, the leftover `memory_graph.wal.checkpoint` was re-read by the "fresh" open → `Corrupted wal file` again → the quarantine looped and dense recall stayed degraded until a human deleted the file.

Observed on prod (`data/memory_graph.*`): `memory_graph.corrupt`, `.shadow.corrupt`, `.wal.corrupt` were quarantined, but **`memory_graph.wal.checkpoint` (12 KB) was left live** and kept re-corrupting every reopen. Trigger: repeated deploy restarts left a dirty WAL.

## Fix

Enumerate the graph + **every** sidecar by glob (`path.*`, excluding our own `.corrupt` quarantine copies) instead of a fixed suffix list, so a sidecar any LadybugDB version adds (`.wal.checkpoint`, …) can't be silently left behind. `_wipe_graph_files` and `_quarantine_graph_files` share one `_graph_files()` enumeration.

## Impact (gitnexus, repo=jarvis)

**LOW** — only `LadybugStore._open` calls these.

## Tests

`test_ladybug_selfheal_sidecars.py` (pure filesystem, no `ladybug` dep so it runs everywhere):
- `_graph_files` lists all live sidecars, excludes `.corrupt`.
- quarantine moves **every** sidecar incl. `.wal.checkpoint`, leaving nothing to re-corrupt the reopen.
- prior `.corrupt` copies preserved (not re-quarantined).
- wipe clears all.

Existing `_open` self-heal tests still green.

## Verification plan

Deploy carries the exact corrupt state already on prod (`memory_graph.wal.checkpoint` present). On restart the fixed self-heal will quarantine it too → fresh open succeeds → startup migration rebuilds from SQLite → semantic index available. No manual file deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)