### PR TITLE
fix(memory): knowledge-graph extraction was hardcoded to Vietnamese

### DIFF
--- a/backend/services/memory/knowledge_graph.py
+++ b/backend/services/memory/knowledge_graph.py
@@ -1,7 +1,7 @@
 """Knowledge-graph triple extraction (memory v2 relations layer).
 
 Turns a memory statement into (subject, predicate, object) triples — e.g.
-"người dùng thích ăn phở" → {"s":"Người dùng","p":"thích","o":"phở"} — stored on
+"the user likes pho" → {"s":"User","p":"likes","o":"pho"} — stored on
 ``MemoryRecord.relations_json`` (SQLite = SoT) and projected to LadybugDB as
 RELATES edges so the graph view is a real knowledge graph, not opaque blobs.
 
@@ -23,11 +23,11 @@ Return ONLY a JSON array (no prose, no code fence). Each item:
 {"s": "<subject>", "p": "<short predicate>", "o": "<object>"}
 
 Rules:
-- Subject ``s`` is almost always "Người dùng" (the user). Use a named entity only when the statement is really about that entity (e.g. an employer's address).
-- Predicate ``p`` is a SHORT relationship phrase: thích / không thích / làm việc tại / sống ở / có / học / chơi / dùng / quan tâm đến …
-- Object ``o`` is a CONCISE noun/entity (phở, a company, a city, a hobby, guitar). Strip explanatory clauses — keep just the entity.
+- Subject ``s`` is almost always "User" (the user) — keep this canonical English label so all the user's facts share ONE super-node. Use a named entity only when the statement is really about that entity (e.g. an employer's address).
+- Predicate ``p`` is a SHORT relationship phrase: likes / dislikes / works at / lives in / has / studies / plays / uses / interested in …
+- Object ``o`` is a CONCISE noun/entity (a company, a city, a hobby, guitar). Strip explanatory clauses — keep just the entity.
 - Split a statement with several facts into several triples.
-- Keep the statement's language.
+- Write the predicate and object in the SAME language as the statement (English statement → English triples; do NOT translate to another language).
 
 If nothing extractable, return exactly: []
 """

--- a/backend/tests/test_services/test_memory_knowledge_graph.py
+++ b/backend/tests/test_services/test_memory_knowledge_graph.py
@@ -21,6 +21,18 @@ def test_parse_triples_tolerant():
     assert kg.parse_triples('[{"s":"a","p":"","o":"c"}]') == []   # missing predicate dropped
 
 
+def test_triple_prompt_is_english_anchored():
+    # Regression (English-First): the extraction prompt must anchor English —
+    # subject "User", English predicate examples — NOT hardcode Vietnamese. When
+    # the subject was forced to "Người dùng" with Vietnamese predicate examples,
+    # the LLM translated EVERY triple to Vietnamese even for English input.
+    p = kg.TRIPLE_PROMPT
+    assert '"User"' in p                 # canonical English subject super-node
+    assert "Người dùng" not in p         # no hardcoded Vietnamese subject
+    assert "works at" in p               # English predicate examples
+    assert "user" in kg._GENERIC_SUBJECTS  # hub still recognised after the rename
+
+
 def _fixed_fn(payload):
     async def gen(_prompt):
         return payload


### PR DESCRIPTION
## Bug
The memory **knowledge-graph** rendered Vietnamese labels for an English chat — e.g. `Người dùng / làm việc tại / cà phê đen` after "I'm a software engineer at Acme Robotics, and I take my coffee black."

## Root cause
`services/memory/knowledge_graph.py` → `TRIPLE_PROMPT` hardcoded Vietnamese:
- Subject forced to `"Người dùng"`.
- Predicate examples were all Vietnamese (`thích / làm việc tại / uống …`).
- Docstring example Vietnamese too.

These anchors overpowered the lone "keep the statement's language" line, so the extractor LLM **translated every triple to Vietnamese** regardless of input language — an English-First violation.

**Evidence it's the prompt (not an inherited language setting):** the same extractor LLM produced **English memory content** but **Vietnamese graph triples** — the only difference between those two calls is the prompt. A global language bias would have made the content Vietnamese too; it didn't.

## Fix
Anchor the prompt to English:
- Canonical subject `"User"` — one stable super-node (`_GENERIC_SUBJECTS` still matches it).
- English predicate examples (`likes / works at / lives in …`).
- Rule: *write predicate & object in the SAME language as the statement — do not translate*.

## Tests
`test_memory_knowledge_graph.py` — **9 passed**, incl. a new `test_triple_prompt_is_english_anchored` regression guard (asserts `"User"` present, `"Người dùng"` gone, English predicate examples).

## Note
A follow-up (parked) will let the graph language follow the user's **preferred language** setting rather than the per-statement language — a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)