### PR TITLE
feat(gateways): Telegram "/" command menu + immediate enable-toggle persistence

### DIFF
--- a/backend/services/gateways/bot_api.py
+++ b/backend/services/gateways/bot_api.py
@@ -84,6 +84,13 @@ class BotApiGateway(BaseGateway):
     api_base: str = ""
     # Method name used for the typing indicator, or None if unsupported.
     typing_method: Optional[str] = None
+    # Whether this platform's Bot API implements ``setMyCommands`` (the native "/"
+    # command menu). Telegram does. The Zalo Bot API (bot.zaloplatforms.com) does
+    # NOT — its method list is getMe/getUpdates/setWebhook/sendMessage/… with no
+    # command registration (verified 2026-07 against bot.zaloplatforms.com/docs),
+    # so registering there would just error every startup. Flip to True only when
+    # a platform actually supports it.
+    registers_commands: bool = False
 
     def __init__(
         self,
@@ -191,6 +198,24 @@ class BotApiGateway(BaseGateway):
 
     # ── Transport API (BaseGateway) ───────────────────────────────────────
 
+    async def _register_command_menu(self) -> None:
+        """Publish the slash-command menu so a native client (Telegram) shows the
+        commands as "/" autocomplete suggestions — the same mechanism OpenClaw uses.
+        delete-then-set mirrors the Bot API contract and clears a stale menu.
+        Best-effort: a failure here is cosmetic and must never stop the gateway."""
+        from services.gateways import commands
+        cmds = commands.menu_commands()
+        if not cmds:
+            return
+        try:
+            await self._call("deleteMyCommands")
+            await self._call("setMyCommands", {"commands": cmds})
+            logger.info("[%s] published %d slash commands to the native menu",
+                        self.name, len(cmds))
+        except Exception as e:  # noqa: BLE001 — cosmetic; never break startup
+            logger.warning("[%s] slash-command menu registration failed: %s",
+                           self.name, self._redact(str(e)))
+
     async def run(self) -> None:
         """Long-poll loop with exponential backoff on transient errors."""
         logger.info("[%s] gateway started (long-polling)", self.name)
@@ -203,6 +228,10 @@ class BotApiGateway(BaseGateway):
             self.connected = True
             self.last_error = None
             logger.info("[%s] connected as %s", self.name, self.bot_username)
+            # Register the "/" command menu once, right after we know the token is
+            # good — this is what surfaces the commands as autocomplete suggestions.
+            if self.registers_commands:
+                await self._register_command_menu()
         except Exception as e:
             self.connected = False
             self.last_error = self._redact(str(e))

--- a/backend/services/gateways/commands.py
+++ b/backend/services/gateways/commands.py
@@ -57,6 +57,15 @@ def help_text() -> str:
     return "\n".join(lines)
 
 
+def menu_commands() -> List[dict]:
+    """The command list for a platform's NATIVE command menu, in the Telegram
+    ``setMyCommands`` shape: ``[{"command": "new", "description": "..."}]``. This
+    is what makes commands show up as "/" autocomplete suggestions. Canonical
+    names only (aliases resolve into these); ``_COMMANDS`` is the single source of
+    truth — add a command there and it appears in the menu for free."""
+    return [{"command": name, "description": desc} for name, desc in _COMMANDS.items()]
+
+
 def handle(text: str, ctx: CommandContext) -> Optional[str]:
     """Execute a slash command and return the reply, or None if ``text`` is not
     a recognized command (the caller then dispatches to the agent)."""

--- a/backend/services/gateways/telegram.py
+++ b/backend/services/gateways/telegram.py
@@ -30,6 +30,7 @@ _MAX_MEDIA_BYTES = 20 * 1024 * 1024
 class TelegramGateway(BotApiGateway):
     api_base = "https://api.telegram.org"
     typing_method = "sendChatAction"
+    registers_commands = True   # Telegram supports setMyCommands → "/" menu suggestions
 
     def __init__(self, **kwargs) -> None:
         super().__init__(name="telegram", **kwargs)

--- a/backend/tests/test_services/test_gateways.py
+++ b/backend/tests/test_services/test_gateways.py
@@ -165,6 +165,37 @@ async def test_handle_inbound_empty_reply_tells_user():
 # ── Unit: platform parsers ─────────────────────────────────────────────────
 
 
+async def test_telegram_registers_slash_command_menu(monkeypatch):
+    # Telegram supports setMyCommands → the commands must be published so a native
+    # client shows them as "/" autocomplete suggestions (the OpenClaw behaviour the
+    # web/gateway lacked). delete-then-set, payload = the canonical command list.
+    from services.gateways import commands as gw_commands
+    gw = TelegramGateway(token="t", dispatcher=None, allow_from=[])
+    assert gw.registers_commands is True
+    calls = []
+
+    async def fake_call(method, body=None):
+        calls.append((method, body))
+        return {}
+
+    monkeypatch.setattr(gw, "_call", fake_call)
+    await gw._register_command_menu()
+    assert [m for m, _ in calls] == ["deleteMyCommands", "setMyCommands"]
+    payload = calls[1][1]["commands"]
+    assert payload == gw_commands.menu_commands()
+    assert {"command": "help", "description": "show this list"} in payload
+    assert {"command": "whoami", "description": "show your user id"} in payload
+
+
+def test_zalo_does_not_register_commands():
+    # Verified against bot.zaloplatforms.com/docs: the Zalo Bot API has NO
+    # setMyCommands (only getMe/getUpdates/sendMessage/…), so the flag must stay
+    # off — otherwise it 400s on every startup.
+    from services.gateways.zalo import ZaloGateway
+    gw = ZaloGateway(token="t", dispatcher=None, allow_from=[])
+    assert gw.registers_commands is False
+
+
 async def test_telegram_poll_parses_and_advances_offset(monkeypatch):
     gw = TelegramGateway(token="t", dispatcher=None, allow_from=[])
     updates = [

--- a/frontend/src/views/settings/SettingsGateways.vue
+++ b/frontend/src/views/settings/SettingsGateways.vue
@@ -165,7 +165,9 @@ function pollStatusAfterSave() {
 // never shows a state we didn't persist.
 async function toggleEnabled(id) {
   const r = rows[id]
-  r.error = ''
+  if (r.saving) return          // guard: a persist is already in flight (the switch
+  r.error = ''                  // is :disabled too, but belt-and-suspenders vs races)
+  r.saving = true
   try {
     await apiFetch('/api/settings/bulk', {
       method: 'POST',
@@ -177,6 +179,8 @@ async function toggleEnabled(id) {
   } catch (err) {
     r.enabled = !r.enabled  // failed to persist → don't lie about the state
     r.error = err?.body?.detail || err?.message || String(err)
+  } finally {
+    r.saving = false
   }
 }
 
@@ -267,7 +271,7 @@ onMounted(reload)
       <div class="card-body">
         <!-- Enable -->
         <label class="switch-row">
-          <input type="checkbox" v-model="r.enabled" @change="toggleEnabled(id)" />
+          <input type="checkbox" v-model="r.enabled" :disabled="r.saving" @change="toggleEnabled(id)" />
           <span class="switch-track"><span class="switch-thumb" /></span>
           <span class="switch-label">{{ t('settings.gateways.enable', { name: metaFor(id).label }) }}</span>
         </label>

--- a/frontend/src/views/settings/SettingsGateways.vue
+++ b/frontend/src/views/settings/SettingsGateways.vue
@@ -158,6 +158,28 @@ function pollStatusAfterSave() {
   setTimeout(tick, 800)
 }
 
+// The enable switch persists IMMEDIATELY on flip — a toggle is expected to APPLY,
+// not sit as a pending edit until "Save changes" (which is for token/allow-list/
+// agent). Without this, flipping off then reloading reverted to the saved value
+// and the gateway never actually stopped. Revert the toggle on failure so the UI
+// never shows a state we didn't persist.
+async function toggleEnabled(id) {
+  const r = rows[id]
+  r.error = ''
+  try {
+    await apiFetch('/api/settings/bulk', {
+      method: 'POST',
+      body: JSON.stringify({ items: [
+        { category: 'gateways', key: `${id}_enabled`, value: r.enabled ? 'true' : 'false', is_secret: false },
+      ] }),
+    })
+    pollStatusAfterSave()   // reflect the gateway start/stop in the status chip
+  } catch (err) {
+    r.enabled = !r.enabled  // failed to persist → don't lie about the state
+    r.error = err?.body?.detail || err?.message || String(err)
+  }
+}
+
 async function save(id) {
   const r = rows[id]
   r.saving = true
@@ -245,7 +267,7 @@ onMounted(reload)
       <div class="card-body">
         <!-- Enable -->
         <label class="switch-row">
-          <input type="checkbox" v-model="r.enabled" />
+          <input type="checkbox" v-model="r.enabled" @change="toggleEnabled(id)" />
           <span class="switch-track"><span class="switch-thumb" /></span>
           <span class="switch-label">{{ t('settings.gateways.enable', { name: metaFor(id).label }) }}</span>
         </label>

--- a/frontend/tests/e2e/flows/settings-gateways.spec.ts
+++ b/frontend/tests/e2e/flows/settings-gateways.spec.ts
@@ -15,7 +15,7 @@ import { expect, test } from '@playwright/test'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { mockBackend, NetworkRecorder, seedApiKey } from '../harness'
+import { mockBackend, seedApiKey } from '../harness'
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures')
 const NOISE = join(FIXTURES, '_app_boot_noise.yaml')
@@ -29,8 +29,6 @@ function telegramCard(page: import('@playwright/test').Page) {
 test('test a token then enable + save Telegram, asserting the bulk POST contract', async ({ page }) => {
   await seedApiKey(page)
   const backend = await mockBackend(page, [NOISE, join(FIXTURES, 'settings_gateways.yaml')])
-  const recorder = new NetworkRecorder()
-  await recorder.attach(page)
 
   await page.goto('/settings')
   await page.getByRole('button', { name: 'Messaging Gateways', exact: true }).click()
@@ -52,10 +50,23 @@ test('test a token then enable + save Telegram, asserting the bulk POST contract
   expect(testResp.status()).toBe(200)
   await expect(card.getByText(/jarvis_bot/)).toBeVisible()
 
-  // 2) Enable + allow-list + Save. The checkbox is visually hidden behind a
-  // custom switch — click the track the user actually sees.
-  await card.locator('.switch-track').click()
+  // 2) Enable — the switch now PERSISTS IMMEDIATELY via its OWN bulk POST
+  // (carrying just telegram_enabled), rather than waiting for "Save changes".
+  // The checkbox is visually hidden behind a custom switch — click the track.
+  const [enableResp] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.request().method() === 'POST' &&
+        new URL(r.url()).pathname === '/api/settings/bulk',
+    ),
+    card.locator('.switch-track').click(),
+  ])
+  expect(enableResp.status()).toBe(200)
   await expect(card.locator('input[type="checkbox"]')).toBeChecked()
+  // The toggle's own POST carries ONLY the enabled flag (not the whole form).
+  const enableItems = (enableResp.request().postDataJSON() as { items?: any[] })?.items || []
+  expect(enableItems).toContainEqual(expect.objectContaining({
+    category: 'gateways', key: 'telegram_enabled', value: 'true',
+  }))
 
   // Security: "*" (allow everyone) must surface a loud warning; specific ids must not.
   const allow = card.getByPlaceholder('123456789, 987654321')
@@ -64,6 +75,7 @@ test('test a token then enable + save Telegram, asserting the bulk POST contract
   await allow.fill('111, 222')
   await expect(card.locator('.allow-danger')).toHaveCount(0)
 
+  // 3) Save changes — batches token + allow-list + agent.
   const [bulkResp] = await Promise.all([
     page.waitForResponse(
       (r) => r.request().method() === 'POST' &&
@@ -73,12 +85,9 @@ test('test a token then enable + save Telegram, asserting the bulk POST contract
   ])
   expect(bulkResp.status()).toBe(200)
 
-  // Assert the bulk body carries the right items (no silent drop of fields).
-  const call = recorder.assertContains('POST', '/api/settings/bulk')
-  const items = (call.body as { items?: any[] })?.items || []
-  expect(items).toContainEqual(expect.objectContaining({
-    category: 'gateways', key: 'telegram_enabled', value: 'true',
-  }))
+  // Assert the SAVE body carries token + allow-list (read THIS request directly —
+  // the toggle above also POSTed, so we can't just grab the first bulk call).
+  const items = (bulkResp.request().postDataJSON() as { items?: any[] })?.items || []
   expect(items).toContainEqual(expect.objectContaining({
     category: 'gateways', key: 'telegram_token', value: '123456:ABCDEF_test-token', is_secret: true,
   }))


### PR DESCRIPTION
## Why
Two gateway UX gaps surfaced while using the Telegram/Zalo bots:

1. **No slash-command discovery on Telegram.** The gateway has a command registry (`/new`, `/agent`, `/whoami`, `/help`) but never published it to Telegram, so typing `/` showed **no autocomplete** — users couldn't discover the commands. This is the exact affordance OpenClaw ships (it calls `setMyCommands`).
2. **The Enable toggle didn't persist on flip.** Toggling a gateway off then reloading reverted to the saved value and the gateway never actually stopped.

## What

### 1. Telegram `/` command menu (`setMyCommands`)
- On startup (right after `getMe`) a registering gateway runs `deleteMyCommands` → `setMyCommands(commands.menu_commands())`. `_COMMANDS` stays the single source of truth — add a command there and it shows in the menu + `/help` for free.
- New flag `BotApiGateway.registers_commands` (default `False`); `TelegramGateway = True`.
- **Zalo stays `False`** — verified against **bot.zaloplatforms.com/docs**: the Zalo Bot API exposes only `getMe`/`getUpdates`/`setWebhook`/`sendMessage`/`sendPhoto`/`sendSticker`/`sendVoice`/`sendChatAction`, **no `setMyCommands`**. Registering there would just error every startup.
- Best-effort: a registration failure logs and never blocks the poll loop.

### 2. Enable toggle persists immediately
- The switch only mutated local state and required a separate **Save changes** click, so a flip-off then reload reverted (confirmed: `zalo_enabled` stayed `'true'` with no history entry, while the save path itself worked — `telegram_enabled=false` had saved fine).
- The toggle now saves immediately via `/settings/bulk` and **reverts on failure** so the UI never shows a state it didn't persist. Token / allow-list / agent still batch through **Save changes** (a switch applies now; form fields batch — the expected pattern).

## Verification
- **44 gateway tests pass** — added `test_telegram_registers_slash_command_menu` (asserts `deleteMyCommands` → `setMyCommands` with the canonical payload) and `test_zalo_does_not_register_commands`.
- **Toggle persistence verified end-to-end on a live instance**: `POST /settings/bulk zalo_enabled=false` → DB flipped to `false` **and** the Zalo gateway stopped (`running=False, connected=False`).
- Grounded, not guessed: read OpenClaw's `bot-native-command-menu.ts` (`setMyCommands` + `BOT_COMMANDS_TOO_MUCH` handling) and the official Zalo Bot API method list.

## Note
To see the menu on a live bot: enable Telegram (the gateway auto-registers on startup) then type `/` in the bot chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)