### PR TITLE
docs(readme): reframe IoT GIF caption around direct subagent chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Self-hostable AI assistant built on [fast-agent](https://github.com/evalstate/fa
 
 ![Jarvis recalling the fact in a new conversation](docs/media/memory-recall.gif)
 
-**It controls real-world devices.** Ask a specialist agent for your robot vacuum's live status — real IoT (Roborock), not a mockup.
+**Chat with any specialist directly — not just the orchestrator.** Switch straight to a subagent (here, the IoT agent) and ask your robot vacuum for its live status — real IoT (Roborock), not a mockup.
 
-![Jarvis reporting a robot vacuum's live status over IoT](docs/media/iot-vacuum.gif)
+![Chatting directly with the IoT subagent to read a robot vacuum's live status](docs/media/iot-vacuum.gif)
 
 ## Quick start
 


### PR DESCRIPTION
Follow-up to the merged demo-GIF PRs (#131, #133).

The `iot-vacuum.gif` demonstrates **two** things, but its caption only called out one (real IoT). The stronger differentiator is that you **chat with a specialist subagent directly** (the IoT agent) instead of everything routing through a single orchestrator — the thing Hermes / OpenClaw don't offer.

Caption now leads with "**Chat with any specialist directly — not just the orchestrator.**"

Text-only change; the GIF is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)