### PR TITLE
fix(iot): store Roborock login session in the DB (encrypted), not a git-cleaned file

### DIFF
--- a/backend/fastagent.config.yaml
+++ b/backend/fastagent.config.yaml
@@ -142,6 +142,12 @@ mcp:
          PYTHONUNBUFFERED: "1"
          ROBOROCK_USERNAME: "${ROBOROCK_USERNAME}"
          ROBOROCK_PASSWORD: "${ROBOROCK_PASSWORD}"
+         # The Roborock session persists to the DB via config_service (encrypted).
+         # Pin BOTH bindings this depends on so a later `cwd:`/chdir can't silently
+         # point config_service at a different jarvis.db, and the master key is
+         # available to decrypt (mirrors meeting_room + the google/other blocks).
+         JARVIS_DB_PATH: "data/jarvis.db"
+         JARVIS_MASTER_KEY: "${JARVIS_MASTER_KEY}"
     scrapling-server:
       command: "scrapling"
       args: ["mcp"]

--- a/backend/tests/test_services/test_iot_roborock_session.py
+++ b/backend/tests/test_services/test_iot_roborock_session.py
@@ -64,3 +64,32 @@ def test_session_round_trips_through_db(monkeypatch):
 def test_load_returns_none_when_nothing_stored(monkeypatch):
     _use_fake_config(monkeypatch)
     assert asyncio.run(iot_server.load_session()) is None
+
+
+def test_session_encrypts_at_rest_via_real_config_service(monkeypatch, tmp_path):
+    """End-to-end crypto: with a real ConfigService + real Fernet, is_secret=True
+    stores CIPHERTEXT in system_config and load_session decrypts it back."""
+    from core import secrets_crypto
+    from core.database import Base, SystemConfig
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from services.config_service import ConfigService
+
+    monkeypatch.setenv("JARVIS_MASTER_KEY", "iot-tests-master-key-please-rotate")
+    secrets_crypto.reload_master_key()
+    engine = create_engine(f"sqlite:///{tmp_path}/cfg.db", future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True, expire_on_commit=False)
+    monkeypatch.setattr("services.config_service.config_service",
+                        ConfigService(db_factory=Session))
+    monkeypatch.setattr(iot_server, "UserData",
+                        type("UD", (), {"from_dict": staticmethod(lambda d: _FakeUserData(d))}))
+
+    ud = _FakeUserData({"token": "s3cr3t-value", "rriot": {"u": "x"}})
+    asyncio.run(iot_server.save_session(ud))
+
+    row = Session().query(SystemConfig).filter_by(
+        category="service.roborock", key="session").one()
+    assert row.is_secret is True
+    assert "s3cr3t-value" not in row.value                       # ciphertext at rest
+    assert asyncio.run(iot_server.load_session()).as_dict() == ud.as_dict()  # decrypts back

--- a/backend/tests/test_services/test_iot_roborock_session.py
+++ b/backend/tests/test_services/test_iot_roborock_session.py
@@ -1,0 +1,66 @@
+"""Roborock login session persistence (tools.iot_server).
+
+The session is a SECRET — it must persist to the DB via config_service with
+is_secret=True (encrypted at rest, survives deploys), like every other credential
+in the app. It used to be a plaintext JSON file under config/credentials/, which
+the deploy's `git clean` wiped every time → repeated 2FA. These lock in the DB
+contract without depending on the roborock lib's UserData shape or real Fernet.
+"""
+import asyncio
+import json
+
+from tools import iot_server
+
+
+class _FakeConfigService:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, category, key, value, *, is_secret=False, **kw):
+        self.store[(category, key)] = {"value": value, "is_secret": is_secret}
+
+    def get(self, category, key, *, default=None):
+        row = self.store.get((category, key))
+        return row["value"] if row else default
+
+
+class _FakeUserData:
+    def __init__(self, d):
+        self._d = d
+
+    def as_dict(self):
+        return self._d
+
+
+def _use_fake_config(monkeypatch):
+    fake = _FakeConfigService()
+    monkeypatch.setattr("services.config_service.config_service", fake)
+    monkeypatch.setattr(iot_server, "UserData",
+                        type("UD", (), {"from_dict": staticmethod(lambda d: _FakeUserData(d))}))
+    return fake
+
+
+def test_session_persists_encrypted_in_db_under_service_roborock(monkeypatch):
+    fake = _use_fake_config(monkeypatch)
+    assert (iot_server._ROBOROCK_CATEGORY, iot_server._ROBOROCK_SESSION_KEY) \
+        == ("service.roborock", "session")
+
+    ud = _FakeUserData({"rriot": {"u": "user", "s": "secret"}, "token": "abc"})
+    asyncio.run(iot_server.save_session(ud))
+
+    row = fake.store[("service.roborock", "session")]
+    assert row["is_secret"] is True                    # encrypted at rest
+    assert json.loads(row["value"]) == ud.as_dict()    # stored as JSON
+
+
+def test_session_round_trips_through_db(monkeypatch):
+    _use_fake_config(monkeypatch)
+    ud = _FakeUserData({"token": "xyz", "n": 1})
+    asyncio.run(iot_server.save_session(ud))
+    loaded = asyncio.run(iot_server.load_session())
+    assert loaded.as_dict() == ud.as_dict()
+
+
+def test_load_returns_none_when_nothing_stored(monkeypatch):
+    _use_fake_config(monkeypatch)
+    assert asyncio.run(iot_server.load_session()) is None

--- a/backend/tools/iot_server.py
+++ b/backend/tools/iot_server.py
@@ -45,7 +45,12 @@ async def save_session(u_data: UserData):
         config_service.set(_ROBOROCK_CATEGORY, _ROBOROCK_SESSION_KEY,
                            json.dumps(u_data.as_dict()), is_secret=True)
     except Exception as e:
-        print(f"Error saving session: {e}")
+        # Log LOUD (not a silent print): a failed persist — e.g. a missing
+        # JARVIS_MASTER_KEY or a DB error — means login worked THIS run but the
+        # session won't survive, so the user re-does 2FA next process/deploy. We
+        # don't re-raise: the current session still works, degrade don't break.
+        logger.error("Roborock session NOT persisted (2FA will recur next "
+                     "deploy): %s", e, exc_info=True)
 
 
 async def load_session() -> UserData | None:

--- a/backend/tools/iot_server.py
+++ b/backend/tools/iot_server.py
@@ -10,7 +10,6 @@ from roborock.command_cache import CacheableAttribute
 from roborock import RoborockCommand
 from roborock.exceptions import RoborockException
 from dotenv import load_dotenv
-import pathlib
 
 load_dotenv()
 
@@ -28,24 +27,35 @@ cached_devices = None
 last_device_fetch = 0
 DEVICE_CACHE_TTL = 300  # 5 minutes
 
-SESSION_FILE = "config/credentials/roborock_session.json"
+# The Roborock login session is a SECRET → store it in the DB via config_service
+# (encrypted at rest, is_secret=True), exactly like every other credential in the
+# app: Google OAuth (oauth.google), Gmail, GitHub PAT (service.github), gateway bot
+# tokens. It used to be a plaintext JSON file under config/credentials/, which is
+# bind-mounted from the CI git checkout — deploy's `actions/checkout clean:true`
+# runs `git clean -ffdx` and WIPED it on every deploy, forcing a fresh 2FA login
+# each time. The DB (system_config) lives in the `data/` volume → survives deploys.
+_ROBOROCK_CATEGORY = "service.roborock"
+_ROBOROCK_SESSION_KEY = "session"
+
 
 async def save_session(u_data: UserData):
-    """Persist the login session to disk."""
+    """Persist the login session to the DB (encrypted)."""
     try:
-        with open(SESSION_FILE, "w") as f:
-            json.dump(u_data.as_dict(), f)
+        from services.config_service import config_service
+        config_service.set(_ROBOROCK_CATEGORY, _ROBOROCK_SESSION_KEY,
+                           json.dumps(u_data.as_dict()), is_secret=True)
     except Exception as e:
         print(f"Error saving session: {e}")
 
+
 async def load_session() -> UserData | None:
-    """Load a previously persisted login session, or None if missing."""
+    """Load the persisted login session from the DB, or None if not stored."""
     try:
-        if not pathlib.Path(SESSION_FILE).exists():
+        from services.config_service import config_service
+        raw = config_service.get(_ROBOROCK_CATEGORY, _ROBOROCK_SESSION_KEY)
+        if not raw:
             return None
-        with open(SESSION_FILE, "r") as f:
-            data = json.load(f)
-            return UserData.from_dict(data)
+        return UserData.from_dict(json.loads(raw))
     except Exception as e:
         print(f"Error loading session: {e}")
         return None


### PR DESCRIPTION
## Problem

The Roborock login session (a **secret**) was persisted as a plaintext JSON file at `config/credentials/roborock_session.json`. That directory is bind-mounted from the CI git checkout, and `deploy.yml`'s `actions/checkout` runs with **`clean: true`** → `git clean -ffdx`, which **wipes the (gitignored) session on every deploy**. So after each redeploy the user had to redo Roborock **2FA**. It was also stored in plaintext, unlike every other credential in the app.

Confirmed on prod: `config/credentials/` was empty (mtime = last deploy), `roborock_session.json` absent.

## Fix

Persist the session in the **DB via `config_service` with `is_secret=True`** (encrypted at rest), category `service.roborock` — the same pattern as Google OAuth (`oauth.google`), Gmail, GitHub PAT (`service.github`) and gateway bot tokens. `system_config` lives in `jarvis.db` on the **`data/` Docker volume**, which `git clean` never touches → the session **survives deploys**.

Verified the MCP subprocess can use this: `config_service` is already called from other tool subprocesses (`skill_server`, `cron_server`, `mcp_admin_server`), and `JARVIS_MASTER_KEY` is present in the container (encrypt/decrypt works).

## Audit (requested: is anything else stored in a git-cleaned path?)

**No — Roborock was the only offender.** Everything else is already DB-backed via `config_service`:

| Credential | Storage | Wiped by deploy? |
|---|---|---|
| Roborock | ~~file `config/credentials/`~~ → **DB `service.roborock` (encrypted)** | fixed |
| Google (Gmail/Calendar) | DB `oauth.google` (encrypted) | no |
| Gmail | DB (encrypted) | no |
| GitHub PAT | DB `service.github`; `hosts.yml` is a regenerated surface | no |
| Telegram / Zalo bot | DB (`is_secret=True`) | no |
| `fastagent.secrets.yaml` | separate host bind mount (not the checkout) | no |

## Impact (gitnexus, repo=jarvis)

**LOW** — `save_session`/`load_session` are called only within `iot_server.py`; all 13 downstream callers (get_session → list_devices/get_target_device → the robot command tools) are transparent (storage backend changed file→DB, same signatures).

## Tests

`test_iot_roborock_session.py`: session persists under `service.roborock` with `is_secret=True` (encrypted), round-trips via the DB, `load` returns `None` when absent. **3 passed.**

## Note

No migration: the prod session file is already gone (git-cleaned), so the user re-does 2FA **once** after this ships, then it lives in the encrypted DB permanently across all future deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)